### PR TITLE
fix(mcp): correct semantic-release paths for subdirectory execution

### DIFF
--- a/katana_mcp_server/pyproject.toml
+++ b/katana_mcp_server/pyproject.toml
@@ -67,8 +67,8 @@ markers = [
 ]
 
 [tool.semantic_release]
-version_toml = ["katana_mcp_server/pyproject.toml:project.version"]
-dist_path = "katana_mcp_server/dist/"
+version_toml = ["pyproject.toml:project.version"]
+dist_path = "dist/"
 upload_to_pypi = false
 upload_to_repository = false
 remove_dist = false


### PR DESCRIPTION
## Summary
Fix FileNotFoundError in MCP release workflow by adjusting semantic-release configuration paths to work correctly when running from a subdirectory.

## Problem
The release workflow for MCP failed with:
```
FileNotFoundError: path PosixPath('/github/workspace/katana_mcp_server/katana_mcp_server/pyproject.toml') does not exist
```

**Root cause:**
- Workflow runs semantic-release with `directory: katana_mcp_server`
- This changes working directory to `katana_mcp_server/`
- But pyproject.toml had paths like `version_toml = ["katana_mcp_server/pyproject.toml"]`
- Semantic-release looked for `katana_mcp_server/katana_mcp_server/pyproject.toml` (duplicated path)

## Solution
Changed paths in `katana_mcp_server/pyproject.toml` to be relative to the subdirectory:
- `version_toml = ["pyproject.toml:project.version"]` (was `["katana_mcp_server/pyproject.toml:project.version"]`)
- `dist_path = "dist/"` (was `"katana_mcp_server/dist/"`)

Now paths are correct when semantic-release runs from within the subdirectory.

## Testing
This will be tested when the PR merges and triggers a new MCP release.

## Related
- Failed workflow: https://github.com/dougborg/katana-openapi-client/actions/runs/18858075892
- Error occurred after PR #73 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)