### PR TITLE
fix(mcp): respect limit param in list_sales_orders

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -361,7 +361,9 @@ async def create_sales_order(
 class ListSalesOrdersRequest(BaseModel):
     """Request to list/filter sales orders."""
 
-    limit: int = Field(default=50, description="Max orders to return (default 50)")
+    limit: int = Field(
+        default=50, ge=1, description="Max orders to return (default 50, min 1)"
+    )
     order_no: str | None = Field(default=None, description="Filter by exact order_no")
     customer_id: int | None = Field(default=None, description="Filter by customer ID")
     location_id: int | None = Field(default=None, description="Filter by location ID")
@@ -443,8 +445,10 @@ async def _list_sales_orders_impl(
     # the API's max page size), pass page=1 to disable PaginationTransport's
     # auto-pagination. Without this, `limit` is treated as a per-page size and
     # the transport fetches up to max_pages pages, returning thousands of rows
-    # when the caller asked for a small cap (see #329).
-    if request.limit <= 250:
+    # when the caller asked for a small cap (see #329). Lower bound keeps us
+    # from bypassing the transport's invalid-limit normalization (ge=1 on the
+    # Field makes this defence-in-depth, but the explicit bound documents intent).
+    if 1 <= request.limit <= 250:
         kwargs["page"] = 1
 
     response = await get_all_sales_orders.asyncio_detailed(**kwargs)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -439,9 +439,19 @@ async def _list_sales_orders_impl(
         "limit": request.limit,
         **{k: v for k, v in filters.items() if v is not None},
     }
+    # Efficiency: when the caller's limit fits in a single Katana page (<=250,
+    # the API's max page size), pass page=1 to disable PaginationTransport's
+    # auto-pagination. Without this, `limit` is treated as a per-page size and
+    # the transport fetches up to max_pages pages, returning thousands of rows
+    # when the caller asked for a small cap (see #329).
+    if request.limit <= 250:
+        kwargs["page"] = 1
 
     response = await get_all_sales_orders.asyncio_detailed(**kwargs)
     attrs_list = unwrap_data(response, default=[])
+    # Safety net: cap to request.limit post-pagination so we never return more
+    # than the caller asked for, regardless of how the transport behaved.
+    attrs_list = attrs_list[: request.limit]
 
     orders: list[SalesOrderSummary] = []
     for so in attrs_list:

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -694,6 +694,72 @@ async def test_list_sales_orders_explicit_production_status_wins_over_shortcut()
 
 
 @pytest.mark.asyncio
+async def test_list_sales_orders_caps_results_to_request_limit():
+    """Regression for #329: even if transport returns more rows than asked,
+    the response is sliced to request.limit."""
+    context, _ = create_mock_context()
+
+    # Simulate transport returning way more rows than requested (this is the
+    # #329 symptom: auto-pagination flooded the response).
+    over_fetched = [_make_mock_so(id=i, order_no=f"SO-{i}") for i in range(200)]
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_DATA, return_value=over_fetched),
+    ):
+        request = ListSalesOrdersRequest(limit=50)
+        result = await _list_sales_orders_impl(request, context)
+
+    assert len(result.orders) == 50
+    assert result.total_count == 50
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_passes_page_1_when_limit_fits_single_page():
+    """Regression for #329: when limit <= 250 (Katana page max), pass page=1
+    so PaginationTransport skips auto-pagination."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    request = ListSalesOrdersRequest(limit=10)
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SO_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_sales_orders_impl(request, context)
+
+    assert captured["page"] == 1
+    assert captured["limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_omits_page_when_limit_exceeds_single_page():
+    """For limit > 250, let auto-pagination do its thing (no explicit page)."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    request = ListSalesOrdersRequest(limit=500)
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SO_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_sales_orders_impl(request, context)
+
+    assert "page" not in captured
+    assert captured["limit"] == 500
+
+
+@pytest.mark.asyncio
 async def test_list_sales_orders_returns_summary_rows():
     """Response rows carry order_no, totals, and row_count."""
     context, _ = create_mock_context()


### PR DESCRIPTION
## Description

`list_sales_orders(limit=50)` was returning thousands of rows instead of 50. The `limit` param was forwarded through to `PaginationTransport`, which treats it as page size (not a total cap) and auto-paginates up to `max_pages=100`. A live probe returned 2420 rows for a `limit=50` call.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this manually (if applicable)

## Code Quality

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run `poetry run lint` and resolved any issues
- [x] I have run `poetry run format-check` and code is properly formatted

## Related Issues

Fixes #329

## Additional Notes

Scope intentionally narrow: fixes `list_sales_orders` only. The same pattern almost certainly affects other list-style MCP tools — at least `katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py` passes `limit=request.limit` the same way (one call site already slices, one does not). A follow-up PR should audit every `list_*` / `search_*` tool for consistency and either (a) fix each one individually or (b) push the cap/short-circuit into a shared helper so it can't drift.

The fix has two layers in `_list_sales_orders_impl`:
1. **Correctness (safety net):** slice the unwrapped list to `request.limit` post-pagination so the return can never exceed the caller's ask.
2. **Efficiency:** when `request.limit <= 250` (Katana's max page size, verified against `PaginationTransport.__init__` in `katana_client.py`), pass `page=1` to `get_all_sales_orders.asyncio_detailed()`. Per the transport docstring ("ANY explicit `page` parameter in URL disables auto-pagination"), this collapses the work to a single HTTP round-trip for the common small-limit case.

### Test plan

- `test_list_sales_orders_caps_results_to_request_limit` — mock unwrap to return 200 rows with `limit=50`; assert `len(orders) == 50` and `total_count == 50`.
- `test_list_sales_orders_passes_page_1_when_limit_fits_single_page` — with `limit=10`, assert the forwarded kwargs include `page=1`.
- `test_list_sales_orders_omits_page_when_limit_exceeds_single_page` — with `limit=500`, assert `page` is not in the forwarded kwargs (auto-pagination remains enabled).
- `uv run poe check` passes locally (2273 tests, 3 unrelated skips).