### PR TITLE
fix(mcp): Docker build fix + chain after both packages publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,8 +215,12 @@ jobs:
 
   publish-mcp-docker:
     name: Publish MCP Docker Image
-    needs: release-mcp
-    if: needs.release-mcp.outputs.released == 'true' || inputs.force_publish_mcp == true
+    needs: [publish-client-pypi, publish-mcp-pypi, release-client, release-mcp]
+    if: |
+      always() &&
+      (needs.release-client.outputs.released == 'true' ||
+       needs.release-mcp.outputs.released == 'true' ||
+       inputs.force_publish_mcp == true)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -224,6 +228,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine MCP version for tagging
+        id: version
+        run: |
+          if [ -n "${{ needs.release-mcp.outputs.version }}" ]; then
+            echo "mcp_version=${{ needs.release-mcp.outputs.version }}" >> $GITHUB_OUTPUT
+          else
+            # No MCP release this run — use the latest mcp-v* tag
+            LATEST_TAG=$(git tag --list 'mcp-v*' --sort=-version:refname | head -n 1)
+            echo "mcp_version=${LATEST_TAG#mcp-v}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -241,9 +258,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/katana-mcp-server
           tags: |
-            type=semver,pattern={{version}},value=${{ needs.release-mcp.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-mcp.outputs.version }}
-            type=semver,pattern={{major}},value=${{ needs.release-mcp.outputs.version }}
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.mcp_version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.mcp_version }}
+            type=semver,pattern={{major}},value=${{ steps.version.outputs.mcp_version }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image

--- a/.github/workflows/update-mcp-dependency.yml
+++ b/.github/workflows/update-mcp-dependency.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -40,11 +39,9 @@ jobs:
           echo "client_version=$CLIENT_VERSION" >> $GITHUB_OUTPUT
 
           # Check if this tag was created in the last workflow run
-          # Get the timestamp of the tag
           TAG_DATE=$(git log -1 --format=%ct "$LATEST_CLIENT_TAG")
           WORKFLOW_DATE=$(date -d "${{ github.event.workflow_run.created_at }}" +%s)
 
-          # If tag is newer than workflow start (created during the workflow)
           if [ "$TAG_DATE" -ge "$WORKFLOW_DATE" ]; then
             echo "New client release detected: $CLIENT_VERSION"
             echo "has_release=true" >> $GITHUB_OUTPUT
@@ -95,42 +92,13 @@ jobs:
       - name: Update lockfile
         if: steps.check-current.outputs.needs_update == 'true'
         run: |
-          # Sync to update lockfile with new dependency
           uv sync --all-extras
 
-      - name: Create Pull Request
+      - name: Commit and push
         if: steps.check-current.outputs.needs_update == 'true'
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
-          commit-message: "feat(mcp): update client dependency to v${{ steps.check-release.outputs.client_version }}"
-          title: "feat(mcp): update client dependency to v${{ steps.check-release.outputs.client_version }}"
-          body: |
-            ## Automated Dependency Update
-
-            This PR updates the MCP server's client dependency to match the latest client release.
-
-            **Changes:**
-            - Update `katana-openapi-client` dependency from
-              `>=${{ steps.check-current.outputs.current_version }}` to
-              `>=${{ steps.check-release.outputs.client_version }}`
-            - Update `uv.lock` to reflect the new dependency
-
-            **Release Information:**
-            - Client version: v${{ steps.check-release.outputs.client_version }}
-            - Tag: client-v${{ steps.check-release.outputs.client_version }}
-
-            **Next Steps:**
-            When this PR is merged, it will trigger a new MCP server release with the
-            conventional commit message `feat(mcp):`, which will bump the MCP server's
-            MINOR version.
-
-            ---
-            *This PR was automatically created by the
-            [Update MCP Client Dependency workflow](.github/workflows/update-mcp-dependency.yml).*
-          branch: auto/update-mcp-dependency-v${{ steps.check-release.outputs.client_version }}
-          delete-branch: true
-          labels: |
-            dependencies
-            mcp
-            automated
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add katana_mcp_server/pyproject.toml uv.lock
+          git commit -m "chore(mcp): update client dependency to v${{ steps.check-release.outputs.client_version }}"
+          git push origin main

--- a/katana_mcp_server/Dockerfile
+++ b/katana_mcp_server/Dockerfile
@@ -24,7 +24,7 @@ COPY src/ /app/src/
 COPY README.md /app/
 
 # Install package
-RUN uv pip install --system --no-cache .
+RUN uv pip install --system --no-cache --no-sources .
 
 # Create non-root user for security
 RUN useradd -m -u 1000 mcp && \

--- a/katana_mcp_server/pyproject.toml
+++ b/katana_mcp_server/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=2.13.0",
-    "katana-openapi-client>=0.44.6",
+    "katana-openapi-client>=0.51.0",
     "prefab-ui>=0.18,<0.19",
     "pydantic>=2.12.0",
     "python-dotenv>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1230,7 +1230,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1257,7 +1257,7 @@ requires-dist = [
 
 [[package]]
 name = "katana-openapi-client"
-version = "0.50.0"
+version = "0.51.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

- **Docker build fix**: Add `--no-sources` to `uv pip install` in the Dockerfile so it resolves `katana-openapi-client` from PyPI instead of failing on the workspace reference
- **Docker rebuild on any release**: Chain `publish-mcp-docker` after both `publish-client-pypi` and `publish-mcp-pypi` so the Docker image always has the latest client baked in — not just when the MCP server itself releases
- **Simplified dependency sync**: Replace the broken PR-based `update-mcp-dependency` workflow with a direct commit to main using `chore(mcp):` (no release trigger)
- **Client dependency bump**: Update minimum `katana-openapi-client` from `>=0.44.6` to `>=0.51.0`

### Release workflow change

Before:
```
test → release-client → publish-client-pypi
test → release-mcp   → publish-mcp-pypi
                      → publish-mcp-docker  (only if MCP released)
```

After:
```
test → release-client → publish-client-pypi ─┐
test → release-mcp   → publish-mcp-pypi   ──┼→ publish-mcp-docker (if EITHER released)
```

## Test plan

- [ ] Verify CI passes
- [ ] Verify Docker image build succeeds in the release workflow after merge
- [ ] Verify `update-mcp-dependency` workflow commits directly on next client release

🤖 Generated with [Claude Code](https://claude.com/claude-code)