### PR TITLE
ci: prevent race conditions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
   release-client:
     needs: test
     runs-on: ubuntu-latest
-    concurrency: release-client
+    concurrency:
+      group: release-client
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: write
@@ -100,7 +102,9 @@ jobs:
   release-mcp:
     needs: test
     runs-on: ubuntu-latest
-    concurrency: release-mcp
+    concurrency:
+      group: release-mcp
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Summary

Adds explicit concurrency control to release workflow jobs to prevent race conditions when multiple agents push to main simultaneously.

## Problem

Without proper concurrency control, parallel release workflows can cause:
- **Git tag conflicts** - Both workflows try to create the same tag
- **Version conflicts** - Semantic release gets confused about version numbers
- **Incomplete releases** - In-progress releases get cancelled

This is especially problematic with multiple AI agents working in parallel.

## Solution

Changed from shorthand `concurrency: release-client` to explicit configuration:

```yaml
concurrency:
  group: release-client
  cancel-in-progress: false  # KEY: Queue instead of cancel
```

### Before (Implicit Behavior)
```yaml
concurrency: release-client  # Defaults to cancel-in-progress: true
```
- Second workflow would cancel first workflow
- Could cause incomplete releases, tag conflicts

### After (Explicit Configuration)
```yaml
concurrency:
  group: release-client
  cancel-in-progress: false  # Queue workflows
```
- Second workflow waits for first to complete
- Sequential, conflict-free releases

## Behavior

| Event | Action |
|-------|--------|
| First push to main | Release starts immediately |
| Second push during release | **Queued**, waits for first |
| Third push | Queued behind second |

Result: Clean, sequential releases with no conflicts

## Testing

Can be tested by:
1. Push first commit to main → Release starts
2. Immediately push second commit → Should queue
3. First release completes → Second release starts
4. No tag/version conflicts

## Closes

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)