### PR TITLE
feat(mcp): complete stock-adjustment CRUD

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -399,15 +399,24 @@ Create a stock adjustment to correct inventory levels.
 ### list_stock_adjustments
 List existing stock adjustments with filters, paging, and optional row detail.
 
-**Parameters:**
-- `limit` (optional, default 50, min 1): Max adjustments to return — also acts as page size when `page` is set
-- `page` (optional): Page number (1-based); when set, disables auto-pagination and the response includes `pagination` metadata
+**Parameters (server-side filters):**
+- `limit` (optional, default 50, min 1, max 250): Max adjustments to return — also the page size when `page` is set
+- `page` (optional, min 1): Page number (1-based); when set, disables auto-pagination and the response includes `pagination` metadata
 - `location_id` (optional): Filter by location
-- `variant_id` (optional): Client-side filter — only adjustments whose rows touch this variant
-- `reason` (optional): Client-side case-insensitive substring match on the `reason` field
-- `created_after` (optional): ISO-8601 datetime lower bound on `created_at`
-- `created_before` (optional): ISO-8601 datetime upper bound on `created_at`
+- `ids` (optional): Restrict to a specific set of adjustment IDs
+- `stock_adjustment_number` (optional): Exact match on the adjustment number
+- `created_after` / `created_before` (optional): ISO-8601 datetime bounds on `created_at`
+- `updated_after` / `updated_before` (optional): ISO-8601 datetime bounds on `updated_at` (useful for incremental sync)
+- `include_deleted` (optional, default false): Include soft-deleted adjustments
+
+**Parameters (client-side filters — scan the fetched page set):**
+- `variant_id` (optional): Only adjustments whose rows touch this variant
+- `reason` (optional): Case-insensitive substring match on the `reason` field
+
+**Other:**
 - `include_rows` (optional, default false): When true, populate row-level details on each summary
+
+When a client-side filter is active, the tool skips the single-page short-circuit so auto-pagination can scan enough rows to find matches that may live on later pages.
 
 **Returns:** Summary rows with `id`, `stock_adjustment_number`, `location_id`, dates,
 `reason`, and row count (plus per-row detail when `include_rows=true`), plus optional

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -42,6 +42,7 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **get_variant_details** - Get full details for a specific item
 - **check_inventory** - Check stock levels for a SKU
 - **list_low_stock_items** - Find items needing reorder
+- **create_stock_adjustment / list_stock_adjustments / update_stock_adjustment / delete_stock_adjustment** - Full CRUD for manual inventory adjustments
 
 ### Purchase Orders
 - **create_purchase_order** - Create PO with preview/confirm pattern
@@ -392,6 +393,57 @@ Create a stock adjustment to correct inventory levels.
 - `confirm` (optional, default false): Set false to preview, true to create
 
 **Returns:** Adjustment ID and summary of changes.
+
+---
+
+### list_stock_adjustments
+List existing stock adjustments with filters, paging, and optional row detail.
+
+**Parameters:**
+- `limit` (optional, default 50, min 1): Max adjustments to return — also acts as page size when `page` is set
+- `page` (optional): Page number (1-based); when set, disables auto-pagination and the response includes `pagination` metadata
+- `location_id` (optional): Filter by location
+- `variant_id` (optional): Client-side filter — only adjustments whose rows touch this variant
+- `reason` (optional): Client-side case-insensitive substring match on the `reason` field
+- `created_after` (optional): ISO-8601 datetime lower bound on `created_at`
+- `created_before` (optional): ISO-8601 datetime upper bound on `created_at`
+- `include_rows` (optional, default false): When true, populate row-level details on each summary
+
+**Returns:** Summary rows with `id`, `stock_adjustment_number`, `location_id`, dates,
+`reason`, and row count (plus per-row detail when `include_rows=true`), plus optional
+`pagination` metadata when `page` is set.
+
+---
+
+### update_stock_adjustment
+Update header fields on an existing stock adjustment.
+
+**Parameters:**
+- `id` (required): Stock adjustment ID to update
+- `stock_adjustment_number` (optional): New number
+- `stock_adjustment_date` (optional): New adjustment date (ISO-8601)
+- `location_id` (optional): New location
+- `reason` (optional): New reason
+- `additional_info` (optional): New additional_info
+- `confirm` (optional, default false): false = preview, true = apply (prompts)
+
+**Safety:** At least one updatable field is required. Row-level edits are not supported
+via this tool — create a new adjustment for that.
+
+**Returns:** Updated adjustment summary plus a summary of the field changes applied.
+
+---
+
+### delete_stock_adjustment
+Delete an existing stock adjustment by ID.
+
+**Parameters:**
+- `id` (required): Stock adjustment ID
+- `confirm` (optional, default false): false = preview, true = delete (prompts)
+
+**Safety:** Deletion reverses the associated inventory movements; the preview returns
+the adjustment number, location, and row count so the change is inspectable before
+confirming.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -7,7 +7,9 @@ and managing inventory operations.
 from __future__ import annotations
 
 import asyncio
+import json
 import time
+from datetime import datetime
 from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
@@ -16,8 +18,15 @@ from pydantic import BaseModel, Field
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
-from katana_mcp.tools.tool_result_utils import make_tool_result
+from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
+from katana_mcp.tools.tool_result_utils import (
+    format_md_table,
+    iso_or_none,
+    make_simple_result,
+    make_tool_result,
+)
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 
 logger = get_logger(__name__)
 
@@ -739,6 +748,713 @@ async def create_stock_adjustment(
     )
 
 
+# ============================================================================
+# Tool 5: list_stock_adjustments
+# ============================================================================
+
+
+class PaginationMeta(BaseModel):
+    """Pagination metadata extracted from Katana's `x-pagination` response header.
+
+    Populated on list responses only when the caller requested a specific page
+    (i.e. passed `page=N`). When auto-pagination is used, this field is `None`
+    because there is no single page to describe.
+    """
+
+    total_records: int | None = Field(
+        default=None, description="Total records across all pages"
+    )
+    total_pages: int | None = Field(default=None, description="Total number of pages")
+    page: int | None = Field(default=None, description="Current page number (1-based)")
+    first_page: bool | None = Field(
+        default=None, description="True if this is the first page"
+    )
+    last_page: bool | None = Field(
+        default=None, description="True if this is the last page"
+    )
+
+
+def _parse_pagination_header(raw: str | None) -> PaginationMeta | None:
+    """Parse Katana's `x-pagination` response header into a PaginationMeta.
+
+    Katana returns this as a JSON string with all fields as strings, e.g.:
+    `{"total_records":"2319","total_pages":"2319","offset":"0","page":"1",
+      "first_page":"true","last_page":"false"}`.
+
+    Returns `None` when the header is absent or the top-level JSON is invalid
+    (non-JSON or not a JSON object). When the header is valid JSON but
+    individual fields are missing or malformed, returns a `PaginationMeta`
+    with those specific fields set to `None` rather than discarding the
+    whole header.
+    """
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    def _as_int(val: Any) -> int | None:
+        if val is None:
+            return None
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            return None
+
+    def _as_bool(val: Any) -> bool | None:
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, str):
+            lowered = val.strip().lower()
+            if lowered == "true":
+                return True
+            if lowered == "false":
+                return False
+        return None
+
+    return PaginationMeta(
+        total_records=_as_int(data.get("total_records")),
+        total_pages=_as_int(data.get("total_pages")),
+        page=_as_int(data.get("page")),
+        first_page=_as_bool(data.get("first_page")),
+        last_page=_as_bool(data.get("last_page")),
+    )
+
+
+class ListStockAdjustmentsRequest(BaseModel):
+    """Request to list/filter stock adjustments."""
+
+    limit: int = Field(
+        default=50,
+        ge=1,
+        description=(
+            "Max adjustments to return (default 50, min 1). When `page` is set, "
+            "acts as the page size for that request."
+        ),
+    )
+    page: int | None = Field(
+        default=None,
+        description=(
+            "Page number (1-based). When set, returns a single page and "
+            "disables auto-pagination; `limit` becomes the page size for "
+            "that request."
+        ),
+    )
+    location_id: int | None = Field(default=None, description="Filter by location ID")
+    variant_id: int | None = Field(
+        default=None,
+        description=(
+            "Filter to adjustments that touch this variant ID (applied "
+            "client-side since Katana's list endpoint does not expose it)"
+        ),
+    )
+    reason: str | None = Field(
+        default=None,
+        description=(
+            "Case-insensitive substring match on the `reason` field (applied "
+            "client-side since Katana's list endpoint does not expose it)"
+        ),
+    )
+    created_after: str | None = Field(
+        default=None,
+        description="ISO-8601 datetime lower bound on created_at",
+    )
+    created_before: str | None = Field(
+        default=None,
+        description="ISO-8601 datetime upper bound on created_at",
+    )
+    include_rows: bool = Field(
+        default=False,
+        description="When true, populate row-level detail on each summary",
+    )
+
+
+class StockAdjustmentRowInfo(BaseModel):
+    """Summary of a stock adjustment line item."""
+
+    id: int | None
+    variant_id: int
+    quantity: float
+    cost_per_unit: float | None
+
+
+class StockAdjustmentSummary(BaseModel):
+    """Summary row for a stock adjustment in a list."""
+
+    id: int
+    stock_adjustment_number: str
+    location_id: int
+    stock_adjustment_date: str | None
+    created_at: str | None
+    updated_at: str | None
+    reason: str | None
+    additional_info: str | None
+    row_count: int
+    rows: list[StockAdjustmentRowInfo] | None = None
+
+
+class ListStockAdjustmentsResponse(BaseModel):
+    """Response containing a list of stock adjustments."""
+
+    adjustments: list[StockAdjustmentSummary]
+    total_count: int
+    pagination: PaginationMeta | None = Field(
+        default=None,
+        description=(
+            "Pagination cursor populated from the API's `x-pagination` header "
+            "when the caller requested a specific page. `None` when "
+            "auto-paginating."
+        ),
+    )
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 string into a datetime, or return None on failure."""
+    if not value:
+        return None
+    try:
+        # datetime.fromisoformat supports "Z" suffix from Python 3.11+
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+async def _list_stock_adjustments_impl(
+    request: ListStockAdjustmentsRequest, context: Context
+) -> ListStockAdjustmentsResponse:
+    """List stock adjustments with filters."""
+    from katana_public_api_client.api.stock_adjustment import (
+        get_all_stock_adjustments,
+    )
+    from katana_public_api_client.utils import unwrap_data
+
+    services = get_services(context)
+
+    # Pass through server-side filters Katana supports; variant_id and reason
+    # are applied client-side below.
+    kwargs: dict[str, Any] = {
+        "client": services.client,
+        "limit": request.limit,
+    }
+    if request.location_id is not None:
+        kwargs["location_id"] = request.location_id
+
+    created_at_min = _parse_iso_datetime(request.created_after)
+    if created_at_min is not None:
+        kwargs["created_at_min"] = created_at_min
+    created_at_max = _parse_iso_datetime(request.created_before)
+    if created_at_max is not None:
+        kwargs["created_at_max"] = created_at_max
+
+    # Pagination strategy:
+    # - If `page` is set, forward it so PaginationTransport disables
+    #   auto-pagination and lets callers walk beyond max_pages.
+    # - Otherwise, when `limit` fits in a single Katana page (<=250), pass
+    #   page=1 to short-circuit auto-pagination and avoid fetching thousands
+    #   of rows. Lower bound is defence-in-depth with `ge=1` on Field.
+    if request.page is not None:
+        kwargs["page"] = request.page
+    elif 1 <= request.limit <= 250:
+        kwargs["page"] = 1
+
+    response = await get_all_stock_adjustments.asyncio_detailed(**kwargs)
+    attrs_list = unwrap_data(response, default=[])
+
+    # Apply client-side filters that Katana's list endpoint doesn't accept.
+    if request.variant_id is not None:
+        target_variant = request.variant_id
+
+        def _matches_variant(adj: Any) -> bool:
+            rows = unwrap_unset(adj.stock_adjustment_rows, [])
+            return any(row.variant_id == target_variant for row in rows)
+
+        attrs_list = [adj for adj in attrs_list if _matches_variant(adj)]
+
+    if request.reason is not None:
+        reason_needle = request.reason.strip().lower()
+        if reason_needle:
+
+            def _matches_reason(adj: Any) -> bool:
+                reason_val = unwrap_unset(adj.reason, None)
+                return bool(reason_val and reason_needle in str(reason_val).lower())
+
+            attrs_list = [adj for adj in attrs_list if _matches_reason(adj)]
+
+    # Safety net: cap to request.limit post-pagination/filter so we never
+    # return more than the caller asked for.
+    attrs_list = attrs_list[: request.limit]
+
+    # Surface pagination metadata from the `x-pagination` header only when
+    # the caller is driving paging manually. During auto-pagination the header
+    # describes just the final fetched page, which would be misleading.
+    pagination: PaginationMeta | None = None
+    if request.page is not None:
+        headers = getattr(response, "headers", None)
+        if headers is not None:
+            pagination = _parse_pagination_header(headers.get("x-pagination"))
+
+    adjustments: list[StockAdjustmentSummary] = []
+    for adj in attrs_list:
+        rows = unwrap_unset(adj.stock_adjustment_rows, [])
+        row_infos: list[StockAdjustmentRowInfo] | None = None
+        if request.include_rows:
+            row_infos = [
+                StockAdjustmentRowInfo(
+                    id=unwrap_unset(row.id, None),
+                    variant_id=row.variant_id,
+                    quantity=row.quantity,
+                    cost_per_unit=unwrap_unset(row.cost_per_unit, None),
+                )
+                for row in rows
+            ]
+        adjustments.append(
+            StockAdjustmentSummary(
+                id=adj.id,
+                stock_adjustment_number=adj.stock_adjustment_number,
+                location_id=adj.location_id,
+                stock_adjustment_date=iso_or_none(
+                    unwrap_unset(adj.stock_adjustment_date, None)
+                ),
+                created_at=iso_or_none(unwrap_unset(adj.created_at, None)),
+                updated_at=iso_or_none(unwrap_unset(adj.updated_at, None)),
+                reason=unwrap_unset(adj.reason, None),
+                additional_info=unwrap_unset(adj.additional_info, None),
+                row_count=len(rows),
+                rows=row_infos,
+            )
+        )
+
+    return ListStockAdjustmentsResponse(
+        adjustments=adjustments,
+        total_count=len(adjustments),
+        pagination=pagination,
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def list_stock_adjustments(
+    request: Annotated[ListStockAdjustmentsRequest, Unpack()], context: Context
+) -> ToolResult:
+    """List stock adjustments with filters.
+
+    Use for discovery — find recent adjustments at a location, adjustments
+    touching a specific variant, or adjustments matching a reason substring.
+    Returns summary rows (number, location, dates, reason, row count). Set
+    `include_rows=true` to also populate per-row details (variant_id, quantity,
+    cost_per_unit).
+
+    **Paging**
+    - `limit` caps the number of rows returned (default 50, min 1).
+    - Set `page=N` for manual paging; the response includes `pagination`
+      metadata parsed from Katana's `x-pagination` header.
+    - Otherwise auto-pagination kicks in automatically (bounded by
+      `KatanaClient.max_pages`).
+
+    **Filters**
+    - `location_id`, `created_after`, `created_before` — server-side.
+    - `variant_id`, `reason` — applied client-side; combine with other filters
+      to narrow the result set before the client-side pass.
+    """
+    response = await _list_stock_adjustments_impl(request, context)
+
+    if not response.adjustments:
+        md = "No stock adjustments match the given filters."
+    else:
+        table = format_md_table(
+            headers=["ID", "Number", "Location", "Date", "Rows", "Reason"],
+            rows=[
+                [
+                    adj.id,
+                    adj.stock_adjustment_number,
+                    adj.location_id,
+                    adj.stock_adjustment_date or "—",
+                    adj.row_count,
+                    (adj.reason or "—")[:40],
+                ]
+                for adj in response.adjustments
+            ],
+        )
+        md = f"## Stock Adjustments ({response.total_count})\n\n{table}"
+
+    return make_simple_result(md, structured_data=response.model_dump())
+
+
+# ============================================================================
+# Tool 6: update_stock_adjustment
+# ============================================================================
+
+
+class UpdateStockAdjustmentParams(BaseModel):
+    """Request to update an existing stock adjustment."""
+
+    id: int = Field(..., description="Stock adjustment ID to update")
+    stock_adjustment_number: str | None = Field(
+        default=None, description="New adjustment number (optional)"
+    )
+    stock_adjustment_date: datetime | None = Field(
+        default=None, description="New adjustment date (ISO-8601, optional)"
+    )
+    location_id: int | None = Field(
+        default=None, description="New location ID (optional)"
+    )
+    reason: str | None = Field(default=None, description="New reason (optional)")
+    additional_info: str | None = Field(
+        default=None, description="New additional_info (optional)"
+    )
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns a preview. If true, applies the update.",
+    )
+
+
+class UpdateStockAdjustmentResponse(BaseModel):
+    """Response from updating a stock adjustment."""
+
+    id: int
+    is_preview: bool
+    stock_adjustment_number: str | None = None
+    location_id: int | None = None
+    stock_adjustment_date: str | None = None
+    reason: str | None = None
+    additional_info: str | None = None
+    changes_summary: str
+    message: str
+
+
+def _format_changes_summary(request: UpdateStockAdjustmentParams) -> str:
+    """Build a human-readable summary of the fields the update will change."""
+    changes: list[str] = []
+    if request.stock_adjustment_number is not None:
+        changes.append(f"- stock_adjustment_number → {request.stock_adjustment_number}")
+    if request.stock_adjustment_date is not None:
+        changes.append(
+            f"- stock_adjustment_date → {request.stock_adjustment_date.isoformat()}"
+        )
+    if request.location_id is not None:
+        changes.append(f"- location_id → {request.location_id}")
+    if request.reason is not None:
+        changes.append(f"- reason → {request.reason}")
+    if request.additional_info is not None:
+        changes.append(f"- additional_info → {request.additional_info}")
+    if not changes:
+        return "No field changes supplied."
+    return "\n".join(changes)
+
+
+async def _update_stock_adjustment_impl(
+    request: UpdateStockAdjustmentParams, context: Context
+) -> UpdateStockAdjustmentResponse:
+    """Update a stock adjustment with preview/confirm safety pattern."""
+    from katana_public_api_client.api.stock_adjustment import (
+        update_stock_adjustment as api_update_stock_adjustment,
+    )
+    from katana_public_api_client.models import (
+        UpdateStockAdjustmentRequest as APIUpdateStockAdjustmentRequest,
+    )
+    from katana_public_api_client.utils import unwrap_as
+
+    changes_summary = _format_changes_summary(request)
+
+    # Fail fast if caller didn't supply any updatable field.
+    has_changes = any(
+        v is not None
+        for v in (
+            request.stock_adjustment_number,
+            request.stock_adjustment_date,
+            request.location_id,
+            request.reason,
+            request.additional_info,
+        )
+    )
+    if not has_changes:
+        raise ValueError(
+            "At least one updatable field must be provided "
+            "(stock_adjustment_number, stock_adjustment_date, location_id, "
+            "reason, additional_info)"
+        )
+
+    # Preview mode — no API call.
+    if not request.confirm:
+        logger.info(
+            "stock_adjustment_update_preview",
+            id=request.id,
+        )
+        return UpdateStockAdjustmentResponse(
+            id=request.id,
+            is_preview=True,
+            stock_adjustment_number=request.stock_adjustment_number,
+            location_id=request.location_id,
+            stock_adjustment_date=request.stock_adjustment_date.isoformat()
+            if request.stock_adjustment_date
+            else None,
+            reason=request.reason,
+            additional_info=request.additional_info,
+            changes_summary=changes_summary,
+            message=(
+                f"Preview — call again with confirm=true to update stock "
+                f"adjustment {request.id}"
+            ),
+        )
+
+    # Confirm mode — elicit user confirmation before hitting the API.
+    confirmation = await require_confirmation(
+        context,
+        f"Update stock adjustment {request.id} with the supplied field changes?",
+    )
+    if confirmation != ConfirmationResult.CONFIRMED:
+        logger.info(
+            "stock_adjustment_update_declined",
+            id=request.id,
+            result=str(confirmation),
+        )
+        return UpdateStockAdjustmentResponse(
+            id=request.id,
+            is_preview=True,
+            stock_adjustment_number=request.stock_adjustment_number,
+            location_id=request.location_id,
+            stock_adjustment_date=request.stock_adjustment_date.isoformat()
+            if request.stock_adjustment_date
+            else None,
+            reason=request.reason,
+            additional_info=request.additional_info,
+            changes_summary=changes_summary,
+            message=(
+                f"Stock adjustment update {confirmation} by user — "
+                "call again with confirm=true to retry"
+            ),
+        )
+
+    services = get_services(context)
+    api_request = APIUpdateStockAdjustmentRequest(
+        stock_adjustment_number=to_unset(request.stock_adjustment_number),
+        stock_adjustment_date=to_unset(request.stock_adjustment_date),
+        location_id=to_unset(request.location_id),
+        reason=to_unset(request.reason),
+        additional_info=to_unset(request.additional_info),
+    )
+
+    response = await api_update_stock_adjustment.asyncio_detailed(
+        id=request.id, client=services.client, body=api_request
+    )
+
+    from katana_public_api_client.models import StockAdjustment
+
+    try:
+        updated = unwrap_as(response, StockAdjustment)
+    except Exception as e:
+        logger.error(
+            "stock_adjustment_update_failed",
+            id=request.id,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        raise
+
+    logger.info(
+        "stock_adjustment_updated",
+        id=updated.id,
+    )
+
+    return UpdateStockAdjustmentResponse(
+        id=updated.id,
+        is_preview=False,
+        stock_adjustment_number=updated.stock_adjustment_number,
+        location_id=updated.location_id,
+        stock_adjustment_date=iso_or_none(
+            unwrap_unset(updated.stock_adjustment_date, None)
+        ),
+        reason=unwrap_unset(updated.reason, None),
+        additional_info=unwrap_unset(updated.additional_info, None),
+        changes_summary=changes_summary,
+        message=f"Stock adjustment {updated.id} updated successfully",
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def update_stock_adjustment(
+    request: Annotated[UpdateStockAdjustmentParams, Unpack()], context: Context
+) -> ToolResult:
+    """Update an existing stock adjustment's header fields.
+
+    Two-step flow: `confirm=false` returns a preview of the changes, `confirm=true`
+    prompts the user for confirmation and applies the update via PATCH. At least
+    one updatable field must be supplied (stock_adjustment_number,
+    stock_adjustment_date, location_id, reason, additional_info). Row-level
+    changes are not supported — create a new adjustment for that.
+    """
+    response = await _update_stock_adjustment_impl(request, context)
+    status = "PREVIEW" if response.is_preview else "UPDATED"
+    md = (
+        f"## Stock Adjustment {response.id} ({status})\n\n"
+        f"{response.message}\n\n"
+        f"### Changes\n{response.changes_summary}\n"
+    )
+    return make_simple_result(md, structured_data=response.model_dump())
+
+
+# ============================================================================
+# Tool 7: delete_stock_adjustment
+# ============================================================================
+
+
+class DeleteStockAdjustmentRequest(BaseModel):
+    """Request to delete an existing stock adjustment."""
+
+    id: int = Field(..., description="Stock adjustment ID to delete")
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns a preview. If true, deletes the adjustment.",
+    )
+
+
+class DeleteStockAdjustmentResponse(BaseModel):
+    """Response from deleting a stock adjustment."""
+
+    id: int
+    is_preview: bool
+    stock_adjustment_number: str | None
+    location_id: int | None
+    row_count: int
+    message: str
+
+
+async def _delete_stock_adjustment_impl(
+    request: DeleteStockAdjustmentRequest, context: Context
+) -> DeleteStockAdjustmentResponse:
+    """Delete a stock adjustment with preview/confirm safety pattern.
+
+    Preview mode fetches the adjustment (via the list endpoint filter) so the
+    caller can see what will be removed before confirming. Confirm mode calls
+    the API's DELETE endpoint, which reverses the associated inventory changes.
+    """
+    from katana_public_api_client.api.stock_adjustment import (
+        delete_stock_adjustment as api_delete_stock_adjustment,
+        get_all_stock_adjustments,
+    )
+    from katana_public_api_client.utils import is_success, unwrap, unwrap_data
+
+    services = get_services(context)
+
+    # Look up what we're about to delete so preview + final response include
+    # enough detail for the user to sanity-check the action. Katana does not
+    # expose GET /stock_adjustments/{id}, so we filter the list endpoint by id.
+    list_response = await get_all_stock_adjustments.asyncio_detailed(
+        client=services.client,
+        ids=[request.id],
+        limit=1,
+    )
+    matches = unwrap_data(list_response, default=[])
+    existing = next((adj for adj in matches if adj.id == request.id), None)
+
+    if existing is None:
+        raise ValueError(f"Stock adjustment {request.id} not found")
+
+    rows = unwrap_unset(existing.stock_adjustment_rows, [])
+    row_count = len(rows)
+    stock_adjustment_number = existing.stock_adjustment_number
+    location_id = existing.location_id
+
+    if not request.confirm:
+        logger.info(
+            "stock_adjustment_delete_preview",
+            id=request.id,
+            row_count=row_count,
+        )
+        return DeleteStockAdjustmentResponse(
+            id=request.id,
+            is_preview=True,
+            stock_adjustment_number=stock_adjustment_number,
+            location_id=location_id,
+            row_count=row_count,
+            message=(
+                f"Preview — call again with confirm=true to delete stock "
+                f"adjustment {stock_adjustment_number} "
+                f"({row_count} row{'s' if row_count != 1 else ''})"
+            ),
+        )
+
+    confirmation = await require_confirmation(
+        context,
+        (
+            f"Delete stock adjustment {stock_adjustment_number} "
+            f"(id={request.id}, {row_count} rows)? "
+            "This reverses the associated inventory movements."
+        ),
+    )
+    if confirmation != ConfirmationResult.CONFIRMED:
+        logger.info(
+            "stock_adjustment_delete_declined",
+            id=request.id,
+            result=str(confirmation),
+        )
+        return DeleteStockAdjustmentResponse(
+            id=request.id,
+            is_preview=True,
+            stock_adjustment_number=stock_adjustment_number,
+            location_id=location_id,
+            row_count=row_count,
+            message=(
+                f"Stock adjustment delete {confirmation} by user — "
+                "call again with confirm=true to retry"
+            ),
+        )
+
+    response = await api_delete_stock_adjustment.asyncio_detailed(
+        id=request.id, client=services.client
+    )
+
+    if not is_success(response):
+        # unwrap raises a typed APIError/ValidationError/etc with a clean message.
+        unwrap(response)
+
+    logger.info(
+        "stock_adjustment_deleted",
+        id=request.id,
+        stock_adjustment_number=stock_adjustment_number,
+    )
+
+    return DeleteStockAdjustmentResponse(
+        id=request.id,
+        is_preview=False,
+        stock_adjustment_number=stock_adjustment_number,
+        location_id=location_id,
+        row_count=row_count,
+        message=(
+            f"Stock adjustment {stock_adjustment_number} (id={request.id}) "
+            "deleted; associated inventory movements reversed"
+        ),
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def delete_stock_adjustment(
+    request: Annotated[DeleteStockAdjustmentRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Delete a stock adjustment by ID.
+
+    Two-step flow: `confirm=false` returns a preview (including the adjustment
+    number, location, and row count that would be affected); `confirm=true`
+    prompts the user for confirmation, then calls DELETE. Deleting a stock
+    adjustment reverses the associated inventory movements.
+    """
+    response = await _delete_stock_adjustment_impl(request, context)
+    status = "PREVIEW" if response.is_preview else "DELETED"
+    md = (
+        f"## Stock Adjustment {response.id} ({status})\n\n"
+        f"{response.message}\n\n"
+        f"- **Number**: {response.stock_adjustment_number or '—'}\n"
+        f"- **Location**: {response.location_id or '—'}\n"
+        f"- **Rows**: {response.row_count}\n"
+    )
+    return make_simple_result(md, structured_data=response.model_dump())
+
+
 def register_tools(mcp: FastMCP) -> None:
     """Register all inventory tools with the FastMCP instance.
 
@@ -760,7 +1476,18 @@ def register_tools(mcp: FastMCP) -> None:
         openWorldHint=True,
     )
 
+    _destructive_write = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        openWorldHint=True,
+    )
+
     mcp.tool(tags={"inventory", "read"}, annotations=_read)(check_inventory)
     mcp.tool(tags={"inventory", "read"}, annotations=_read)(list_low_stock_items)
     mcp.tool(tags={"inventory", "read"}, annotations=_read)(get_inventory_movements)
+    mcp.tool(tags={"inventory", "read"}, annotations=_read)(list_stock_adjustments)
     mcp.tool(tags={"inventory", "write"}, annotations=_write)(create_stock_adjustment)
+    mcp.tool(tags={"inventory", "write"}, annotations=_write)(update_stock_adjustment)
+    mcp.tool(tags={"inventory", "write"}, annotations=_destructive_write)(
+        delete_stock_adjustment
+    )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -830,17 +830,20 @@ class ListStockAdjustmentsRequest(BaseModel):
     limit: int = Field(
         default=50,
         ge=1,
+        le=250,
         description=(
-            "Max adjustments to return (default 50, min 1). When `page` is set, "
-            "acts as the page size for that request."
+            "Max adjustments to return (default 50, min 1, max 250 — Katana's "
+            "API page-size cap). When `page` is set, acts as the page size for "
+            "that request."
         ),
     )
     page: int | None = Field(
         default=None,
+        ge=1,
         description=(
             "Page number (1-based). When set, returns a single page and "
-            "disables auto-pagination; `limit` becomes the page size for "
-            "that request."
+            "disables auto-pagination; `limit` becomes the page size. Invalid "
+            "pages (0, negative) are rejected at the schema boundary."
         ),
     )
     location_id: int | None = Field(default=None, description="Filter by location ID")
@@ -911,15 +914,25 @@ class ListStockAdjustmentsResponse(BaseModel):
     )
 
 
-def _parse_iso_datetime(value: str | None) -> datetime | None:
-    """Parse an ISO-8601 string into a datetime, or return None on failure."""
+def _parse_iso_datetime(value: str | None, field_name: str) -> datetime | None:
+    """Parse an ISO-8601 string into a datetime.
+
+    Returns ``None`` when ``value`` is ``None``/empty. Raises ``ValueError``
+    with ``field_name`` context when ``value`` is a non-empty string that can't
+    be parsed — silently dropping filters would hide caller mistakes.
+
+    Normalizes trailing ``Z`` / ``z`` (UTC) to ``+00:00`` before parsing since
+    ``fromisoformat`` is strict about uppercase ``Z`` on older Python releases.
+    """
     if not value:
         return None
+    normalized = value[:-1] + "+00:00" if value.endswith(("Z", "z")) else value
     try:
-        # datetime.fromisoformat supports "Z" suffix from Python 3.11+
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except (ValueError, TypeError):
-        return None
+        return datetime.fromisoformat(normalized)
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
+        ) from e
 
 
 async def _list_stock_adjustments_impl(
@@ -942,10 +955,10 @@ async def _list_stock_adjustments_impl(
     if request.location_id is not None:
         kwargs["location_id"] = request.location_id
 
-    created_at_min = _parse_iso_datetime(request.created_after)
+    created_at_min = _parse_iso_datetime(request.created_after, "created_after")
     if created_at_min is not None:
         kwargs["created_at_min"] = created_at_min
-    created_at_max = _parse_iso_datetime(request.created_before)
+    created_at_max = _parse_iso_datetime(request.created_before, "created_before")
     if created_at_max is not None:
         kwargs["created_at_max"] = created_at_max
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -846,20 +846,14 @@ class ListStockAdjustmentsRequest(BaseModel):
             "pages (0, negative) are rejected at the schema boundary."
         ),
     )
+    # Server-side filters (forwarded to Katana's GET /stock_adjustments)
     location_id: int | None = Field(default=None, description="Filter by location ID")
-    variant_id: int | None = Field(
+    ids: list[int] | None = Field(
         default=None,
-        description=(
-            "Filter to adjustments that touch this variant ID (applied "
-            "client-side since Katana's list endpoint does not expose it)"
-        ),
+        description="Restrict to a specific set of stock adjustment IDs",
     )
-    reason: str | None = Field(
-        default=None,
-        description=(
-            "Case-insensitive substring match on the `reason` field (applied "
-            "client-side since Katana's list endpoint does not expose it)"
-        ),
+    stock_adjustment_number: str | None = Field(
+        default=None, description="Exact match on the stock adjustment number"
     )
     created_after: str | None = Field(
         default=None,
@@ -869,6 +863,31 @@ class ListStockAdjustmentsRequest(BaseModel):
         default=None,
         description="ISO-8601 datetime upper bound on created_at",
     )
+    updated_after: str | None = Field(
+        default=None,
+        description="ISO-8601 datetime lower bound on updated_at (useful for sync)",
+    )
+    updated_before: str | None = Field(
+        default=None,
+        description="ISO-8601 datetime upper bound on updated_at",
+    )
+    include_deleted: bool = Field(
+        default=False,
+        description="Include soft-deleted adjustments in the result",
+    )
+
+    # Client-side filters (applied post-fetch; Katana's list endpoint does not
+    # expose these server-side). When either is set the `page=1` short-circuit
+    # is skipped so auto-pagination can scan enough rows to find matches.
+    variant_id: int | None = Field(
+        default=None,
+        description="Filter to adjustments that touch this variant ID (client-side)",
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Case-insensitive substring match on the `reason` field (client-side)",
+    )
+
     include_rows: bool = Field(
         default=False,
         description="When true, populate row-level detail on each summary",
@@ -954,6 +973,12 @@ async def _list_stock_adjustments_impl(
     }
     if request.location_id is not None:
         kwargs["location_id"] = request.location_id
+    if request.ids is not None:
+        kwargs["ids"] = request.ids
+    if request.stock_adjustment_number is not None:
+        kwargs["stock_adjustment_number"] = request.stock_adjustment_number
+    if request.include_deleted:
+        kwargs["include_deleted"] = True
 
     created_at_min = _parse_iso_datetime(request.created_after, "created_after")
     if created_at_min is not None:
@@ -961,16 +986,26 @@ async def _list_stock_adjustments_impl(
     created_at_max = _parse_iso_datetime(request.created_before, "created_before")
     if created_at_max is not None:
         kwargs["created_at_max"] = created_at_max
+    updated_at_min = _parse_iso_datetime(request.updated_after, "updated_after")
+    if updated_at_min is not None:
+        kwargs["updated_at_min"] = updated_at_min
+    updated_at_max = _parse_iso_datetime(request.updated_before, "updated_before")
+    if updated_at_max is not None:
+        kwargs["updated_at_max"] = updated_at_max
 
     # Pagination strategy:
     # - If `page` is set, forward it so PaginationTransport disables
     #   auto-pagination and lets callers walk beyond max_pages.
+    # - Else if any client-side-only filter (variant_id, reason) is active,
+    #   skip the short-circuit so auto-pagination scans enough rows to find
+    #   matches; a single page would miss records on later pages.
     # - Otherwise, when `limit` fits in a single Katana page (<=250), pass
     #   page=1 to short-circuit auto-pagination and avoid fetching thousands
     #   of rows. Lower bound is defence-in-depth with `ge=1` on Field.
+    has_client_filter = request.variant_id is not None or request.reason is not None
     if request.page is not None:
         kwargs["page"] = request.page
-    elif 1 <= request.limit <= 250:
+    elif not has_client_filter and 1 <= request.limit <= 250:
         kwargs["page"] = 1
 
     response = await get_all_stock_adjustments.asyncio_detailed(**kwargs)
@@ -1360,6 +1395,7 @@ async def _delete_stock_adjustment_impl(
         client=services.client,
         ids=[request.id],
         limit=1,
+        page=1,  # Explicit page disables auto-pagination — one HTTP call suffices.
     )
     matches = unwrap_data(list_response, default=[])
     existing = next((adj for adj in matches if adj.id == request.id), None)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -1201,10 +1201,10 @@ async def _update_stock_adjustment_impl(
         )
 
     # Confirm mode — elicit user confirmation before hitting the API.
-    confirmation = await require_confirmation(
-        context,
-        f"Update stock adjustment {request.id} with the supplied field changes?",
+    confirm_prompt = (
+        f"Apply the supplied field changes to stock adjustment {request.id}?"
     )
+    confirmation = await require_confirmation(context, confirm_prompt)
     if confirmation != ConfirmationResult.CONFIRMED:
         logger.info(
             "stock_adjustment_update_declined",
@@ -1378,14 +1378,12 @@ async def _delete_stock_adjustment_impl(
             ),
         )
 
-    confirmation = await require_confirmation(
-        context,
-        (
-            f"Delete stock adjustment {stock_adjustment_number} "
-            f"(id={request.id}, {row_count} rows)? "
-            "This reverses the associated inventory movements."
-        ),
+    confirm_prompt = (
+        f"Remove stock adjustment {stock_adjustment_number} "
+        f"(id={request.id}, {row_count} rows)? "
+        "This reverses the associated inventory movements."
     )
+    confirmation = await require_confirmation(context, confirm_prompt)
     if confirmation != ConfirmationResult.CONFIRMED:
         logger.info(
             "stock_adjustment_delete_declined",

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -1,18 +1,25 @@
 """Tests for inventory and item MCP tools."""
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from katana_mcp.tools.foundation.inventory import (
     CheckInventoryRequest,
     CreateStockAdjustmentRequest,
+    DeleteStockAdjustmentRequest,
     GetInventoryMovementsRequest,
+    ListStockAdjustmentsRequest,
     LowStockRequest,
     StockAdjustmentRow,
+    UpdateStockAdjustmentParams,
     _check_inventory_impl,
     _create_stock_adjustment_impl,
+    _delete_stock_adjustment_impl,
     _get_inventory_movements_impl,
     _list_low_stock_items_impl,
+    _list_stock_adjustments_impl,
+    _update_stock_adjustment_impl,
 )
 from katana_mcp.tools.foundation.items import (
     GetVariantDetailsRequest,
@@ -21,6 +28,7 @@ from katana_mcp.tools.foundation.items import (
     _search_items_impl,
 )
 
+from katana_public_api_client.client_types import UNSET
 from tests.conftest import create_mock_context
 
 # ============================================================================
@@ -695,6 +703,530 @@ async def test_get_variant_details_with_timestamps():
 
     assert result.created_at == "2024-01-01T12:00:00+00:00"
     assert result.updated_at == "2024-06-01T14:30:00+00:00"
+
+
+# ============================================================================
+# list_stock_adjustments Tests
+# ============================================================================
+
+_SA_GET_ALL = "katana_public_api_client.api.stock_adjustment.get_all_stock_adjustments"
+_SA_UNWRAP_DATA = "katana_public_api_client.utils.unwrap_data"
+_SA_UPDATE = "katana_public_api_client.api.stock_adjustment.update_stock_adjustment"
+_SA_DELETE = "katana_public_api_client.api.stock_adjustment.delete_stock_adjustment"
+_SA_UNWRAP_AS = "katana_public_api_client.utils.unwrap_as"
+_SA_UNWRAP = "katana_public_api_client.utils.unwrap"
+
+
+def _make_mock_adjustment(
+    *,
+    id: int = 500,
+    stock_adjustment_number: str = "SA-TEST-001",
+    location_id: int = 1,
+    reason: str | None = "Cycle count",
+    additional_info: str | None = None,
+    rows: list | None = None,
+    created_at: datetime | None = None,
+) -> MagicMock:
+    """Build a mock StockAdjustment attrs object for testing."""
+    adj = MagicMock()
+    adj.id = id
+    adj.stock_adjustment_number = stock_adjustment_number
+    adj.location_id = location_id
+    adj.reason = reason if reason is not None else UNSET
+    adj.additional_info = additional_info if additional_info is not None else UNSET
+    adj.stock_adjustment_date = datetime(2026, 4, 1, 9, 0, tzinfo=UTC)
+    adj.created_at = (
+        created_at if created_at is not None else datetime(2026, 4, 1, 9, 0, tzinfo=UTC)
+    )
+    adj.updated_at = datetime(2026, 4, 1, 9, 0, tzinfo=UTC)
+    adj.stock_adjustment_rows = rows if rows is not None else []
+    return adj
+
+
+def _make_mock_adjustment_row(
+    *,
+    id: int = 1,
+    variant_id: int = 100,
+    quantity: float = 5.0,
+    cost_per_unit: float | None = None,
+) -> MagicMock:
+    """Build a mock StockAdjustmentRow for testing."""
+    row = MagicMock()
+    row.id = id
+    row.variant_id = variant_id
+    row.quantity = quantity
+    row.cost_per_unit = cost_per_unit if cost_per_unit is not None else UNSET
+    return row
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_short_circuits_page_for_small_limit():
+    """Small `limit` (<=250) with no explicit `page` injects page=1 to short-circuit."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SA_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(limit=25), context
+        )
+
+    assert captured["page"] == 1
+    assert captured["limit"] == 25
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_forwards_explicit_page():
+    """Explicit `page=N` is forwarded (overrides the short-circuit)."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SA_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(limit=50, page=3), context
+        )
+
+    assert captured["page"] == 3
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_does_not_short_circuit_large_limit():
+    """`limit` above 250 skips the auto-page short-circuit."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SA_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(limit=500), context
+        )
+
+    assert "page" not in captured
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_pagination_meta_populated_on_explicit_page():
+    """An explicit `page` populates `pagination` from the x-pagination header."""
+    context, _ = create_mock_context()
+
+    mock_response = MagicMock()
+    mock_response.headers = {
+        "x-pagination": (
+            '{"total_records":"231","total_pages":"5","page":"2",'
+            '"first_page":"false","last_page":"false"}'
+        )
+    }
+
+    with (
+        patch(
+            f"{_SA_GET_ALL}.asyncio_detailed",
+            new=AsyncMock(return_value=mock_response),
+        ),
+        patch(_SA_UNWRAP_DATA, return_value=[]),
+    ):
+        result = await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(limit=50, page=2), context
+        )
+
+    assert result.pagination is not None
+    assert result.pagination.total_records == 231
+    assert result.pagination.total_pages == 5
+    assert result.pagination.page == 2
+    assert result.pagination.first_page is False
+    assert result.pagination.last_page is False
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_pagination_meta_none_on_auto_pagination():
+    """Without an explicit `page`, `pagination` is `None` (auto-pagination)."""
+    context, _ = create_mock_context()
+
+    mock_response = MagicMock()
+    mock_response.headers = {
+        "x-pagination": '{"total_records":"10","total_pages":"1","page":"1"}'
+    }
+
+    with (
+        patch(
+            f"{_SA_GET_ALL}.asyncio_detailed",
+            new=AsyncMock(return_value=mock_response),
+        ),
+        patch(_SA_UNWRAP_DATA, return_value=[]),
+    ):
+        result = await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(limit=50), context
+        )
+
+    assert result.pagination is None
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_date_filters_forwarded():
+    """`created_after` and `created_before` map to `created_at_min`/`_max`."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SA_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(
+                created_after="2026-01-01T00:00:00Z",
+                created_before="2026-04-01T00:00:00Z",
+            ),
+            context,
+        )
+
+    assert isinstance(captured["created_at_min"], datetime)
+    assert isinstance(captured["created_at_max"], datetime)
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_location_filter_forwarded():
+    """`location_id` is forwarded as-is to the API."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SA_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(location_id=7), context
+        )
+
+    assert captured["location_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_variant_id_filter_clientside():
+    """`variant_id` is applied client-side against returned rows."""
+    context, _ = create_mock_context()
+
+    adj_match = _make_mock_adjustment(
+        id=1, rows=[_make_mock_adjustment_row(variant_id=777)]
+    )
+    adj_skip = _make_mock_adjustment(
+        id=2, rows=[_make_mock_adjustment_row(variant_id=888)]
+    )
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
+        patch(_SA_UNWRAP_DATA, return_value=[adj_match, adj_skip]),
+    ):
+        result = await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(variant_id=777), context
+        )
+
+    assert result.total_count == 1
+    assert result.adjustments[0].id == 1
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_reason_filter_clientside():
+    """`reason` applies a case-insensitive substring match client-side."""
+    context, _ = create_mock_context()
+
+    adj_match = _make_mock_adjustment(id=1, reason="Cycle count correction")
+    adj_skip = _make_mock_adjustment(id=2, reason="Sample received")
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
+        patch(_SA_UNWRAP_DATA, return_value=[adj_match, adj_skip]),
+    ):
+        result = await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(reason="cycle"), context
+        )
+
+    assert result.total_count == 1
+    assert result.adjustments[0].id == 1
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_include_rows_false_omits_rows():
+    """With `include_rows=False`, summary rows is None."""
+    context, _ = create_mock_context()
+
+    adj = _make_mock_adjustment(
+        id=10,
+        rows=[
+            _make_mock_adjustment_row(id=1, variant_id=100, quantity=5.0),
+            _make_mock_adjustment_row(id=2, variant_id=101, quantity=-2.0),
+        ],
+    )
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
+        patch(_SA_UNWRAP_DATA, return_value=[adj]),
+    ):
+        result = await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(include_rows=False), context
+        )
+
+    assert result.adjustments[0].row_count == 2
+    assert result.adjustments[0].rows is None
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_include_rows_true_populates_rows():
+    """With `include_rows=True`, summary rows contains row details."""
+    context, _ = create_mock_context()
+
+    adj = _make_mock_adjustment(
+        id=11,
+        rows=[
+            _make_mock_adjustment_row(
+                id=1, variant_id=100, quantity=5.0, cost_per_unit=1.23
+            ),
+            _make_mock_adjustment_row(id=2, variant_id=101, quantity=-2.0),
+        ],
+    )
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
+        patch(_SA_UNWRAP_DATA, return_value=[adj]),
+    ):
+        result = await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(include_rows=True), context
+        )
+
+    rows = result.adjustments[0].rows
+    assert rows is not None
+    assert len(rows) == 2
+    assert rows[0].variant_id == 100
+    assert rows[0].quantity == 5.0
+    assert rows[0].cost_per_unit == 1.23
+    assert rows[1].variant_id == 101
+    assert rows[1].cost_per_unit is None
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_limit_caps_result_size():
+    """Result list is capped at `request.limit` even when API returns more."""
+    context, _ = create_mock_context()
+
+    many = [_make_mock_adjustment(id=i) for i in range(20)]
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
+        patch(_SA_UNWRAP_DATA, return_value=many),
+    ):
+        result = await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(limit=5), context
+        )
+
+    assert len(result.adjustments) == 5
+    assert result.total_count == 5
+
+
+# ============================================================================
+# update_stock_adjustment Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_update_stock_adjustment_preview_returns_is_preview_true():
+    """confirm=False returns preview without calling the API."""
+    context, _ = create_mock_context()
+
+    request = UpdateStockAdjustmentParams(id=42, reason="Updated reason", confirm=False)
+
+    with patch(f"{_SA_UPDATE}.asyncio_detailed", new=AsyncMock()) as mock_api:
+        result = await _update_stock_adjustment_impl(request, context)
+
+    assert result.is_preview is True
+    assert result.id == 42
+    assert "Updated reason" in result.changes_summary
+    mock_api.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_stock_adjustment_confirm_calls_api():
+    """confirm=True elicits confirmation and calls the PATCH endpoint."""
+    context, _ = create_mock_context(elicit_confirm=True)
+
+    # The API returns an updated StockAdjustment. `_update_stock_adjustment_impl`
+    # imports `unwrap_as` from katana_public_api_client.utils inside the
+    # function, so patching the source module intercepts the lookup.
+    updated = _make_mock_adjustment(
+        id=42, stock_adjustment_number="SA-UPDATED", reason="Updated reason"
+    )
+
+    request = UpdateStockAdjustmentParams(
+        id=42,
+        reason="Updated reason",
+        stock_adjustment_number="SA-UPDATED",
+        confirm=True,
+    )
+
+    with (
+        patch(
+            f"{_SA_UPDATE}.asyncio_detailed",
+            new=AsyncMock(return_value=MagicMock()),
+        ) as mock_api,
+        patch(_SA_UNWRAP_AS, return_value=updated),
+    ):
+        result = await _update_stock_adjustment_impl(request, context)
+
+    assert result.is_preview is False
+    assert result.id == 42
+    assert result.stock_adjustment_number == "SA-UPDATED"
+    mock_api.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_stock_adjustment_decline_short_circuits():
+    """When the user declines the elicitation, API is not called."""
+    context, _ = create_mock_context(elicit_confirm=False)
+
+    request = UpdateStockAdjustmentParams(id=42, reason="Updated reason", confirm=True)
+
+    with patch(f"{_SA_UPDATE}.asyncio_detailed", new=AsyncMock()) as mock_api:
+        result = await _update_stock_adjustment_impl(request, context)
+
+    assert result.is_preview is True
+    mock_api.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_stock_adjustment_rejects_empty_change_set():
+    """Missing all updatable fields raises ValueError."""
+    context, _ = create_mock_context()
+
+    request = UpdateStockAdjustmentParams(id=42, confirm=False)
+
+    with pytest.raises(ValueError, match="At least one updatable field"):
+        await _update_stock_adjustment_impl(request, context)
+
+
+# ============================================================================
+# delete_stock_adjustment Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_stock_adjustment_preview_returns_what_would_be_deleted():
+    """confirm=False fetches the adjustment and returns it in preview."""
+    context, _ = create_mock_context()
+
+    adj = _make_mock_adjustment(
+        id=99,
+        stock_adjustment_number="SA-DELETE",
+        location_id=3,
+        rows=[_make_mock_adjustment_row(id=1, variant_id=100, quantity=5.0)],
+    )
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
+        patch(_SA_UNWRAP_DATA, return_value=[adj]),
+        patch(f"{_SA_DELETE}.asyncio_detailed", new=AsyncMock()) as mock_delete,
+    ):
+        result = await _delete_stock_adjustment_impl(
+            DeleteStockAdjustmentRequest(id=99, confirm=False), context
+        )
+
+    assert result.is_preview is True
+    assert result.id == 99
+    assert result.stock_adjustment_number == "SA-DELETE"
+    assert result.location_id == 3
+    assert result.row_count == 1
+    mock_delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_stock_adjustment_confirm_calls_api():
+    """confirm=True elicits confirmation then calls DELETE."""
+    context, _ = create_mock_context(elicit_confirm=True)
+
+    adj = _make_mock_adjustment(
+        id=99,
+        stock_adjustment_number="SA-DELETE",
+        rows=[_make_mock_adjustment_row(id=1, variant_id=100, quantity=5.0)],
+    )
+
+    # DELETE returns 204 No Content
+    mock_delete_response = MagicMock()
+    mock_delete_response.status_code = 204
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
+        patch(_SA_UNWRAP_DATA, return_value=[adj]),
+        patch(
+            f"{_SA_DELETE}.asyncio_detailed",
+            new=AsyncMock(return_value=mock_delete_response),
+        ) as mock_delete,
+    ):
+        result = await _delete_stock_adjustment_impl(
+            DeleteStockAdjustmentRequest(id=99, confirm=True), context
+        )
+
+    assert result.is_preview is False
+    assert result.id == 99
+    assert result.stock_adjustment_number == "SA-DELETE"
+    mock_delete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_stock_adjustment_decline_short_circuits():
+    """When the user declines the elicitation, DELETE is not called."""
+    context, _ = create_mock_context(elicit_confirm=False)
+
+    adj = _make_mock_adjustment(id=99, stock_adjustment_number="SA-DELETE")
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
+        patch(_SA_UNWRAP_DATA, return_value=[adj]),
+        patch(f"{_SA_DELETE}.asyncio_detailed", new=AsyncMock()) as mock_delete,
+    ):
+        result = await _delete_stock_adjustment_impl(
+            DeleteStockAdjustmentRequest(id=99, confirm=True), context
+        )
+
+    assert result.is_preview is True
+    mock_delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_stock_adjustment_not_found_raises():
+    """A non-existent adjustment id raises ValueError."""
+    context, _ = create_mock_context()
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
+        patch(_SA_UNWRAP_DATA, return_value=[]),
+        pytest.raises(ValueError, match="not found"),
+    ):
+        await _delete_stock_adjustment_impl(
+            DeleteStockAdjustmentRequest(id=12345, confirm=False), context
+        )
 
 
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -810,6 +810,83 @@ def test_list_stock_adjustments_rejects_limit_above_page_cap():
 
 
 @pytest.mark.asyncio
+async def test_list_stock_adjustments_forwards_new_server_side_filters():
+    """ids, stock_adjustment_number, updated_after/before, include_deleted forward to the API."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SA_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(
+                limit=10,
+                ids=[101, 102],
+                stock_adjustment_number="SA-00042",
+                updated_after="2026-01-01T00:00:00+00:00",
+                updated_before="2026-04-01T00:00:00+00:00",
+                include_deleted=True,
+            ),
+            context,
+        )
+
+    assert captured["ids"] == [101, 102]
+    assert captured["stock_adjustment_number"] == "SA-00042"
+    assert captured["updated_at_min"] == datetime(2026, 1, 1, tzinfo=UTC)
+    assert captured["updated_at_max"] == datetime(2026, 4, 1, tzinfo=UTC)
+    assert captured["include_deleted"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_skips_short_circuit_when_variant_id_filter_set():
+    """Client-side filters need to scan more than one page; short-circuit must be skipped."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SA_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(limit=10, variant_id=42), context
+        )
+
+    # No `page` forwarded → auto-pagination runs → can find variant_id matches
+    # on later pages. Without this, a single page would be the whole haystack.
+    assert "page" not in captured
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_skips_short_circuit_when_reason_filter_set():
+    """Same as above but for the `reason` client-side filter."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SA_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_stock_adjustments_impl(
+            ListStockAdjustmentsRequest(limit=10, reason="recount"), context
+        )
+
+    assert "page" not in captured
+
+
+@pytest.mark.asyncio
 async def test_list_stock_adjustments_pagination_meta_populated_on_explicit_page():
     """An explicit `page` populates `pagination` from the x-pagination header."""
     context, _ = create_mock_context()
@@ -1120,7 +1197,11 @@ async def test_update_stock_adjustment_rejects_empty_change_set():
 
 @pytest.mark.asyncio
 async def test_delete_stock_adjustment_preview_returns_what_would_be_deleted():
-    """confirm=False fetches the adjustment and returns it in preview."""
+    """confirm=False fetches the adjustment and returns it in preview.
+
+    Also asserts the lookup passes page=1 so auto-pagination doesn't chase
+    extra pages for a single-record fetch.
+    """
     context, _ = create_mock_context()
 
     adj = _make_mock_adjustment(
@@ -1131,7 +1212,10 @@ async def test_delete_stock_adjustment_preview_returns_what_would_be_deleted():
     )
 
     with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
+        patch(
+            f"{_SA_GET_ALL}.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_get_all,
         patch(_SA_UNWRAP_DATA, return_value=[adj]),
         patch(f"{_SA_DELETE}.asyncio_detailed", new=AsyncMock()) as mock_delete,
     ):
@@ -1145,6 +1229,8 @@ async def test_delete_stock_adjustment_preview_returns_what_would_be_deleted():
     assert result.location_id == 3
     assert result.row_count == 1
     mock_delete.assert_not_called()
+    # The delete-preview lookup should short-circuit auto-pagination.
+    assert mock_get_all.call_args.kwargs["page"] == 1
 
 
 @pytest.mark.asyncio

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -27,6 +27,7 @@ from katana_mcp.tools.foundation.items import (
     _get_variant_details_impl,
     _search_items_impl,
 )
+from pydantic import ValidationError
 
 from katana_public_api_client.client_types import UNSET
 from tests.conftest import create_mock_context
@@ -802,25 +803,10 @@ async def test_list_stock_adjustments_forwards_explicit_page():
     assert captured["page"] == 3
 
 
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_does_not_short_circuit_large_limit():
-    """`limit` above 250 skips the auto-page short-circuit."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SA_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(limit=500), context
-        )
-
-    assert "page" not in captured
+def test_list_stock_adjustments_rejects_limit_above_page_cap():
+    """`limit > 250` is rejected at the schema boundary (Katana's API page-size cap)."""
+    with pytest.raises(ValidationError):
+        ListStockAdjustmentsRequest(limit=500)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Completes the stock-adjustment tool surface so the full CRUD can be driven from MCP without dropping to the web UI. `create_stock_adjustment` already existed — this PR adds list/update/delete, each using the post-#329/#330 conventions.

- **`list_stock_adjustments`** — list-tool pattern v2: `ge=1 limit` (default 50), `page` with auto-pagination short-circuit for `limit <= 250`, `PaginationMeta` surfaced from the `x-pagination` header only when `page` is set, `created_after`/`created_before` date filters (mapped to Katana's `created_at_min`/`_max`), plus server-side `location_id` and client-side `variant_id`/`reason` filters. `include_rows=true` populates row-level detail on each summary. Limit-cap safety net after client-side filtering.
- **`update_stock_adjustment`** — two-step `confirm` pattern mirroring `receive_purchase_order`. Optional updatable body fields match `UpdateStockAdjustmentRequest` (stock_adjustment_number / _date / location_id / reason / additional_info). `confirm=False` returns `is_preview=True`; `confirm=True` elicits user confirmation, then calls PATCH. Rejects empty change sets.
- **`delete_stock_adjustment`** — same two-step pattern. Preview fetches the adjustment via the list endpoint and returns its number / location / row count so the caller can see what will be reversed before confirming. Deletion reverses the associated inventory movements.

Also appended to `resources/help.py` (HELP_TOOLS + the inventory bullet in HELP_INDEX) — documentation-only, no existing sections were rewritten so sibling agents can merge cleanly.

Fixes #337

## Test plan

- [x] `uv run poe check` passes locally (2293 passed, 3 skipped — unrelated doc/mcp skips)
- [x] `list_stock_adjustments` unit tests cover: auto-page short-circuit with small limit, explicit `page` forwarded, no short-circuit for `limit > 250`, `x-pagination` header parsing, pagination meta is `None` during auto-pagination, date filters mapped to `created_at_min`/`_max`, location filter forwarded, client-side `variant_id` filter, client-side `reason` substring match, `include_rows=false/true` toggling, `limit` cap safety net.
- [x] `update_stock_adjustment` unit tests cover: preview mode doesn't call API, confirm mode elicits and calls PATCH, user decline short-circuits, empty change set raises ValueError.
- [x] `delete_stock_adjustment` unit tests cover: preview returns what would be deleted, confirm mode elicits and calls DELETE, user decline short-circuits, not-found raises ValueError.
- [ ] Live round-trip against the real API post-merge: create → update → delete to validate the full CRUD flow end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)