### PR TITLE
docs(spec): document cost_per_unit constraint on stock adjustment rows

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -8629,7 +8629,11 @@ components:
                 description: Quantity to adjust (positive or negative)
               cost_per_unit:
                 type: number
-                description: Cost per unit for this adjustment (defaults to current average cost if not specified)
+                description: >-
+                  Cost per unit for this adjustment. Only allowed when quantity
+                  is positive; for negative adjustments, the item's average cost
+                  is used automatically and sending this field will result in a
+                  422 validation error.
               batch_transactions:
                 type: array
                 description: Optional batch-specific adjustments for tracked inventory
@@ -8648,7 +8652,6 @@ components:
             cost_per_unit: 123.45
           - variant_id: 502
             quantity: -25
-            cost_per_unit: 234.56
     UpdateStockAdjustmentRequest:
       description: Request payload for updating an existing stock adjustment
       type: object

--- a/katana_public_api_client/api/stock_adjustment/create_stock_adjustment.py
+++ b/katana_public_api_client/api/stock_adjustment/create_stock_adjustment.py
@@ -91,7 +91,7 @@ def sync_detailed(
             'stock_adjustment_date': '2024-01-17T14:30:00.000Z', 'location_id': 1, 'reason': 'Cycle
             count correction', 'additional_info': 'Q1 2024 physical inventory',
             'stock_adjustment_rows': [{'variant_id': 501, 'quantity': 100, 'cost_per_unit': 123.45},
-            {'variant_id': 502, 'quantity': -25, 'cost_per_unit': 234.56}]}.
+            {'variant_id': 502, 'quantity': -25}]}.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -128,7 +128,7 @@ def sync(
             'stock_adjustment_date': '2024-01-17T14:30:00.000Z', 'location_id': 1, 'reason': 'Cycle
             count correction', 'additional_info': 'Q1 2024 physical inventory',
             'stock_adjustment_rows': [{'variant_id': 501, 'quantity': 100, 'cost_per_unit': 123.45},
-            {'variant_id': 502, 'quantity': -25, 'cost_per_unit': 234.56}]}.
+            {'variant_id': 502, 'quantity': -25}]}.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -160,7 +160,7 @@ async def asyncio_detailed(
             'stock_adjustment_date': '2024-01-17T14:30:00.000Z', 'location_id': 1, 'reason': 'Cycle
             count correction', 'additional_info': 'Q1 2024 physical inventory',
             'stock_adjustment_rows': [{'variant_id': 501, 'quantity': 100, 'cost_per_unit': 123.45},
-            {'variant_id': 502, 'quantity': -25, 'cost_per_unit': 234.56}]}.
+            {'variant_id': 502, 'quantity': -25}]}.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -195,7 +195,7 @@ async def asyncio(
             'stock_adjustment_date': '2024-01-17T14:30:00.000Z', 'location_id': 1, 'reason': 'Cycle
             count correction', 'additional_info': 'Q1 2024 physical inventory',
             'stock_adjustment_rows': [{'variant_id': 501, 'quantity': 100, 'cost_per_unit': 123.45},
-            {'variant_id': 502, 'quantity': -25, 'cost_per_unit': 234.56}]}.
+            {'variant_id': 502, 'quantity': -25}]}.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/katana_public_api_client/models/create_stock_adjustment_request.py
+++ b/katana_public_api_client/models/create_stock_adjustment_request.py
@@ -25,8 +25,7 @@ class CreateStockAdjustmentRequest:
     Example:
         {'stock_adjustment_number': 'SA-2024-003', 'stock_adjustment_date': '2024-01-17T14:30:00.000Z', 'location_id':
             1, 'reason': 'Cycle count correction', 'additional_info': 'Q1 2024 physical inventory', 'stock_adjustment_rows':
-            [{'variant_id': 501, 'quantity': 100, 'cost_per_unit': 123.45}, {'variant_id': 502, 'quantity': -25,
-            'cost_per_unit': 234.56}]}
+            [{'variant_id': 501, 'quantity': 100, 'cost_per_unit': 123.45}, {'variant_id': 502, 'quantity': -25}]}
     """
 
     location_id: int

--- a/katana_public_api_client/models_pydantic/_generated/stock.py
+++ b/katana_public_api_client/models_pydantic/_generated/stock.py
@@ -381,7 +381,7 @@ class StockAdjustmentRow1(KatanaPydanticBase):
     cost_per_unit: Annotated[
         float | None,
         Field(
-            description="Cost per unit for this adjustment (defaults to current average cost if not specified)"
+            description="Cost per unit for this adjustment. Only allowed when quantity is positive; for negative adjustments, the item's average cost is used automatically and sending this field will result in a 422 validation error."
         ),
     ] = None
     batch_transactions: Annotated[


### PR DESCRIPTION
## Summary

- Katana rejects `cost_per_unit` on negative-quantity stock adjustment rows with a 422 error ("cost per unit is not allowed when quantity is negative"). Updated the field description on `CreateStockAdjustmentRequest` to clearly document this constraint.
- Removed `cost_per_unit` from the negative-quantity example row that was incorrectly showing it as valid.

## Test plan

- [x] `uv run poe agent-check` passes
- [x] Spec validates cleanly
- No behavior change — this is a documentation-only fix (description + example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)