### PR TITLE
feat(mcp): add stock-transfer tools (#338)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -53,6 +53,13 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **fulfill_order** - Complete manufacturing or sales orders
 - **create_sales_order** - Create sales orders with preview/confirm
 
+### Stock Transfers
+- **create_stock_transfer** - Move inventory between locations (preview/confirm)
+- **list_stock_transfers** - List transfers with status / location / date filters
+- **update_stock_transfer** - Update transfer body fields
+- **update_stock_transfer_status** - Transition status (PENDING → IN_TRANSIT → COMPLETED)
+- **delete_stock_transfer** - Delete a transfer
+
 ## Safety Pattern
 
 All create/modify operations use a **two-step confirmation**:
@@ -555,6 +562,84 @@ Complete a manufacturing or sales order.
 - `order_id` (required): Order ID to fulfill
 - `order_type` (required): "manufacturing" or "sales"
 - `confirm` (optional, default false): false=preview, true=fulfill
+
+---
+
+## Stock Transfer Tools
+
+### create_stock_transfer
+Create a stock transfer moving inventory between two locations.
+
+**Parameters:**
+- `source_location_id` (required): Source location ID
+- `destination_location_id` (required): Destination location ID (target_location_id)
+- `expected_arrival_date` (required): Expected arrival datetime (ISO-8601)
+- `rows` (required): Line items `[{variant_id, quantity, batch_transactions?}]` —
+  `batch_transactions` is `[{batch_id, quantity}]` for batch-tracked variants
+- `order_no` (optional): Stock transfer number (auto-assigned when omitted)
+- `additional_info` (optional): Notes
+- `confirm` (optional, default false): false=preview, true=create
+
+**Safety:** When confirm=true, prompts user for confirmation before creating.
+
+---
+
+### list_stock_transfers
+List stock transfers with filters (list-tool pattern v2).
+
+**Parameters:**
+- `limit` (optional, default 50, min 1): Max rows to return
+- `page` (optional): Page number (1-based) — disables auto-pagination
+- `status` (optional): "PENDING", "IN_TRANSIT", "COMPLETED", or "CANCELLED"
+- `source_location_id` (optional): Filter by source location ID
+- `destination_location_id` (optional): Filter by destination (target) location ID
+- `stock_transfer_number` (optional): Exact match on the transfer number
+- `created_after` / `created_before` (optional): ISO-8601 datetime bounds on created_at
+- `include_rows` (optional, default false): Populate per-transfer row details
+
+**Returns:** Summary rows (id, number, status, source/destination, row_count,
+expected_arrival). `pagination` metadata is populated when `page` is set.
+
+---
+
+### update_stock_transfer
+Update body fields on an existing stock transfer.
+
+**Parameters:**
+- `id` (required): Stock transfer ID
+- `stock_transfer_number` (optional): New transfer number
+- `transfer_date` (optional): New transfer datetime (ISO-8601)
+- `expected_arrival_date` (optional): New expected arrival datetime (ISO-8601)
+- `additional_info` (optional): Updated notes
+- `confirm` (optional, default false): false=preview, true=apply
+
+At least one updatable field must be provided. Use `update_stock_transfer_status`
+to change the transfer's status — it's a separate endpoint.
+
+---
+
+### update_stock_transfer_status
+Transition a stock transfer through the 4-state machine.
+
+**Parameters:**
+- `id` (required): Stock transfer ID
+- `new_status` (required): "PENDING", "IN_TRANSIT", "COMPLETED", or "CANCELLED"
+- `confirm` (optional, default false): false=preview, true=apply
+
+**Typical flow:** PENDING → IN_TRANSIT → COMPLETED. Katana rejects invalid
+transitions (e.g. COMPLETED → IN_TRANSIT); the tool surfaces the API error
+message as a ValueError.
+
+---
+
+### delete_stock_transfer
+Delete a stock transfer.
+
+**Parameters:**
+- `id` (required): Stock transfer ID
+- `confirm` (optional, default false): false=preview, true=delete
+
+Destructive — removes the transfer record.
 """
 
 HELP_RESOURCES = """

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/__init__.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/__init__.py
@@ -24,6 +24,7 @@ from .manufacturing_orders import register_tools as register_manufacturing_order
 from .orders import register_tools as register_order_tools
 from .purchase_orders import register_tools as register_purchase_order_tools
 from .sales_orders import register_tools as register_sales_order_tools
+from .stock_transfers import register_tools as register_stock_transfer_tools
 
 
 def register_all_foundation_tools(mcp: FastMCP) -> None:
@@ -40,6 +41,7 @@ def register_all_foundation_tools(mcp: FastMCP) -> None:
     register_catalog_tools(mcp)
     register_manufacturing_order_tools(mcp)
     register_order_tools(mcp)
+    register_stock_transfer_tools(mcp)
 
 
 __all__ = [

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -1,0 +1,1012 @@
+"""Stock transfer management tools for Katana MCP Server.
+
+Foundation tools covering the full stock-transfer lifecycle: create a transfer
+between locations, list transfers with filters, update transfer body fields,
+transition status through the four-state machine
+(PENDING / IN_TRANSIT / COMPLETED / CANCELLED), and delete.
+
+These tools provide:
+- create_stock_transfer: Create a transfer with preview/confirm pattern
+- list_stock_transfers: List transfers with paging, date, status filters
+- update_stock_transfer: Update body fields with preview/confirm pattern
+- update_stock_transfer_status: Transition state with preview/confirm pattern
+- delete_stock_transfer: Delete transfer with preview/confirm pattern
+"""
+
+from __future__ import annotations
+
+import datetime as _datetime
+import json
+from datetime import UTC, datetime
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context, FastMCP
+from fastmcp.tools import ToolResult
+from pydantic import BaseModel, Field
+
+from katana_mcp.logging import get_logger, observe_tool
+from katana_mcp.services import get_services
+from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
+from katana_mcp.tools.tool_result_utils import (
+    enum_to_str,
+    format_md_table,
+    iso_or_none,
+    make_simple_result,
+)
+from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_public_api_client.domain.converters import to_unset, unwrap_unset
+from katana_public_api_client.models import (
+    CreateStockTransferRequest as APICreateStockTransferRequest,
+    StockTransfer,
+    StockTransferRowBatchTransactionsItem,
+    StockTransferRowRequest,
+    StockTransferStatus,
+    UpdateStockTransferRequest as APIUpdateStockTransferRequest,
+    UpdateStockTransferStatusRequest as APIUpdateStockTransferStatusRequest,
+)
+from katana_public_api_client.utils import APIError, is_success, unwrap, unwrap_as
+
+logger = get_logger(__name__)
+
+
+# Status literal shared across tools — mirrors the 4-state enum in
+# StockTransferStatus while keeping the tool surface user-friendly (uppercase).
+StatusLiteral = Literal["PENDING", "IN_TRANSIT", "COMPLETED", "CANCELLED"]
+
+
+def _status_literal_to_enum(status: StatusLiteral) -> StockTransferStatus:
+    """Map the tool-facing uppercase literal to the lowercase API enum."""
+    return StockTransferStatus(status.lower())
+
+
+# ============================================================================
+# Shared response models
+# ============================================================================
+
+
+class PaginationMeta(BaseModel):
+    """Pagination metadata parsed from X-Pagination header."""
+
+    page: int | None = None
+    total_pages: int | None = None
+    total_items: int | None = None
+    per_page: int | None = None
+
+
+def _parse_pagination_header(headers: Any) -> PaginationMeta | None:
+    """Parse Katana's X-Pagination header into a PaginationMeta instance.
+
+    Returns None if the header is absent, empty, or malformed. Numeric values
+    may arrive as strings; we coerce to int where possible and skip bad values.
+    """
+    if not headers:
+        return None
+    raw = headers.get("X-Pagination") if hasattr(headers, "get") else None
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+
+    def _as_int(value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    meta = PaginationMeta(
+        page=_as_int(parsed.get("page")),
+        total_pages=_as_int(parsed.get("total_pages")),
+        total_items=_as_int(parsed.get("total_items")),
+        per_page=_as_int(parsed.get("per_page")),
+    )
+    if (
+        meta.page is None
+        and meta.total_pages is None
+        and meta.total_items is None
+        and meta.per_page is None
+    ):
+        return None
+    return meta
+
+
+class StockTransferRowInfo(BaseModel):
+    """Summary of a stock transfer line item."""
+
+    id: int | None = None
+    variant_id: int | None = None
+    quantity: float | None = None
+    cost_per_unit: float | None = None
+    batch_transactions: list[dict[str, Any]] | None = None
+
+
+class StockTransferSummary(BaseModel):
+    """Summary row for a stock transfer in a list."""
+
+    id: int
+    stock_transfer_number: str | None
+    source_location_id: int | None
+    target_location_id: int | None
+    status: str | None
+    transfer_date: str | None
+    expected_arrival_date: str | None
+    created_at: str | None
+    row_count: int
+    rows: list[StockTransferRowInfo] | None = None
+
+
+def _build_row_info(row: Any) -> StockTransferRowInfo:
+    """Extract a StockTransferRowInfo from an attrs StockTransferRow."""
+    raw_batches = unwrap_unset(row.batch_transactions, None)
+    batches: list[dict[str, Any]] | None = None
+    if raw_batches:
+        batches = [
+            {"batch_id": b.batch_id, "quantity": b.quantity} for b in raw_batches
+        ]
+    return StockTransferRowInfo(
+        id=unwrap_unset(row.id, None),
+        variant_id=unwrap_unset(row.variant_id, None),
+        quantity=unwrap_unset(row.quantity, None),
+        cost_per_unit=unwrap_unset(row.cost_per_unit, None),
+        batch_transactions=batches,
+    )
+
+
+def _build_summary(transfer: Any, *, include_rows: bool) -> StockTransferSummary:
+    """Convert an attrs StockTransfer into a StockTransferSummary."""
+    raw_rows = unwrap_unset(transfer.stock_transfer_rows, []) or []
+    row_infos = [_build_row_info(r) for r in raw_rows] if include_rows else None
+    transfer_date = unwrap_unset(transfer.transfer_date, None)
+    expected = unwrap_unset(transfer.expected_arrival_date, None)
+    created = unwrap_unset(transfer.created_at, None)
+    status = unwrap_unset(transfer.status, None)
+    return StockTransferSummary(
+        id=transfer.id,
+        stock_transfer_number=unwrap_unset(transfer.stock_transfer_number, None),
+        source_location_id=unwrap_unset(transfer.source_location_id, None),
+        target_location_id=unwrap_unset(transfer.target_location_id, None),
+        status=enum_to_str(status),
+        transfer_date=iso_or_none(transfer_date)
+        if isinstance(transfer_date, _datetime.datetime)
+        else None,
+        expected_arrival_date=iso_or_none(expected)
+        if isinstance(expected, _datetime.datetime)
+        else None,
+        created_at=iso_or_none(created)
+        if isinstance(created, _datetime.datetime)
+        else None,
+        row_count=len(raw_rows),
+        rows=row_infos,
+    )
+
+
+def _parse_iso_datetime(value: str, field_name: str) -> datetime:
+    """Parse an ISO-8601 datetime string, raising ValueError with a clear message."""
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
+        ) from e
+
+
+# ============================================================================
+# Tool 1: create_stock_transfer
+# ============================================================================
+
+
+class StockTransferBatchTransactionInput(BaseModel):
+    """Batch transaction for a batch-tracked variant on a stock transfer row."""
+
+    batch_id: int = Field(..., description="Batch ID being transferred")
+    quantity: float = Field(..., description="Quantity drawn from this batch", gt=0)
+
+
+class StockTransferRowInput(BaseModel):
+    """Line item for a stock transfer."""
+
+    variant_id: int = Field(..., description="Variant ID to transfer")
+    quantity: float = Field(..., description="Quantity to transfer", gt=0)
+    batch_transactions: list[StockTransferBatchTransactionInput] | None = Field(
+        default=None,
+        description=(
+            "Batch transactions for batch-tracked items. Required for batch-tracked "
+            "variants — each entry picks a batch_id and quantity."
+        ),
+    )
+
+
+class CreateStockTransferRequest(BaseModel):
+    """Request to create a stock transfer between two locations."""
+
+    source_location_id: int = Field(..., description="Source location ID")
+    destination_location_id: int = Field(
+        ..., description="Destination location ID (target_location_id in API terms)"
+    )
+    expected_arrival_date: datetime = Field(
+        ..., description="Expected arrival date at the destination location"
+    )
+    rows: list[StockTransferRowInput] = Field(
+        ..., description="Line items to transfer", min_length=1
+    )
+    order_no: str | None = Field(
+        default=None,
+        description=(
+            "Optional transfer number (stock_transfer_number). Katana auto-assigns "
+            "one when omitted."
+        ),
+    )
+    additional_info: str | None = Field(
+        default=None, description="Additional notes (optional)"
+    )
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, creates the transfer.",
+    )
+
+
+class StockTransferResponse(BaseModel):
+    """Response from a stock transfer create/update/status-change operation."""
+
+    id: int | None = None
+    stock_transfer_number: str | None = None
+    source_location_id: int | None = None
+    target_location_id: int | None = None
+    status: str | None = None
+    expected_arrival_date: str | None = None
+    is_preview: bool
+    next_actions: list[str] = Field(default_factory=list)
+    message: str
+
+
+def _transfer_to_response(
+    transfer: StockTransfer, *, message: str, is_preview: bool = False
+) -> StockTransferResponse:
+    """Build a StockTransferResponse from an attrs StockTransfer."""
+    expected = unwrap_unset(transfer.expected_arrival_date, None)
+    status = unwrap_unset(transfer.status, None)
+    return StockTransferResponse(
+        id=transfer.id,
+        stock_transfer_number=unwrap_unset(transfer.stock_transfer_number, None),
+        source_location_id=unwrap_unset(transfer.source_location_id, None),
+        target_location_id=unwrap_unset(transfer.target_location_id, None),
+        status=enum_to_str(status),
+        expected_arrival_date=iso_or_none(expected)
+        if isinstance(expected, _datetime.datetime)
+        else None,
+        is_preview=is_preview,
+        message=message,
+    )
+
+
+def _build_row_requests(
+    rows: list[StockTransferRowInput],
+) -> list[StockTransferRowRequest]:
+    """Convert pydantic row inputs to attrs request rows.
+
+    The generated `StockTransferRowRequest` model exposes only `variant_id` and
+    `quantity` as declared attrs fields, but Katana's API accepts
+    `batch_transactions` on transfer rows (see `StockTransferRow` response).
+    We stash batch transactions through the row's `additional_properties` bag
+    so they flow into the serialized JSON body.
+    """
+    out: list[StockTransferRowRequest] = []
+    for row in rows:
+        api_row = StockTransferRowRequest(
+            variant_id=row.variant_id,
+            quantity=row.quantity,
+        )
+        if row.batch_transactions:
+            batch_items = [
+                StockTransferRowBatchTransactionsItem(
+                    batch_id=bt.batch_id, quantity=bt.quantity
+                )
+                for bt in row.batch_transactions
+            ]
+            api_row.additional_properties = {
+                "batch_transactions": [bi.to_dict() for bi in batch_items]
+            }
+        out.append(api_row)
+    return out
+
+
+async def _create_stock_transfer_impl(
+    request: CreateStockTransferRequest, context: Context
+) -> StockTransferResponse:
+    """Implementation of create_stock_transfer tool."""
+    logger.info(
+        f"{'Previewing' if not request.confirm else 'Creating'} stock transfer "
+        f"{request.order_no or '(auto)'} "
+        f"({request.source_location_id} -> {request.destination_location_id})"
+    )
+
+    row_count = len(request.rows)
+    preview_message = (
+        f"Preview: Stock transfer with {row_count} row(s) from location "
+        f"{request.source_location_id} to {request.destination_location_id}"
+    )
+
+    if not request.confirm:
+        return StockTransferResponse(
+            stock_transfer_number=request.order_no,
+            source_location_id=request.source_location_id,
+            target_location_id=request.destination_location_id,
+            status="PENDING",
+            expected_arrival_date=request.expected_arrival_date.isoformat(),
+            is_preview=True,
+            next_actions=[
+                "Review the transfer details",
+                "Set confirm=true to create the stock transfer",
+            ],
+            message=preview_message,
+        )
+
+    confirmation = await require_confirmation(
+        context,
+        f"Create stock transfer with {row_count} row(s) from location "
+        f"{request.source_location_id} to {request.destination_location_id}?",
+    )
+    if confirmation != ConfirmationResult.CONFIRMED:
+        logger.info("User did not confirm stock transfer creation")
+        return StockTransferResponse(
+            stock_transfer_number=request.order_no,
+            source_location_id=request.source_location_id,
+            target_location_id=request.destination_location_id,
+            status="PENDING",
+            expected_arrival_date=request.expected_arrival_date.isoformat(),
+            is_preview=True,
+            message=f"Stock transfer creation {confirmation} by user",
+            next_actions=[
+                "Review the transfer details and try again with confirm=true"
+            ],
+        )
+
+    services = get_services(context)
+    api_rows = _build_row_requests(request.rows)
+
+    api_request = APICreateStockTransferRequest(
+        source_location_id=request.source_location_id,
+        target_location_id=request.destination_location_id,
+        expected_arrival_date=request.expected_arrival_date,
+        order_created_date=datetime.now(UTC),
+        stock_transfer_number=to_unset(request.order_no),
+        additional_info=to_unset(request.additional_info),
+        stock_transfer_rows=api_rows,
+    )
+
+    from katana_public_api_client.api.stock_transfer import create_stock_transfer
+
+    response = await create_stock_transfer.asyncio_detailed(
+        client=services.client, body=api_request
+    )
+    transfer = unwrap_as(response, StockTransfer)
+    logger.info(f"Created stock transfer ID {transfer.id}")
+
+    result = _transfer_to_response(
+        transfer,
+        message=f"Successfully created stock transfer (ID: {transfer.id})",
+    )
+    result.next_actions = [
+        f"Stock transfer created with ID {transfer.id}",
+        "Use update_stock_transfer_status to transition it through IN_TRANSIT → COMPLETED",
+    ]
+    return result
+
+
+@observe_tool
+@unpack_pydantic_params
+async def create_stock_transfer(
+    request: Annotated[CreateStockTransferRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Create a stock transfer moving inventory between two locations.
+
+    Two-step flow: confirm=false to preview, confirm=true to create (prompts for
+    confirmation). Requires source_location_id, destination_location_id,
+    expected_arrival_date, and at least one row with variant_id + quantity.
+    For batch-tracked variants, supply `batch_transactions` on the row.
+    """
+    response = await _create_stock_transfer_impl(request, context)
+
+    lines = [
+        f"## Stock Transfer ({'PREVIEW' if response.is_preview else 'CREATED'})",
+        f"- **Message**: {response.message}",
+    ]
+    if response.id is not None:
+        lines.append(f"- **ID**: {response.id}")
+    if response.stock_transfer_number:
+        lines.append(f"- **Number**: {response.stock_transfer_number}")
+    if response.source_location_id is not None:
+        lines.append(f"- **Source Location**: {response.source_location_id}")
+    if response.target_location_id is not None:
+        lines.append(f"- **Destination Location**: {response.target_location_id}")
+    if response.expected_arrival_date:
+        lines.append(f"- **Expected Arrival**: {response.expected_arrival_date}")
+    if response.status:
+        lines.append(f"- **Status**: {response.status}")
+    if response.next_actions:
+        lines.append("")
+        lines.append("### Next Actions")
+        lines.extend(f"- {action}" for action in response.next_actions)
+
+    return make_simple_result("\n".join(lines), structured_data=response.model_dump())
+
+
+# ============================================================================
+# Tool 2: list_stock_transfers
+# ============================================================================
+
+
+class ListStockTransfersRequest(BaseModel):
+    """Request to list/filter stock transfers (list-tool pattern v2)."""
+
+    # Paging
+    limit: int = Field(
+        default=50,
+        ge=1,
+        description="Max rows to return (default 50, min 1). When `page` is set, acts as page size.",
+    )
+    page: int | None = Field(
+        default=None,
+        description="Page number (1-based). When set, disables auto-pagination; use with `limit` as page size.",
+    )
+
+    # Domain filters
+    status: StatusLiteral | None = Field(
+        default=None,
+        description="Filter by transfer status (PENDING, IN_TRANSIT, COMPLETED, CANCELLED)",
+    )
+    source_location_id: int | None = Field(
+        default=None, description="Filter by source location ID"
+    )
+    destination_location_id: int | None = Field(
+        default=None,
+        description="Filter by destination location ID (target_location_id).",
+    )
+    stock_transfer_number: str | None = Field(
+        default=None, description="Filter by exact stock transfer number"
+    )
+
+    # Time-window filters
+    created_after: str | None = Field(
+        default=None, description="ISO-8601 datetime lower bound on created_at."
+    )
+    created_before: str | None = Field(
+        default=None, description="ISO-8601 datetime upper bound on created_at."
+    )
+
+    # Row inclusion
+    include_rows: bool = Field(
+        default=False,
+        description="When true, populate row-level detail on each summary.",
+    )
+
+
+class ListStockTransfersResponse(BaseModel):
+    """Response containing a list of stock transfers."""
+
+    transfers: list[StockTransferSummary]
+    total_count: int
+    pagination: PaginationMeta | None = None
+
+
+async def _list_stock_transfers_impl(
+    request: ListStockTransfersRequest, context: Context
+) -> ListStockTransfersResponse:
+    """List stock transfers with filters — follows list-tool pattern v2."""
+    from katana_public_api_client.api.stock_transfer import get_all_stock_transfers
+    from katana_public_api_client.utils import unwrap_data
+
+    services = get_services(context)
+
+    kwargs: dict[str, Any] = {
+        "client": services.client,
+        "limit": request.limit,
+    }
+
+    # Short-circuit auto-pagination when limit fits in a single Katana page
+    # (<=250) unless the caller explicitly set `page`.
+    if request.page is not None:
+        kwargs["page"] = request.page
+    elif 1 <= request.limit <= 250:
+        kwargs["page"] = 1
+
+    if request.source_location_id is not None:
+        kwargs["source_location_id"] = request.source_location_id
+    if request.destination_location_id is not None:
+        kwargs["target_location_id"] = request.destination_location_id
+    if request.stock_transfer_number is not None:
+        kwargs["stock_transfer_number"] = request.stock_transfer_number
+    if request.created_after is not None:
+        kwargs["created_at_min"] = _parse_iso_datetime(
+            request.created_after, "created_after"
+        )
+    if request.created_before is not None:
+        kwargs["created_at_max"] = _parse_iso_datetime(
+            request.created_before, "created_before"
+        )
+
+    response = await get_all_stock_transfers.asyncio_detailed(**kwargs)
+    attrs_list = unwrap_data(response, default=[])
+
+    # Status is not exposed as a server-side filter on this endpoint, so we
+    # apply it client-side when specified.
+    if request.status is not None:
+        api_status = request.status.lower()
+        attrs_list = [
+            t
+            for t in attrs_list
+            if enum_to_str(unwrap_unset(t.status, None)) == api_status
+            or enum_to_str(unwrap_unset(t.status, None)) == request.status
+        ]
+
+    # Safety net: cap to request.limit post-pagination.
+    attrs_list = attrs_list[: request.limit]
+
+    summaries = [
+        _build_summary(t, include_rows=request.include_rows) for t in attrs_list
+    ]
+
+    pagination = None
+    if request.page is not None:
+        pagination = _parse_pagination_header(getattr(response, "headers", None))
+
+    return ListStockTransfersResponse(
+        transfers=summaries,
+        total_count=len(summaries),
+        pagination=pagination,
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def list_stock_transfers(
+    request: Annotated[ListStockTransfersRequest, Unpack()], context: Context
+) -> ToolResult:
+    """List stock transfers with filters.
+
+    Use for discovery workflows — find transfers by status, between specific
+    locations, or within a date range. Follows list-tool pattern v2: small
+    `limit` values skip auto-pagination for a single fast call; set `page`
+    for explicit paging through large result sets. Pass `include_rows=true`
+    to populate per-transfer line items.
+    """
+    response = await _list_stock_transfers_impl(request, context)
+
+    if not response.transfers:
+        md = "No stock transfers match the given filters."
+    else:
+        table = format_md_table(
+            headers=[
+                "ID",
+                "Number",
+                "Status",
+                "Source",
+                "Destination",
+                "Rows",
+                "Expected Arrival",
+            ],
+            rows=[
+                [
+                    t.id,
+                    t.stock_transfer_number or "—",
+                    t.status or "—",
+                    t.source_location_id if t.source_location_id is not None else "—",
+                    t.target_location_id if t.target_location_id is not None else "—",
+                    t.row_count,
+                    t.expected_arrival_date or "—",
+                ]
+                for t in response.transfers
+            ],
+        )
+        md = f"## Stock Transfers ({response.total_count})\n\n{table}"
+
+    return make_simple_result(md, structured_data=response.model_dump())
+
+
+# ============================================================================
+# Tool 3: update_stock_transfer
+# ============================================================================
+
+
+class UpdateStockTransferRequest(BaseModel):
+    """Request to update body fields on a stock transfer."""
+
+    id: int = Field(..., description="Stock transfer ID")
+    stock_transfer_number: str | None = Field(
+        default=None, description="New stock transfer number"
+    )
+    transfer_date: datetime | None = Field(
+        default=None, description="New transfer date"
+    )
+    expected_arrival_date: datetime | None = Field(
+        default=None, description="New expected arrival date"
+    )
+    additional_info: str | None = Field(
+        default=None, description="New additional info/notes"
+    )
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, applies the update.",
+    )
+
+
+async def _update_stock_transfer_impl(
+    request: UpdateStockTransferRequest, context: Context
+) -> StockTransferResponse:
+    """Implementation of update_stock_transfer tool."""
+    updates = {
+        "stock_transfer_number": request.stock_transfer_number,
+        "transfer_date": (
+            request.transfer_date.isoformat() if request.transfer_date else None
+        ),
+        "expected_arrival_date": (
+            request.expected_arrival_date.isoformat()
+            if request.expected_arrival_date
+            else None
+        ),
+        "additional_info": request.additional_info,
+    }
+    set_fields = {k: v for k, v in updates.items() if v is not None}
+
+    if not set_fields:
+        raise ValueError(
+            "At least one field must be provided to update (stock_transfer_number, "
+            "transfer_date, expected_arrival_date, additional_info)"
+        )
+
+    preview_message = (
+        f"Preview: Update stock transfer {request.id} — fields: "
+        + ", ".join(f"{k}={v}" for k, v in set_fields.items())
+    )
+
+    if not request.confirm:
+        return StockTransferResponse(
+            id=request.id,
+            is_preview=True,
+            next_actions=[
+                "Review the update details",
+                "Set confirm=true to apply the update",
+            ],
+            message=preview_message,
+        )
+
+    confirmation = await require_confirmation(
+        context,
+        f"Update stock transfer {request.id}? Fields: " + ", ".join(set_fields.keys()),
+    )
+    if confirmation != ConfirmationResult.CONFIRMED:
+        logger.info(f"User did not confirm update of stock transfer {request.id}")
+        return StockTransferResponse(
+            id=request.id,
+            is_preview=True,
+            message=f"Stock transfer update {confirmation} by user",
+            next_actions=["Review the update and try again with confirm=true"],
+        )
+
+    services = get_services(context)
+    api_request = APIUpdateStockTransferRequest(
+        stock_transfer_number=to_unset(request.stock_transfer_number),
+        transfer_date=to_unset(request.transfer_date),
+        expected_arrival_date=to_unset(request.expected_arrival_date),
+        additional_info=to_unset(request.additional_info),
+    )
+
+    from katana_public_api_client.api.stock_transfer import update_stock_transfer
+
+    response = await update_stock_transfer.asyncio_detailed(
+        id=request.id, client=services.client, body=api_request
+    )
+    transfer = unwrap_as(response, StockTransfer)
+    logger.info(f"Updated stock transfer ID {transfer.id}")
+
+    result = _transfer_to_response(
+        transfer,
+        message=f"Successfully updated stock transfer {transfer.id}",
+    )
+    result.next_actions = [f"Stock transfer {transfer.id} updated"]
+    return result
+
+
+@observe_tool
+@unpack_pydantic_params
+async def update_stock_transfer(
+    request: Annotated[UpdateStockTransferRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Update body fields on an existing stock transfer.
+
+    Two-step flow: confirm=false to preview, confirm=true to apply. Accepts
+    `stock_transfer_number`, `transfer_date`, `expected_arrival_date`, and
+    `additional_info`. Use `update_stock_transfer_status` to change status.
+    """
+    response = await _update_stock_transfer_impl(request, context)
+
+    lines = [
+        f"## Update Stock Transfer ({'PREVIEW' if response.is_preview else 'UPDATED'})",
+        f"- **ID**: {response.id}",
+        f"- **Message**: {response.message}",
+    ]
+    if response.stock_transfer_number:
+        lines.append(f"- **Number**: {response.stock_transfer_number}")
+    if response.status:
+        lines.append(f"- **Status**: {response.status}")
+    if response.expected_arrival_date:
+        lines.append(f"- **Expected Arrival**: {response.expected_arrival_date}")
+    if response.next_actions:
+        lines.append("")
+        lines.append("### Next Actions")
+        lines.extend(f"- {action}" for action in response.next_actions)
+
+    return make_simple_result("\n".join(lines), structured_data=response.model_dump())
+
+
+# ============================================================================
+# Tool 4: update_stock_transfer_status
+# ============================================================================
+
+
+class UpdateStockTransferStatusRequest(BaseModel):
+    """Request to transition a stock transfer through the 4-state machine."""
+
+    id: int = Field(..., description="Stock transfer ID")
+    new_status: StatusLiteral = Field(
+        ...,
+        description=(
+            "Target status. Valid transitions are governed by Katana — typical flow "
+            "is PENDING → IN_TRANSIT → COMPLETED. CANCELLED reverses."
+        ),
+    )
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, applies the transition.",
+    )
+
+
+async def _update_stock_transfer_status_impl(
+    request: UpdateStockTransferStatusRequest, context: Context
+) -> StockTransferResponse:
+    """Implementation of update_stock_transfer_status tool."""
+    preview_message = (
+        f"Preview: Transition stock transfer {request.id} to status "
+        f"{request.new_status}"
+    )
+
+    if not request.confirm:
+        return StockTransferResponse(
+            id=request.id,
+            status=request.new_status,
+            is_preview=True,
+            next_actions=[
+                "Review the transition",
+                "Set confirm=true to apply the status change",
+            ],
+            message=preview_message,
+        )
+
+    confirmation = await require_confirmation(
+        context,
+        f"Transition stock transfer {request.id} to {request.new_status}?",
+    )
+    if confirmation != ConfirmationResult.CONFIRMED:
+        logger.info(
+            f"User did not confirm status change of stock transfer {request.id}"
+        )
+        return StockTransferResponse(
+            id=request.id,
+            status=request.new_status,
+            is_preview=True,
+            message=f"Stock transfer status change {confirmation} by user",
+            next_actions=["Review the transition and try again with confirm=true"],
+        )
+
+    services = get_services(context)
+    api_request = APIUpdateStockTransferStatusRequest(
+        status=_status_literal_to_enum(request.new_status),
+    )
+
+    from katana_public_api_client.api.stock_transfer import update_stock_transfer_status
+
+    try:
+        response = await update_stock_transfer_status.asyncio_detailed(
+            id=request.id, client=services.client, body=api_request
+        )
+        transfer = unwrap_as(response, StockTransfer)
+    except APIError as e:
+        # Katana rejects invalid state transitions (e.g. COMPLETED → IN_TRANSIT)
+        # with a typed error. Re-raise as ValueError so the tool surfaces a
+        # clean, caller-actionable message.
+        logger.warning(
+            f"Invalid stock transfer status transition for ID {request.id}: {e}"
+        )
+        raise ValueError(
+            f"Failed to transition stock transfer {request.id} to "
+            f"{request.new_status}: {e}"
+        ) from e
+
+    logger.info(
+        f"Transitioned stock transfer {transfer.id} to status "
+        f"{enum_to_str(unwrap_unset(transfer.status, None))}"
+    )
+
+    result = _transfer_to_response(
+        transfer,
+        message=(
+            f"Successfully transitioned stock transfer {transfer.id} to "
+            f"{request.new_status}"
+        ),
+    )
+    result.next_actions = [
+        f"Stock transfer {transfer.id} now in status {request.new_status}"
+    ]
+    return result
+
+
+@observe_tool
+@unpack_pydantic_params
+async def update_stock_transfer_status(
+    request: Annotated[UpdateStockTransferStatusRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Transition a stock transfer through the 4-state machine.
+
+    Two-step flow: confirm=false to preview, confirm=true to apply. The four
+    valid states are PENDING, IN_TRANSIT, COMPLETED, CANCELLED. Katana rejects
+    invalid transitions (e.g. COMPLETED → IN_TRANSIT); the tool surfaces the
+    API error message as a ValueError.
+    """
+    response = await _update_stock_transfer_status_impl(request, context)
+
+    lines = [
+        f"## Stock Transfer Status ({'PREVIEW' if response.is_preview else 'UPDATED'})",
+        f"- **ID**: {response.id}",
+        f"- **Status**: {response.status}",
+        f"- **Message**: {response.message}",
+    ]
+    if response.next_actions:
+        lines.append("")
+        lines.append("### Next Actions")
+        lines.extend(f"- {action}" for action in response.next_actions)
+
+    return make_simple_result("\n".join(lines), structured_data=response.model_dump())
+
+
+# ============================================================================
+# Tool 5: delete_stock_transfer
+# ============================================================================
+
+
+class DeleteStockTransferRequest(BaseModel):
+    """Request to delete a stock transfer."""
+
+    id: int = Field(..., description="Stock transfer ID to delete")
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, deletes the transfer.",
+    )
+
+
+class DeleteStockTransferResponse(BaseModel):
+    """Response from a stock transfer delete operation."""
+
+    id: int
+    is_preview: bool
+    next_actions: list[str] = Field(default_factory=list)
+    message: str
+
+
+async def _delete_stock_transfer_impl(
+    request: DeleteStockTransferRequest, context: Context
+) -> DeleteStockTransferResponse:
+    """Implementation of delete_stock_transfer tool."""
+    preview_message = f"Preview: Delete stock transfer {request.id}"
+
+    if not request.confirm:
+        return DeleteStockTransferResponse(
+            id=request.id,
+            is_preview=True,
+            next_actions=[
+                "Review the deletion",
+                "Set confirm=true to delete the stock transfer",
+            ],
+            message=preview_message,
+        )
+
+    confirmation = await require_confirmation(
+        context, f"Delete stock transfer {request.id}? This action is destructive."
+    )
+    if confirmation != ConfirmationResult.CONFIRMED:
+        logger.info(f"User did not confirm deletion of stock transfer {request.id}")
+        return DeleteStockTransferResponse(
+            id=request.id,
+            is_preview=True,
+            message=f"Stock transfer deletion {confirmation} by user",
+            next_actions=["Review the deletion and try again with confirm=true"],
+        )
+
+    services = get_services(context)
+    from katana_public_api_client.api.stock_transfer import delete_stock_transfer
+
+    response = await delete_stock_transfer.asyncio_detailed(
+        id=request.id, client=services.client
+    )
+    if not is_success(response):
+        unwrap(response)
+
+    logger.info(f"Deleted stock transfer ID {request.id}")
+    return DeleteStockTransferResponse(
+        id=request.id,
+        is_preview=False,
+        message=f"Successfully deleted stock transfer {request.id}",
+        next_actions=[f"Stock transfer {request.id} has been deleted"],
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def delete_stock_transfer(
+    request: Annotated[DeleteStockTransferRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Delete a stock transfer.
+
+    Two-step flow: confirm=false to preview, confirm=true to delete (prompts
+    for confirmation). Destructive — the transfer record is removed.
+    """
+    response = await _delete_stock_transfer_impl(request, context)
+
+    lines = [
+        f"## Delete Stock Transfer ({'PREVIEW' if response.is_preview else 'DELETED'})",
+        f"- **ID**: {response.id}",
+        f"- **Message**: {response.message}",
+    ]
+    if response.next_actions:
+        lines.append("")
+        lines.append("### Next Actions")
+        lines.extend(f"- {action}" for action in response.next_actions)
+
+    return make_simple_result("\n".join(lines), structured_data=response.model_dump())
+
+
+# ============================================================================
+# Registration
+# ============================================================================
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register all stock-transfer tools with the FastMCP instance.
+
+    Args:
+        mcp: FastMCP server instance to register tools with
+    """
+    from mcp.types import ToolAnnotations
+
+    _read = ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+    _write = ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, openWorldHint=True
+    )
+    _destructive = ToolAnnotations(
+        readOnlyHint=False, destructiveHint=True, openWorldHint=True
+    )
+
+    mcp.tool(tags={"inventory", "stock_transfer", "write"}, annotations=_write)(
+        create_stock_transfer
+    )
+    mcp.tool(tags={"inventory", "stock_transfer", "read"}, annotations=_read)(
+        list_stock_transfers
+    )
+    mcp.tool(tags={"inventory", "stock_transfer", "write"}, annotations=_write)(
+        update_stock_transfer
+    )
+    mcp.tool(tags={"inventory", "stock_transfer", "write"}, annotations=_write)(
+        update_stock_transfer_status
+    )
+    mcp.tool(tags={"inventory", "stock_transfer", "write"}, annotations=_destructive)(
+        delete_stock_transfer
+    )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -186,9 +186,15 @@ def _build_summary(transfer: Any, *, include_rows: bool) -> StockTransferSummary
 
 
 def _parse_iso_datetime(value: str, field_name: str) -> datetime:
-    """Parse an ISO-8601 datetime string, raising ValueError with a clear message."""
+    """Parse an ISO-8601 datetime string, raising ValueError with a clear message.
+
+    Normalizes trailing ``Z`` (UTC) to ``+00:00`` before parsing — ``datetime.
+    fromisoformat`` only accepts the offset form in Python < 3.11 and still is
+    strict about ``Z`` in older APIs/clients.
+    """
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
     try:
-        return datetime.fromisoformat(value)
+        return datetime.fromisoformat(normalized)
     except ValueError as e:
         raise ValueError(
             f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
@@ -452,6 +458,7 @@ class ListStockTransfersRequest(BaseModel):
     )
     page: int | None = Field(
         default=None,
+        ge=1,
         description="Page number (1-based). When set, disables auto-pagination; use with `limit` as page size.",
     )
 

--- a/katana_mcp_server/tests/tools/test_stock_transfers.py
+++ b/katana_mcp_server/tests/tools/test_stock_transfers.py
@@ -1,0 +1,674 @@
+"""Tests for stock transfer MCP tools (issue #338).
+
+Covers the full five-tool surface:
+- create_stock_transfer (preview + confirm)
+- list_stock_transfers (list-tool pattern v2 — limit, page, dates, filters)
+- update_stock_transfer (preview + confirm)
+- update_stock_transfer_status (preview + confirm + invalid-transition error)
+- delete_stock_transfer (preview + confirm)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from katana_mcp.tools.foundation.stock_transfers import (
+    CreateStockTransferRequest,
+    DeleteStockTransferRequest,
+    ListStockTransfersRequest,
+    StockTransferBatchTransactionInput,
+    StockTransferRowInput,
+    UpdateStockTransferRequest,
+    UpdateStockTransferStatusRequest,
+    _create_stock_transfer_impl,
+    _delete_stock_transfer_impl,
+    _list_stock_transfers_impl,
+    _update_stock_transfer_impl,
+    _update_stock_transfer_status_impl,
+)
+
+from katana_public_api_client.client_types import UNSET
+from katana_public_api_client.utils import APIError
+from tests.conftest import create_mock_context
+
+_ST_CREATE = "katana_public_api_client.api.stock_transfer.create_stock_transfer"
+_ST_LIST = "katana_public_api_client.api.stock_transfer.get_all_stock_transfers"
+_ST_UPDATE = "katana_public_api_client.api.stock_transfer.update_stock_transfer"
+_ST_UPDATE_STATUS = (
+    "katana_public_api_client.api.stock_transfer.update_stock_transfer_status"
+)
+_ST_DELETE = "katana_public_api_client.api.stock_transfer.delete_stock_transfer"
+
+_ST_UNWRAP_AS = "katana_mcp.tools.foundation.stock_transfers.unwrap_as"
+_ST_UNWRAP_DATA = "katana_public_api_client.utils.unwrap_data"
+_ST_IS_SUCCESS = "katana_mcp.tools.foundation.stock_transfers.is_success"
+
+
+# ============================================================================
+# Test helpers
+# ============================================================================
+
+
+def _make_mock_transfer(
+    *,
+    id: int = 1,
+    stock_transfer_number: str | None = "ST-1",
+    source_location_id: int = 1,
+    target_location_id: int = 2,
+    status: str = "pending",
+    transfer_date: datetime | None = None,
+    expected_arrival_date: datetime | None = None,
+    created_at: datetime | None = None,
+    rows: list | None = None,
+) -> MagicMock:
+    """Build a mock StockTransfer attrs object for tests."""
+    t = MagicMock()
+    t.id = id
+    t.stock_transfer_number = stock_transfer_number if stock_transfer_number else UNSET
+    t.source_location_id = source_location_id
+    t.target_location_id = target_location_id
+    t.status = status
+    t.transfer_date = transfer_date if transfer_date is not None else UNSET
+    t.expected_arrival_date = (
+        expected_arrival_date if expected_arrival_date is not None else UNSET
+    )
+    t.created_at = created_at if created_at is not None else UNSET
+    t.stock_transfer_rows = rows if rows is not None else UNSET
+    t.additional_info = UNSET
+    return t
+
+
+def _make_mock_row(
+    *,
+    id: int = 1,
+    variant_id: int = 100,
+    quantity: float = 5,
+    cost_per_unit: float | None = None,
+    batch_transactions: list | None = None,
+) -> MagicMock:
+    r = MagicMock()
+    r.id = id
+    r.variant_id = variant_id
+    r.quantity = quantity
+    r.cost_per_unit = cost_per_unit if cost_per_unit is not None else UNSET
+    r.batch_transactions = (
+        batch_transactions if batch_transactions is not None else UNSET
+    )
+    return r
+
+
+# ============================================================================
+# create_stock_transfer
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_create_stock_transfer_preview():
+    """Preview returns is_preview=True and does not call API."""
+    context, _ = create_mock_context()
+
+    request = CreateStockTransferRequest(
+        source_location_id=1,
+        destination_location_id=2,
+        expected_arrival_date=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        rows=[StockTransferRowInput(variant_id=100, quantity=5)],
+        order_no="ST-PREVIEW-1",
+        confirm=False,
+    )
+    result = await _create_stock_transfer_impl(request, context)
+
+    assert result.is_preview is True
+    assert result.source_location_id == 1
+    assert result.target_location_id == 2
+    assert result.stock_transfer_number == "ST-PREVIEW-1"
+    assert result.id is None
+    assert "Preview" in result.message
+    assert len(result.next_actions) > 0
+
+
+@pytest.mark.asyncio
+async def test_create_stock_transfer_confirm_success():
+    """confirm=True builds the request and returns the created transfer."""
+    context, _ = create_mock_context()
+
+    mock_transfer = _make_mock_transfer(
+        id=42,
+        stock_transfer_number="ST-42",
+        source_location_id=1,
+        target_location_id=2,
+        status="pending",
+        expected_arrival_date=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+    )
+
+    with (
+        patch(f"{_ST_CREATE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_ST_UNWRAP_AS, return_value=mock_transfer),
+    ):
+        request = CreateStockTransferRequest(
+            source_location_id=1,
+            destination_location_id=2,
+            expected_arrival_date=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+            rows=[
+                StockTransferRowInput(
+                    variant_id=100,
+                    quantity=5,
+                    batch_transactions=[
+                        StockTransferBatchTransactionInput(batch_id=77, quantity=5)
+                    ],
+                )
+            ],
+            confirm=True,
+        )
+        result = await _create_stock_transfer_impl(request, context)
+
+    assert result.is_preview is False
+    assert result.id == 42
+    assert result.stock_transfer_number == "ST-42"
+    assert result.status == "pending"
+
+    # Verify API was called
+    mock_api.assert_awaited_once()
+    call_body = mock_api.await_args.kwargs["body"]
+    assert call_body.source_location_id == 1
+    assert call_body.target_location_id == 2
+    # Batch transactions should serialize into the row body
+    row_dict = call_body.stock_transfer_rows[0].to_dict()
+    assert "batch_transactions" in row_dict
+    assert row_dict["batch_transactions"] == [{"batch_id": 77, "quantity": 5}]
+
+
+@pytest.mark.asyncio
+async def test_create_stock_transfer_user_declines():
+    """When user declines elicitation, no API call happens; preview returned."""
+    context, _ = create_mock_context(elicit_confirm=False)
+
+    request = CreateStockTransferRequest(
+        source_location_id=1,
+        destination_location_id=2,
+        expected_arrival_date=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        rows=[StockTransferRowInput(variant_id=100, quantity=5)],
+        confirm=True,
+    )
+
+    with patch(f"{_ST_CREATE}.asyncio_detailed", new_callable=AsyncMock) as mock_api:
+        result = await _create_stock_transfer_impl(request, context)
+
+    assert result.is_preview is True
+    assert result.id is None
+    assert "cancelled" in result.message.lower()
+    mock_api.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_stock_transfer_rejects_empty_rows():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CreateStockTransferRequest(
+            source_location_id=1,
+            destination_location_id=2,
+            expected_arrival_date=datetime(2026, 5, 1, tzinfo=UTC),
+            rows=[],
+            confirm=False,
+        )
+
+
+# ============================================================================
+# list_stock_transfers — pattern v2
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_page_short_circuit_single_page():
+    """limit <= 250 (and no explicit page) adds page=1 to disable auto-pagination."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_ST_LIST}.asyncio_detailed", side_effect=fake),
+        patch(_ST_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_transfers_impl(ListStockTransfersRequest(limit=10), context)
+
+    assert captured["page"] == 1
+    assert captured["limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_caller_page_preserved():
+    """An explicit page overrides the short-circuit."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_ST_LIST}.asyncio_detailed", side_effect=fake),
+        patch(_ST_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_transfers_impl(
+            ListStockTransfersRequest(limit=50, page=3), context
+        )
+
+    assert captured["page"] == 3
+    assert captured["limit"] == 50
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_large_limit_omits_page():
+    """limit > 250 lets auto-pagination drive."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_ST_LIST}.asyncio_detailed", side_effect=fake),
+        patch(_ST_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_transfers_impl(ListStockTransfersRequest(limit=500), context)
+
+    assert "page" not in captured
+    assert captured["limit"] == 500
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_caps_results_to_request_limit():
+    """Safety net: even if transport returns more rows than limit, slice them."""
+    context, _ = create_mock_context()
+
+    over_fetched = [
+        _make_mock_transfer(id=i, stock_transfer_number=f"ST-{i}") for i in range(100)
+    ]
+
+    with (
+        patch(f"{_ST_LIST}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_ST_UNWRAP_DATA, return_value=over_fetched),
+    ):
+        result = await _list_stock_transfers_impl(
+            ListStockTransfersRequest(limit=25), context
+        )
+
+    assert len(result.transfers) == 25
+    assert result.total_count == 25
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_date_filters_passed_through():
+    """created_after / created_before forward as created_at_min / created_at_max datetimes."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_ST_LIST}.asyncio_detailed", side_effect=fake),
+        patch(_ST_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_transfers_impl(
+            ListStockTransfersRequest(
+                created_after="2026-01-01T00:00:00+00:00",
+                created_before="2026-04-01T00:00:00+00:00",
+            ),
+            context,
+        )
+
+    assert isinstance(captured["created_at_min"], datetime)
+    assert isinstance(captured["created_at_max"], datetime)
+    assert captured["created_at_min"].year == 2026
+    assert captured["created_at_max"].month == 4
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_invalid_date_raises():
+    """Malformed ISO-8601 date is surfaced as ValueError."""
+    context, _ = create_mock_context()
+
+    with (
+        patch(f"{_ST_LIST}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_ST_UNWRAP_DATA, return_value=[]),
+        pytest.raises(ValueError, match="Invalid ISO-8601"),
+    ):
+        await _list_stock_transfers_impl(
+            ListStockTransfersRequest(created_after="not-a-date"), context
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_status_filter_client_side():
+    """status filter is applied client-side (Katana endpoint has no server filter)."""
+    context, _ = create_mock_context()
+
+    transfers = [
+        _make_mock_transfer(id=1, status="pending"),
+        _make_mock_transfer(id=2, status="in_transit"),
+        _make_mock_transfer(id=3, status="completed"),
+    ]
+
+    with (
+        patch(f"{_ST_LIST}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_ST_UNWRAP_DATA, return_value=transfers),
+    ):
+        result = await _list_stock_transfers_impl(
+            ListStockTransfersRequest(status="IN_TRANSIT"), context
+        )
+
+    assert result.total_count == 1
+    assert result.transfers[0].id == 2
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_location_filters_passed_through():
+    """source/destination filters forward to API kwargs."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_ST_LIST}.asyncio_detailed", side_effect=fake),
+        patch(_ST_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_transfers_impl(
+            ListStockTransfersRequest(source_location_id=5, destination_location_id=9),
+            context,
+        )
+
+    assert captured["source_location_id"] == 5
+    assert captured["target_location_id"] == 9
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_include_rows_populates_details():
+    """include_rows=True exposes per-transfer row details."""
+    context, _ = create_mock_context()
+
+    mock_transfer = _make_mock_transfer(
+        id=7,
+        rows=[
+            _make_mock_row(id=1, variant_id=100, quantity=5),
+            _make_mock_row(id=2, variant_id=200, quantity=2),
+        ],
+    )
+
+    with (
+        patch(f"{_ST_LIST}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_ST_UNWRAP_DATA, return_value=[mock_transfer]),
+    ):
+        result_with = await _list_stock_transfers_impl(
+            ListStockTransfersRequest(include_rows=True), context
+        )
+        result_without = await _list_stock_transfers_impl(
+            ListStockTransfersRequest(include_rows=False), context
+        )
+
+    assert result_with.transfers[0].rows is not None
+    assert len(result_with.transfers[0].rows) == 2
+    assert result_with.transfers[0].row_count == 2
+    assert result_without.transfers[0].rows is None
+    assert result_without.transfers[0].row_count == 2
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_pagination_meta_when_page_set():
+    """When page is set, parse X-Pagination into PaginationMeta on response."""
+    context, _ = create_mock_context()
+
+    mock_response = MagicMock()
+    mock_response.headers = {
+        "X-Pagination": json.dumps(
+            {"page": 2, "total_pages": 5, "total_items": 120, "per_page": 50}
+        )
+    }
+
+    async def fake(**kwargs):
+        return mock_response
+
+    with (
+        patch(f"{_ST_LIST}.asyncio_detailed", side_effect=fake),
+        patch(_ST_UNWRAP_DATA, return_value=[]),
+    ):
+        result = await _list_stock_transfers_impl(
+            ListStockTransfersRequest(page=2, limit=50), context
+        )
+
+    assert result.pagination is not None
+    assert result.pagination.page == 2
+    assert result.pagination.total_pages == 5
+    assert result.pagination.total_items == 120
+    assert result.pagination.per_page == 50
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_no_pagination_when_page_not_set():
+    """When page is not set, pagination meta stays None."""
+    context, _ = create_mock_context()
+
+    mock_response = MagicMock()
+    mock_response.headers = {"X-Pagination": json.dumps({"page": 1, "total_pages": 1})}
+
+    async def fake(**kwargs):
+        return mock_response
+
+    with (
+        patch(f"{_ST_LIST}.asyncio_detailed", side_effect=fake),
+        patch(_ST_UNWRAP_DATA, return_value=[]),
+    ):
+        result = await _list_stock_transfers_impl(
+            ListStockTransfersRequest(limit=10), context
+        )
+
+    assert result.pagination is None
+
+
+# ============================================================================
+# update_stock_transfer
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_update_stock_transfer_preview():
+    context, _ = create_mock_context()
+
+    request = UpdateStockTransferRequest(
+        id=42,
+        stock_transfer_number="ST-42-revised",
+        additional_info="Updated notes",
+        confirm=False,
+    )
+    result = await _update_stock_transfer_impl(request, context)
+
+    assert result.is_preview is True
+    assert result.id == 42
+    assert "Preview" in result.message
+    assert "stock_transfer_number" in result.message
+
+
+@pytest.mark.asyncio
+async def test_update_stock_transfer_requires_at_least_one_field():
+    context, _ = create_mock_context()
+
+    request = UpdateStockTransferRequest(id=42, confirm=False)
+    with pytest.raises(ValueError, match="At least one field"):
+        await _update_stock_transfer_impl(request, context)
+
+
+@pytest.mark.asyncio
+async def test_update_stock_transfer_confirm_success():
+    context, _ = create_mock_context()
+
+    mock_transfer = _make_mock_transfer(
+        id=42, stock_transfer_number="ST-42-revised", status="pending"
+    )
+
+    with (
+        patch(f"{_ST_UPDATE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_ST_UNWRAP_AS, return_value=mock_transfer),
+    ):
+        request = UpdateStockTransferRequest(
+            id=42, stock_transfer_number="ST-42-revised", confirm=True
+        )
+        result = await _update_stock_transfer_impl(request, context)
+
+    assert result.is_preview is False
+    assert result.id == 42
+    assert result.stock_transfer_number == "ST-42-revised"
+    mock_api.assert_awaited_once()
+    kwargs = mock_api.await_args.kwargs
+    assert kwargs["id"] == 42
+    assert kwargs["body"].stock_transfer_number == "ST-42-revised"
+
+
+# ============================================================================
+# update_stock_transfer_status
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_update_stock_transfer_status_preview():
+    context, _ = create_mock_context()
+
+    request = UpdateStockTransferStatusRequest(
+        id=42, new_status="IN_TRANSIT", confirm=False
+    )
+    result = await _update_stock_transfer_status_impl(request, context)
+
+    assert result.is_preview is True
+    assert result.id == 42
+    assert result.status == "IN_TRANSIT"
+    assert "Preview" in result.message
+
+
+@pytest.mark.asyncio
+async def test_update_stock_transfer_status_confirm_success():
+    context, _ = create_mock_context()
+
+    mock_transfer = _make_mock_transfer(id=42, status="in_transit")
+
+    with (
+        patch(
+            f"{_ST_UPDATE_STATUS}.asyncio_detailed", new_callable=AsyncMock
+        ) as mock_api,
+        patch(_ST_UNWRAP_AS, return_value=mock_transfer),
+    ):
+        request = UpdateStockTransferStatusRequest(
+            id=42, new_status="IN_TRANSIT", confirm=True
+        )
+        result = await _update_stock_transfer_status_impl(request, context)
+
+    assert result.is_preview is False
+    assert result.id == 42
+    assert result.status == "in_transit"
+    mock_api.assert_awaited_once()
+    kwargs = mock_api.await_args.kwargs
+    assert kwargs["id"] == 42
+    # Verify the API status enum was set to "in_transit"
+    assert kwargs["body"].status.value == "in_transit"
+
+
+@pytest.mark.asyncio
+async def test_update_stock_transfer_status_invalid_transition_surfaces_error():
+    """APIError from invalid transition is surfaced as ValueError with message."""
+    context, _ = create_mock_context()
+
+    api_error = APIError("Cannot transition from COMPLETED to IN_TRANSIT", 400)
+
+    with (
+        patch(f"{_ST_UPDATE_STATUS}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_ST_UNWRAP_AS, side_effect=api_error),
+    ):
+        request = UpdateStockTransferStatusRequest(
+            id=42, new_status="IN_TRANSIT", confirm=True
+        )
+        with pytest.raises(ValueError, match="Cannot transition"):
+            await _update_stock_transfer_status_impl(request, context)
+
+
+@pytest.mark.asyncio
+async def test_update_stock_transfer_status_user_declines():
+    """Declined elicitation — no API call, preview returned."""
+    context, _ = create_mock_context(elicit_confirm=False)
+
+    with patch(
+        f"{_ST_UPDATE_STATUS}.asyncio_detailed", new_callable=AsyncMock
+    ) as mock_api:
+        request = UpdateStockTransferStatusRequest(
+            id=42, new_status="CANCELLED", confirm=True
+        )
+        result = await _update_stock_transfer_status_impl(request, context)
+
+    assert result.is_preview is True
+    assert "cancelled" in result.message.lower()
+    mock_api.assert_not_awaited()
+
+
+# ============================================================================
+# delete_stock_transfer
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_stock_transfer_preview():
+    context, _ = create_mock_context()
+
+    request = DeleteStockTransferRequest(id=42, confirm=False)
+    result = await _delete_stock_transfer_impl(request, context)
+
+    assert result.is_preview is True
+    assert result.id == 42
+    assert "Preview" in result.message
+
+
+@pytest.mark.asyncio
+async def test_delete_stock_transfer_confirm_success():
+    context, _ = create_mock_context()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 204
+    mock_response.parsed = None
+
+    with (
+        patch(
+            f"{_ST_DELETE}.asyncio_detailed",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_api,
+        patch(_ST_IS_SUCCESS, return_value=True),
+    ):
+        request = DeleteStockTransferRequest(id=42, confirm=True)
+        result = await _delete_stock_transfer_impl(request, context)
+
+    assert result.is_preview is False
+    assert result.id == 42
+    assert "deleted" in result.message.lower()
+    mock_api.assert_awaited_once()
+    kwargs = mock_api.await_args.kwargs
+    assert kwargs["id"] == 42
+
+
+@pytest.mark.asyncio
+async def test_delete_stock_transfer_user_declines():
+    context, _ = create_mock_context(elicit_confirm=False)
+
+    with patch(f"{_ST_DELETE}.asyncio_detailed", new_callable=AsyncMock) as mock_api:
+        request = DeleteStockTransferRequest(id=42, confirm=True)
+        result = await _delete_stock_transfer_impl(request, context)
+
+    assert result.is_preview is True
+    assert "cancelled" in result.message.lower()
+    mock_api.assert_not_awaited()


### PR DESCRIPTION
## Description

Adds five MCP tools in a new `katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py` module, covering the full stock-transfer lifecycle. Fills the gap where moving inventory between locations was previously browser-only.

- **create_stock_transfer** — preview/confirm create with batch-tracked-variant support (`batch_transactions` on rows)
- **list_stock_transfers** — follows **list-tool pattern v2** (ge=1 limit, `page`/`PaginationMeta`, date filters, status filter, `include_rows`)
- **update_stock_transfer** — preview/confirm body update (number, dates, notes)
- **update_stock_transfer_status** — preview/confirm 4-state transition (PENDING / IN_TRANSIT / COMPLETED / CANCELLED); invalid transitions surface a clean `ValueError` from the API error message
- **delete_stock_transfer** — preview/confirm delete (destructive annotation)

Tools are registered at the **end** of `foundation/__init__.py` (parallel-agent-safe append). `resources/help.py` gains a stock-transfer section with per-tool parameter reference + a line in the capability overview. A new pattern-v2 `PaginationMeta` lives alongside the tools (local to this module for now; plan phase-2 can promote it once sibling agents settle).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing

- [x] 25 new unit tests in `katana_mcp_server/tests/tools/test_stock_transfers.py` cover: preview/confirm for all 5 tools, list-tool pattern v2 (limit cap, page short-circuit, caller-set page preserved, `include_rows`, client-side status filter, date filter pass-through, invalid ISO date, PaginationMeta parsing), batch-transaction serialization, user-declines elicitation, and invalid-transition `APIError` → `ValueError` translation.
- [x] `uv run poe check` — clean (2298 passed, 3 skipped, 0 failed).

## Test Plan

- [ ] Live `create_stock_transfer` between two real locations
- [ ] Live `update_stock_transfer_status` walking PENDING → IN_TRANSIT → COMPLETED
- [ ] Live `list_stock_transfers(status="IN_TRANSIT", source_location_id=N)` returns only matching transfers in one call
- [ ] Live `update_stock_transfer_status(id=X, new_status="IN_TRANSIT")` against a COMPLETED transfer surfaces a readable error

## Related Issues

Fixes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)