### PR TITLE
feat(mcp): add aggregation/reporting tools

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -74,6 +74,18 @@ All create/modify operations use a **two-step confirmation**:
 4. **Create production**: search_items → create_manufacturing_order
 
 Use `katana://help/workflows` for detailed step-by-step guides.
+
+## Reporting & Analytics
+
+Aggregation tools compute rollups in one MCP call instead of paginating
+through hundreds of sales orders client-side. All read-only, no `confirm`.
+
+- **top_selling_variants** — top-N variants by units or revenue over a
+  date window. Filters: category, location.
+- **sales_summary** — group sales by day/week/month, variant, customer,
+  or category over a window.
+- **inventory_velocity** — units sold, avg-daily, stock-on-hand, and
+  days-of-cover for a single SKU or variant.
 """
 
 HELP_WORKFLOWS = """
@@ -245,6 +257,51 @@ Detailed step-by-step guides for common manufacturing ERP workflows.
    Request: {"sku": "WIDGET-001"}
    ```
    Returns current stock levels and availability.
+
+---
+
+## Workflow 6: Sales Analytics & Velocity
+
+**Goal:** Answer analytical questions ("top sellers", "sales by month", "how
+fast is this SKU moving?") in a single tool call instead of paginating
+through hundreds of orders.
+
+### Steps
+
+1. **Find top sellers for a category and period**
+   ```json
+   Tool: top_selling_variants
+   Request: {
+     "start_date": "2026-01-22",
+     "end_date": "2026-04-22",
+     "limit": 20,
+     "category": "bikes",
+     "order_by": "units"
+   }
+   ```
+   Returns the top 20 SKUs in the `bikes` category by units sold over the
+   last 90 days. Substitute `order_by="revenue"` to sort by dollar volume.
+
+2. **Group sales by time or dimension**
+   ```json
+   Tool: sales_summary
+   Request: {
+     "start_date": "2026-01-01",
+     "end_date": "2026-03-31",
+     "group_by": "month"
+   }
+   ```
+   Supports `group_by` of `day`, `week` (ISO weeks), `month`, `variant`,
+   `customer`, or `category`.
+
+3. **Check velocity and days-of-cover for a SKU**
+   ```json
+   Tool: inventory_velocity
+   Request: {"sku_or_variant_id": "BIKE-MTB-01", "period_days": 90}
+   ```
+   Returns `units_sold`, `avg_daily`, `stock_on_hand`, and `days_of_cover`.
+   Use to decide when to reorder. `days_of_cover` is `null` when there
+   have been no sales in the window (can't project).
 """
 
 HELP_TOOLS = """
@@ -645,6 +702,53 @@ Delete a stock transfer.
 - `confirm` (optional, default false): false=preview, true=delete
 
 Destructive — removes the transfer record.
+
+---
+
+## Reporting & Analytics Tools
+
+### top_selling_variants
+Top-selling variants over a date window (single call; auto-paginates and
+aggregates DELIVERED sales orders in memory).
+
+**Parameters:**
+- `start_date` (required): ISO-8601 date — window start (inclusive)
+- `end_date` (required): ISO-8601 date — window end (inclusive)
+- `limit` (optional, default 20, min 1): Max rows to return
+- `category` (optional): Item category name to filter by (e.g. "bikes")
+- `order_by` (optional, default "units"): "units" or "revenue"
+- `location_id` (optional): Filter to a single location
+
+**Returns:** List of `{sku, variant_id, name, units, revenue, order_count}`
+sorted by the `order_by` key descending.
+
+---
+
+### sales_summary
+Grouped sales totals for DELIVERED orders in a window.
+
+**Parameters:**
+- `start_date` (required): ISO-8601 date — window start (inclusive)
+- `end_date` (required): ISO-8601 date — window end (inclusive)
+- `group_by` (required): one of `day`, `week`, `month`, `variant`,
+  `customer`, `category`
+
+**Returns:** List of `{group, units, revenue, order_count}`. Time groups
+(`day`/`week`/`month`) sort ascending; dimension groups sort by revenue
+descending.
+
+---
+
+### inventory_velocity
+Velocity stats and days-of-cover for a single SKU or variant.
+
+**Parameters:**
+- `sku_or_variant_id` (required): SKU (string) or variant_id (int)
+- `period_days` (optional, default 90, max 365): Rolling window size
+
+**Returns:** `{sku, variant_id, units_sold, avg_daily, stock_on_hand,
+days_of_cover, period_days, window_start, window_end}`. `days_of_cover`
+is `null` when `avg_daily` is 0 (no sales in window).
 """
 
 HELP_RESOURCES = """

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/__init__.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/__init__.py
@@ -23,6 +23,7 @@ from .items import register_tools as register_items_tools
 from .manufacturing_orders import register_tools as register_manufacturing_order_tools
 from .orders import register_tools as register_order_tools
 from .purchase_orders import register_tools as register_purchase_order_tools
+from .reporting import register_tools as register_reporting_tools
 from .sales_orders import register_tools as register_sales_order_tools
 from .stock_transfers import register_tools as register_stock_transfer_tools
 
@@ -42,6 +43,7 @@ def register_all_foundation_tools(mcp: FastMCP) -> None:
     register_manufacturing_order_tools(mcp)
     register_order_tools(mcp)
     register_stock_transfer_tools(mcp)
+    register_reporting_tools(mcp)
 
 
 __all__ = [

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -1,0 +1,793 @@
+"""Reporting and aggregation tools for Katana MCP Server.
+
+Read-only aggregation tools that compute rollups client-side from paginated
+sales-order data. These exist to replace multi-call analytical workflows
+(e.g. "top 20 selling bikes over the last 90 days") with a single tool call.
+
+Tools:
+- top_selling_variants: top-N variants by units or revenue over a date window
+- sales_summary: group sales in a window by day/week/month/variant/customer/category
+- inventory_velocity: units_sold, avg_daily, stock_on_hand, days_of_cover for a SKU
+
+**Implementation notes:**
+
+- All three tools call ``get_all_sales_orders.asyncio_detailed()`` with
+  ``status="DELIVERED"``. The transport's PaginationTransport auto-paginates
+  and materializes the full result set in memory — no streaming iterator
+  exists today. For very large windows (100k+ SOs) this may be slow; accept
+  the cost and flag to the user if they hit it.
+- Date filtering is applied server-side via ``created_at_min`` /
+  ``created_at_max`` (Katana's supported params on /sales_orders). The window
+  semantics are "order was created within [start, end]".
+- Variant → category lookup is cached per tool call in a local dict to avoid
+  N+1 API calls across many sales-order rows.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from datetime import UTC, date, datetime, timedelta
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context, FastMCP
+from fastmcp.tools import ToolResult
+from pydantic import BaseModel, Field
+
+from katana_mcp.logging import get_logger, observe_tool
+from katana_mcp.services import get_services
+from katana_mcp.tools.tool_result_utils import (
+    format_md_table,
+    make_simple_result,
+)
+from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_public_api_client.api.inventory import get_all_inventory_point
+from katana_public_api_client.api.sales_order import get_all_sales_orders
+from katana_public_api_client.domain.converters import unwrap_unset
+from katana_public_api_client.utils import unwrap_data
+
+logger = get_logger(__name__)
+
+
+# ============================================================================
+# Shared helpers
+# ============================================================================
+
+
+def _to_datetime(d: date | str) -> datetime:
+    """Normalize a ``date`` or ISO-8601 string to a UTC ``datetime``.
+
+    For bare dates we anchor at 00:00 UTC; callers generally pass ``date``
+    objects, but Pydantic may hand us a string when the JSON caller sends one.
+    """
+    if isinstance(d, datetime):
+        if d.tzinfo is None:
+            return d.replace(tzinfo=UTC)
+        return d
+    if isinstance(d, date):
+        return datetime(d.year, d.month, d.day, tzinfo=UTC)
+    # string
+    parsed = datetime.fromisoformat(str(d).replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _end_of_day(d: date | str) -> datetime:
+    """End-of-day UTC for an inclusive upper bound."""
+    base = _to_datetime(d)
+    # If caller passed a plain date we want inclusive end-of-day; if they
+    # passed a datetime we honor the exact timestamp.
+    if isinstance(d, datetime) or (isinstance(d, str) and "T" in str(d)):
+        return base
+    return base + timedelta(days=1) - timedelta(microseconds=1)
+
+
+async def _fetch_delivered_sales_orders_in_window(
+    services: Any,
+    start: date | str,
+    end: date | str,
+    *,
+    location_id: int | None = None,
+) -> list[Any]:
+    """Fetch all DELIVERED sales orders whose ``created_at`` falls in the window.
+
+    Auto-paginates via PaginationTransport. Applies a client-side fallback
+    filter in case the server's ``created_at_min`` / ``created_at_max`` are
+    not honored on every deployment.
+    """
+    start_dt = _to_datetime(start)
+    end_dt = _end_of_day(end)
+
+    kwargs: dict[str, Any] = {
+        "client": services.client,
+        "status": "DELIVERED",
+        "limit": 250,  # max page size; auto-pagination walks all pages
+        "created_at_min": start_dt,
+        "created_at_max": end_dt,
+    }
+    if location_id is not None:
+        kwargs["location_id"] = location_id
+
+    response = await get_all_sales_orders.asyncio_detailed(**kwargs)
+    attrs_list = unwrap_data(response, default=[])
+
+    # Client-side safety filter — drop rows outside the window in case the
+    # server-side filter was ignored by this tenant / endpoint.
+    filtered: list[Any] = []
+    for so in attrs_list:
+        created_at = unwrap_unset(so.created_at, None)
+        if created_at is None:
+            # No timestamp — we can't verify, include by default.
+            filtered.append(so)
+            continue
+        if isinstance(created_at, datetime):
+            ts = created_at if created_at.tzinfo else created_at.replace(tzinfo=UTC)
+            if start_dt <= ts <= end_dt:
+                filtered.append(so)
+        else:
+            filtered.append(so)
+
+    return filtered
+
+
+async def _resolve_variant_info(
+    services: Any,
+    variant_id: int,
+    variant_cache: dict[int, dict[str, Any]],
+    category_cache: dict[int, str | None],
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Resolve variant dict and its item-category, caching both.
+
+    Returns ``(variant_dict, category_name)``. Both may be None if lookups
+    miss (cache-only path; we do not fall back to API to keep aggregation
+    calls bounded — unknown variants are still counted in aggregates, just
+    without SKU/name/category enrichment).
+    """
+    variant = variant_cache.get(variant_id)
+    if variant is None:
+        from katana_mcp.cache import EntityType
+
+        variant = await services.cache.get_by_id(EntityType.VARIANT, variant_id)
+        variant_cache[variant_id] = variant or {}
+
+    if not variant:
+        return None, None
+
+    product_id = variant.get("product_id")
+    if product_id is None:
+        return variant, None
+
+    category = category_cache.get(product_id)
+    if category is not None or product_id in category_cache:
+        return variant, category
+
+    # Try product → then material → then service for category_name. The
+    # variant dict alone doesn't tell us which one, so we try in order and
+    # stop at the first hit.
+    category = await _fetch_category_for_product(services, product_id)
+    category_cache[product_id] = category
+    return variant, category
+
+
+async def _fetch_category_for_product(services: Any, product_id: int) -> str | None:
+    """Look up the category_name for a given product/material/service ID.
+
+    Tries product first, then material, then service. Returns None if none
+    match or category is unset.
+    """
+    from katana_public_api_client.api.material import get_material
+    from katana_public_api_client.api.product import get_product
+    from katana_public_api_client.api.services import get_service
+    from katana_public_api_client.models import ErrorResponse
+    from katana_public_api_client.utils import unwrap
+
+    for fetcher in (
+        get_product.asyncio_detailed,
+        get_material.asyncio_detailed,
+        get_service.asyncio_detailed,
+    ):
+        try:
+            response = await fetcher(id=product_id, client=services.client)
+        except Exception:
+            continue
+        obj = unwrap(response, raise_on_error=False)
+        if obj is None or isinstance(obj, ErrorResponse):
+            continue
+        cat = unwrap_unset(getattr(obj, "category_name", None), None)
+        if cat is not None:
+            return cat
+        # Found a matching record but no category — stop here.
+        return None
+    return None
+
+
+def _iter_rows(so: Any) -> Iterable[Any]:
+    """Yield sales-order rows, handling the UNSET sentinel."""
+    return unwrap_unset(so.sales_order_rows, [])
+
+
+def _row_revenue(row: Any) -> float:
+    """Revenue contribution for a single sales-order row."""
+    qty = unwrap_unset(row.quantity, 0) or 0
+    price = unwrap_unset(row.price_per_unit, 0) or 0
+    total_discount = unwrap_unset(getattr(row, "total_discount", None), 0) or 0
+    return float(qty) * float(price) - float(total_discount)
+
+
+# ============================================================================
+# Tool 1: top_selling_variants
+# ============================================================================
+
+
+class TopSellingVariantsRequest(BaseModel):
+    """Request for top-selling variants over a date window."""
+
+    start_date: date = Field(
+        ..., description="Start of the window (inclusive, ISO-8601 date)"
+    )
+    end_date: date = Field(
+        ..., description="End of the window (inclusive, ISO-8601 date)"
+    )
+    limit: int = Field(
+        default=20,
+        ge=1,
+        description="Maximum number of variants to return (default 20, min 1)",
+    )
+    category: str | None = Field(
+        default=None,
+        description="Optional item category name to filter by (e.g. 'bikes')",
+    )
+    order_by: Literal["units", "revenue"] = Field(
+        default="units",
+        description="Sort key: 'units' (quantity sold) or 'revenue' (dollar volume)",
+    )
+    location_id: int | None = Field(
+        default=None, description="Optional location ID to filter by"
+    )
+
+
+class VariantSalesRow(BaseModel):
+    """Per-variant sales aggregate row."""
+
+    sku: str | None
+    variant_id: int
+    name: str | None
+    units: float
+    revenue: float
+    order_count: int
+
+
+class TopSellingVariantsResponse(BaseModel):
+    """Response for top_selling_variants."""
+
+    rows: list[VariantSalesRow]
+    total_variants: int
+    window_start: str
+    window_end: str
+
+
+async def _top_selling_variants_impl(
+    request: TopSellingVariantsRequest, context: Context
+) -> TopSellingVariantsResponse:
+    """Compute top-selling variants from DELIVERED sales orders in the window."""
+    services = get_services(context)
+
+    logger.info(
+        "top_selling_variants_started",
+        start_date=str(request.start_date),
+        end_date=str(request.end_date),
+        limit=request.limit,
+        category=request.category,
+        order_by=request.order_by,
+        location_id=request.location_id,
+    )
+
+    orders = await _fetch_delivered_sales_orders_in_window(
+        services,
+        request.start_date,
+        request.end_date,
+        location_id=request.location_id,
+    )
+
+    # variant_id -> {units, revenue, order_ids}
+    agg: dict[int, dict[str, Any]] = defaultdict(
+        lambda: {"units": 0.0, "revenue": 0.0, "order_ids": set()}
+    )
+    variant_cache: dict[int, dict[str, Any]] = {}
+    category_cache: dict[int, str | None] = {}
+
+    for so in orders:
+        so_id = so.id
+        for row in _iter_rows(so):
+            variant_id = unwrap_unset(row.variant_id, None)
+            if variant_id is None:
+                continue
+            qty = float(unwrap_unset(row.quantity, 0) or 0)
+            revenue = _row_revenue(row)
+            bucket = agg[variant_id]
+            bucket["units"] += qty
+            bucket["revenue"] += revenue
+            bucket["order_ids"].add(so_id)
+
+    # Resolve variant info (SKU, name, category) for each aggregated variant
+    rows: list[VariantSalesRow] = []
+    for variant_id, bucket in agg.items():
+        variant, category = await _resolve_variant_info(
+            services, variant_id, variant_cache, category_cache
+        )
+        # Filter by category; case-insensitive match
+        if request.category is not None and (
+            category is None or category.lower() != request.category.lower()
+        ):
+            continue
+        rows.append(
+            VariantSalesRow(
+                sku=(variant or {}).get("sku"),
+                variant_id=variant_id,
+                name=(variant or {}).get("display_name") or (variant or {}).get("sku"),
+                units=round(bucket["units"], 4),
+                revenue=round(bucket["revenue"], 2),
+                order_count=len(bucket["order_ids"]),
+            )
+        )
+
+    sort_key = (
+        (lambda r: r.units) if request.order_by == "units" else (lambda r: r.revenue)
+    )
+    rows.sort(key=sort_key, reverse=True)
+    limited = rows[: request.limit]
+
+    logger.info(
+        "top_selling_variants_completed",
+        orders_scanned=len(orders),
+        variants_aggregated=len(agg),
+        rows_returned=len(limited),
+    )
+
+    return TopSellingVariantsResponse(
+        rows=limited,
+        total_variants=len(rows),
+        window_start=str(request.start_date),
+        window_end=str(request.end_date),
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def top_selling_variants(
+    request: Annotated[TopSellingVariantsRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Top-selling product variants over a date window.
+
+    Aggregates DELIVERED sales orders in the window, rolls up units sold and
+    revenue per variant, and returns the top-N sorted by ``order_by`` (default
+    ``units``). Supports optional category and location filters.
+
+    Use when an agent needs a single answer to "what sold best last quarter?"
+    instead of paginating through orders client-side.
+    """
+    response = await _top_selling_variants_impl(request, context)
+
+    if not response.rows:
+        md = (
+            f"No DELIVERED sales in window "
+            f"{response.window_start} - {response.window_end}."
+        )
+    else:
+        table = format_md_table(
+            headers=["SKU", "Variant", "Name", "Units", "Revenue", "Orders"],
+            rows=[
+                [
+                    r.sku or "-",
+                    r.variant_id,
+                    r.name or "-",
+                    f"{r.units:g}",
+                    f"{r.revenue:,.2f}",
+                    r.order_count,
+                ]
+                for r in response.rows
+            ],
+        )
+        md = (
+            f"## Top Selling Variants "
+            f"({response.window_start} - {response.window_end})\n\n"
+            f"{table}\n\n"
+            f"_{response.total_variants} variant(s) matched; "
+            f"showing top {len(response.rows)}._"
+        )
+
+    return make_simple_result(md, structured_data=response.model_dump())
+
+
+# ============================================================================
+# Tool 2: sales_summary
+# ============================================================================
+
+
+SalesGroupBy = Literal["day", "week", "month", "variant", "customer", "category"]
+
+
+class SalesSummaryRequest(BaseModel):
+    """Request for grouped sales summary."""
+
+    start_date: date = Field(..., description="Start of window (inclusive)")
+    end_date: date = Field(..., description="End of window (inclusive)")
+    group_by: SalesGroupBy = Field(
+        ...,
+        description="Grouping key: day, week, month, variant, customer, or category",
+    )
+
+
+class SummaryRow(BaseModel):
+    """Grouped sales aggregate row."""
+
+    group: str
+    units: float
+    revenue: float
+    order_count: int
+
+
+class SalesSummaryResponse(BaseModel):
+    """Response for sales_summary."""
+
+    rows: list[SummaryRow]
+    group_by: SalesGroupBy
+    window_start: str
+    window_end: str
+
+
+def _group_key_time(so_created: datetime, group_by: SalesGroupBy) -> str:
+    """Compute a time-based group key (day/week/month) from ``created_at``."""
+    if group_by == "day":
+        return so_created.date().isoformat()
+    if group_by == "week":
+        iso = so_created.date().isocalendar()
+        return f"{iso.year}-W{iso.week:02d}"
+    # month
+    return f"{so_created.year:04d}-{so_created.month:02d}"
+
+
+async def _sales_summary_impl(
+    request: SalesSummaryRequest, context: Context
+) -> SalesSummaryResponse:
+    """Compute grouped sales summary for DELIVERED orders in the window."""
+    services = get_services(context)
+
+    logger.info(
+        "sales_summary_started",
+        start_date=str(request.start_date),
+        end_date=str(request.end_date),
+        group_by=request.group_by,
+    )
+
+    orders = await _fetch_delivered_sales_orders_in_window(
+        services, request.start_date, request.end_date
+    )
+
+    agg: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"units": 0.0, "revenue": 0.0, "order_ids": set()}
+    )
+    variant_cache: dict[int, dict[str, Any]] = {}
+    category_cache: dict[int, str | None] = {}
+
+    for so in orders:
+        so_id = so.id
+        created = unwrap_unset(so.created_at, None)
+        if created is not None and not isinstance(created, datetime):
+            created = None
+        if created is not None and created.tzinfo is None:
+            created = created.replace(tzinfo=UTC)
+
+        # customer grouping works at SO level (aggregate over all rows)
+        if request.group_by == "customer":
+            key = str(unwrap_unset(so.customer_id, "unknown"))
+            bucket = agg[key]
+            for row in _iter_rows(so):
+                bucket["units"] += float(unwrap_unset(row.quantity, 0) or 0)
+                bucket["revenue"] += _row_revenue(row)
+            bucket["order_ids"].add(so_id)
+            continue
+
+        if request.group_by in ("day", "week", "month"):
+            if created is None:
+                key = "unknown"
+            else:
+                key = _group_key_time(created, request.group_by)
+            bucket = agg[key]
+            for row in _iter_rows(so):
+                bucket["units"] += float(unwrap_unset(row.quantity, 0) or 0)
+                bucket["revenue"] += _row_revenue(row)
+            bucket["order_ids"].add(so_id)
+            continue
+
+        # variant / category: aggregate per row
+        for row in _iter_rows(so):
+            variant_id = unwrap_unset(row.variant_id, None)
+            if variant_id is None:
+                continue
+            qty = float(unwrap_unset(row.quantity, 0) or 0)
+            revenue = _row_revenue(row)
+
+            if request.group_by == "variant":
+                variant, _ = await _resolve_variant_info(
+                    services, variant_id, variant_cache, category_cache
+                )
+                key = (variant or {}).get("sku") or f"variant:{variant_id}"
+            else:  # category
+                _, category = await _resolve_variant_info(
+                    services, variant_id, variant_cache, category_cache
+                )
+                key = category or "uncategorized"
+
+            bucket = agg[key]
+            bucket["units"] += qty
+            bucket["revenue"] += revenue
+            bucket["order_ids"].add(so_id)
+
+    rows = [
+        SummaryRow(
+            group=group,
+            units=round(b["units"], 4),
+            revenue=round(b["revenue"], 2),
+            order_count=len(b["order_ids"]),
+        )
+        for group, b in agg.items()
+    ]
+    # For time groups, sort by key ascending; for others sort by revenue desc.
+    if request.group_by in ("day", "week", "month"):
+        rows.sort(key=lambda r: r.group)
+    else:
+        rows.sort(key=lambda r: r.revenue, reverse=True)
+
+    logger.info(
+        "sales_summary_completed",
+        orders_scanned=len(orders),
+        groups=len(rows),
+    )
+
+    return SalesSummaryResponse(
+        rows=rows,
+        group_by=request.group_by,
+        window_start=str(request.start_date),
+        window_end=str(request.end_date),
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def sales_summary(
+    request: Annotated[SalesSummaryRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Group DELIVERED sales in a window by time or dimension.
+
+    ``group_by`` supports ``day``, ``week`` (ISO week), ``month``, ``variant``
+    (by SKU), ``customer`` (by customer ID), and ``category`` (by item
+    category name). Returns one row per group with units, revenue, and order
+    count.
+    """
+    response = await _sales_summary_impl(request, context)
+
+    if not response.rows:
+        md = (
+            f"No DELIVERED sales in window "
+            f"{response.window_start} - {response.window_end}."
+        )
+    else:
+        table = format_md_table(
+            headers=[response.group_by.title(), "Units", "Revenue", "Orders"],
+            rows=[
+                [
+                    r.group,
+                    f"{r.units:g}",
+                    f"{r.revenue:,.2f}",
+                    r.order_count,
+                ]
+                for r in response.rows
+            ],
+        )
+        md = (
+            f"## Sales Summary by {response.group_by} "
+            f"({response.window_start} - {response.window_end})\n\n{table}"
+        )
+
+    return make_simple_result(md, structured_data=response.model_dump())
+
+
+# ============================================================================
+# Tool 3: inventory_velocity
+# ============================================================================
+
+
+class InventoryVelocityRequest(BaseModel):
+    """Request for inventory-velocity stats for a SKU/variant."""
+
+    sku_or_variant_id: str | int = Field(
+        ..., description="SKU (string) or variant_id (int) to analyze"
+    )
+    period_days: int = Field(
+        default=90,
+        ge=1,
+        le=365,
+        description="Rolling-window size in days (default 90, max 365)",
+    )
+
+
+class VelocityStats(BaseModel):
+    """Velocity response."""
+
+    sku: str | None
+    variant_id: int
+    units_sold: float
+    avg_daily: float
+    stock_on_hand: float
+    days_of_cover: float | None
+    period_days: int
+    window_start: str
+    window_end: str
+
+
+async def _resolve_sku_or_variant_id(
+    services: Any, sku_or_id: str | int
+) -> tuple[int, str | None]:
+    """Return (variant_id, sku) for either an integer ID or a SKU string."""
+    if isinstance(sku_or_id, int):
+        from katana_mcp.cache import EntityType
+
+        variant = await services.cache.get_by_id(EntityType.VARIANT, sku_or_id)
+        sku = (variant or {}).get("sku")
+        return sku_or_id, sku
+
+    sku_str = str(sku_or_id).strip()
+    if not sku_str:
+        raise ValueError("sku_or_variant_id cannot be empty")
+    # Try to parse as integer first — some callers pass the id as a string
+    if sku_str.isdigit():
+        from katana_mcp.cache import EntityType
+
+        vid = int(sku_str)
+        variant = await services.cache.get_by_id(EntityType.VARIANT, vid)
+        sku = (variant or {}).get("sku")
+        return vid, sku
+
+    variant = await services.cache.get_by_sku(sku=sku_str)
+    if not variant:
+        raise ValueError(f"SKU '{sku_str}' not found in variant cache")
+    return variant["id"], sku_str
+
+
+async def _fetch_stock_on_hand(services: Any, variant_id: int) -> float:
+    """Sum quantity_in_stock across all locations for a variant."""
+    response = await get_all_inventory_point.asyncio_detailed(
+        client=services.client, variant_id=variant_id
+    )
+    items = unwrap_data(response, default=[])
+    total = 0.0
+    for inv in items:
+        total += float(unwrap_unset(inv.quantity_in_stock, "0") or 0)
+    return total
+
+
+async def _inventory_velocity_impl(
+    request: InventoryVelocityRequest, context: Context
+) -> VelocityStats:
+    """Compute inventory-velocity stats for one variant."""
+    services = get_services(context)
+
+    variant_id, sku = await _resolve_sku_or_variant_id(
+        services, request.sku_or_variant_id
+    )
+
+    end_dt = datetime.now(tz=UTC)
+    start_dt = end_dt - timedelta(days=request.period_days)
+    window_start = start_dt.date()
+    window_end = end_dt.date()
+
+    logger.info(
+        "inventory_velocity_started",
+        variant_id=variant_id,
+        sku=sku,
+        period_days=request.period_days,
+    )
+
+    orders = await _fetch_delivered_sales_orders_in_window(
+        services, window_start, window_end
+    )
+
+    units_sold = 0.0
+    for so in orders:
+        for row in _iter_rows(so):
+            if unwrap_unset(row.variant_id, None) == variant_id:
+                units_sold += float(unwrap_unset(row.quantity, 0) or 0)
+
+    stock_on_hand = await _fetch_stock_on_hand(services, variant_id)
+
+    avg_daily = units_sold / request.period_days if request.period_days > 0 else 0.0
+    days_of_cover: float | None
+    if avg_daily > 0:
+        days_of_cover = round(stock_on_hand / avg_daily, 2)
+    else:
+        days_of_cover = None
+
+    logger.info(
+        "inventory_velocity_completed",
+        variant_id=variant_id,
+        units_sold=units_sold,
+        stock_on_hand=stock_on_hand,
+        avg_daily=avg_daily,
+    )
+
+    return VelocityStats(
+        sku=sku,
+        variant_id=variant_id,
+        units_sold=round(units_sold, 4),
+        avg_daily=round(avg_daily, 4),
+        stock_on_hand=round(stock_on_hand, 4),
+        days_of_cover=days_of_cover,
+        period_days=request.period_days,
+        window_start=window_start.isoformat(),
+        window_end=window_end.isoformat(),
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def inventory_velocity(
+    request: Annotated[InventoryVelocityRequest, Unpack()], context: Context
+) -> ToolResult:
+    """How fast is a SKU moving? Units sold, avg-daily, stock, and days of cover.
+
+    Computes units sold in the trailing ``period_days`` (default 90) from
+    DELIVERED sales orders, divides by the period to get average daily sales,
+    and pairs it with current stock-on-hand to produce a ``days_of_cover``
+    estimate. ``days_of_cover`` is ``None`` when average daily sales are 0
+    (no sales history, can't project).
+    """
+    response = await _inventory_velocity_impl(request, context)
+
+    cover = (
+        f"{response.days_of_cover:.1f} days"
+        if response.days_of_cover is not None
+        else "∞ (no sales history)"
+    )
+    lines = [
+        f"## Inventory Velocity: {response.sku or response.variant_id}",
+        f"- **Variant ID**: {response.variant_id}",
+        f"- **Window**: {response.window_start} to {response.window_end} "
+        f"({response.period_days} days)",
+        f"- **Units Sold**: {response.units_sold:g}",
+        f"- **Average Daily**: {response.avg_daily:.2f}",
+        f"- **Stock on Hand**: {response.stock_on_hand:g}",
+        f"- **Days of Cover**: {cover}",
+    ]
+
+    return make_simple_result("\n".join(lines), structured_data=response.model_dump())
+
+
+# ============================================================================
+# Registration
+# ============================================================================
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register reporting tools with the FastMCP instance.
+
+    Args:
+        mcp: FastMCP server instance to register tools with
+    """
+    from mcp.types import ToolAnnotations
+
+    _read = ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+
+    mcp.tool(tags={"reporting", "sales", "read"}, annotations=_read)(
+        top_selling_variants
+    )
+    mcp.tool(tags={"reporting", "sales", "read"}, annotations=_read)(sales_summary)
+    mcp.tool(tags={"reporting", "inventory", "read"}, annotations=_read)(
+        inventory_velocity
+    )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -179,7 +179,6 @@ async def _fetch_category_for_product(services: Any, product_id: int) -> str | N
     from katana_public_api_client.api.material import get_material
     from katana_public_api_client.api.product import get_product
     from katana_public_api_client.api.services import get_service
-    from katana_public_api_client.models import ErrorResponse
     from katana_public_api_client.utils import unwrap
 
     for fetcher in (
@@ -191,8 +190,10 @@ async def _fetch_category_for_product(services: Any, product_id: int) -> str | N
             response = await fetcher(id=product_id, client=services.client)
         except Exception:
             continue
+        # unwrap(..., raise_on_error=False) returns None for ErrorResponse,
+        # so a None here covers both "not this type" and "error payload".
         obj = unwrap(response, raise_on_error=False)
-        if obj is None or isinstance(obj, ErrorResponse):
+        if obj is None:
             continue
         cat = unwrap_unset(getattr(obj, "category_name", None), None)
         if cat is not None:
@@ -678,10 +679,12 @@ async def _inventory_velocity_impl(
         services, request.sku_or_variant_id
     )
 
-    end_dt = datetime.now(tz=UTC)
-    start_dt = end_dt - timedelta(days=request.period_days)
-    window_start = start_dt.date()
-    window_end = end_dt.date()
+    # Calendar-day semantics: the inclusive window [window_start, window_end]
+    # covers exactly ``period_days`` days. Using date() on both ends of a
+    # naive timedelta subtraction would silently stretch the window by one
+    # day (because the inclusive bound adds a day at the end). See #331.
+    window_end = datetime.now(tz=UTC).date()
+    window_start = window_end - timedelta(days=request.period_days - 1)
 
     logger.info(
         "inventory_velocity_started",
@@ -748,7 +751,7 @@ async def inventory_velocity(
     cover = (
         f"{response.days_of_cover:.1f} days"
         if response.days_of_cover is not None
-        else "∞ (no sales history)"
+        else "N/A (no sales history in window)"
     )
     lines = [
         f"## Inventory Velocity: {response.sku or response.variant_id}",

--- a/katana_mcp_server/tests/tools/test_reporting.py
+++ b/katana_mcp_server/tests/tools/test_reporting.py
@@ -1,0 +1,473 @@
+"""Tests for reporting/aggregation MCP tools."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from katana_mcp.tools.foundation.reporting import (
+    InventoryVelocityRequest,
+    SalesSummaryRequest,
+    TopSellingVariantsRequest,
+    _inventory_velocity_impl,
+    _sales_summary_impl,
+    _top_selling_variants_impl,
+)
+
+from katana_public_api_client.client_types import UNSET
+from tests.conftest import create_mock_context
+
+# ============================================================================
+# Mock helpers
+# ============================================================================
+
+_SO_GET_ALL = "katana_public_api_client.api.sales_order.get_all_sales_orders"
+_INV_GET_ALL = "katana_public_api_client.api.inventory.get_all_inventory_point"
+_REPORTING_UNWRAP_DATA = "katana_mcp.tools.foundation.reporting.unwrap_data"
+
+
+def _mock_row(
+    *,
+    id: int,
+    variant_id: int,
+    quantity: float,
+    price_per_unit: float,
+    total_discount: float | None = None,
+) -> MagicMock:
+    r = MagicMock()
+    r.id = id
+    r.variant_id = variant_id
+    r.quantity = quantity
+    r.price_per_unit = price_per_unit
+    r.total_discount = total_discount if total_discount is not None else UNSET
+    return r
+
+
+def _mock_so(
+    *,
+    id: int,
+    customer_id: int = 1,
+    created_at: datetime | None = None,
+    rows: list | None = None,
+) -> MagicMock:
+    so = MagicMock()
+    so.id = id
+    so.customer_id = customer_id
+    so.created_at = (
+        created_at if created_at is not None else datetime(2026, 3, 1, 9, 0, tzinfo=UTC)
+    )
+    so.sales_order_rows = rows or []
+    return so
+
+
+def _mock_inv_item(qty: float) -> MagicMock:
+    item = MagicMock()
+    item.quantity_in_stock = str(qty)
+    item.quantity_committed = "0"
+    item.quantity_expected = "0"
+    return item
+
+
+# ============================================================================
+# top_selling_variants
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_top_selling_variants_sorts_by_units_and_applies_limit():
+    """Three variants, sort by units descending, limit trims to 2."""
+    context, lifespan_ctx = create_mock_context()
+
+    # Variant cache returns variant dicts for enrichment
+    async def fake_get_by_id(entity_type, variant_id):
+        return {
+            100: {
+                "id": 100,
+                "sku": "BIKE-A",
+                "display_name": "Bike A",
+                "product_id": 10,
+            },
+            200: {
+                "id": 200,
+                "sku": "BIKE-B",
+                "display_name": "Bike B",
+                "product_id": 20,
+            },
+            300: {
+                "id": 300,
+                "sku": "HELMET-X",
+                "display_name": "Helmet X",
+                "product_id": 30,
+            },
+        }.get(variant_id)
+
+    lifespan_ctx.cache.get_by_id = AsyncMock(side_effect=fake_get_by_id)
+
+    # Three variants: BIKE-B=10u/2000, BIKE-A=5u/3000, HELMET-X=15u/450
+    orders = [
+        _mock_so(
+            id=1,
+            created_at=datetime(2026, 3, 5, tzinfo=UTC),
+            rows=[
+                _mock_row(id=1, variant_id=100, quantity=5, price_per_unit=600),
+                _mock_row(id=2, variant_id=200, quantity=10, price_per_unit=200),
+            ],
+        ),
+        _mock_so(
+            id=2,
+            created_at=datetime(2026, 3, 10, tzinfo=UTC),
+            rows=[
+                _mock_row(id=3, variant_id=300, quantity=15, price_per_unit=30),
+            ],
+        ),
+    ]
+
+    # No category lookup will succeed — no filter in this test
+    request = TopSellingVariantsRequest(
+        start_date=date(2026, 3, 1),
+        end_date=date(2026, 3, 31),
+        limit=2,
+        order_by="units",
+    )
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_REPORTING_UNWRAP_DATA, return_value=orders),
+    ):
+        result = await _top_selling_variants_impl(request, context)
+
+    assert len(result.rows) == 2
+    # HELMET-X has 15 units (highest), then BIKE-B with 10
+    assert result.rows[0].sku == "HELMET-X"
+    assert result.rows[0].units == 15
+    assert result.rows[0].revenue == 450.0
+    assert result.rows[0].order_count == 1
+    assert result.rows[1].sku == "BIKE-B"
+    assert result.rows[1].units == 10
+
+
+@pytest.mark.asyncio
+async def test_top_selling_variants_sort_by_revenue():
+    """order_by='revenue' sorts by dollar volume, not units."""
+    context, lifespan_ctx = create_mock_context()
+
+    async def fake_get_by_id(entity_type, variant_id):
+        return {
+            100: {
+                "id": 100,
+                "sku": "BIKE-A",
+                "display_name": "Bike A",
+                "product_id": 10,
+            },
+            200: {
+                "id": 200,
+                "sku": "BIKE-B",
+                "display_name": "Bike B",
+                "product_id": 20,
+            },
+            300: {
+                "id": 300,
+                "sku": "HELMET-X",
+                "display_name": "Helmet X",
+                "product_id": 30,
+            },
+        }.get(variant_id)
+
+    lifespan_ctx.cache.get_by_id = AsyncMock(side_effect=fake_get_by_id)
+
+    orders = [
+        _mock_so(
+            id=1,
+            rows=[
+                _mock_row(id=1, variant_id=100, quantity=5, price_per_unit=600),  # 3000
+                _mock_row(
+                    id=2, variant_id=200, quantity=10, price_per_unit=200
+                ),  # 2000
+                _mock_row(id=3, variant_id=300, quantity=15, price_per_unit=30),  # 450
+            ],
+        ),
+    ]
+
+    request = TopSellingVariantsRequest(
+        start_date=date(2026, 3, 1),
+        end_date=date(2026, 3, 31),
+        order_by="revenue",
+    )
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_REPORTING_UNWRAP_DATA, return_value=orders),
+    ):
+        result = await _top_selling_variants_impl(request, context)
+
+    assert result.rows[0].sku == "BIKE-A"
+    assert result.rows[0].revenue == 3000.0
+    assert result.rows[1].sku == "BIKE-B"
+    assert result.rows[2].sku == "HELMET-X"
+
+
+@pytest.mark.asyncio
+async def test_top_selling_variants_category_filter():
+    """category filter drops variants whose item category doesn't match."""
+    context, lifespan_ctx = create_mock_context()
+
+    async def fake_get_by_id(entity_type, variant_id):
+        return {
+            100: {
+                "id": 100,
+                "sku": "BIKE-A",
+                "display_name": "Bike A",
+                "product_id": 10,
+            },
+            300: {
+                "id": 300,
+                "sku": "HELMET-X",
+                "display_name": "Helmet X",
+                "product_id": 30,
+            },
+        }.get(variant_id)
+
+    lifespan_ctx.cache.get_by_id = AsyncMock(side_effect=fake_get_by_id)
+
+    # Mock the category fetcher: product_id 10 -> "bikes", product_id 30 -> "accessories"
+    async def fake_fetch_category(services, product_id):
+        return {10: "bikes", 30: "accessories"}.get(product_id)
+
+    orders = [
+        _mock_so(
+            id=1,
+            rows=[
+                _mock_row(id=1, variant_id=100, quantity=5, price_per_unit=600),
+                _mock_row(id=2, variant_id=300, quantity=15, price_per_unit=30),
+            ],
+        ),
+    ]
+
+    request = TopSellingVariantsRequest(
+        start_date=date(2026, 3, 1),
+        end_date=date(2026, 3, 31),
+        category="bikes",
+    )
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_REPORTING_UNWRAP_DATA, return_value=orders),
+        patch(
+            "katana_mcp.tools.foundation.reporting._fetch_category_for_product",
+            side_effect=fake_fetch_category,
+        ),
+    ):
+        result = await _top_selling_variants_impl(request, context)
+
+    # Only BIKE-A (category=bikes) should remain
+    assert len(result.rows) == 1
+    assert result.rows[0].sku == "BIKE-A"
+
+
+# ============================================================================
+# sales_summary
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_sales_summary_group_by_day_produces_row_per_day():
+    """Two orders across two distinct days produces two rows, sorted by day."""
+    context, _ = create_mock_context()
+
+    orders = [
+        _mock_so(
+            id=1,
+            created_at=datetime(2026, 3, 5, 10, 0, tzinfo=UTC),
+            rows=[
+                _mock_row(id=1, variant_id=100, quantity=3, price_per_unit=100),
+            ],
+        ),
+        _mock_so(
+            id=2,
+            created_at=datetime(2026, 3, 6, 14, 0, tzinfo=UTC),
+            rows=[
+                _mock_row(id=2, variant_id=200, quantity=7, price_per_unit=50),
+            ],
+        ),
+    ]
+
+    request = SalesSummaryRequest(
+        start_date=date(2026, 3, 1),
+        end_date=date(2026, 3, 31),
+        group_by="day",
+    )
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_REPORTING_UNWRAP_DATA, return_value=orders),
+    ):
+        result = await _sales_summary_impl(request, context)
+
+    assert len(result.rows) == 2
+    assert result.rows[0].group == "2026-03-05"
+    assert result.rows[0].units == 3
+    assert result.rows[0].revenue == 300.0
+    assert result.rows[0].order_count == 1
+    assert result.rows[1].group == "2026-03-06"
+    assert result.rows[1].units == 7
+    assert result.rows[1].revenue == 350.0
+
+
+@pytest.mark.asyncio
+async def test_sales_summary_group_by_customer():
+    """group_by=customer aggregates across all rows per customer."""
+    context, _ = create_mock_context()
+
+    orders = [
+        _mock_so(
+            id=1,
+            customer_id=42,
+            rows=[_mock_row(id=1, variant_id=100, quantity=2, price_per_unit=50)],
+        ),
+        _mock_so(
+            id=2,
+            customer_id=42,
+            rows=[_mock_row(id=2, variant_id=200, quantity=3, price_per_unit=100)],
+        ),
+        _mock_so(
+            id=3,
+            customer_id=99,
+            rows=[_mock_row(id=3, variant_id=100, quantity=5, price_per_unit=20)],
+        ),
+    ]
+
+    request = SalesSummaryRequest(
+        start_date=date(2026, 3, 1),
+        end_date=date(2026, 3, 31),
+        group_by="customer",
+    )
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_REPORTING_UNWRAP_DATA, return_value=orders),
+    ):
+        result = await _sales_summary_impl(request, context)
+
+    # Sort by revenue descending — customer 42 has 100+300=400, 99 has 100
+    assert len(result.rows) == 2
+    assert result.rows[0].group == "42"
+    assert result.rows[0].revenue == 400.0
+    assert result.rows[0].order_count == 2
+    assert result.rows[1].group == "99"
+    assert result.rows[1].revenue == 100.0
+
+
+# ============================================================================
+# inventory_velocity
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_inventory_velocity_computes_avg_daily_and_days_of_cover():
+    """One variant, 180 units over 90 days, 600 stock on hand → 2u/day, 300 days cover."""
+    context, lifespan_ctx = create_mock_context()
+
+    lifespan_ctx.cache.get_by_sku = AsyncMock(
+        return_value={"id": 500, "sku": "BIKE-MTB-01", "display_name": "Mountain Bike"}
+    )
+
+    orders = [
+        _mock_so(
+            id=1,
+            rows=[_mock_row(id=1, variant_id=500, quantity=100, price_per_unit=0)],
+        ),
+        _mock_so(
+            id=2,
+            rows=[_mock_row(id=2, variant_id=500, quantity=80, price_per_unit=0)],
+        ),
+        # Other-variant row is ignored
+        _mock_so(
+            id=3,
+            rows=[_mock_row(id=3, variant_id=999, quantity=50, price_per_unit=0)],
+        ),
+    ]
+
+    inv_items = [_mock_inv_item(400), _mock_inv_item(200)]  # sum = 600
+
+    request = InventoryVelocityRequest(
+        sku_or_variant_id="BIKE-MTB-01",
+        period_days=90,
+    )
+
+    # The inventory fetch inside _fetch_stock_on_hand uses a different
+    # unwrap_data import path — patch both the reporting alias (used by
+    # _fetch_delivered_sales_orders_in_window) and the inventory call site.
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(
+            f"{_INV_GET_ALL}.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        patch(_REPORTING_UNWRAP_DATA, side_effect=[orders, inv_items]),
+    ):
+        result = await _inventory_velocity_impl(request, context)
+
+    assert result.variant_id == 500
+    assert result.sku == "BIKE-MTB-01"
+    assert result.units_sold == 180
+    assert result.avg_daily == pytest.approx(2.0)
+    assert result.stock_on_hand == 600
+    assert result.days_of_cover == pytest.approx(300.0)
+    assert result.period_days == 90
+
+
+@pytest.mark.asyncio
+async def test_inventory_velocity_zero_sales_returns_none_cover():
+    """avg_daily=0 ⇒ days_of_cover is None (no divide-by-zero)."""
+    context, lifespan_ctx = create_mock_context()
+
+    lifespan_ctx.cache.get_by_sku = AsyncMock(
+        return_value={"id": 500, "sku": "DEAD-SKU", "display_name": "Unsold"}
+    )
+
+    inv_items = [_mock_inv_item(50)]
+
+    request = InventoryVelocityRequest(
+        sku_or_variant_id="DEAD-SKU",
+        period_days=90,
+    )
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(f"{_INV_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_REPORTING_UNWRAP_DATA, side_effect=[[], inv_items]),
+    ):
+        result = await _inventory_velocity_impl(request, context)
+
+    assert result.units_sold == 0
+    assert result.avg_daily == 0.0
+    assert result.stock_on_hand == 50
+    assert result.days_of_cover is None
+
+
+# ============================================================================
+# Validation
+# ============================================================================
+
+
+def test_top_selling_variants_rejects_limit_zero():
+    """limit must be >= 1."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        TopSellingVariantsRequest(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 3, 31),
+            limit=0,
+        )
+
+
+def test_inventory_velocity_rejects_out_of_bounds_period():
+    """period_days must be in [1, 365]."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        InventoryVelocityRequest(sku_or_variant_id="X", period_days=0)
+    with pytest.raises(ValidationError):
+        InventoryVelocityRequest(sku_or_variant_id="X", period_days=400)

--- a/katana_mcp_server/tests/tools/test_reporting.py
+++ b/katana_mcp_server/tests/tools/test_reporting.py
@@ -44,19 +44,26 @@ def _mock_row(
     return r
 
 
+_UNSET_CREATED_AT = object()
+
+
 def _mock_so(
     *,
     id: int,
     customer_id: int = 1,
-    created_at: datetime | None = None,
+    created_at: datetime | None | object = _UNSET_CREATED_AT,
     rows: list | None = None,
 ) -> MagicMock:
     so = MagicMock()
     so.id = id
     so.customer_id = customer_id
-    so.created_at = (
-        created_at if created_at is not None else datetime(2026, 3, 1, 9, 0, tzinfo=UTC)
-    )
+    # `created_at` can be explicitly None (safety-filter will skip date check)
+    # or a datetime (will be filtered against the window). Default is an
+    # arbitrary in-March date used by the stable non-velocity tests.
+    if created_at is _UNSET_CREATED_AT:
+        so.created_at = datetime(2026, 3, 1, 9, 0, tzinfo=UTC)
+    else:
+        so.created_at = created_at
     so.sales_order_rows = rows or []
     return so
 
@@ -372,18 +379,24 @@ async def test_inventory_velocity_computes_avg_daily_and_days_of_cover():
         return_value={"id": 500, "sku": "BIKE-MTB-01", "display_name": "Mountain Bike"}
     )
 
+    # created_at=None means the safety-filter in
+    # _fetch_delivered_sales_orders_in_window skips the date check, so these
+    # fixtures are stable regardless of what "now" is at test time.
     orders = [
         _mock_so(
             id=1,
+            created_at=None,
             rows=[_mock_row(id=1, variant_id=500, quantity=100, price_per_unit=0)],
         ),
         _mock_so(
             id=2,
+            created_at=None,
             rows=[_mock_row(id=2, variant_id=500, quantity=80, price_per_unit=0)],
         ),
         # Other-variant row is ignored
         _mock_so(
             id=3,
+            created_at=None,
             rows=[_mock_row(id=3, variant_id=999, quantity=50, price_per_unit=0)],
         ),
     ]


### PR DESCRIPTION
## Description

Adds three read-only MCP aggregation tools in a new
`katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py`:

- **`top_selling_variants`** — top-N variants by units or revenue over a
  date window, with optional `category` and `location_id` filters.
- **`sales_summary`** — group sales in a window by `day` / `week` (ISO) /
  `month` / `variant` / `customer` / `category`.
- **`inventory_velocity`** — `units_sold`, `avg_daily`, `stock_on_hand`,
  and `days_of_cover` for one SKU/variant over a rolling window.

All three aggregate DELIVERED sales orders fetched via
`get_all_sales_orders.asyncio_detailed()` (auto-paginated via
`PaginationTransport`, materialized in memory). No streaming iterator
exists on the client today; accept the memory cost and flag in docs.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Nine new unit tests in `katana_mcp_server/tests/tools/test_reporting.py`
  covering sort order / limit / category filter / group_by day / customer /
  velocity math (including divide-by-zero) / validation.
- [x] `uv run poe check` passes clean (2282 passed, 3 skipped).
- [ ] Manual live-API acceptance: run the 90-day "top-selling bikes" query
  and confirm ≤10 MCP calls (was 123).

## Code Quality

- [x] Follows the existing list-tool pattern — Pydantic request/response,
  `@observe_tool` / `@unpack_pydantic_params`, structured-data plus
  markdown rendering via `make_simple_result`.
- [x] Help resource (`resources/help.py`) updated: added Reporting &
  Analytics section to `HELP_INDEX`, workflow-6 to `HELP_WORKFLOWS`,
  and per-tool reference to `HELP_TOOLS`.
- [x] Variant→category lookups are cached per tool call to avoid N+1.
- [x] Registered at the end of `foundation/__init__.py` (append-only to
  minimize conflict with sibling phase-1 agents).

## Related Issues

Fixes #331

## Additional Notes

- **No `confirm` flag** — these are read-only aggregations, not write tools.
- **Memory footprint** — paginating large windows (100k+ SOs in 90 days)
  will materialize everything. Future work: a streaming iterator on the
  client. Flag to users who hit it.
- **`days_of_cover`** returns `null` when `avg_daily == 0` (no sales history
  in window) rather than `inf` / divide-by-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)