### PR TITLE
fix(client): add SalesOrderFulfillmentRow to SerialNumberResourceType enum

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -3032,6 +3032,7 @@ components:
             - StockTransferRow
             - PurchaseOrderRow
             - SalesOrderRow
+            - SalesOrderFulfillmentRow
         resource_id:
           type: integer
           description: Unique identifier of the specific resource instance

--- a/katana_public_api_client/models/serial_number_resource_type.py
+++ b/katana_public_api_client/models/serial_number_resource_type.py
@@ -5,6 +5,7 @@ class SerialNumberResourceType(str, Enum):
     MANUFACTURINGORDER = "ManufacturingOrder"
     PRODUCTION = "Production"
     PURCHASEORDERROW = "PurchaseOrderRow"
+    SALESORDERFULFILLMENTROW = "SalesOrderFulfillmentRow"
     SALESORDERROW = "SalesOrderRow"
     STOCKADJUSTMENTROW = "StockAdjustmentRow"
     STOCKTRANSFERROW = "StockTransferRow"

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "fastmcp" },
@@ -2046,6 +2046,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/fa/3234f913fe9a6525a7b97c6dad1f51e72b917e6872e051a5e2ffd8b16fbb/ruamel.yaml.clib-0.2.14-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:70eda7703b8126f5e52fcf276e6c0f40b0d314674f896fc58c47b0aef2b9ae83", size = 137970, upload-time = "2025-09-22T19:51:09.472Z" },
     { url = "https://files.pythonhosted.org/packages/ef/ec/4edbf17ac2c87fa0845dd366ef8d5852b96eb58fcd65fc1ecf5fe27b4641/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a0cb71ccc6ef9ce36eecb6272c81afdc2f565950cdcec33ae8e6cd8f7fc86f27", size = 739639, upload-time = "2025-09-22T19:51:10.566Z" },
     { url = "https://files.pythonhosted.org/packages/15/18/b0e1fafe59051de9e79cdd431863b03593ecfa8341c110affad7c8121efc/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7cb9ad1d525d40f7d87b6df7c0ff916a66bc52cb61b66ac1b2a16d0c1b07640", size = 764456, upload-time = "2025-09-22T19:51:11.736Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/cd/150fdb96b8fab27fe08d8a59fe67554568727981806e6bc2677a16081ec7/ruamel_yaml_clib-0.2.14-cp314-cp314-win32.whl", hash = "sha256:9b4104bf43ca0cd4e6f738cb86326a3b2f6eef00f417bd1e7efb7bdffe74c539", size = 102394, upload-time = "2025-11-14T21:57:36.703Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e6/a3fa40084558c7e1dc9546385f22a93949c890a8b2e445b2ba43935f51da/ruamel_yaml_clib-0.2.14-cp314-cp314-win_amd64.whl", hash = "sha256:13997d7d354a9890ea1ec5937a219817464e5cc344805b37671562a401ca3008", size = 122673, upload-time = "2025-11-14T21:57:38.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #182 

Adds the missing `SalesOrderFulfillmentRow` value to the `SerialNumberResourceType` enum.

## Problem

The Katana API returns `"SalesOrderFulfillmentRow"` as a `resource_type` value when fetching serial numbers, but this value was missing from the `SerialNumberResourceType` enum. This caused deserialization errors:

```python
ValueError: 'SalesOrderFulfillmentRow' is not a valid SerialNumberResourceType
```

## Solution

- Added `SalesOrderFulfillmentRow` to the `SerialNumberResourceType` enum in the OpenAPI spec
- Regenerated the client to pick up the new enum value

## Testing

- All 1694 tests passing
- Verified the enum now includes all 7 valid resource types

## Impact

Users can now successfully call `get_all_serial_numbers.asyncio_detailed()` without errors when the API returns sales order fulfillment serial numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>