### PR TITLE
feat(client): add thin API wrapper layer (client.api)

### DIFF
--- a/katana_public_api_client/api_wrapper/__init__.py
+++ b/katana_public_api_client/api_wrapper/__init__.py
@@ -1,0 +1,15 @@
+"""Thin CRUD wrappers for all Katana API resources.
+
+Usage::
+
+    async with KatanaClient() as client:
+        products = await client.api.products.list(is_sellable=True)
+        product = await client.api.products.get(123)
+        await client.api.products.delete(123)
+"""
+
+from ._namespace import ApiNamespace
+from ._registry import RESOURCE_REGISTRY, ResourceConfig
+from ._resource import Resource
+
+__all__ = ["RESOURCE_REGISTRY", "ApiNamespace", "Resource", "ResourceConfig"]

--- a/katana_public_api_client/api_wrapper/_namespace.py
+++ b/katana_public_api_client/api_wrapper/_namespace.py
@@ -1,0 +1,40 @@
+"""Lazy namespace that exposes :class:`Resource` instances by name."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ._registry import RESOURCE_REGISTRY
+from ._resource import Resource
+
+if TYPE_CHECKING:
+    from ..client import AuthenticatedClient
+
+
+class ApiNamespace:
+    """Dynamic namespace providing ``client.api.<resource>`` access.
+
+    Resources are created lazily on first attribute access and cached on the
+    instance for subsequent calls.  Tab-completion is supported via
+    :meth:`__dir__`.
+    """
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        self._client = client
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        try:
+            config = RESOURCE_REGISTRY[name]
+        except KeyError:
+            available = ", ".join(sorted(RESOURCE_REGISTRY))
+            msg = f"No resource named '{name}'. Available resources: {available}"
+            raise AttributeError(msg) from None
+        resource = Resource(self._client, config)
+        # Cache on the instance so __getattr__ is not called again
+        object.__setattr__(self, name, resource)
+        return resource
+
+    def __dir__(self) -> list[str]:
+        return sorted(RESOURCE_REGISTRY)

--- a/katana_public_api_client/api_wrapper/_registry.py
+++ b/katana_public_api_client/api_wrapper/_registry.py
@@ -1,0 +1,396 @@
+"""Data-driven registry mapping accessor names to generated API modules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceConfig:
+    """Maps a logical resource to its generated API module functions.
+
+    Attributes:
+        module: Directory name under ``api/`` (e.g. ``"product"``).
+        get_one: Module name for single-resource GET, or ``None``.
+        get_all: Module name for list GET, or ``None``.
+        create: Module name for POST, or ``None``.
+        update: Module name for PATCH/PUT, or ``None``.
+        delete: Module name for DELETE, or ``None``.
+    """
+
+    module: str
+    get_one: str | None = None
+    get_all: str | None = None
+    create: str | None = None
+    update: str | None = None
+    delete: str | None = None
+
+
+RESOURCE_REGISTRY: dict[str, ResourceConfig] = {
+    # ── Full CRUD (get, list, create, update, delete) ────────────────────
+    "products": ResourceConfig(
+        "product",
+        "get_product",
+        "get_all_products",
+        "create_product",
+        "update_product",
+        "delete_product",
+    ),
+    "variants": ResourceConfig(
+        "variant",
+        "get_variant",
+        "get_all_variants",
+        "create_variant",
+        "update_variant",
+        "delete_variant",
+    ),
+    "materials": ResourceConfig(
+        "material",
+        "get_material",
+        "get_all_materials",
+        "create_material",
+        "update_material",
+        "delete_material",
+    ),
+    "services": ResourceConfig(
+        "services",
+        "get_service",
+        "get_all_services",
+        "create_service",
+        "update_service",
+        "delete_service",
+    ),
+    "price_lists": ResourceConfig(
+        "price_list",
+        "get_price_list",
+        "get_all_price_lists",
+        "create_price_list",
+        "update_price_list",
+        "delete_price_list",
+    ),
+    "price_list_customers": ResourceConfig(
+        "price_list_customer",
+        "get_price_list_customer",
+        "get_all_price_list_customers",
+        "create_price_list_customer",
+        "update_price_list_customer",
+        "delete_price_list_customer",
+    ),
+    "price_list_rows": ResourceConfig(
+        "price_list_row",
+        "get_price_list_row",
+        "get_all_price_list_rows",
+        "create_price_list_row",
+        "update_price_list_row",
+        "delete_price_list_row",
+    ),
+    "sales_orders": ResourceConfig(
+        "sales_order",
+        "get_sales_order",
+        "get_all_sales_orders",
+        "create_sales_order",
+        "update_sales_order",
+        "delete_sales_order",
+    ),
+    "sales_order_fulfillments": ResourceConfig(
+        "sales_order_fulfillment",
+        "get_sales_order_fulfillment",
+        "get_all_sales_order_fulfillments",
+        "create_sales_order_fulfillment",
+        "update_sales_order_fulfillment",
+        "delete_sales_order_fulfillment",
+    ),
+    "sales_order_rows": ResourceConfig(
+        "sales_order_row",
+        "get_sales_order_row",
+        "get_all_sales_order_rows",
+        "create_sales_order_row",
+        "update_sales_order_row",
+        "delete_sales_order_row",
+    ),
+    "sales_returns": ResourceConfig(
+        "sales_return",
+        "get_sales_return",
+        "get_all_sales_returns",
+        "create_sales_return",
+        "update_sales_return",
+        "delete_sales_return",
+    ),
+    "sales_return_rows": ResourceConfig(
+        "sales_return_row",
+        "get_sales_return_row",
+        "get_all_sales_return_rows",
+        "create_sales_return_row",
+        "update_sales_return_row",
+        "delete_sales_return_row",
+    ),
+    "manufacturing_orders": ResourceConfig(
+        "manufacturing_order",
+        "get_manufacturing_order",
+        "get_all_manufacturing_orders",
+        "create_manufacturing_order",
+        "update_manufacturing_order",
+        "delete_manufacturing_order",
+    ),
+    "manufacturing_order_operations": ResourceConfig(
+        "manufacturing_order_operation",
+        "get_manufacturing_order_operation_row",
+        "get_all_manufacturing_order_operation_rows",
+        "create_manufacturing_order_operation_row",
+        "update_manufacturing_order_operation_row",
+        "delete_manufacturing_order_operation_row",
+    ),
+    "manufacturing_order_recipes": ResourceConfig(
+        "manufacturing_order_recipe",
+        "get_manufacturing_order_recipe_row",
+        "get_all_manufacturing_order_recipe_rows",
+        "create_manufacturing_order_recipe_rows",
+        "update_manufacturing_order_recipe_rows",
+        "delete_manufacturing_order_recipe_row",
+    ),
+    "manufacturing_order_productions": ResourceConfig(
+        "manufacturing_order_production",
+        "get_manufacturing_order_production",
+        None,
+        "create_manufacturing_order_production",
+        "update_manufacturing_order_production",
+        "delete_manufacturing_order_production",
+    ),
+    "webhooks": ResourceConfig(
+        "webhook",
+        "get_webhook",
+        "get_all_webhooks",
+        "create_webhook",
+        "update_webhook",
+        "delete_webhook",
+    ),
+    "purchase_orders": ResourceConfig(
+        "purchase_order",
+        "get_purchase_order",
+        "find_purchase_orders",
+        "create_purchase_order",
+        "update_purchase_order",
+        "delete_purchase_order",
+    ),
+    "purchase_order_rows": ResourceConfig(
+        "purchase_order_row",
+        "get_purchase_order_row",
+        "get_all_purchase_order_rows",
+        "create_purchase_order_row",
+        "update_purchase_order_row",
+        "delete_purchase_order_row",
+    ),
+    "purchase_order_additional_cost_rows": ResourceConfig(
+        "purchase_order_additional_cost_row",
+        "get_po_additional_cost_row",
+        "get_purchase_order_additional_cost_rows",
+        "create_po_additional_cost_row",
+        "update_additional_cost_row",
+        "delete_po_additional_cost",
+    ),
+    # ── CRUD without get-one ─────────────────────────────────────────────
+    "customers": ResourceConfig(
+        "customer",
+        None,
+        "get_all_customers",
+        "create_customer",
+        "update_customer",
+        "delete_customer",
+    ),
+    "customer_addresses": ResourceConfig(
+        "customer_address",
+        None,
+        "get_all_customer_addresses",
+        "create_customer_address",
+        "update_customer_address",
+        "delete_customer_address",
+    ),
+    "suppliers": ResourceConfig(
+        "supplier",
+        None,
+        "get_all_suppliers",
+        "create_supplier",
+        "update_supplier",
+        "delete_supplier",
+    ),
+    "supplier_addresses": ResourceConfig(
+        "supplier_address",
+        None,
+        "get_supplier_addresses",
+        "create_supplier_address",
+        "update_supplier_address",
+        "delete_supplier_address",
+    ),
+    "sales_order_addresses": ResourceConfig(
+        "sales_order_address",
+        None,
+        "get_all_sales_order_addresses",
+        "create_sales_order_address",
+        "update_sales_order_address",
+        "delete_sales_order_address",
+    ),
+    "bom_rows": ResourceConfig(
+        "bom_row",
+        None,
+        "get_all_bom_rows",
+        "create_bom_row",
+        "update_bom_row",
+        "delete_bom_row",
+    ),
+    "stocktakes": ResourceConfig(
+        "stocktake",
+        None,
+        "get_all_stocktakes",
+        "create_stocktake",
+        "update_stocktake",
+        "delete_stocktake",
+    ),
+    "stocktake_rows": ResourceConfig(
+        "stocktake_row",
+        None,
+        "get_all_stocktake_rows",
+        "create_stocktake_row",
+        "update_stocktake_row",
+        "delete_stocktake_row",
+    ),
+    "stock_adjustments": ResourceConfig(
+        "stock_adjustment",
+        None,
+        "get_all_stock_adjustments",
+        "create_stock_adjustment",
+        "update_stock_adjustment",
+        "delete_stock_adjustment",
+    ),
+    "stock_transfers": ResourceConfig(
+        "stock_transfer",
+        None,
+        "get_all_stock_transfers",
+        "create_stock_transfer",
+        "update_stock_transfer",
+        "delete_stock_transfer",
+    ),
+    # ── Sub-resources in "plural" API directories ────────────────────────
+    "product_operation_rows": ResourceConfig(
+        "products",
+        None,
+        "get_all_product_operation_rows",
+        "create_product_operation_rows",
+        "update_product_operation_row",
+        "delete_product_operation_row",
+    ),
+    "outsourced_po_recipe_rows": ResourceConfig(
+        "purchase_orders",
+        "get_outsourced_purchase_order_recipe_row",
+        "get_outsourced_purchase_order_recipe_rows",
+        "create_outsourced_purchase_order_recipe_row",
+        "update_outsourced_purchase_order_recipe_row",
+        "delete_outsourced_purchase_order_recipe_row",
+    ),
+    "sales_order_shipping_fees": ResourceConfig(
+        "sales_orders",
+        "get_sales_order_shipping_fee",
+        "get_sales_order_shipping_fees",
+        "create_sales_order_shipping_fee",
+        "update_sales_order_shipping_fee",
+        "delete_sales_order_shipping_fee",
+    ),
+    # ── Partial / non-standard CRUD ──────────────────────────────────────
+    "recipes": ResourceConfig(
+        "recipe",
+        None,
+        "get_all_recipes",
+        "create_recipes",
+        "update_recipe_row",
+        "delete_recipe_row",
+    ),
+    "serial_numbers": ResourceConfig(
+        "serial_number",
+        None,
+        "get_all_serial_numbers",
+        "create_serial_numbers",
+    ),
+    "batches": ResourceConfig(
+        "batch",
+        None,
+        "get_batch_stock",
+        "create_batch",
+        "update_batch_stock",
+    ),
+    "demand_forecasts": ResourceConfig(
+        "demand_forecast",
+        None,
+        "get_demand_forecasts",
+        "create_demand_forecast",
+    ),
+    "storage_bins": ResourceConfig(
+        "storage_bin",
+        None,
+        "get_all_storage_bins",
+        None,
+        None,
+        "delete_storage_bin",
+    ),
+    "tax_rates": ResourceConfig(
+        "tax_rate",
+        None,
+        "get_all_tax_rates",
+        "create_tax_rate",
+    ),
+    # ── Read-only resources ──────────────────────────────────────────────
+    "additional_costs": ResourceConfig(
+        "additional_costs",
+        None,
+        "get_additional_costs",
+    ),
+    "custom_fields": ResourceConfig(
+        "custom_fields",
+        None,
+        "get_all_custom_fields_collections",
+    ),
+    # factory excluded: singleton endpoint (no ID param), use Layer 1 directly
+    "inventory": ResourceConfig(
+        "inventory",
+        None,
+        "get_all_inventory_point",
+    ),
+    "inventory_movements": ResourceConfig(
+        "inventory_movements",
+        None,
+        "get_all_inventory_movements",
+    ),
+    "locations": ResourceConfig(
+        "location",
+        "get_location",
+        "get_all_locations",
+    ),
+    "operators": ResourceConfig(
+        "operator",
+        None,
+        "get_all_operators",
+    ),
+    "purchase_order_accounting_metadata": ResourceConfig(
+        "purchase_order_accounting_metadata",
+        None,
+        "get_all_purchase_order_accounting_metadata",
+    ),
+    "sales_order_accounting_metadata": ResourceConfig(
+        "sales_orders",
+        None,
+        "get_sales_order_accounting_metadata",
+    ),
+    "serial_number_stock": ResourceConfig(
+        "serial_number",
+        None,
+        "get_all_serial_numbers_stock",
+    ),
+    "negative_stock": ResourceConfig(
+        "inventory",
+        None,
+        "get_all_negative_stock",
+    ),
+    "users": ResourceConfig(
+        "user",
+        None,
+        "get_all_users",
+    ),
+}

--- a/katana_public_api_client/api_wrapper/_resource.py
+++ b/katana_public_api_client/api_wrapper/_resource.py
@@ -1,0 +1,112 @@
+"""Generic async CRUD resource that delegates to generated API modules."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+from ..utils import is_success, unwrap, unwrap_data
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from ..client import AuthenticatedClient
+    from ._registry import ResourceConfig
+
+_list = list  # alias to avoid shadowing by the method name
+
+
+class Resource:
+    """Thin async CRUD wrapper around a single Katana API resource.
+
+    Each method delegates to the corresponding generated ``asyncio_detailed``
+    function, unwraps the response, and returns the raw *attrs* model.
+
+    Generated modules are imported lazily on first call and cached for reuse.
+    """
+
+    def __init__(self, client: AuthenticatedClient, config: ResourceConfig) -> None:
+        self._client = client
+        self._config = config
+        self._module_cache: dict[str, ModuleType] = {}
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _load_module(self, func_name: str) -> ModuleType:
+        """Import and cache a generated API module by function name.
+
+        Only values from the frozen :class:`ResourceConfig` are accepted;
+        the import path is always
+        ``katana_public_api_client.api.<module>.<func_name>``.
+        """
+        if func_name not in self._module_cache:
+            # Validate that func_name is one of the config's known values
+            # so the import path is guaranteed to be from the registry.
+            allowed = {
+                self._config.get_one,
+                self._config.get_all,
+                self._config.create,
+                self._config.update,
+                self._config.delete,
+            }
+            if func_name not in allowed:
+                msg = f"'{func_name}' is not a configured operation for '{self._config.module}'"
+                raise ValueError(msg)
+            path = f"katana_public_api_client.api.{self._config.module}.{func_name}"
+            self._module_cache[func_name] = importlib.import_module(path)
+        return self._module_cache[func_name]
+
+    def _require(self, operation: str, func_name: str | None) -> str:
+        """Return *func_name* or raise ``NotImplementedError``."""
+        if func_name is None:
+            msg = (
+                f"'{self._config.module}' does not support the '{operation}' operation"
+            )
+            raise NotImplementedError(msg)
+        return func_name
+
+    # -- CRUD ------------------------------------------------------------------
+
+    async def get(self, resource_id: int, **kwargs: Any) -> Any:
+        """Fetch a single resource by ID."""
+        name = self._require("get", self._config.get_one)
+        mod = self._load_module(name)
+        response = await mod.asyncio_detailed(
+            resource_id, client=self._client, **kwargs
+        )
+        return unwrap(response)
+
+    async def list(self, **kwargs: Any) -> _list[Any]:
+        """Fetch all resources (with optional filters)."""
+        name = self._require("list", self._config.get_all)
+        mod = self._load_module(name)
+        response = await mod.asyncio_detailed(client=self._client, **kwargs)
+        return unwrap_data(response, default=[])
+
+    async def create(self, body: Any, **kwargs: Any) -> Any:
+        """Create a new resource."""
+        name = self._require("create", self._config.create)
+        mod = self._load_module(name)
+        response = await mod.asyncio_detailed(client=self._client, body=body, **kwargs)
+        return unwrap(response)
+
+    async def update(self, resource_id: int, body: Any, **kwargs: Any) -> Any:
+        """Update an existing resource by ID."""
+        name = self._require("update", self._config.update)
+        mod = self._load_module(name)
+        response = await mod.asyncio_detailed(
+            resource_id, client=self._client, body=body, **kwargs
+        )
+        return unwrap(response)
+
+    async def delete(self, resource_id: int, **kwargs: Any) -> None:
+        """Delete a resource by ID.  Raises on error, returns ``None``."""
+        name = self._require("delete", self._config.delete)
+        mod = self._load_module(name)
+        response = await mod.asyncio_detailed(
+            resource_id, client=self._client, **kwargs
+        )
+        # DELETE endpoints return 204 with parsed=None on success;
+        # unwrap() would raise on None, so check status first.
+        if not is_success(response):
+            unwrap(response)  # raises the appropriate typed error

--- a/katana_public_api_client/katana_client.py
+++ b/katana_public_api_client/katana_client.py
@@ -23,6 +23,7 @@ from httpx import AsyncHTTPTransport
 from httpx_retries import Retry, RetryTransport
 
 from ._logging import Logger
+from .api_wrapper import ApiNamespace
 from .client import AuthenticatedClient
 from .client_types import Unset
 from .helpers.inventory import Inventory
@@ -1147,6 +1148,7 @@ class KatanaClient(AuthenticatedClient):
         self._variants: Variants | None = None
         self._services: Services | None = None
         self._inventory: Inventory | None = None
+        self._api_namespace: ApiNamespace | None = None
 
         # Extract client-level parameters that shouldn't go to the transport
         # Event hooks for observability - start with our defaults
@@ -1298,6 +1300,20 @@ class KatanaClient(AuthenticatedClient):
         if self._inventory is None:
             self._inventory = Inventory(self)
         return self._inventory
+
+    @property
+    def api(self) -> ApiNamespace:
+        """Thin CRUD wrappers for all API resources.  Returns raw attrs models.
+
+        Example:
+            >>> async with KatanaClient() as client:
+            ...     products = await client.api.products.list(is_sellable=True)
+            ...     product = await client.api.products.get(123)
+            ...     await client.api.products.delete(123)
+        """
+        if self._api_namespace is None:
+            self._api_namespace = ApiNamespace(self)
+        return self._api_namespace
 
     # Event hooks for observability
     async def _capture_pagination_metadata(self, response: httpx.Response) -> None:

--- a/tests/test_api_wrapper.py
+++ b/tests/test_api_wrapper.py
@@ -1,0 +1,473 @@
+"""Tests for the thin API wrapper layer (client.api)."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from katana_public_api_client.api_wrapper import (
+    RESOURCE_REGISTRY,
+    ApiNamespace,
+    Resource,
+    ResourceConfig,
+)
+from katana_public_api_client.utils import APIError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """A minimal stand-in for AuthenticatedClient."""
+    return MagicMock()
+
+
+@pytest.fixture
+def full_config() -> ResourceConfig:
+    """A ResourceConfig with all five operations configured."""
+    return ResourceConfig(
+        module="product",
+        get_one="get_product",
+        get_all="get_all_products",
+        create="create_product",
+        update="update_product",
+        delete="delete_product",
+    )
+
+
+@pytest.fixture
+def readonly_config() -> ResourceConfig:
+    """A ResourceConfig with only a list operation."""
+    return ResourceConfig(
+        module="operator",
+        get_all="get_all_operators",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resource CRUD dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResourceCrudDispatch:
+    """Verify that each CRUD method calls the correct generated module."""
+
+    async def test_get_calls_asyncio_detailed_with_id(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mock_mod = MagicMock()
+        sentinel = object()
+        mock_mod.asyncio_detailed = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch.object(resource, "_load_module", return_value=mock_mod),
+            patch(
+                "katana_public_api_client.api_wrapper._resource.unwrap",
+                return_value=sentinel,
+            ) as mock_unwrap,
+        ):
+            result = await resource.get(42, extend=["rows"])
+
+        mock_mod.asyncio_detailed.assert_awaited_once_with(
+            42, client=mock_client, extend=["rows"]
+        )
+        mock_unwrap.assert_called_once_with(mock_mod.asyncio_detailed.return_value)
+        assert result is sentinel
+
+    async def test_list_calls_asyncio_detailed_without_id(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mock_mod = MagicMock()
+        sentinel = [object()]
+        mock_mod.asyncio_detailed = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch.object(resource, "_load_module", return_value=mock_mod),
+            patch(
+                "katana_public_api_client.api_wrapper._resource.unwrap_data",
+                return_value=sentinel,
+            ) as mock_unwrap_data,
+        ):
+            result = await resource.list(limit=100)
+
+        mock_mod.asyncio_detailed.assert_awaited_once_with(
+            client=mock_client, limit=100
+        )
+        mock_unwrap_data.assert_called_once_with(
+            mock_mod.asyncio_detailed.return_value, default=[]
+        )
+        assert result is sentinel
+
+    async def test_create_passes_body(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mock_mod = MagicMock()
+        body = {"name": "Widget"}
+        sentinel = object()
+        mock_mod.asyncio_detailed = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch.object(resource, "_load_module", return_value=mock_mod),
+            patch(
+                "katana_public_api_client.api_wrapper._resource.unwrap",
+                return_value=sentinel,
+            ),
+        ):
+            result = await resource.create(body)
+
+        mock_mod.asyncio_detailed.assert_awaited_once_with(
+            client=mock_client, body=body
+        )
+        assert result is sentinel
+
+    async def test_update_passes_id_and_body(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mock_mod = MagicMock()
+        body = {"name": "Updated"}
+        sentinel = object()
+        mock_mod.asyncio_detailed = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch.object(resource, "_load_module", return_value=mock_mod),
+            patch(
+                "katana_public_api_client.api_wrapper._resource.unwrap",
+                return_value=sentinel,
+            ),
+        ):
+            result = await resource.update(42, body)
+
+        mock_mod.asyncio_detailed.assert_awaited_once_with(
+            42, client=mock_client, body=body
+        )
+        assert result is sentinel
+
+    async def test_delete_succeeds_on_204(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mock_mod = MagicMock()
+        # Simulate a 204 response: parsed=None, status_code=204
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.parsed = None
+        mock_mod.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+        with patch.object(resource, "_load_module", return_value=mock_mod):
+            result = await resource.delete(42)
+
+        mock_mod.asyncio_detailed.assert_awaited_once_with(42, client=mock_client)
+        assert result is None
+
+    async def test_delete_raises_on_error(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mock_mod = MagicMock()
+        # Simulate a 404 error response
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_mod.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+        with (
+            patch.object(resource, "_load_module", return_value=mock_mod),
+            patch(
+                "katana_public_api_client.api_wrapper._resource.unwrap",
+                side_effect=APIError(message="Not found", status_code=404),
+            ),
+            pytest.raises(APIError),
+        ):
+            await resource.delete(999)
+
+
+# ---------------------------------------------------------------------------
+# NotImplementedError for unconfigured operations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResourceNotImplemented:
+    """Verify clear errors for unconfigured CRUD operations."""
+
+    async def test_get_raises_when_not_configured(
+        self, mock_client: MagicMock, readonly_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, readonly_config)
+        with pytest.raises(NotImplementedError, match="does not support the 'get'"):
+            await resource.get(1)
+
+    async def test_create_raises_when_not_configured(
+        self, mock_client: MagicMock, readonly_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, readonly_config)
+        with pytest.raises(NotImplementedError, match="does not support the 'create'"):
+            await resource.create({"name": "x"})
+
+    async def test_update_raises_when_not_configured(
+        self, mock_client: MagicMock, readonly_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, readonly_config)
+        with pytest.raises(NotImplementedError, match="does not support the 'update'"):
+            await resource.update(1, {"name": "x"})
+
+    async def test_delete_raises_when_not_configured(
+        self, mock_client: MagicMock, readonly_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, readonly_config)
+        with pytest.raises(NotImplementedError, match="does not support the 'delete'"):
+            await resource.delete(1)
+
+
+# ---------------------------------------------------------------------------
+# ApiNamespace access & caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestApiNamespace:
+    """Verify namespace lookup, caching, and error behaviour."""
+
+    def test_returns_resource_for_valid_name(self, mock_client: MagicMock) -> None:
+        ns = ApiNamespace(mock_client)
+        resource = ns.products
+        assert isinstance(resource, Resource)
+
+    def test_caches_resource_across_accesses(self, mock_client: MagicMock) -> None:
+        ns = ApiNamespace(mock_client)
+        first = ns.products
+        second = ns.products
+        assert first is second
+
+    def test_raises_attribute_error_for_unknown(self, mock_client: MagicMock) -> None:
+        ns = ApiNamespace(mock_client)
+        with pytest.raises(AttributeError, match="No resource named 'nonexistent'"):
+            ns.nonexistent  # noqa: B018 (intentional attribute access)
+
+    def test_error_message_lists_available_resources(
+        self, mock_client: MagicMock
+    ) -> None:
+        ns = ApiNamespace(mock_client)
+        with pytest.raises(AttributeError, match="Available resources:"):
+            ns.nonexistent  # noqa: B018
+
+    def test_dir_returns_registry_keys(self, mock_client: MagicMock) -> None:
+        ns = ApiNamespace(mock_client)
+        entries = dir(ns)
+        assert entries == sorted(RESOURCE_REGISTRY)
+
+
+# ---------------------------------------------------------------------------
+# Registry completeness - every entry must point to importable modules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRegistryCompleteness:
+    """Ensure every registry entry references real generated API modules."""
+
+    @pytest.mark.parametrize(
+        "resource_name,config",
+        list(RESOURCE_REGISTRY.items()),
+        ids=list(RESOURCE_REGISTRY),
+    )
+    def test_all_configured_modules_are_importable(
+        self, resource_name: str, config: ResourceConfig
+    ) -> None:
+        for op_name in ("get_one", "get_all", "create", "update", "delete"):
+            func_name = getattr(config, op_name)
+            if func_name is None:
+                continue
+            module_path = f"katana_public_api_client.api.{config.module}.{func_name}"
+            try:
+                mod = importlib.import_module(module_path)
+            except ModuleNotFoundError:
+                pytest.fail(
+                    f"Registry entry '{resource_name}' references "
+                    f"non-existent module: {module_path}"
+                )
+            assert hasattr(mod, "asyncio_detailed"), (
+                f"{module_path} missing asyncio_detailed"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Kwargs passthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestKwargsPassthrough:
+    """Verify that extra kwargs (extend, filters, etc.) reach the module."""
+
+    async def test_get_forwards_extend(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mock_mod = MagicMock()
+        mock_mod.asyncio_detailed = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch.object(resource, "_load_module", return_value=mock_mod),
+            patch(
+                "katana_public_api_client.api_wrapper._resource.unwrap",
+                return_value=None,
+            ),
+        ):
+            await resource.get(1, extend=["rows", "ingredients"])
+
+        _, kwargs = mock_mod.asyncio_detailed.call_args
+        assert kwargs["extend"] == ["rows", "ingredients"]
+
+    async def test_list_forwards_filters(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mock_mod = MagicMock()
+        mock_mod.asyncio_detailed = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch.object(resource, "_load_module", return_value=mock_mod),
+            patch(
+                "katana_public_api_client.api_wrapper._resource.unwrap_data",
+                return_value=[],
+            ),
+        ):
+            await resource.list(is_sellable=True, limit=50, include_archived=True)
+
+        _, kwargs = mock_mod.asyncio_detailed.call_args
+        assert kwargs["is_sellable"] is True
+        assert kwargs["limit"] == 50
+        assert kwargs["include_archived"] is True
+
+    async def test_create_forwards_extra_kwargs(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mock_mod = MagicMock()
+        mock_mod.asyncio_detailed = AsyncMock(return_value=MagicMock())
+        body = {"name": "Widget"}
+
+        with (
+            patch.object(resource, "_load_module", return_value=mock_mod),
+            patch(
+                "katana_public_api_client.api_wrapper._resource.unwrap",
+                return_value=None,
+            ),
+        ):
+            await resource.create(body, extend=["rows"])
+
+        _, kwargs = mock_mod.asyncio_detailed.call_args
+        assert kwargs["body"] is body
+        assert kwargs["extend"] == ["rows"]
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestErrorPropagation:
+    """Verify that unwrap() exceptions bubble up transparently."""
+
+    async def test_api_error_propagates_from_get(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mock_mod = MagicMock()
+        mock_mod.asyncio_detailed = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch.object(resource, "_load_module", return_value=mock_mod),
+            patch(
+                "katana_public_api_client.api_wrapper._resource.unwrap",
+                side_effect=APIError(message="Not found", status_code=404),
+            ),
+            pytest.raises(APIError),
+        ):
+            await resource.get(999)
+
+    async def test_api_error_propagates_from_list(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mock_mod = MagicMock()
+        mock_mod.asyncio_detailed = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch.object(resource, "_load_module", return_value=mock_mod),
+            patch(
+                "katana_public_api_client.api_wrapper._resource.unwrap_data",
+                side_effect=APIError(message="Server error", status_code=500),
+            ),
+            pytest.raises(APIError),
+        ):
+            await resource.list()
+
+
+# ---------------------------------------------------------------------------
+# Lazy module loading & caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModuleLoading:
+    """Verify lazy import and caching behaviour of Resource._load_module."""
+
+    def test_load_module_imports_correct_path(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        mod = resource._load_module("get_product")
+        assert hasattr(mod, "asyncio_detailed")
+
+    def test_load_module_caches_result(
+        self, mock_client: MagicMock, full_config: ResourceConfig
+    ) -> None:
+        resource = Resource(mock_client, full_config)
+        first = resource._load_module("get_product")
+        second = resource._load_module("get_product")
+        assert first is second
+
+    def test_load_module_rejects_unconfigured_func(
+        self, mock_client: MagicMock
+    ) -> None:
+        config = ResourceConfig(module="nonexistent_api_dir")
+        resource = Resource(mock_client, config)
+        with pytest.raises(ValueError, match="not a configured operation"):
+            resource._load_module("does_not_exist")
+
+
+# ---------------------------------------------------------------------------
+# KatanaClient.api integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestKatanaClientApiProperty:
+    """Verify the .api property on KatanaClient."""
+
+    def test_api_returns_namespace(self) -> None:
+        with patch.dict("os.environ", {"KATANA_API_KEY": "test-key"}):
+            from katana_public_api_client import KatanaClient
+
+            client = KatanaClient(api_key="test-key")
+            assert isinstance(client.api, ApiNamespace)
+
+    def test_api_is_cached(self) -> None:
+        with patch.dict("os.environ", {"KATANA_API_KEY": "test-key"}):
+            from katana_public_api_client import KatanaClient
+
+            client = KatanaClient(api_key="test-key")
+            first = client.api
+            second = client.api
+            assert first is second

--- a/uv.lock
+++ b/uv.lock
@@ -1210,7 +1210,7 @@ requires-dist = [
 
 [[package]]
 name = "katana-openapi-client"
-version = "0.44.6"
+version = "0.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

- Adds `client.api` namespace with thin CRUD wrappers (`get`, `list`, `create`, `update`, `delete`) for 48 API resources
- Resources delegate to generated modules via lazy `importlib` imports, unwrapping responses automatically
- Data-driven `RESOURCE_REGISTRY` maps accessor names to generated API modules, verified by tests
- 3 truly non-standard resources excluded (`variant_default_storage_bin`, `webhook_logs`, `manufacturing_order_production_ingredient`)

**Before:**
```python
response = await get_variant.asyncio_detailed(client=client, id=variant_id, extend=[...])
variant = unwrap(response)
```

**After:**
```python
variant = await client.api.variants.get(variant_id, extend=[...])
```

## Test plan

- [x] 75 new tests covering CRUD dispatch, NotImplementedError, namespace access/caching, registry completeness (all 48 resources importable), kwargs passthrough, error propagation, lazy module loading
- [x] `agent-check` passes (format + lint + type check)
- [x] Full test suite passes (1865 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)