### PR TITLE
fix(client): preserve array query params across paginated requests

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -16907,9 +16907,11 @@ paths:
         - $ref: "#/components/parameters/ingredient_variant_id"
         - name: product_variant_ids
           in: query
-          description: Filter by product variant IDs (comma-separated)
+          description: Filters recipes by an array of product variant IDs.
           schema:
-            type: string
+            type: array
+            items:
+              type: integer
         - $ref: "#/components/parameters/product_id"
         - name: recipe_row_id
           in: query

--- a/katana_public_api_client/api/additional_costs/get_additional_costs.py
+++ b/katana_public_api_client/api/additional_costs/get_additional_costs.py
@@ -23,6 +23,7 @@ def _get_kwargs(
     name: str | Unset = UNSET,
     include_deleted: bool | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/batch/get_batch_stock.py
+++ b/katana_public_api_client/api/batch/get_batch_stock.py
@@ -23,6 +23,7 @@ def _get_kwargs(
     limit: int | Unset = UNSET,
     page: int | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["batch_id"] = batch_id

--- a/katana_public_api_client/api/bom_row/delete_bom_row.py
+++ b/katana_public_api_client/api/bom_row/delete_bom_row.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/bom_rows/{id}".format(

--- a/katana_public_api_client/api/bom_row/get_all_bom_rows.py
+++ b/katana_public_api_client/api/bom_row/get_all_bom_rows.py
@@ -24,6 +24,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/custom_fields/get_all_custom_fields_collections.py
+++ b/katana_public_api_client/api/custom_fields/get_all_custom_fields_collections.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 
 
 def _get_kwargs() -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/custom_fields_collections",

--- a/katana_public_api_client/api/customer/delete_customer.py
+++ b/katana_public_api_client/api/customer/delete_customer.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/customers/{id}".format(

--- a/katana_public_api_client/api/customer/get_all_customers.py
+++ b/katana_public_api_client/api/customer/get_all_customers.py
@@ -31,6 +31,7 @@ def _get_kwargs(
     currency: str | Unset = UNSET,
     reference_id: str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/customer_address/delete_customer_address.py
+++ b/katana_public_api_client/api/customer_address/delete_customer_address.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/customer_addresses/{id}".format(

--- a/katana_public_api_client/api/customer_address/get_all_customer_addresses.py
+++ b/katana_public_api_client/api/customer_address/get_all_customer_addresses.py
@@ -37,6 +37,7 @@ def _get_kwargs(
     country: str | Unset = UNSET,
     phone: str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/demand_forecast/get_demand_forecasts.py
+++ b/katana_public_api_client/api/demand_forecast/get_demand_forecasts.py
@@ -15,6 +15,7 @@ def _get_kwargs(
     variant_id: int,
     location_id: int,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["variant_id"] = variant_id

--- a/katana_public_api_client/api/factory/get_factory.py
+++ b/katana_public_api_client/api/factory/get_factory.py
@@ -11,6 +11,7 @@ from ...models.factory import Factory
 
 
 def _get_kwargs() -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/factory",

--- a/katana_public_api_client/api/inventory/get_all_inventory_point.py
+++ b/katana_public_api_client/api/inventory/get_all_inventory_point.py
@@ -20,6 +20,7 @@ def _get_kwargs(
     limit: int | Unset = UNSET,
     page: int | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["location_id"] = location_id

--- a/katana_public_api_client/api/inventory/get_all_negative_stock.py
+++ b/katana_public_api_client/api/inventory/get_all_negative_stock.py
@@ -22,6 +22,7 @@ def _get_kwargs(
     limit: int | Unset = UNSET,
     page: int | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["location_id"] = location_id

--- a/katana_public_api_client/api/inventory_movements/get_all_inventory_movements.py
+++ b/katana_public_api_client/api/inventory_movements/get_all_inventory_movements.py
@@ -30,6 +30,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/location/get_all_locations.py
+++ b/katana_public_api_client/api/location/get_all_locations.py
@@ -29,6 +29,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/location/get_location.py
+++ b/katana_public_api_client/api/location/get_location.py
@@ -16,6 +16,7 @@ from ...models.location_type_0 import LocationType0
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/locations/{id}".format(

--- a/katana_public_api_client/api/manufacturing_order/delete_manufacturing_order.py
+++ b/katana_public_api_client/api/manufacturing_order/delete_manufacturing_order.py
@@ -14,6 +14,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/manufacturing_orders/{id}".format(

--- a/katana_public_api_client/api/manufacturing_order/get_all_manufacturing_order_productions.py
+++ b/katana_public_api_client/api/manufacturing_order/get_all_manufacturing_order_productions.py
@@ -25,6 +25,7 @@ def _get_kwargs(
     updated_at_max: datetime.datetime | Unset = UNSET,
     include_deleted: bool | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/manufacturing_order/get_all_manufacturing_orders.py
+++ b/katana_public_api_client/api/manufacturing_order/get_all_manufacturing_orders.py
@@ -29,6 +29,7 @@ def _get_kwargs(
     updated_at_max: datetime.datetime | Unset = UNSET,
     include_deleted: bool | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/manufacturing_order/get_manufacturing_order.py
+++ b/katana_public_api_client/api/manufacturing_order/get_manufacturing_order.py
@@ -14,6 +14,7 @@ from ...models.manufacturing_order import ManufacturingOrder
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/manufacturing_orders/{id}".format(

--- a/katana_public_api_client/api/manufacturing_order_operation/delete_manufacturing_order_operation_row.py
+++ b/katana_public_api_client/api/manufacturing_order_operation/delete_manufacturing_order_operation_row.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/manufacturing_order_operation_rows/{id}".format(

--- a/katana_public_api_client/api/manufacturing_order_operation/get_all_manufacturing_order_operation_rows.py
+++ b/katana_public_api_client/api/manufacturing_order_operation/get_all_manufacturing_order_operation_rows.py
@@ -29,6 +29,7 @@ def _get_kwargs(
     updated_at_max: datetime.datetime | Unset = UNSET,
     include_deleted: bool | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/manufacturing_order_operation/get_manufacturing_order_operation_row.py
+++ b/katana_public_api_client/api/manufacturing_order_operation/get_manufacturing_order_operation_row.py
@@ -14,6 +14,7 @@ from ...models.manufacturing_order_operation_row import ManufacturingOrderOperat
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/manufacturing_order_operation_rows/{id}".format(

--- a/katana_public_api_client/api/manufacturing_order_production/delete_manufacturing_order_production.py
+++ b/katana_public_api_client/api/manufacturing_order_production/delete_manufacturing_order_production.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/manufacturing_order_productions/{id}".format(

--- a/katana_public_api_client/api/manufacturing_order_production/get_manufacturing_order_production.py
+++ b/katana_public_api_client/api/manufacturing_order_production/get_manufacturing_order_production.py
@@ -14,6 +14,7 @@ from ...models.manufacturing_order_production import ManufacturingOrderProductio
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/manufacturing_order_productions/{id}".format(

--- a/katana_public_api_client/api/manufacturing_order_recipe/delete_manufacturing_order_recipe_row.py
+++ b/katana_public_api_client/api/manufacturing_order_recipe/delete_manufacturing_order_recipe_row.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/manufacturing_order_recipe_rows/{id}".format(

--- a/katana_public_api_client/api/manufacturing_order_recipe/get_all_manufacturing_order_recipe_rows.py
+++ b/katana_public_api_client/api/manufacturing_order_recipe/get_all_manufacturing_order_recipe_rows.py
@@ -31,6 +31,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/manufacturing_order_recipe/get_manufacturing_order_recipe_row.py
+++ b/katana_public_api_client/api/manufacturing_order_recipe/get_manufacturing_order_recipe_row.py
@@ -14,6 +14,7 @@ from ...models.manufacturing_order_recipe_row import ManufacturingOrderRecipeRow
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/manufacturing_order_recipe_rows/{id}".format(

--- a/katana_public_api_client/api/material/delete_material.py
+++ b/katana_public_api_client/api/material/delete_material.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/materials/{id}".format(

--- a/katana_public_api_client/api/material/get_all_materials.py
+++ b/katana_public_api_client/api/material/get_all_materials.py
@@ -32,6 +32,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/material/get_material.py
+++ b/katana_public_api_client/api/material/get_material.py
@@ -17,6 +17,7 @@ def _get_kwargs(
     *,
     extend: list[GetMaterialExtendItem] | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_extend: list[str] | Unset = UNSET

--- a/katana_public_api_client/api/operator/get_all_operators.py
+++ b/katana_public_api_client/api/operator/get_all_operators.py
@@ -17,6 +17,7 @@ def _get_kwargs(
     limit: int | Unset = UNSET,
     page: int | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["working_area"] = working_area

--- a/katana_public_api_client/api/price_list/delete_price_list.py
+++ b/katana_public_api_client/api/price_list/delete_price_list.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/price_lists/{id}".format(

--- a/katana_public_api_client/api/price_list/get_all_price_lists.py
+++ b/katana_public_api_client/api/price_list/get_all_price_lists.py
@@ -18,6 +18,7 @@ def _get_kwargs(
     name: str | Unset = UNSET,
     is_active: bool | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/price_list/get_price_list.py
+++ b/katana_public_api_client/api/price_list/get_price_list.py
@@ -14,6 +14,7 @@ from ...models.price_list import PriceList
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/price_lists/{id}".format(

--- a/katana_public_api_client/api/price_list_customer/delete_price_list_customer.py
+++ b/katana_public_api_client/api/price_list_customer/delete_price_list_customer.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/price_list_customers/{id}".format(

--- a/katana_public_api_client/api/price_list_customer/get_all_price_list_customers.py
+++ b/katana_public_api_client/api/price_list_customer/get_all_price_list_customers.py
@@ -18,6 +18,7 @@ def _get_kwargs(
     customer_ids: list[int] | Unset = UNSET,
     ids: list[int] | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/price_list_customer/get_price_list_customer.py
+++ b/katana_public_api_client/api/price_list_customer/get_price_list_customer.py
@@ -14,6 +14,7 @@ from ...models.price_list_customer import PriceListCustomer
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/price_list_customers/{id}".format(

--- a/katana_public_api_client/api/price_list_row/delete_price_list_row.py
+++ b/katana_public_api_client/api/price_list_row/delete_price_list_row.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/price_list_rows/{id}".format(

--- a/katana_public_api_client/api/price_list_row/get_all_price_list_rows.py
+++ b/katana_public_api_client/api/price_list_row/get_all_price_list_rows.py
@@ -18,6 +18,7 @@ def _get_kwargs(
     price_list_ids: list[int] | Unset = UNSET,
     variant_ids: list[int] | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/price_list_row/get_price_list_row.py
+++ b/katana_public_api_client/api/price_list_row/get_price_list_row.py
@@ -14,6 +14,7 @@ from ...models.price_list_row import PriceListRow
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/price_list_rows/{id}".format(

--- a/katana_public_api_client/api/product/delete_product.py
+++ b/katana_public_api_client/api/product/delete_product.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/products/{id}".format(

--- a/katana_public_api_client/api/product/get_all_products.py
+++ b/katana_public_api_client/api/product/get_all_products.py
@@ -37,6 +37,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/product/get_product.py
+++ b/katana_public_api_client/api/product/get_product.py
@@ -17,6 +17,7 @@ def _get_kwargs(
     *,
     extend: list[GetProductExtendItem] | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_extend: list[str] | Unset = UNSET

--- a/katana_public_api_client/api/products/delete_product_operation_row.py
+++ b/katana_public_api_client/api/products/delete_product_operation_row.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/product_operation_rows/{id}".format(

--- a/katana_public_api_client/api/products/get_all_product_operation_rows.py
+++ b/katana_public_api_client/api/products/get_all_product_operation_rows.py
@@ -29,6 +29,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/purchase_order/delete_purchase_order.py
+++ b/katana_public_api_client/api/purchase_order/delete_purchase_order.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/purchase_orders/{id}".format(

--- a/katana_public_api_client/api/purchase_order/find_purchase_orders.py
+++ b/katana_public_api_client/api/purchase_order/find_purchase_orders.py
@@ -37,6 +37,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/purchase_order/get_purchase_order.py
+++ b/katana_public_api_client/api/purchase_order/get_purchase_order.py
@@ -19,6 +19,7 @@ def _get_kwargs(
     *,
     extend: list[GetPurchaseOrderExtendItem] | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_extend: list[str] | Unset = UNSET

--- a/katana_public_api_client/api/purchase_order_accounting_metadata/get_all_purchase_order_accounting_metadata.py
+++ b/katana_public_api_client/api/purchase_order_accounting_metadata/get_all_purchase_order_accounting_metadata.py
@@ -19,6 +19,7 @@ def _get_kwargs(
     limit: int | Unset = UNSET,
     page: int | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["purchase_order_id"] = purchase_order_id

--- a/katana_public_api_client/api/purchase_order_additional_cost_row/delete_po_additional_cost.py
+++ b/katana_public_api_client/api/purchase_order_additional_cost_row/delete_po_additional_cost.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/po_additional_cost_rows/{id}".format(

--- a/katana_public_api_client/api/purchase_order_additional_cost_row/get_po_additional_cost_row.py
+++ b/katana_public_api_client/api/purchase_order_additional_cost_row/get_po_additional_cost_row.py
@@ -14,6 +14,7 @@ from ...models.purchase_order_additional_cost_row import PurchaseOrderAdditional
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/po_additional_cost_rows/{id}".format(

--- a/katana_public_api_client/api/purchase_order_additional_cost_row/get_purchase_order_additional_cost_rows.py
+++ b/katana_public_api_client/api/purchase_order_additional_cost_row/get_purchase_order_additional_cost_rows.py
@@ -33,6 +33,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/purchase_order_row/delete_purchase_order_row.py
+++ b/katana_public_api_client/api/purchase_order_row/delete_purchase_order_row.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/purchase_order_rows/{id}".format(

--- a/katana_public_api_client/api/purchase_order_row/get_all_purchase_order_rows.py
+++ b/katana_public_api_client/api/purchase_order_row/get_all_purchase_order_rows.py
@@ -27,6 +27,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/purchase_order_row/get_purchase_order_row.py
+++ b/katana_public_api_client/api/purchase_order_row/get_purchase_order_row.py
@@ -14,6 +14,7 @@ from ...models.purchase_order_row import PurchaseOrderRow
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/purchase_order_rows/{id}".format(

--- a/katana_public_api_client/api/purchase_orders/delete_outsourced_purchase_order_recipe_row.py
+++ b/katana_public_api_client/api/purchase_orders/delete_outsourced_purchase_order_recipe_row.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/outsourced_purchase_order_recipe_rows/{id}".format(

--- a/katana_public_api_client/api/purchase_orders/get_outsourced_purchase_order_recipe_row.py
+++ b/katana_public_api_client/api/purchase_orders/get_outsourced_purchase_order_recipe_row.py
@@ -16,6 +16,7 @@ from ...models.outsourced_purchase_order_recipe_row import (
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/outsourced_purchase_order_recipe_rows/{id}".format(

--- a/katana_public_api_client/api/purchase_orders/get_outsourced_purchase_order_recipe_rows.py
+++ b/katana_public_api_client/api/purchase_orders/get_outsourced_purchase_order_recipe_rows.py
@@ -27,6 +27,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/recipe/delete_recipe_row.py
+++ b/katana_public_api_client/api/recipe/delete_recipe_row.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/recipe_rows/{id}".format(

--- a/katana_public_api_client/api/recipe/get_all_recipes.py
+++ b/katana_public_api_client/api/recipe/get_all_recipes.py
@@ -20,10 +20,11 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
     ingredient_variant_id: int | Unset = UNSET,
-    product_variant_ids: str | Unset = UNSET,
+    product_variant_ids: list[int] | Unset = UNSET,
     product_id: int | Unset = UNSET,
     recipe_row_id: int | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit
@@ -52,7 +53,11 @@ def _get_kwargs(
 
     params["ingredient_variant_id"] = ingredient_variant_id
 
-    params["product_variant_ids"] = product_variant_ids
+    json_product_variant_ids: list[int] | Unset = UNSET
+    if not isinstance(product_variant_ids, Unset):
+        json_product_variant_ids = product_variant_ids
+
+    params["product_variant_ids"] = json_product_variant_ids
 
     params["product_id"] = product_id
 
@@ -119,7 +124,7 @@ def sync_detailed(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
     ingredient_variant_id: int | Unset = UNSET,
-    product_variant_ids: str | Unset = UNSET,
+    product_variant_ids: list[int] | Unset = UNSET,
     product_id: int | Unset = UNSET,
     recipe_row_id: int | Unset = UNSET,
 ) -> Response[ErrorResponse | RecipeListResponse]:
@@ -135,7 +140,7 @@ def sync_detailed(
         updated_at_min (datetime.datetime | Unset):
         updated_at_max (datetime.datetime | Unset):
         ingredient_variant_id (int | Unset):
-        product_variant_ids (str | Unset):
+        product_variant_ids (list[int] | Unset):
         product_id (int | Unset):
         recipe_row_id (int | Unset):
 
@@ -178,7 +183,7 @@ def sync(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
     ingredient_variant_id: int | Unset = UNSET,
-    product_variant_ids: str | Unset = UNSET,
+    product_variant_ids: list[int] | Unset = UNSET,
     product_id: int | Unset = UNSET,
     recipe_row_id: int | Unset = UNSET,
 ) -> ErrorResponse | RecipeListResponse | None:
@@ -194,7 +199,7 @@ def sync(
         updated_at_min (datetime.datetime | Unset):
         updated_at_max (datetime.datetime | Unset):
         ingredient_variant_id (int | Unset):
-        product_variant_ids (str | Unset):
+        product_variant_ids (list[int] | Unset):
         product_id (int | Unset):
         recipe_row_id (int | Unset):
 
@@ -232,7 +237,7 @@ async def asyncio_detailed(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
     ingredient_variant_id: int | Unset = UNSET,
-    product_variant_ids: str | Unset = UNSET,
+    product_variant_ids: list[int] | Unset = UNSET,
     product_id: int | Unset = UNSET,
     recipe_row_id: int | Unset = UNSET,
 ) -> Response[ErrorResponse | RecipeListResponse]:
@@ -248,7 +253,7 @@ async def asyncio_detailed(
         updated_at_min (datetime.datetime | Unset):
         updated_at_max (datetime.datetime | Unset):
         ingredient_variant_id (int | Unset):
-        product_variant_ids (str | Unset):
+        product_variant_ids (list[int] | Unset):
         product_id (int | Unset):
         recipe_row_id (int | Unset):
 
@@ -289,7 +294,7 @@ async def asyncio(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
     ingredient_variant_id: int | Unset = UNSET,
-    product_variant_ids: str | Unset = UNSET,
+    product_variant_ids: list[int] | Unset = UNSET,
     product_id: int | Unset = UNSET,
     recipe_row_id: int | Unset = UNSET,
 ) -> ErrorResponse | RecipeListResponse | None:
@@ -305,7 +310,7 @@ async def asyncio(
         updated_at_min (datetime.datetime | Unset):
         updated_at_max (datetime.datetime | Unset):
         ingredient_variant_id (int | Unset):
-        product_variant_ids (str | Unset):
+        product_variant_ids (list[int] | Unset):
         product_id (int | Unset):
         recipe_row_id (int | Unset):
 

--- a/katana_public_api_client/api/sales_order/delete_sales_order.py
+++ b/katana_public_api_client/api/sales_order/delete_sales_order.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/sales_orders/{id}".format(

--- a/katana_public_api_client/api/sales_order/get_all_sales_orders.py
+++ b/katana_public_api_client/api/sales_order/get_all_sales_orders.py
@@ -41,6 +41,7 @@ def _get_kwargs(
     ingredient_availability: GetAllSalesOrdersIngredientAvailability | Unset = UNSET,
     product_availability: GetAllSalesOrdersProductAvailability | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/sales_order/get_sales_order.py
+++ b/katana_public_api_client/api/sales_order/get_sales_order.py
@@ -14,6 +14,7 @@ from ...models.sales_order import SalesOrder
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sales_orders/{id}".format(

--- a/katana_public_api_client/api/sales_order/get_sales_order_returnable_items.py
+++ b/katana_public_api_client/api/sales_order/get_sales_order_returnable_items.py
@@ -14,6 +14,7 @@ from ...models.returnable_item import ReturnableItem
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sales_orders/{id}/returnable_items".format(

--- a/katana_public_api_client/api/sales_order_address/delete_sales_order_address.py
+++ b/katana_public_api_client/api/sales_order_address/delete_sales_order_address.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/sales_order_addresses/{id}".format(

--- a/katana_public_api_client/api/sales_order_address/get_all_sales_order_addresses.py
+++ b/katana_public_api_client/api/sales_order_address/get_all_sales_order_addresses.py
@@ -37,6 +37,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/sales_order_fulfillment/delete_sales_order_fulfillment.py
+++ b/katana_public_api_client/api/sales_order_fulfillment/delete_sales_order_fulfillment.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/sales_order_fulfillments/{id}".format(

--- a/katana_public_api_client/api/sales_order_fulfillment/get_all_sales_order_fulfillments.py
+++ b/katana_public_api_client/api/sales_order_fulfillment/get_all_sales_order_fulfillments.py
@@ -30,6 +30,7 @@ def _get_kwargs(
     updated_at_max: datetime.datetime | Unset = UNSET,
     include_deleted: bool | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/sales_order_fulfillment/get_sales_order_fulfillment.py
+++ b/katana_public_api_client/api/sales_order_fulfillment/get_sales_order_fulfillment.py
@@ -14,6 +14,7 @@ from ...models.sales_order_fulfillment import SalesOrderFulfillment
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sales_order_fulfillments/{id}".format(

--- a/katana_public_api_client/api/sales_order_row/delete_sales_order_row.py
+++ b/katana_public_api_client/api/sales_order_row/delete_sales_order_row.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/sales_order_rows/{id}".format(

--- a/katana_public_api_client/api/sales_order_row/get_all_sales_order_rows.py
+++ b/katana_public_api_client/api/sales_order_row/get_all_sales_order_rows.py
@@ -35,6 +35,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/sales_order_row/get_sales_order_row.py
+++ b/katana_public_api_client/api/sales_order_row/get_sales_order_row.py
@@ -17,6 +17,7 @@ def _get_kwargs(
     *,
     extend: list[GetSalesOrderRowExtendItem] | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_extend: list[str] | Unset = UNSET

--- a/katana_public_api_client/api/sales_orders/delete_sales_order_shipping_fee.py
+++ b/katana_public_api_client/api/sales_orders/delete_sales_order_shipping_fee.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/sales_order_shipping_fee/{id}".format(

--- a/katana_public_api_client/api/sales_orders/get_sales_order_accounting_metadata.py
+++ b/katana_public_api_client/api/sales_orders/get_sales_order_accounting_metadata.py
@@ -19,6 +19,7 @@ def _get_kwargs(
     sales_order_id: int | Unset = UNSET,
     fulfillment_id: float | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/sales_orders/get_sales_order_shipping_fee.py
+++ b/katana_public_api_client/api/sales_orders/get_sales_order_shipping_fee.py
@@ -14,6 +14,7 @@ from ...models.sales_order_shipping_fee import SalesOrderShippingFee
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sales_order_shipping_fee/{id}".format(

--- a/katana_public_api_client/api/sales_orders/get_sales_order_shipping_fees.py
+++ b/katana_public_api_client/api/sales_orders/get_sales_order_shipping_fees.py
@@ -24,6 +24,7 @@ def _get_kwargs(
     updated_at_max: datetime.datetime | Unset = UNSET,
     include_deleted: bool | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/sales_return/delete_sales_return.py
+++ b/katana_public_api_client/api/sales_return/delete_sales_return.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/sales_returns/{id}".format(

--- a/katana_public_api_client/api/sales_return/get_all_sales_returns.py
+++ b/katana_public_api_client/api/sales_return/get_all_sales_returns.py
@@ -31,6 +31,7 @@ def _get_kwargs(
     order_created_date_min: datetime.datetime | Unset = UNSET,
     order_created_date_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/sales_return/get_sales_return.py
+++ b/katana_public_api_client/api/sales_return/get_sales_return.py
@@ -14,6 +14,7 @@ from ...models.sales_return import SalesReturn
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sales_returns/{id}".format(

--- a/katana_public_api_client/api/sales_return/get_sales_return_reasons.py
+++ b/katana_public_api_client/api/sales_return/get_sales_return_reasons.py
@@ -11,6 +11,7 @@ from ...models.sales_return_reason import SalesReturnReason
 
 
 def _get_kwargs() -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sales_returns/return_reasons",

--- a/katana_public_api_client/api/sales_return_row/delete_sales_return_row.py
+++ b/katana_public_api_client/api/sales_return_row/delete_sales_return_row.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/sales_return_rows/{id}".format(

--- a/katana_public_api_client/api/sales_return_row/get_all_sales_return_rows.py
+++ b/katana_public_api_client/api/sales_return_row/get_all_sales_return_rows.py
@@ -27,6 +27,7 @@ def _get_kwargs(
     reason_id: int | Unset = UNSET,
     sales_order_row_id: int | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/sales_return_row/get_sales_return_row.py
+++ b/katana_public_api_client/api/sales_return_row/get_sales_return_row.py
@@ -14,6 +14,7 @@ from ...models.sales_return_row import SalesReturnRow
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sales_return_rows/{id}".format(

--- a/katana_public_api_client/api/sales_return_row/get_sales_return_row_unassigned_batch_transactions.py
+++ b/katana_public_api_client/api/sales_return_row/get_sales_return_row_unassigned_batch_transactions.py
@@ -16,6 +16,7 @@ from ...models.unassigned_batch_transaction_list_response import (
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sales_return_rows/{id}/unassigned_batch_transactions".format(

--- a/katana_public_api_client/api/serial_number/delete_serial_numbers.py
+++ b/katana_public_api_client/api/serial_number/delete_serial_numbers.py
@@ -10,6 +10,7 @@ from ...models.error_response import ErrorResponse
 
 
 def _get_kwargs() -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/serial_numbers",

--- a/katana_public_api_client/api/serial_number/get_all_serial_numbers.py
+++ b/katana_public_api_client/api/serial_number/get_all_serial_numbers.py
@@ -20,6 +20,7 @@ def _get_kwargs(
     limit: int | Unset = UNSET,
     page: int | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_resource_type: str | Unset = UNSET

--- a/katana_public_api_client/api/serial_number/get_all_serial_numbers_stock.py
+++ b/katana_public_api_client/api/serial_number/get_all_serial_numbers_stock.py
@@ -11,6 +11,7 @@ from ...models.serial_number_stock_list_response import SerialNumberStockListRes
 
 
 def _get_kwargs() -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/serial_numbers_stock",

--- a/katana_public_api_client/api/services/delete_service.py
+++ b/katana_public_api_client/api/services/delete_service.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/services/{id}".format(

--- a/katana_public_api_client/api/services/get_all_services.py
+++ b/katana_public_api_client/api/services/get_all_services.py
@@ -27,6 +27,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/services/get_service.py
+++ b/katana_public_api_client/api/services/get_service.py
@@ -14,6 +14,7 @@ from ...models.service import Service
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/services/{id}".format(

--- a/katana_public_api_client/api/stock_adjustment/delete_stock_adjustment.py
+++ b/katana_public_api_client/api/stock_adjustment/delete_stock_adjustment.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/stock_adjustments/{id}".format(

--- a/katana_public_api_client/api/stock_adjustment/get_all_stock_adjustments.py
+++ b/katana_public_api_client/api/stock_adjustment/get_all_stock_adjustments.py
@@ -24,6 +24,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/stock_transfer/delete_stock_transfer.py
+++ b/katana_public_api_client/api/stock_transfer/delete_stock_transfer.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/stock_transfers/{id}".format(

--- a/katana_public_api_client/api/stock_transfer/get_all_stock_transfers.py
+++ b/katana_public_api_client/api/stock_transfer/get_all_stock_transfers.py
@@ -25,6 +25,7 @@ def _get_kwargs(
     target_location_id: int | Unset = UNSET,
     stock_transfer_number: str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/stocktake/delete_stocktake.py
+++ b/katana_public_api_client/api/stocktake/delete_stocktake.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/stocktakes/{id}".format(

--- a/katana_public_api_client/api/stocktake/get_all_stocktakes.py
+++ b/katana_public_api_client/api/stocktake/get_all_stocktakes.py
@@ -26,6 +26,7 @@ def _get_kwargs(
     updated_at_max: datetime.datetime | Unset = UNSET,
     include_deleted: bool | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/stocktake_row/delete_stocktake_row.py
+++ b/katana_public_api_client/api/stocktake_row/delete_stocktake_row.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/stocktake_rows/{id}".format(

--- a/katana_public_api_client/api/stocktake_row/get_all_stocktake_rows.py
+++ b/katana_public_api_client/api/stocktake_row/get_all_stocktake_rows.py
@@ -26,6 +26,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/storage_bin/delete_storage_bin.py
+++ b/katana_public_api_client/api/storage_bin/delete_storage_bin.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/bin_locations/{id}".format(

--- a/katana_public_api_client/api/storage_bin/get_all_storage_bins.py
+++ b/katana_public_api_client/api/storage_bin/get_all_storage_bins.py
@@ -18,6 +18,7 @@ def _get_kwargs(
     page: int | Unset = UNSET,
     bin_name: str | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["location_id"] = location_id

--- a/katana_public_api_client/api/supplier/delete_supplier.py
+++ b/katana_public_api_client/api/supplier/delete_supplier.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/suppliers/{id}".format(

--- a/katana_public_api_client/api/supplier/get_all_suppliers.py
+++ b/katana_public_api_client/api/supplier/get_all_suppliers.py
@@ -25,6 +25,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["name"] = name

--- a/katana_public_api_client/api/supplier_address/delete_supplier_address.py
+++ b/katana_public_api_client/api/supplier_address/delete_supplier_address.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/supplier_addresses/{id}".format(

--- a/katana_public_api_client/api/supplier_address/get_supplier_addresses.py
+++ b/katana_public_api_client/api/supplier_address/get_supplier_addresses.py
@@ -29,6 +29,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/tax_rate/get_all_tax_rates.py
+++ b/katana_public_api_client/api/tax_rate/get_all_tax_rates.py
@@ -25,6 +25,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["rate"] = rate

--- a/katana_public_api_client/api/user/get_all_users.py
+++ b/katana_public_api_client/api/user/get_all_users.py
@@ -20,6 +20,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     params["limit"] = limit

--- a/katana_public_api_client/api/variant/delete_variant.py
+++ b/katana_public_api_client/api/variant/delete_variant.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/variants/{id}".format(

--- a/katana_public_api_client/api/variant/get_all_variants.py
+++ b/katana_public_api_client/api/variant/get_all_variants.py
@@ -33,6 +33,7 @@ def _get_kwargs(
     updated_at_min: datetime.datetime | Unset = UNSET,
     updated_at_max: datetime.datetime | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/variant/get_variant.py
+++ b/katana_public_api_client/api/variant/get_variant.py
@@ -17,6 +17,7 @@ def _get_kwargs(
     *,
     extend: list[GetVariantExtendItem] | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_extend: list[str] | Unset = UNSET

--- a/katana_public_api_client/api/webhook/delete_webhook.py
+++ b/katana_public_api_client/api/webhook/delete_webhook.py
@@ -13,6 +13,7 @@ from ...models.error_response import ErrorResponse
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
         "url": "/webhooks/{id}".format(

--- a/katana_public_api_client/api/webhook/get_all_webhooks.py
+++ b/katana_public_api_client/api/webhook/get_all_webhooks.py
@@ -18,6 +18,7 @@ def _get_kwargs(
     limit: int | Unset = UNSET,
     page: int | Unset = UNSET,
 ) -> dict[str, Any]:
+
     params: dict[str, Any] = {}
 
     json_ids: list[int] | Unset = UNSET

--- a/katana_public_api_client/api/webhook/get_webhook.py
+++ b/katana_public_api_client/api/webhook/get_webhook.py
@@ -14,6 +14,7 @@ from ...models.webhook import Webhook
 def _get_kwargs(
     id: int,
 ) -> dict[str, Any]:
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/webhooks/{id}".format(

--- a/katana_public_api_client/models/factory_legal_address.py
+++ b/katana_public_api_client/models/factory_legal_address.py
@@ -18,6 +18,7 @@ class FactoryLegalAddress:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1189,7 +1189,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.29.0"
+version = "0.30.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- **Fix**: `dict(request.url.params)` in `PaginationTransport` collapsed multi-value query keys (e.g., `ids=1&ids=2&ids=3` → `{ids: 1}`), silently dropping filter values on page 2+. Switched to `multi_items()` to preserve all values across pages.
- **Spec fix**: Changed `/recipes` `product_variant_ids` from `type: string` to `type: array, items: integer` to match Katana's actual API (comma-separated format returns 400 errors).
- **Tests**: Added 5 unit tests for array param preservation and 1 integration test for multi-ID filtering.

## Test plan

- [x] All 35 pagination unit tests pass (5 new + 30 existing)
- [x] `uv run poe agent-check` passes clean
- [ ] `uv run pytest tests/test_real_api.py -k "test_multi_id_filter" -v --integration` — validates against live Katana API (requires `KATANA_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)