### PR TITLE
fix(test): use .test TLD for mock URLs to avoid DNS lookups

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def mock_api_credentials():
     """Provide mock API credentials for testing."""
     return {
         "api_key": "test-api-key-12345",
-        "base_url": "https://api.test.katana.example.com",
+        "base_url": "https://api.katana.test",  # .test TLD reserved for testing (RFC 6761)
     }
 
 
@@ -157,9 +157,9 @@ def setup_test_env(monkeypatch, request):
         if not os.getenv("KATANA_BASE_URL"):
             monkeypatch.setenv("KATANA_BASE_URL", "https://api.katanamrp.com/v1")
     else:
-        # For unit tests, use test values
+        # For unit tests, use test values with .test TLD (RFC 6761 reserved for testing)
         monkeypatch.setenv("KATANA_API_KEY", "test-key")
-        monkeypatch.setenv("KATANA_BASE_URL", "https://api.test.katana.example.com")
+        monkeypatch.setenv("KATANA_BASE_URL", "https://api.katana.test")
 
 
 # Async test utilities


### PR DESCRIPTION
## Problem

When Copilot agents run tests in GitHub Actions, they're hitting firewall blocks for `api.test.katana.example.com`:

```
I tried to connect to the following addresses, but was blocked by firewall rules:
api.test.katana.example.com
```

This is a **false positive** - the URL is just a mock value in test fixtures, not a real service.

## Root Cause

The test configuration in [`tests/conftest.py`](tests/conftest.py) uses `api.test.katana.example.com` as a mock base URL. Even though all HTTP calls should be mocked, the firewall is blocking DNS lookups for this domain.

## Solution

Changed mock test URLs to use the `.test` top-level domain (TLD) which is **reserved for testing per [RFC 6761](https://datatracker.ietf.org/doc/html/rfc6761#section-6.2)**:

- **Before**: `https://api.test.katana.example.com`
- **After**: `https://api.katana.test`

The `.test` TLD is guaranteed to:
- Never resolve to a real IP address
- Not trigger DNS lookups in properly configured environments
- Be recognized as a testing domain

## Changes

- ✅ Updated `mock_api_credentials` fixture to use `api.katana.test`
- ✅ Updated `katana_env` fixture to use `api.katana.test`
- ✅ Added RFC 6761 comment explaining the choice
- ✅ All 1671 tests pass locally

## Testing

```bash
$ uv run poe test
======================= 1671 passed, 1 skipped in 16.90s =======================
```

## Benefits

- ✅ **Eliminates firewall false positives** in Copilot agent environments
- ✅ **Standards-compliant** - follows RFC 6761 best practices
- ✅ **No functional changes** - tests behave identically
- ✅ **Future-proof** - `.test` TLD won't conflict with real domains

## References

- [RFC 6761 - Special-Use Domain Names](https://datatracker.ietf.org/doc/html/rfc6761#section-6.2)
- Related: Issue #134 (pre-commit CI environment issues)

---

**Type**: Bug fix
**Impact**: Low (CI environment only)
**Risk**: None (test-only change)