### PR TITLE
fix(deps): bump urllib3 to 2.6.3 for CVE-2026-21441

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ dependencies = [
   # Enhanced client dependencies
   "tenacity>=9.1.0",
   "python-dotenv>=1.0.0",
-  # Security-critical: urllib3 >= 2.6.0 fixes CVE-2025-66471 and CVE-2025-66418
-  "urllib3>=2.6.0",
+  # Security-critical: urllib3 >= 2.6.3 fixes CVE-2025-66471, CVE-2025-66418, and CVE-2026-21441
+  "urllib3>=2.6.3",
   "pydantic>=2.12.0",
   "email-validator>=2.2.0",  # Required for Pydantic EmailStr fields
   "typing-extensions>=4.13.0",

--- a/uv.lock
+++ b/uv.lock
@@ -967,7 +967,7 @@ requires-dist = [
 
 [[package]]
 name = "katana-openapi-client"
-version = "0.42.0"
+version = "0.43.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -1063,7 +1063,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "types-urllib3", marker = "extra == 'dev'", specifier = ">=1.26.0" },
     { name = "typing-extensions", specifier = ">=4.13.0" },
-    { name = "urllib3", specifier = ">=2.6.0" },
+    { name = "urllib3", specifier = ">=2.6.3" },
     { name = "yamllint", marker = "extra == 'dev'", specifier = ">=1.37.0" },
 ]
 provides-extras = ["dev", "docs"]
@@ -2777,11 +2777,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump urllib3 minimum version from 2.6.0 to 2.6.3
- Fixes CVE-2026-21441 (high severity): decompression-bomb safeguards in the streaming API were bypassed when HTTP redirects were followed
- Also covers CVE-2025-66471 and CVE-2025-66418 (already fixed in 2.6.0)

## Security References
- [GitHub Advisory - CVE-2025-66418](https://github.com/advisories/GHSA-gm62-xv2j-4w53)
- [NVD - CVE-2025-66471](https://nvd.nist.gov/vuln/detail/CVE-2025-66471)
- [Fedora Advisory - CVE-2026-21441](https://linuxsecurity.com/advisories/fedora/python-urllib3-fedora-43-2026-21441)

## Test plan
- [x] All tests pass (1756 passed, 1 skipped)
- [x] Pre-commit hooks pass
- [x] `uv sync` confirms urllib3 2.6.3 installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)