### PR TITLE
docs(client): update ADR-003 to reflect limit=250 default

### DIFF
--- a/katana_public_api_client/docs/adr/0003-transparent-pagination.md
+++ b/katana_public_api_client/docs/adr/0003-transparent-pagination.md
@@ -11,6 +11,7 @@ Date: 2024-08-13 (estimated based on transport implementation)
 The Katana API uses cursor-based pagination with Link headers:
 
 - Maximum page size: 250 items
+- Default page size: 250 items (transport default for efficiency)
 - Link header provides `next` URL for additional pages
 - Many resources have hundreds or thousands of items
 

--- a/uv.lock
+++ b/uv.lock
@@ -1210,7 +1210,7 @@ requires-dist = [
 
 [[package]]
 name = "katana-openapi-client"
-version = "0.44.2"
+version = "0.44.3"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary
- Update ADR-003 transparent pagination documentation to reflect current behavior where transport defaults to `limit=250` (Katana's max) for efficiency

This is a follow-up to PR #234 which fixed pagination defaults. The ADR documentation still referenced the old `limit=50` default.

## Test plan
- [x] Documentation-only change
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)