### PR TITLE
fix(client): correct BatchCreateBomRowsRequest field name from bom_rows to data

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -8421,15 +8421,15 @@ components:
       type: object
       description: Request payload for creating multiple BOM rows in a single operation
       properties:
-        bom_rows:
+        data:
           type: array
           description: Array of BOM rows to create
           items:
             $ref: "#/components/schemas/CreateBomRowRequest"
       required:
-        - bom_rows
+        - data
       example:
-        bom_rows:
+        data:
           - product_item_id: 3001
             product_variant_id: 2001
             ingredient_variant_id: 2002

--- a/katana_public_api_client/api/bom_row/batch_create_bom_rows.py
+++ b/katana_public_api_client/api/bom_row/batch_create_bom_rows.py
@@ -85,8 +85,8 @@ def sync_detailed(
 
     Args:
         body (BatchCreateBomRowsRequest): Request payload for creating multiple BOM rows in a
-            single operation Example: {'bom_rows': [{'product_item_id': 3001, 'product_variant_id':
-            2001, 'ingredient_variant_id': 2002, 'quantity': 2.5, 'notes': 'Primary component'},
+            single operation Example: {'data': [{'product_item_id': 3001, 'product_variant_id': 2001,
+            'ingredient_variant_id': 2002, 'quantity': 2.5, 'notes': 'Primary component'},
             {'product_item_id': 3001, 'product_variant_id': 2001, 'ingredient_variant_id': 2003,
             'quantity': 1.0, 'notes': 'Secondary component'}]}.
 
@@ -121,8 +121,8 @@ def sync(
 
     Args:
         body (BatchCreateBomRowsRequest): Request payload for creating multiple BOM rows in a
-            single operation Example: {'bom_rows': [{'product_item_id': 3001, 'product_variant_id':
-            2001, 'ingredient_variant_id': 2002, 'quantity': 2.5, 'notes': 'Primary component'},
+            single operation Example: {'data': [{'product_item_id': 3001, 'product_variant_id': 2001,
+            'ingredient_variant_id': 2002, 'quantity': 2.5, 'notes': 'Primary component'},
             {'product_item_id': 3001, 'product_variant_id': 2001, 'ingredient_variant_id': 2003,
             'quantity': 1.0, 'notes': 'Secondary component'}]}.
 
@@ -152,8 +152,8 @@ async def asyncio_detailed(
 
     Args:
         body (BatchCreateBomRowsRequest): Request payload for creating multiple BOM rows in a
-            single operation Example: {'bom_rows': [{'product_item_id': 3001, 'product_variant_id':
-            2001, 'ingredient_variant_id': 2002, 'quantity': 2.5, 'notes': 'Primary component'},
+            single operation Example: {'data': [{'product_item_id': 3001, 'product_variant_id': 2001,
+            'ingredient_variant_id': 2002, 'quantity': 2.5, 'notes': 'Primary component'},
             {'product_item_id': 3001, 'product_variant_id': 2001, 'ingredient_variant_id': 2003,
             'quantity': 1.0, 'notes': 'Secondary component'}]}.
 
@@ -186,8 +186,8 @@ async def asyncio(
 
     Args:
         body (BatchCreateBomRowsRequest): Request payload for creating multiple BOM rows in a
-            single operation Example: {'bom_rows': [{'product_item_id': 3001, 'product_variant_id':
-            2001, 'ingredient_variant_id': 2002, 'quantity': 2.5, 'notes': 'Primary component'},
+            single operation Example: {'data': [{'product_item_id': 3001, 'product_variant_id': 2001,
+            'ingredient_variant_id': 2002, 'quantity': 2.5, 'notes': 'Primary component'},
             {'product_item_id': 3001, 'product_variant_id': 2001, 'ingredient_variant_id': 2003,
             'quantity': 1.0, 'notes': 'Secondary component'}]}.
 

--- a/katana_public_api_client/models/batch_create_bom_rows_request.py
+++ b/katana_public_api_client/models/batch_create_bom_rows_request.py
@@ -18,25 +18,25 @@ class BatchCreateBomRowsRequest:
     """Request payload for creating multiple BOM rows in a single operation
 
     Example:
-        {'bom_rows': [{'product_item_id': 3001, 'product_variant_id': 2001, 'ingredient_variant_id': 2002, 'quantity':
-            2.5, 'notes': 'Primary component'}, {'product_item_id': 3001, 'product_variant_id': 2001,
-            'ingredient_variant_id': 2003, 'quantity': 1.0, 'notes': 'Secondary component'}]}
+        {'data': [{'product_item_id': 3001, 'product_variant_id': 2001, 'ingredient_variant_id': 2002, 'quantity': 2.5,
+            'notes': 'Primary component'}, {'product_item_id': 3001, 'product_variant_id': 2001, 'ingredient_variant_id':
+            2003, 'quantity': 1.0, 'notes': 'Secondary component'}]}
     """
 
-    bom_rows: list["CreateBomRowRequest"]
+    data: list["CreateBomRowRequest"]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        bom_rows = []
-        for bom_rows_item_data in self.bom_rows:
-            bom_rows_item = bom_rows_item_data.to_dict()
-            bom_rows.append(bom_rows_item)
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "bom_rows": bom_rows,
+                "data": data,
             }
         )
 
@@ -47,15 +47,15 @@ class BatchCreateBomRowsRequest:
         from ..models.create_bom_row_request import CreateBomRowRequest
 
         d = dict(src_dict)
-        bom_rows = []
-        _bom_rows = d.pop("bom_rows")
-        for bom_rows_item_data in _bom_rows:
-            bom_rows_item = CreateBomRowRequest.from_dict(bom_rows_item_data)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = CreateBomRowRequest.from_dict(data_item_data)
 
-            bom_rows.append(bom_rows_item)
+            data.append(data_item)
 
         batch_create_bom_rows_request = cls(
-            bom_rows=bom_rows,
+            data=data,
         )
 
         batch_create_bom_rows_request.additional_properties = d


### PR DESCRIPTION
## Problem
`BatchCreateBomRowsRequest` was using `bom_rows` as the field name, but the actual Katana API endpoint `/bom_rows/batch/create` expects `data` according to:
- [Katana API documentation](https://developer.katanamrp.com/reference/createbomrow)
- Comprehensive OpenAPI spec (`docs/katana-api-comprehensive/openapi-spec.json`)

This would cause API calls using the generated client to fail with invalid request body errors.

## Changes
Updated `docs/katana-openapi.yaml` `BatchCreateBomRowsRequest` schema (lines 8420-8442):
- Property name: `bom_rows` → `data`
- Required field: `bom_rows` → `data`
- Example: `bom_rows` → `data`

Regenerated client to reflect corrected schema.

## Verification
✅ Confirmed field name `data` in comprehensive spec:
```bash
jq '.paths."/bom_rows/batch/create".post.requestBody.content."application/json".schema.properties | keys' \
  docs/katana-api-comprehensive/openapi-spec.json
# Output: ["data"]
```

✅ All tests passing: 1663 passed, 1 skipped
✅ Schema validation successful
✅ Client generation successful

## Notes
- The 112 Redocly warnings from spec validation are about **examples not matching schemas** (informational only), not functional issues
- This fix corrects an actual API contract mismatch that would cause runtime failures
- Replaces #113 with clean commits (no unrelated MCP changes)

## Related
- Issue #114: Track fixing all 112 Redocly example validation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)