### PR TITLE
feat(mcp): HTTP transport support for Docker and Claude.ai co-work

### DIFF
--- a/katana_mcp_server/.env.example
+++ b/katana_mcp_server/.env.example
@@ -1,0 +1,11 @@
+# Katana MCP Server Configuration
+# Copy to .env and fill in your values, or set in your environment.
+
+# Required: Your Katana API key (from Katana account settings)
+KATANA_API_KEY=your-api-key-here
+
+# Optional: Override the Katana API base URL
+# KATANA_BASE_URL=https://api.katanamrp.com/v1
+
+# Optional: Override the MCP server port (default: 8765)
+# MCP_PORT=8765

--- a/katana_mcp_server/Dockerfile
+++ b/katana_mcp_server/Dockerfile
@@ -1,6 +1,11 @@
 # Katana MCP Server Docker Image
 # Provides an isolated, secure environment for running the Katana Manufacturing ERP MCP server
 # Compatible with Docker MCP Catalog and Toolkit
+#
+# Supports multiple transport modes via MCP_TRANSPORT env var:
+#   - streamable-http (default): HTTP transport for Claude.ai co-work and remote clients
+#   - stdio: Standard I/O for Claude Desktop and Claude Code
+#   - sse: Server-Sent Events for Cursor IDE
 
 FROM python:3.14-slim
 
@@ -23,7 +28,7 @@ COPY pyproject.toml /app/
 COPY src/ /app/src/
 COPY README.md /app/
 
-# Install package
+# Install package (--no-sources skips workspace reference, resolves from PyPI)
 RUN uv pip install --system --no-cache --no-sources .
 
 # Create non-root user for security
@@ -33,9 +38,9 @@ USER mcp
 
 # Environment variables (can be overridden at runtime)
 ENV KATANA_BASE_URL="https://api.katanamrp.com/v1"
+# Expose HTTP port (used by streamable-http, http, and sse transports)
+EXPOSE 8765
 
-# Expose MCP server (stdio-based, no network port needed)
-# The server uses stdio for communication with Claude Desktop
-
-# Run the MCP server
+# Run the MCP server with configurable transport
 ENTRYPOINT ["python", "-m", "katana_mcp"]
+CMD ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8765"]

--- a/katana_mcp_server/MCP_CURSOR_SETUP.md
+++ b/katana_mcp_server/MCP_CURSOR_SETUP.md
@@ -1,7 +1,8 @@
 # Katana MCP Server - Cursor IDE Setup
 
 This guide explains how to run the Katana MCP server independently and connect Cursor
-IDE to it via SSE transport.
+IDE to it via SSE transport. For Claude.ai co-work or other HTTP clients, see the
+[Docker guide](docs/docker.md) or the [README](README.md).
 
 ## Quick Start
 
@@ -89,6 +90,16 @@ Then update `.mcp.json`:
   "url": "http://127.0.0.1:8765"
 }
 ```
+
+### Streamable HTTP Transport
+
+For Claude.ai co-work or other MCP clients that support streamable-http:
+
+```bash
+./scripts/start_mcp_server.sh --transport streamable-http
+```
+
+The server will be available at `http://127.0.0.1:8765/mcp`.
 
 ## Environment Variables
 

--- a/katana_mcp_server/README.md
+++ b/katana_mcp_server/README.md
@@ -43,7 +43,18 @@ KATANA_API_KEY=your-api-key-here
 KATANA_BASE_URL=https://api.katanamrp.com/v1  # Optional, uses default if not set
 ```
 
-### 3. Use with Claude Desktop
+### 3. Choose Your Transport
+
+The MCP server supports multiple transport protocols for different environments:
+
+| Transport         | Use Case                          | Command                                         |
+| ----------------- | --------------------------------- | ----------------------------------------------- |
+| `stdio` (default) | Claude Desktop, Claude Code       | `katana-mcp-server`                             |
+| `streamable-http` | Claude.ai co-work, remote clients | `katana-mcp-server --transport streamable-http` |
+| `sse`             | Cursor IDE                        | `katana-mcp-server --transport sse`             |
+| `http`            | Generic HTTP clients              | `katana-mcp-server --transport http`            |
+
+### 4. Use with Claude Desktop (stdio)
 
 Add to your Claude Desktop configuration
 (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
@@ -64,7 +75,29 @@ Add to your Claude Desktop configuration
 
 Restart Claude Desktop, and you'll see Katana inventory tools available!
 
-### 4. Run Standalone (Optional)
+### 5. Use with Claude.ai Co-work (streamable-http)
+
+Start the server with HTTP transport:
+
+```bash
+export KATANA_API_KEY=your-api-key-here
+katana-mcp-server --transport streamable-http --host 0.0.0.0 --port 8765
+```
+
+The server will be available at `http://localhost:8765/mcp`. To connect from Claude.ai:
+
+1. Go to **Customize > Connectors** in your Claude.ai project
+1. Select **"Add custom connector"**
+1. Enter your server URL (use a tunnel like `ngrok http 8765` for local development, or
+   deploy to a cloud host for persistent access)
+
+Or run via Docker:
+
+```bash
+docker run -p 8765:8765 -e KATANA_API_KEY=your-key ghcr.io/dougborg/katana-mcp-server:latest
+```
+
+### 6. Run Standalone (Optional)
 
 For testing or development:
 

--- a/katana_mcp_server/docker-compose.yml
+++ b/katana_mcp_server/docker-compose.yml
@@ -1,5 +1,14 @@
+# Katana MCP Server — Docker Compose
+#
+# Quick start:
+#   cp .env.example .env          # add your KATANA_API_KEY
+#   docker compose up             # starts HTTP server on port 8765
+#
+# The .env file is loaded automatically from the project root.
+# Run from the repo root: docker compose -f katana_mcp_server/docker-compose.yml up
+# Or from this directory:  docker compose --env-file ../.env up
+
 services:
-  # HTTP transport (default) — for Claude.ai co-work, remote clients, and web UIs
   katana-mcp:
     image: ghcr.io/dougborg/katana-mcp-server:latest
     pull_policy: missing
@@ -7,46 +16,12 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: katana-mcp-server
+    restart: unless-stopped
     ports:
       - "${MCP_PORT:-8765}:8765"
     environment:
-      # Required: Set your Katana API key
-      - KATANA_API_KEY=${KATANA_API_KEY}
-      # Optional: Override base URL
+      - KATANA_API_KEY=${KATANA_API_KEY:?Set KATANA_API_KEY in .env or environment}
       - KATANA_BASE_URL=${KATANA_BASE_URL:-https://api.katanamrp.com/v1}
-    # Security: Run as non-root user
-    user: "1000:1000"
-    # Security: Prevent privilege escalation
-    security_opt:
-      - no-new-privileges:true
-    # Security: Read-only filesystem
-    read_only: true
-    # Resource limits
-    deploy:
-      resources:
-        limits:
-          cpus: '0.5'
-          memory: 512M
-        reservations:
-          cpus: '0.25'
-          memory: 256M
-
-  # stdio transport — for Claude Desktop and Docker MCP Catalog
-  katana-mcp-stdio:
-    image: ghcr.io/dougborg/katana-mcp-server:latest
-    pull_policy: missing
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: katana-mcp-server-stdio
-    # Override default HTTP transport with stdio
-    command: []
-    environment:
-      - KATANA_API_KEY=${KATANA_API_KEY}
-      - KATANA_BASE_URL=${KATANA_BASE_URL:-https://api.katanamrp.com/v1}
-    # MCP stdio requires interactive mode
-    stdin_open: true
-    tty: true
     user: "1000:1000"
     security_opt:
       - no-new-privileges:true
@@ -59,3 +34,9 @@ services:
         reservations:
           cpus: '0.25'
           memory: 256M
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/mcp')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/katana_mcp_server/docker-compose.yml
+++ b/katana_mcp_server/docker-compose.yml
@@ -1,20 +1,19 @@
 services:
+  # HTTP transport (default) — for Claude.ai co-work, remote clients, and web UIs
   katana-mcp:
-    # Use pre-built image from GHCR, or build locally if not available
     image: ghcr.io/dougborg/katana-mcp-server:latest
     pull_policy: missing
     build:
       context: .
       dockerfile: Dockerfile
     container_name: katana-mcp-server
+    ports:
+      - "${MCP_PORT:-8765}:8765"
     environment:
       # Required: Set your Katana API key
       - KATANA_API_KEY=${KATANA_API_KEY}
       # Optional: Override base URL
       - KATANA_BASE_URL=${KATANA_BASE_URL:-https://api.katanamrp.com/v1}
-    # MCP uses stdio, so we need to run interactively
-    stdin_open: true
-    tty: true
     # Security: Run as non-root user
     user: "1000:1000"
     # Security: Prevent privilege escalation
@@ -23,6 +22,35 @@ services:
     # Security: Read-only filesystem
     read_only: true
     # Resource limits
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+  # stdio transport — for Claude Desktop and Docker MCP Catalog
+  katana-mcp-stdio:
+    image: ghcr.io/dougborg/katana-mcp-server:latest
+    pull_policy: missing
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: katana-mcp-server-stdio
+    # Override default HTTP transport with stdio
+    command: []
+    environment:
+      - KATANA_API_KEY=${KATANA_API_KEY}
+      - KATANA_BASE_URL=${KATANA_BASE_URL:-https://api.katanamrp.com/v1}
+    # MCP stdio requires interactive mode
+    stdin_open: true
+    tty: true
+    user: "1000:1000"
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
     deploy:
       resources:
         limits:

--- a/katana_mcp_server/docs/docker.md
+++ b/katana_mcp_server/docs/docker.md
@@ -60,18 +60,27 @@ docker run -p 8765:8765 -e KATANA_API_KEY=your-key katana-mcp-server:latest \
 
 ## Running Locally
 
-### Using Docker Compose
+### Using Docker Compose (recommended)
 
 ```bash
-# Set your API key
-export KATANA_API_KEY="your-api-key-here"
+cd katana_mcp_server
 
-# Start with HTTP transport (default)
-docker-compose up katana-mcp
+# Configure your API key
+cp .env.example .env
+# Edit .env and set KATANA_API_KEY
 
-# Or start with stdio transport
-docker-compose up katana-mcp-stdio
+# Start the server (HTTP on port 8765)
+docker compose up
 ```
+
+Or from the repo root, pointing at the compose file:
+
+```bash
+docker compose -f katana_mcp_server/docker-compose.yml up
+```
+
+The server starts on `http://localhost:8765/mcp` with a health check and automatic
+restart.
 
 ### Using Docker Run
 
@@ -79,21 +88,21 @@ docker-compose up katana-mcp-stdio
 # HTTP transport (for Claude.ai co-work / remote access)
 docker run -p 8765:8765 \
   -e KATANA_API_KEY="your-api-key-here" \
-  katana-mcp-server:latest
+  ghcr.io/dougborg/katana-mcp-server:latest
 
 # stdio transport (for Claude Desktop)
 docker run -it \
   -e KATANA_API_KEY="your-api-key-here" \
-  katana-mcp-server:latest --transport stdio
+  ghcr.io/dougborg/katana-mcp-server:latest --transport stdio
 ```
 
 ## Testing the Container
 
 ```bash
-# Test HTTP transport
+# Start the server
 docker run -p 8765:8765 \
-  -e KATANA_API_KEY="test-key" \
-  katana-mcp-server:latest
+  -e KATANA_API_KEY="your-api-key-here" \
+  ghcr.io/dougborg/katana-mcp-server:latest
 
 # Should show:
 # - Server initialization logs

--- a/katana_mcp_server/docs/docker.md
+++ b/katana_mcp_server/docs/docker.md
@@ -33,6 +33,31 @@ docker buildx build --platform linux/amd64,linux/arm64 \
   --push .
 ```
 
+## Transport Modes
+
+The Docker image supports multiple transport modes. The default is `streamable-http`,
+which serves HTTP on port 8765.
+
+| Transport         | Default      | Use Case                           |
+| ----------------- | ------------ | ---------------------------------- |
+| `streamable-http` | Yes (Docker) | Claude.ai co-work, remote clients  |
+| `stdio`           | No           | Claude Desktop, Docker MCP Catalog |
+| `sse`             | No           | Cursor IDE                         |
+
+Override the transport by replacing the `CMD` arguments:
+
+```bash
+# HTTP (default) — no override needed
+docker run -p 8765:8765 -e KATANA_API_KEY=your-key katana-mcp-server:latest
+
+# stdio — for Claude Desktop
+docker run -it -e KATANA_API_KEY=your-key katana-mcp-server:latest --transport stdio
+
+# SSE — for Cursor IDE
+docker run -p 8765:8765 -e KATANA_API_KEY=your-key katana-mcp-server:latest \
+  --transport sse --host 0.0.0.0 --port 8765
+```
+
 ## Running Locally
 
 ### Using Docker Compose
@@ -41,30 +66,42 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 # Set your API key
 export KATANA_API_KEY="your-api-key-here"
 
-# Start the server
-docker-compose up
+# Start with HTTP transport (default)
+docker-compose up katana-mcp
+
+# Or start with stdio transport
+docker-compose up katana-mcp-stdio
 ```
 
 ### Using Docker Run
 
 ```bash
-docker run -it \
+# HTTP transport (for Claude.ai co-work / remote access)
+docker run -p 8765:8765 \
   -e KATANA_API_KEY="your-api-key-here" \
   katana-mcp-server:latest
+
+# stdio transport (for Claude Desktop)
+docker run -it \
+  -e KATANA_API_KEY="your-api-key-here" \
+  katana-mcp-server:latest --transport stdio
 ```
 
 ## Testing the Container
 
 ```bash
-# Run with test API key
-docker run -it \
+# Test HTTP transport
+docker run -p 8765:8765 \
   -e KATANA_API_KEY="test-key" \
   katana-mcp-server:latest
 
 # Should show:
 # - Server initialization logs
 # - Ready message
-# - Listening for MCP requests on stdio
+# - Listening on http://0.0.0.0:8765/mcp
+
+# Verify the endpoint is reachable
+curl http://localhost:8765/mcp
 ```
 
 ## Docker MCP Catalog Submission
@@ -169,9 +206,9 @@ categories:
 build_type: docker-built  # Docker will build and maintain
 ```
 
-## Configuration in Claude Desktop
+## Configuration Examples
 
-Once published to the Docker MCP Catalog, users can configure it in Claude Desktop:
+### Claude Desktop (stdio via Docker)
 
 ```json
 {
@@ -180,16 +217,35 @@ Once published to the Docker MCP Catalog, users can configure it in Claude Deskt
       "command": "docker",
       "args": ["run", "-i", "--rm",
                "-e", "KATANA_API_KEY=your-key-here",
-               "mcp/katana-mcp-server:latest"]
+               "mcp/katana-mcp-server:latest",
+               "--transport", "stdio"]
     }
   }
 }
 ```
 
+### Claude.ai Co-work (streamable-http via Docker)
+
+```bash
+# Start the server
+docker run -p 8765:8765 -e KATANA_API_KEY=your-key-here \
+  ghcr.io/dougborg/katana-mcp-server:latest
+
+# Then in Claude.ai: Customize > Connectors > Add custom connector
+# Enter: http://your-host:8765/mcp
+```
+
+For local development, use a tunnel to expose the server:
+
+```bash
+ngrok http 8765
+# Use the ngrok URL as your connector URL in Claude.ai
+```
+
 ## Security Considerations
 
 - ✅ Non-root user (UID 1000)
-- ✅ Minimal base image (python:3.13-slim)
+- ✅ Minimal base image (python:3.14-slim)
 - ✅ No unnecessary packages
 - ✅ API key passed via environment variable (never hardcoded)
 - ✅ Resource limits in docker-compose

--- a/katana_mcp_server/src/katana_mcp/__main__.py
+++ b/katana_mcp_server/src/katana_mcp/__main__.py
@@ -1,13 +1,16 @@
 """Entry point for running Katana MCP Server as a module.
 
 Usage:
-    python -m katana_mcp [--transport stdio|sse|http] [--host HOST] [--port PORT]
+    python -m katana_mcp [--transport stdio|sse|http|streamable-http] [--host HOST] [--port PORT]
 
 Examples:
     # Run with stdio (default, for Claude Desktop/CLI)
     python -m katana_mcp
 
-    # Run with SSE transport for development
+    # Run with streamable-http for Claude.ai co-work or remote clients
+    python -m katana_mcp --transport streamable-http --host 0.0.0.0 --port 8765
+
+    # Run with SSE transport for Cursor IDE
     python -m katana_mcp --transport sse --port 8765
 
     # Run with HTTP transport
@@ -24,7 +27,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--transport",
-        choices=["stdio", "sse", "http"],
+        choices=["stdio", "sse", "http", "streamable-http"],
         default="stdio",
         help="Transport protocol (default: stdio)",
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1230,7 +1230,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.35.0"
+version = "0.36.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- **Dockerfile** defaults to `streamable-http` on port 8765 (override with `--transport stdio` for Claude Desktop)
- **docker-compose.yml** provides both HTTP (`katana-mcp`) and stdio (`katana-mcp-stdio`) services
- **CLI** now accepts `--transport streamable-http` alongside existing options
- **Docs** updated across README, docker.md, and MCP_CURSOR_SETUP.md with transport selection guide and Claude.ai co-work setup instructions

### Transport options

| Transport | Use Case | Default In |
|-----------|----------|------------|
| `streamable-http` | Claude.ai co-work, remote clients | Docker |
| `stdio` | Claude Desktop, Claude Code | CLI |
| `sse` | Cursor IDE | — |
| `http` | Generic HTTP clients | — |

### Usage

```bash
# Docker (HTTP by default)
docker run -p 8765:8765 -e KATANA_API_KEY=your-key ghcr.io/dougborg/katana-mcp-server:latest

# Docker (stdio override for Claude Desktop)
docker run -it -e KATANA_API_KEY=your-key ghcr.io/dougborg/katana-mcp-server:latest --transport stdio

# Local HTTP
katana-mcp-server --transport streamable-http --host 0.0.0.0 --port 8765
```

## Test plan

- [ ] Verify CI passes
- [ ] Test `katana-mcp-server --transport streamable-http --port 8765` starts and serves on `/mcp`
- [ ] Test `docker build` and `docker run` with default HTTP transport
- [ ] Test Docker stdio override: `docker run -it ... --transport stdio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)