### PR TITLE
feat(mcp): date-range filters + list_manufacturing_orders + list_purchase_orders

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -46,13 +46,18 @@ Manufacturing ERP tools for inventory, orders, and production management.
 
 ### Purchase Orders
 - **create_purchase_order** - Create PO with preview/confirm pattern
+- **list_purchase_orders** - List POs with supplier/status/date filters
 - **receive_purchase_order** - Receive items and update inventory
 - **verify_order_document** - Verify supplier documents against POs
+- **get_purchase_order** - Look up a PO by number or ID with line items
 
 ### Manufacturing & Sales
 - **create_manufacturing_order** - Create production work orders
+- **list_manufacturing_orders** - List MOs with status/location/date filters
+- **get_manufacturing_order** - Look up an MO with full details
 - **fulfill_order** - Complete manufacturing or sales orders
 - **create_sales_order** - Create sales orders with preview/confirm
+- **list_sales_orders** - List SOs with customer/status/date filters
 
 ### Stock Transfers
 - **create_stock_transfer** - Move inventory between locations (preview/confirm)
@@ -456,6 +461,42 @@ confirming.
 
 ---
 
+### list_manufacturing_orders
+List manufacturing orders with filters (list-tool pattern v2).
+
+**Paging:**
+- `limit` (optional, default 50, min 1, max 250): Max rows to return
+- `page` (optional, min 1): Page number (1-based), disables auto-pagination
+
+**Domain filters:**
+- `ids` (optional): Explicit list of MO IDs
+- `order_no` (optional): Exact order_no
+- `status` (optional): NOT_STARTED, IN_PROGRESS, BLOCKED, PAUSED, COMPLETED
+- `location_id` (optional): Production location ID
+- `is_linked_to_sales_order` (optional): True/False filter on SO linkage
+- `include_deleted` (optional): Include soft-deleted MOs
+
+**Time windows (server-side):**
+- `created_after` / `created_before`: ISO-8601 bounds on `created_at`
+- `updated_after` / `updated_before`: ISO-8601 bounds on `updated_at`
+
+**Time windows (client-side — Katana has no server filter):**
+- `production_deadline_after` / `production_deadline_before`: bounds on
+  `production_deadline_date`. When set, the tool skips the page=1
+  short-circuit so auto-pagination can scan enough rows to find `limit`
+  matches post-filter.
+
+- `include_rows` (optional, default false): Reserved for future row-detail
+  support. The list endpoint does not return recipe rows inline; use
+  `get_manufacturing_order_recipe` for a specific MO to inspect ingredients.
+
+**Returns:** Summary rows with id, order_no, status, variant_id, planned/
+actual qty, location_id, order_created_date, production_deadline_date,
+done_date, is_linked_to_sales_order, sales_order_id, total_cost. When `page`
+is set, also returns `pagination` with total_records/total_pages/etc.
+
+---
+
 ### get_manufacturing_order
 Look up manufacturing orders by order number or ID.
 
@@ -520,6 +561,46 @@ Verify a supplier document (invoice, packing slip) against a PO.
 - `document_items` (required): Array of items from document with sku, quantity, unit_price
 
 **Returns:** Match status, discrepancies, and suggested actions.
+
+---
+
+### list_purchase_orders
+List purchase orders with filters (list-tool pattern v2).
+
+**Paging:**
+- `limit` (optional, default 50, min 1, max 250): Max rows to return
+- `page` (optional, min 1): Page number (1-based), disables auto-pagination
+
+**Domain filters:**
+- `ids` (optional): Explicit list of PO IDs
+- `order_no` (optional): Exact order_no
+- `entity_type` (optional): "regular" or "outsourced"
+- `status` (optional): DRAFT, NOT_RECEIVED, PARTIALLY_RECEIVED, RECEIVED
+- `billing_status` (optional): BILLED, NOT_BILLED, PARTIALLY_BILLED
+- `currency` (optional): Currency code (e.g. "USD")
+- `location_id` (optional): Receiving location ID
+- `tracking_location_id` (optional): Tracking location ID (outsourced)
+- `supplier_id` (optional): Supplier ID
+- `include_deleted` (optional): Include soft-deleted POs
+
+**Time windows (server-side):**
+- `created_after` / `created_before`: ISO-8601 bounds on `created_at`
+- `updated_after` / `updated_before`: ISO-8601 bounds on `updated_at`
+
+**Time windows (client-side — Katana has no server filter):**
+- `expected_arrival_after` / `expected_arrival_before`: bounds on
+  `expected_arrival_date`. When set, the tool skips the page=1
+  short-circuit so auto-pagination can scan enough rows to find `limit`
+  matches post-filter.
+
+- `include_rows` (optional, default false): Populate per-PO line item detail
+  (variant_id, quantity, price, arrival). The list endpoint bundles rows
+  inline, so this is free compared to `list_sales_orders`.
+
+**Returns:** Summary rows with id, order_no, status, billing_status,
+entity_type, supplier_id, location_id, currency, created_date,
+expected_arrival_date, total, row_count. When `page` is set, also returns
+`pagination` with total_records/total_pages/etc.
 
 ---
 
@@ -638,20 +719,36 @@ Create a sales order.
 ---
 
 ### list_sales_orders
-List sales orders with filters.
+List sales orders with filters (list-tool pattern v2).
 
-**Parameters:**
+**Paging:**
+- `limit` (optional, default 50, min 1, max 250): Max rows to return. When
+  `page` is set, acts as the page size.
+- `page` (optional, min 1): Page number (1-based). When set, disables
+  auto-pagination; use with `limit` as page size.
+
+**Domain filters:**
 - `order_no` (optional): Exact order number
+- `ids` (optional): Explicit list of sales order IDs
 - `customer_id` (optional): Filter to a customer
 - `location_id` (optional): Filter to a location
-- `status` (optional): Order status (e.g., "PENDING", "DELIVERED")
+- `status` (optional): Order status (e.g., "NOT_SHIPPED", "DELIVERED")
 - `production_status` (optional): Production status
+- `invoicing_status` (optional): e.g. "NOT_INVOICED", "INVOICED"
+- `currency` (optional): Currency code (e.g. "USD")
+- `include_deleted` (optional): When true, include soft-deleted SOs
 - `needs_work_orders` (optional): Shortcut for `production_status="NONE"` —
   finds sales orders that haven't had manufacturing orders created yet
-- `limit` (optional, default 50): Max rows to return
-- `page` (optional): Page number (1-based). When set, returns a single page
-  and disables auto-pagination; use with `limit` as page size to walk the
-  full result set without hitting the transport's auto-pag ceiling.
+
+**Time windows (server-side):**
+- `created_after` / `created_before`: ISO-8601 bounds on `created_at`
+- `updated_after` / `updated_before`: ISO-8601 bounds on `updated_at`
+
+**Time windows (client-side — Katana has no server filter):**
+- `delivered_after` / `delivered_before`: ISO-8601 bounds on `delivery_date`.
+  When set, the tool skips the page=1 short-circuit so auto-pagination can
+  scan enough rows to find `limit` matching results post-filter. Pair with a
+  `created_at` window to keep fetched rows bounded.
 
 **Returns:** Summary rows with order_no, status, production_status, row_count,
 total, currency, created_at, delivery_date. When `page` is set, the response

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -9,6 +9,8 @@ These tools provide:
 from __future__ import annotations
 
 import asyncio
+import datetime as _datetime
+import json
 from datetime import datetime
 from enum import StrEnum
 from typing import Annotated, Any
@@ -22,7 +24,10 @@ from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
+    enum_to_str,
     format_md_table,
+    iso_or_none,
+    make_simple_result,
     make_tool_result,
     none_coro,
 )
@@ -31,6 +36,7 @@ from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     CreateManufacturingOrderRequest as APICreateManufacturingOrderRequest,
+    GetAllManufacturingOrdersStatus,
     ManufacturingOrder,
 )
 from katana_public_api_client.utils import unwrap_as
@@ -1447,6 +1453,397 @@ async def batch_update_manufacturing_order_recipes(
     return ToolResult(content=markdown, structured_content=prefab_json)
 
 
+# ============================================================================
+# Tool: list_manufacturing_orders (list-tool pattern v2)
+# ============================================================================
+
+
+def _parse_iso_datetime(value: str, field_name: str) -> datetime:
+    """Parse an ISO-8601 datetime string, raising ValueError on bad input.
+
+    Normalizes trailing ``Z`` / ``z`` (UTC shorthand) to ``+00:00`` before
+    parsing. Raises ``ValueError`` with the field name on unparseable input
+    so caller mistakes surface loudly instead of being silently dropped.
+    """
+    normalized = value
+    if normalized.endswith(("Z", "z")):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
+        ) from e
+
+
+class MOPaginationMeta(BaseModel):
+    """Pagination metadata parsed from Katana's ``x-pagination`` header."""
+
+    total_records: int | None = None
+    total_pages: int | None = None
+    page: int | None = None
+    first_page: bool | None = None
+    last_page: bool | None = None
+
+
+def _parse_mo_pagination_header(raw: str | None) -> MOPaginationMeta | None:
+    """Parse the ``x-pagination`` response header (JSON with stringy values).
+
+    Returns ``None`` for absent or non-JSON-object headers; partial/malformed
+    fields become ``None`` on the returned meta rather than discarding the
+    whole object.
+    """
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    def _as_int(val: Any) -> int | None:
+        if val is None:
+            return None
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            return None
+
+    def _as_bool(val: Any) -> bool | None:
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, str):
+            lowered = val.strip().lower()
+            if lowered == "true":
+                return True
+            if lowered == "false":
+                return False
+        return None
+
+    return MOPaginationMeta(
+        total_records=_as_int(data.get("total_records")),
+        total_pages=_as_int(data.get("total_pages")),
+        page=_as_int(data.get("page")),
+        first_page=_as_bool(data.get("first_page")),
+        last_page=_as_bool(data.get("last_page")),
+    )
+
+
+class ListManufacturingOrdersRequest(BaseModel):
+    """Request to list/filter manufacturing orders (list-tool pattern v2)."""
+
+    # Paging
+    limit: int = Field(
+        default=50,
+        ge=1,
+        le=250,
+        description=(
+            "Max rows to return (default 50, min 1, max 250 — Katana's "
+            "per-page ceiling). When `page` is set, acts as the page size."
+        ),
+    )
+    page: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Page number (1-based). When set, disables auto-pagination; "
+            "use with `limit` as page size."
+        ),
+    )
+
+    # Domain filters (server-side on Katana)
+    ids: list[int] | None = Field(
+        default=None, description="Filter by explicit list of manufacturing order IDs"
+    )
+    order_no: str | None = Field(default=None, description="Filter by exact order_no")
+    status: GetAllManufacturingOrdersStatus | None = Field(
+        default=None,
+        description=(
+            "Filter by MO status: NOT_STARTED, IN_PROGRESS, BLOCKED, PAUSED, COMPLETED."
+        ),
+    )
+    location_id: int | None = Field(
+        default=None, description="Filter by production location ID"
+    )
+    is_linked_to_sales_order: bool | None = Field(
+        default=None,
+        description="When set, filters to MOs linked (True) / not linked (False) to a SO.",
+    )
+    include_deleted: bool | None = Field(
+        default=None,
+        description="When true, include soft-deleted manufacturing orders.",
+    )
+
+    # Time-window filters (server-side)
+    created_after: str | None = Field(
+        default=None, description="ISO-8601 datetime lower bound on created_at."
+    )
+    created_before: str | None = Field(
+        default=None, description="ISO-8601 datetime upper bound on created_at."
+    )
+    updated_after: str | None = Field(
+        default=None, description="ISO-8601 datetime lower bound on updated_at."
+    )
+    updated_before: str | None = Field(
+        default=None, description="ISO-8601 datetime upper bound on updated_at."
+    )
+
+    # Time-window filters (client-side — Katana does not expose server-side
+    # filters for production_deadline).
+    production_deadline_after: str | None = Field(
+        default=None,
+        description=(
+            "ISO-8601 datetime lower bound on production_deadline_date. "
+            "Applied client-side — Katana has no server-side filter. Pair "
+            "with a created_at window to keep fetched rows bounded."
+        ),
+    )
+    production_deadline_before: str | None = Field(
+        default=None,
+        description=(
+            "ISO-8601 datetime upper bound on production_deadline_date. "
+            "Applied client-side — see `production_deadline_after`."
+        ),
+    )
+
+    # Row inclusion
+    include_rows: bool = Field(
+        default=False,
+        description=(
+            "Reserved for future row-detail support. Katana's "
+            "/manufacturing_orders list endpoint does not return recipe "
+            "rows inline; to inspect ingredients use "
+            "`get_manufacturing_order_recipe` for a specific MO."
+        ),
+    )
+
+
+class ManufacturingOrderSummary(BaseModel):
+    """Summary row for a manufacturing order in a list."""
+
+    id: int
+    order_no: str | None
+    status: str | None
+    variant_id: int | None
+    planned_quantity: float | None
+    actual_quantity: float | None
+    location_id: int | None
+    order_created_date: str | None
+    production_deadline_date: str | None
+    done_date: str | None
+    is_linked_to_sales_order: bool | None
+    sales_order_id: int | None
+    total_cost: float | None
+    row_count: int
+
+
+class ListManufacturingOrdersResponse(BaseModel):
+    """Response containing a list of manufacturing orders."""
+
+    orders: list[ManufacturingOrderSummary]
+    total_count: int
+    pagination: MOPaginationMeta | None = None
+
+
+async def _list_manufacturing_orders_impl(
+    request: ListManufacturingOrdersRequest, context: Context
+) -> ListManufacturingOrdersResponse:
+    """List manufacturing orders with filters — follows list-tool pattern v2."""
+    from katana_public_api_client.api.manufacturing_order import (
+        get_all_manufacturing_orders,
+    )
+    from katana_public_api_client.utils import unwrap_data
+
+    services = get_services(context)
+
+    kwargs: dict[str, Any] = {
+        "client": services.client,
+        "limit": request.limit,
+    }
+    if request.ids is not None:
+        kwargs["ids"] = request.ids
+    if request.order_no is not None:
+        kwargs["order_no"] = request.order_no
+    if request.status is not None:
+        kwargs["status"] = request.status
+    if request.location_id is not None:
+        kwargs["location_id"] = request.location_id
+    if request.is_linked_to_sales_order is not None:
+        kwargs["is_linked_to_sales_order"] = request.is_linked_to_sales_order
+    if request.include_deleted is not None:
+        kwargs["include_deleted"] = request.include_deleted
+
+    # Server-side date filters
+    if request.created_after is not None:
+        kwargs["created_at_min"] = _parse_iso_datetime(
+            request.created_after, "created_after"
+        )
+    if request.created_before is not None:
+        kwargs["created_at_max"] = _parse_iso_datetime(
+            request.created_before, "created_before"
+        )
+    if request.updated_after is not None:
+        kwargs["updated_at_min"] = _parse_iso_datetime(
+            request.updated_after, "updated_after"
+        )
+    if request.updated_before is not None:
+        kwargs["updated_at_max"] = _parse_iso_datetime(
+            request.updated_before, "updated_before"
+        )
+
+    # Client-side filter parsing (eager — bad input fails loudly)
+    deadline_after_dt: datetime | None = None
+    deadline_before_dt: datetime | None = None
+    if request.production_deadline_after is not None:
+        deadline_after_dt = _parse_iso_datetime(
+            request.production_deadline_after, "production_deadline_after"
+        )
+    if request.production_deadline_before is not None:
+        deadline_before_dt = _parse_iso_datetime(
+            request.production_deadline_before, "production_deadline_before"
+        )
+    has_client_filter = deadline_after_dt is not None or deadline_before_dt is not None
+
+    # Pagination strategy — short-circuit only when no client-side filter is
+    # active, otherwise auto-pag needs to scan enough rows to satisfy `limit`
+    # after post-filter.
+    if request.page is not None:
+        kwargs["page"] = request.page
+    elif 1 <= request.limit <= 250 and not has_client_filter:
+        kwargs["page"] = 1
+
+    response = await get_all_manufacturing_orders.asyncio_detailed(**kwargs)
+    attrs_list = unwrap_data(response, default=[])
+
+    if has_client_filter:
+
+        def _in_deadline_window(mo: Any) -> bool:
+            deadline = unwrap_unset(mo.production_deadline_date, None)
+            if not isinstance(deadline, _datetime.datetime):
+                return False
+            if deadline_after_dt is not None and deadline < deadline_after_dt:
+                return False
+            return not (
+                deadline_before_dt is not None and deadline > deadline_before_dt
+            )
+
+        attrs_list = [mo for mo in attrs_list if _in_deadline_window(mo)]
+
+    # Safety net: cap to request.limit post-pagination.
+    attrs_list = attrs_list[: request.limit]
+
+    # Pagination meta — only when caller set `page` explicitly.
+    pagination: MOPaginationMeta | None = None
+    if request.page is not None:
+        headers = getattr(response, "headers", None)
+        if headers is not None:
+            pagination = _parse_mo_pagination_header(headers.get("x-pagination"))
+
+    summaries: list[ManufacturingOrderSummary] = []
+    for mo in attrs_list:
+        summaries.append(
+            ManufacturingOrderSummary(
+                id=mo.id,
+                order_no=unwrap_unset(mo.order_no, None),
+                status=enum_to_str(unwrap_unset(mo.status, None)),
+                variant_id=unwrap_unset(mo.variant_id, None),
+                planned_quantity=unwrap_unset(mo.planned_quantity, None),
+                actual_quantity=unwrap_unset(mo.actual_quantity, None),
+                location_id=unwrap_unset(mo.location_id, None),
+                order_created_date=iso_or_none(
+                    unwrap_unset(mo.order_created_date, None)
+                ),
+                production_deadline_date=iso_or_none(
+                    unwrap_unset(mo.production_deadline_date, None)
+                ),
+                done_date=iso_or_none(unwrap_unset(mo.done_date, None)),
+                is_linked_to_sales_order=unwrap_unset(
+                    mo.is_linked_to_sales_order, None
+                ),
+                sales_order_id=unwrap_unset(mo.sales_order_id, None),
+                total_cost=unwrap_unset(mo.total_cost, None),
+                # Row count on the list endpoint: Katana doesn't bundle recipe
+                # rows in this response, so `include_rows` is reserved for
+                # future work. Report 0 rather than lying about the count.
+                row_count=0,
+            )
+        )
+
+    return ListManufacturingOrdersResponse(
+        orders=summaries, total_count=len(summaries), pagination=pagination
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def list_manufacturing_orders(
+    request: Annotated[ListManufacturingOrdersRequest, Unpack()], context: Context
+) -> ToolResult:
+    """List manufacturing orders with filters (list-tool pattern v2).
+
+    Use this for discovery workflows — find MOs by status, location, linkage
+    to a sales order, or within a date window. Returns summary info (order_no,
+    status, variant, qty, costs, deadlines).
+
+    **Common filters:**
+    - `status="IN_PROGRESS"` — MOs currently being produced
+    - `is_linked_to_sales_order=true` — MOs tied to a customer order
+    - `location_id=N` — MOs at a specific production location
+
+    **Time windows:**
+    - `created_after` / `created_before` — server-side bounds on `created_at`
+    - `updated_after` / `updated_before` — server-side bounds on `updated_at`
+    - `production_deadline_after` / `production_deadline_before` —
+      client-side bounds on `production_deadline_date` (Katana has no
+      server-side filter). When set, the tool skips the page=1 short-circuit
+      so auto-pagination can scan enough rows to find `limit` matches
+      post-filter.
+
+    For full details on a specific MO, use `get_manufacturing_order`.
+    For its recipe rows, use `get_manufacturing_order_recipe`.
+    """
+    response = await _list_manufacturing_orders_impl(request, context)
+
+    if not response.orders:
+        md = "No manufacturing orders match the given filters."
+    else:
+        table = format_md_table(
+            headers=[
+                "Order #",
+                "Status",
+                "Variant",
+                "Planned",
+                "Actual",
+                "Deadline",
+                "Total Cost",
+            ],
+            rows=[
+                [
+                    o.order_no or o.id,
+                    o.status or "—",
+                    o.variant_id if o.variant_id is not None else "—",
+                    o.planned_quantity if o.planned_quantity is not None else "—",
+                    o.actual_quantity if o.actual_quantity is not None else "—",
+                    o.production_deadline_date or "—",
+                    f"{o.total_cost:.2f}" if o.total_cost is not None else "—",
+                ]
+                for o in response.orders
+            ],
+        )
+        md = f"## Manufacturing Orders ({response.total_count})\n\n{table}"
+
+    if response.pagination is not None:
+        p = response.pagination
+        if p.page is not None and p.total_pages is not None:
+            summary = f"\n\nPage {p.page} of {p.total_pages}"
+            if p.total_records is not None:
+                summary += f" (total: {p.total_records} records)"
+            md += summary
+
+    return make_simple_result(md, structured_data=response.model_dump())
+
+
 def register_tools(mcp: FastMCP) -> None:
     """Register all manufacturing order tools with the FastMCP instance.
 
@@ -1472,6 +1869,10 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "manufacturing", "write"},
         annotations=_write,
     )(create_manufacturing_order)
+    mcp.tool(
+        tags={"orders", "manufacturing", "read"},
+        annotations=_read,
+    )(list_manufacturing_orders)
     mcp.tool(
         tags={"orders", "manufacturing", "read"},
         annotations=_read,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -10,6 +10,8 @@ These tools provide:
 
 from __future__ import annotations
 
+import datetime as _datetime
+import json
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Annotated, Any, Literal
@@ -25,6 +27,7 @@ from katana_mcp.tools.tool_result_utils import (
     enum_to_str,
     format_md_table,
     iso_or_none,
+    make_simple_result,
     make_tool_result,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
@@ -33,6 +36,8 @@ from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     CreatePurchaseOrderInitialStatus,
     CreatePurchaseOrderRequest as APICreatePurchaseOrderRequest,
+    FindPurchaseOrdersBillingStatus,
+    FindPurchaseOrdersStatus,
     PurchaseOrderEntityType,
     PurchaseOrderRowRequest,
     RegularPurchaseOrder,
@@ -973,6 +978,432 @@ async def get_purchase_order(
     )
 
 
+# ============================================================================
+# Tool: list_purchase_orders (list-tool pattern v2)
+# ============================================================================
+
+
+def _parse_iso_datetime(value: str, field_name: str) -> datetime:
+    """Parse an ISO-8601 datetime string, raising ValueError on bad input.
+
+    Normalizes trailing ``Z`` / ``z`` (UTC shorthand) to ``+00:00`` before
+    parsing. Raises ``ValueError`` with the field name on unparseable input.
+    """
+    normalized = value
+    if normalized.endswith(("Z", "z")):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
+        ) from e
+
+
+class POPaginationMeta(BaseModel):
+    """Pagination metadata parsed from Katana's ``x-pagination`` header."""
+
+    total_records: int | None = None
+    total_pages: int | None = None
+    page: int | None = None
+    first_page: bool | None = None
+    last_page: bool | None = None
+
+
+def _parse_po_pagination_header(raw: str | None) -> POPaginationMeta | None:
+    """Parse Katana's ``x-pagination`` response header into POPaginationMeta."""
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    def _as_int(val: Any) -> int | None:
+        if val is None:
+            return None
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            return None
+
+    def _as_bool(val: Any) -> bool | None:
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, str):
+            lowered = val.strip().lower()
+            if lowered == "true":
+                return True
+            if lowered == "false":
+                return False
+        return None
+
+    return POPaginationMeta(
+        total_records=_as_int(data.get("total_records")),
+        total_pages=_as_int(data.get("total_pages")),
+        page=_as_int(data.get("page")),
+        first_page=_as_bool(data.get("first_page")),
+        last_page=_as_bool(data.get("last_page")),
+    )
+
+
+class ListPurchaseOrdersRequest(BaseModel):
+    """Request to list/filter purchase orders (list-tool pattern v2)."""
+
+    # Paging
+    limit: int = Field(
+        default=50,
+        ge=1,
+        le=250,
+        description=(
+            "Max rows to return (default 50, min 1, max 250 — Katana's "
+            "per-page ceiling). When `page` is set, acts as the page size."
+        ),
+    )
+    page: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Page number (1-based). When set, disables auto-pagination; "
+            "use with `limit` as page size."
+        ),
+    )
+
+    # Domain filters (server-side on Katana)
+    ids: list[int] | None = Field(
+        default=None, description="Filter by explicit list of purchase order IDs"
+    )
+    order_no: str | None = Field(default=None, description="Filter by exact order_no")
+    entity_type: PurchaseOrderEntityType | None = Field(
+        default=None,
+        description=(
+            "Filter by entity_type: 'regular' (materials) or 'outsourced' "
+            "(subcontracted)."
+        ),
+    )
+    status: FindPurchaseOrdersStatus | None = Field(
+        default=None,
+        description=(
+            "Filter by PO status: DRAFT, NOT_RECEIVED, PARTIALLY_RECEIVED, RECEIVED."
+        ),
+    )
+    billing_status: FindPurchaseOrdersBillingStatus | None = Field(
+        default=None,
+        description="Filter by billing status: BILLED, NOT_BILLED, PARTIALLY_BILLED.",
+    )
+    currency: str | None = Field(
+        default=None, description="Filter by currency code (e.g. 'USD')"
+    )
+    location_id: int | None = Field(
+        default=None, description="Filter by receiving location ID"
+    )
+    tracking_location_id: float | None = Field(
+        default=None, description="Filter by tracking location ID (outsourced POs)"
+    )
+    supplier_id: float | None = Field(default=None, description="Filter by supplier ID")
+    include_deleted: bool | None = Field(
+        default=None, description="When true, include soft-deleted purchase orders."
+    )
+
+    # Time-window filters (server-side)
+    created_after: str | None = Field(
+        default=None, description="ISO-8601 datetime lower bound on created_at."
+    )
+    created_before: str | None = Field(
+        default=None, description="ISO-8601 datetime upper bound on created_at."
+    )
+    updated_after: str | None = Field(
+        default=None, description="ISO-8601 datetime lower bound on updated_at."
+    )
+    updated_before: str | None = Field(
+        default=None, description="ISO-8601 datetime upper bound on updated_at."
+    )
+
+    # Time-window filters (client-side — Katana does not expose server-side
+    # filters for expected_arrival_date).
+    expected_arrival_after: str | None = Field(
+        default=None,
+        description=(
+            "ISO-8601 datetime lower bound on expected_arrival_date. "
+            "Applied client-side — Katana has no server-side filter. Pair "
+            "with a created_at window to keep fetched rows bounded."
+        ),
+    )
+    expected_arrival_before: str | None = Field(
+        default=None,
+        description=(
+            "ISO-8601 datetime upper bound on expected_arrival_date. "
+            "Applied client-side — see `expected_arrival_after`."
+        ),
+    )
+
+    # Row inclusion
+    include_rows: bool = Field(
+        default=False,
+        description=(
+            "When true, populate row-level detail (variant_id, quantity, "
+            "price, arrival date) on each summary. Katana bundles "
+            "purchase_order_rows inline on the list endpoint, so this is "
+            "free compared to `list_sales_orders`."
+        ),
+    )
+
+
+class PurchaseOrderRowSummary(BaseModel):
+    """Summary of a purchase order line item (used when include_rows=True)."""
+
+    id: int | None = None
+    variant_id: int | None = None
+    quantity: float | None = None
+    price_per_unit: float | None = None
+    arrival_date: str | None = None
+    received_date: str | None = None
+    total: float | None = None
+
+
+class PurchaseOrderSummary(BaseModel):
+    """Summary row for a purchase order in a list."""
+
+    id: int
+    order_no: str | None
+    status: str | None
+    billing_status: str | None
+    entity_type: str | None
+    supplier_id: int | None
+    location_id: int | None
+    currency: str | None
+    created_date: str | None
+    expected_arrival_date: str | None
+    total: float | None
+    row_count: int
+    rows: list[PurchaseOrderRowSummary] | None = None
+
+
+class ListPurchaseOrdersResponse(BaseModel):
+    """Response containing a list of purchase orders."""
+
+    orders: list[PurchaseOrderSummary]
+    total_count: int
+    pagination: POPaginationMeta | None = None
+
+
+def _po_row_summary(row: Any) -> PurchaseOrderRowSummary:
+    arrival = unwrap_unset(row.arrival_date, None)
+    received = unwrap_unset(row.received_date, None)
+    return PurchaseOrderRowSummary(
+        id=unwrap_unset(row.id, None),
+        variant_id=unwrap_unset(row.variant_id, None),
+        quantity=unwrap_unset(row.quantity, None),
+        price_per_unit=unwrap_unset(row.price_per_unit, None),
+        arrival_date=iso_or_none(arrival)
+        if isinstance(arrival, _datetime.datetime)
+        else None,
+        received_date=iso_or_none(received)
+        if isinstance(received, _datetime.datetime)
+        else None,
+        total=unwrap_unset(row.total, None),
+    )
+
+
+async def _list_purchase_orders_impl(
+    request: ListPurchaseOrdersRequest, context: Context
+) -> ListPurchaseOrdersResponse:
+    """List purchase orders with filters — follows list-tool pattern v2."""
+    from katana_public_api_client.api.purchase_order import find_purchase_orders
+    from katana_public_api_client.utils import unwrap_data
+
+    services = get_services(context)
+
+    kwargs: dict[str, Any] = {
+        "client": services.client,
+        "limit": request.limit,
+    }
+    if request.ids is not None:
+        kwargs["ids"] = request.ids
+    if request.order_no is not None:
+        kwargs["order_no"] = request.order_no
+    if request.entity_type is not None:
+        kwargs["entity_type"] = request.entity_type
+    if request.status is not None:
+        kwargs["status"] = request.status
+    if request.billing_status is not None:
+        kwargs["billing_status"] = request.billing_status
+    if request.currency is not None:
+        kwargs["currency"] = request.currency
+    if request.location_id is not None:
+        kwargs["location_id"] = request.location_id
+    if request.tracking_location_id is not None:
+        kwargs["tracking_location_id"] = request.tracking_location_id
+    if request.supplier_id is not None:
+        kwargs["supplier_id"] = request.supplier_id
+    if request.include_deleted is not None:
+        kwargs["include_deleted"] = request.include_deleted
+
+    # Server-side date filters
+    if request.created_after is not None:
+        kwargs["created_at_min"] = _parse_iso_datetime(
+            request.created_after, "created_after"
+        )
+    if request.created_before is not None:
+        kwargs["created_at_max"] = _parse_iso_datetime(
+            request.created_before, "created_before"
+        )
+    if request.updated_after is not None:
+        kwargs["updated_at_min"] = _parse_iso_datetime(
+            request.updated_after, "updated_after"
+        )
+    if request.updated_before is not None:
+        kwargs["updated_at_max"] = _parse_iso_datetime(
+            request.updated_before, "updated_before"
+        )
+
+    # Client-side filter parsing (eager — bad input fails loudly)
+    arrival_after_dt: datetime | None = None
+    arrival_before_dt: datetime | None = None
+    if request.expected_arrival_after is not None:
+        arrival_after_dt = _parse_iso_datetime(
+            request.expected_arrival_after, "expected_arrival_after"
+        )
+    if request.expected_arrival_before is not None:
+        arrival_before_dt = _parse_iso_datetime(
+            request.expected_arrival_before, "expected_arrival_before"
+        )
+    has_client_filter = arrival_after_dt is not None or arrival_before_dt is not None
+
+    # Pagination — skip short-circuit when client-side filter active.
+    if request.page is not None:
+        kwargs["page"] = request.page
+    elif 1 <= request.limit <= 250 and not has_client_filter:
+        kwargs["page"] = 1
+
+    response = await find_purchase_orders.asyncio_detailed(**kwargs)
+    attrs_list = unwrap_data(response, default=[])
+
+    if has_client_filter:
+
+        def _in_arrival_window(po: Any) -> bool:
+            arrival = unwrap_unset(po.expected_arrival_date, None)
+            if not isinstance(arrival, _datetime.datetime):
+                return False
+            if arrival_after_dt is not None and arrival < arrival_after_dt:
+                return False
+            return not (arrival_before_dt is not None and arrival > arrival_before_dt)
+
+        attrs_list = [po for po in attrs_list if _in_arrival_window(po)]
+
+    # Safety net: cap to request.limit post-pagination.
+    attrs_list = attrs_list[: request.limit]
+
+    # Pagination meta — only when caller set `page` explicitly.
+    pagination: POPaginationMeta | None = None
+    if request.page is not None:
+        headers = getattr(response, "headers", None)
+        if headers is not None:
+            pagination = _parse_po_pagination_header(headers.get("x-pagination"))
+
+    summaries: list[PurchaseOrderSummary] = []
+    for po in attrs_list:
+        raw_rows = unwrap_unset(po.purchase_order_rows, None) or []
+        rows = [_po_row_summary(r) for r in raw_rows] if request.include_rows else None
+        created_date = unwrap_unset(po.order_created_date, None)
+        expected = unwrap_unset(po.expected_arrival_date, None)
+        summaries.append(
+            PurchaseOrderSummary(
+                id=po.id,
+                order_no=unwrap_unset(po.order_no, None),
+                status=enum_to_str(unwrap_unset(po.status, None)),
+                billing_status=enum_to_str(unwrap_unset(po.billing_status, None)),
+                entity_type=enum_to_str(unwrap_unset(po.entity_type, None)),
+                supplier_id=unwrap_unset(po.supplier_id, None),
+                location_id=unwrap_unset(po.location_id, None),
+                currency=unwrap_unset(po.currency, None),
+                created_date=iso_or_none(created_date)
+                if isinstance(created_date, _datetime.datetime)
+                else None,
+                expected_arrival_date=iso_or_none(expected)
+                if isinstance(expected, _datetime.datetime)
+                else None,
+                total=unwrap_unset(po.total, None),
+                row_count=len(raw_rows),
+                rows=rows,
+            )
+        )
+
+    return ListPurchaseOrdersResponse(
+        orders=summaries, total_count=len(summaries), pagination=pagination
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def list_purchase_orders(
+    request: Annotated[ListPurchaseOrdersRequest, Unpack()], context: Context
+) -> ToolResult:
+    """List purchase orders with filters (list-tool pattern v2).
+
+    Use this for discovery workflows — find POs by supplier, status, location,
+    or within a date window. Returns summary info (order_no, status, supplier,
+    total, expected arrival, row_count).
+
+    **Common filters:**
+    - `status="NOT_RECEIVED"` — open POs awaiting delivery
+    - `supplier_id=N` — POs for a specific supplier
+    - `billing_status="NOT_BILLED"` — unbilled POs
+
+    **Time windows:**
+    - `created_after` / `created_before` — server-side bounds on `created_at`
+    - `updated_after` / `updated_before` — server-side bounds on `updated_at`
+    - `expected_arrival_after` / `expected_arrival_before` — client-side
+      bounds on `expected_arrival_date` (Katana has no server-side filter).
+      When set, the tool skips the page=1 short-circuit so auto-pagination
+      can scan enough rows to find `limit` matches post-filter.
+
+    Pass `include_rows=True` to populate per-PO line item details.
+    For full details on a specific PO, use `get_purchase_order`.
+    """
+    response = await _list_purchase_orders_impl(request, context)
+
+    if not response.orders:
+        md = "No purchase orders match the given filters."
+    else:
+        table = format_md_table(
+            headers=[
+                "Order #",
+                "Status",
+                "Supplier",
+                "Location",
+                "Rows",
+                "Total",
+                "Expected Arrival",
+            ],
+            rows=[
+                [
+                    o.order_no or o.id,
+                    o.status or "—",
+                    o.supplier_id if o.supplier_id is not None else "—",
+                    o.location_id if o.location_id is not None else "—",
+                    o.row_count,
+                    f"{o.total:.2f} {o.currency or ''}" if o.total is not None else "—",
+                    o.expected_arrival_date or "—",
+                ]
+                for o in response.orders
+            ],
+        )
+        md = f"## Purchase Orders ({response.total_count})\n\n{table}"
+
+    if response.pagination is not None:
+        p = response.pagination
+        if p.page is not None and p.total_pages is not None:
+            summary = f"\n\nPage {p.page} of {p.total_pages}"
+            if p.total_records is not None:
+                summary += f" (total: {p.total_records} records)"
+            md += summary
+
+    return make_simple_result(md, structured_data=response.model_dump())
+
+
 def register_tools(mcp: FastMCP) -> None:
     """Register all purchase order tools with the FastMCP instance.
 
@@ -999,6 +1430,9 @@ def register_tools(mcp: FastMCP) -> None:
     )
     mcp.tool(tags={"orders", "purchasing", "read"}, annotations=_read)(
         verify_order_document
+    )
+    mcp.tool(tags={"orders", "purchasing", "read"}, annotations=_read)(
+        list_purchase_orders
     )
     mcp.tool(tags={"orders", "purchasing", "read"}, annotations=_read)(
         get_purchase_order

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -1099,10 +1099,10 @@ class ListPurchaseOrdersRequest(BaseModel):
     location_id: int | None = Field(
         default=None, description="Filter by receiving location ID"
     )
-    tracking_location_id: float | None = Field(
+    tracking_location_id: int | None = Field(
         default=None, description="Filter by tracking location ID (outsourced POs)"
     )
-    supplier_id: float | None = Field(default=None, description="Filter by supplier ID")
+    supplier_id: int | None = Field(default=None, description="Filter by supplier ID")
     include_deleted: bool | None = Field(
         default=None, description="When true, include soft-deleted purchase orders."
     )
@@ -1234,10 +1234,12 @@ async def _list_purchase_orders_impl(
         kwargs["currency"] = request.currency
     if request.location_id is not None:
         kwargs["location_id"] = request.location_id
+    # Generated client types these as float for historical spec reasons;
+    # cast ints we accept at the tool boundary to keep the schema consistent.
     if request.tracking_location_id is not None:
-        kwargs["tracking_location_id"] = request.tracking_location_id
+        kwargs["tracking_location_id"] = float(request.tracking_location_id)
     if request.supplier_id is not None:
-        kwargs["supplier_id"] = request.supplier_id
+        kwargs["supplier_id"] = float(request.supplier_id)
     if request.include_deleted is not None:
         kwargs["include_deleted"] = request.include_deleted
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -9,6 +9,7 @@ These tools provide:
 from __future__ import annotations
 
 import asyncio
+import datetime as _datetime
 import json
 from datetime import UTC, datetime
 from typing import Annotated, Any, Literal
@@ -360,25 +361,34 @@ async def create_sales_order(
 
 
 class ListSalesOrdersRequest(BaseModel):
-    """Request to list/filter sales orders."""
+    """Request to list/filter sales orders (list-tool pattern v2)."""
 
+    # Paging
     limit: int = Field(
         default=50,
         ge=1,
+        le=250,
         description=(
-            "Max orders to return (default 50, min 1). When `page` is set, "
-            "acts as the page size for that request."
+            "Max orders to return (default 50, min 1, max 250 — Katana's "
+            "per-page ceiling). When `page` is set, acts as the page size "
+            "for that request."
         ),
     )
     page: int | None = Field(
         default=None,
+        ge=1,
         description=(
             "Page number (1-based). When set, returns a single page and "
             "disables auto-pagination; `limit` becomes the page size for "
             "that request."
         ),
     )
+
+    # Domain filters
     order_no: str | None = Field(default=None, description="Filter by exact order_no")
+    ids: list[int] | None = Field(
+        default=None, description="Filter by explicit list of sales order IDs"
+    )
     customer_id: int | None = Field(default=None, description="Filter by customer ID")
     location_id: int | None = Field(default=None, description="Filter by location ID")
     status: str | None = Field(
@@ -388,9 +398,54 @@ class ListSalesOrdersRequest(BaseModel):
         default=None,
         description="Filter by production status (NONE, NOT_STARTED, IN_PROGRESS, BLOCKED, DONE, NOT_APPLICABLE)",
     )
+    invoicing_status: str | None = Field(
+        default=None,
+        description="Filter by invoicing status (e.g. NOT_INVOICED, INVOICED)",
+    )
+    currency: str | None = Field(
+        default=None, description="Filter by currency code (e.g. 'USD')"
+    )
+    include_deleted: bool | None = Field(
+        default=None,
+        description="When true, include soft-deleted sales orders in the results.",
+    )
     needs_work_orders: bool = Field(
         default=False,
         description="Convenience: filter to orders with production_status=NONE (no MOs created yet)",
+    )
+
+    # Time-window filters (server-side on Katana)
+    created_after: str | None = Field(
+        default=None, description="ISO-8601 datetime lower bound on created_at."
+    )
+    created_before: str | None = Field(
+        default=None, description="ISO-8601 datetime upper bound on created_at."
+    )
+    updated_after: str | None = Field(
+        default=None, description="ISO-8601 datetime lower bound on updated_at."
+    )
+    updated_before: str | None = Field(
+        default=None, description="ISO-8601 datetime upper bound on updated_at."
+    )
+
+    # Time-window filters (client-side — Katana does not expose
+    # delivery_date_min/max as server-side filters, so the tool applies them
+    # after fetch).
+    delivered_after: str | None = Field(
+        default=None,
+        description=(
+            "ISO-8601 datetime lower bound on delivery_date. Applied "
+            "client-side — Katana does not expose a server-side filter "
+            "for delivery_date, so this filters post-fetch. Combine with a "
+            "created_at window to keep fetched rows bounded."
+        ),
+    )
+    delivered_before: str | None = Field(
+        default=None,
+        description=(
+            "ISO-8601 datetime upper bound on delivery_date. Applied "
+            "client-side — see `delivered_after`."
+        ),
     )
 
 
@@ -457,6 +512,25 @@ class ListSalesOrdersResponse(BaseModel):
     )
 
 
+def _parse_iso_datetime(value: str, field_name: str) -> datetime:
+    """Parse an ISO-8601 datetime string, raising ValueError on malformed input.
+
+    Normalizes trailing ``Z`` / ``z`` (UTC shorthand) to ``+00:00`` before
+    parsing — ``datetime.fromisoformat`` didn't accept ``Z`` before Python
+    3.11. Raises ``ValueError`` with the field name on unparseable input so
+    caller mistakes surface loudly instead of being silently dropped.
+    """
+    normalized = value
+    if normalized.endswith(("Z", "z")):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
+        ) from e
+
+
 def _parse_pagination_header(raw: str | None) -> PaginationMeta | None:
     """Parse Katana's `x-pagination` response header into a PaginationMeta.
 
@@ -510,7 +584,7 @@ def _parse_pagination_header(raw: str | None) -> PaginationMeta | None:
 async def _list_sales_orders_impl(
     request: ListSalesOrdersRequest, context: Context
 ) -> ListSalesOrdersResponse:
-    """List sales orders with filters."""
+    """List sales orders with filters (list-tool pattern v2)."""
     from katana_public_api_client.api.sales_order import get_all_sales_orders
     from katana_public_api_client.utils import unwrap_data
 
@@ -521,34 +595,95 @@ async def _list_sales_orders_impl(
     production_status = request.production_status
     if production_status is None and request.needs_work_orders:
         production_status = "NONE"
-    filters = {
-        "order_no": request.order_no,
-        "customer_id": request.customer_id,
-        "location_id": request.location_id,
-        "status": request.status,
-        "production_status": production_status,
-    }
     kwargs: dict[str, Any] = {
         "client": services.client,
         "limit": request.limit,
-        **{k: v for k, v in filters.items() if v is not None},
     }
+    if request.order_no is not None:
+        kwargs["order_no"] = request.order_no
+    if request.ids is not None:
+        kwargs["ids"] = request.ids
+    if request.customer_id is not None:
+        kwargs["customer_id"] = request.customer_id
+    if request.location_id is not None:
+        kwargs["location_id"] = request.location_id
+    if request.status is not None:
+        kwargs["status"] = request.status
+    if production_status is not None:
+        kwargs["production_status"] = production_status
+    if request.invoicing_status is not None:
+        kwargs["invoicing_status"] = request.invoicing_status
+    if request.currency is not None:
+        kwargs["currency"] = request.currency
+    if request.include_deleted is not None:
+        kwargs["include_deleted"] = request.include_deleted
+
+    # Server-side date filters
+    if request.created_after is not None:
+        kwargs["created_at_min"] = _parse_iso_datetime(
+            request.created_after, "created_after"
+        )
+    if request.created_before is not None:
+        kwargs["created_at_max"] = _parse_iso_datetime(
+            request.created_before, "created_before"
+        )
+    if request.updated_after is not None:
+        kwargs["updated_at_min"] = _parse_iso_datetime(
+            request.updated_after, "updated_after"
+        )
+    if request.updated_before is not None:
+        kwargs["updated_at_max"] = _parse_iso_datetime(
+            request.updated_before, "updated_before"
+        )
+
+    # Client-side date filters — parsed eagerly so bad input fails loudly
+    # before we spend an API call.
+    delivered_after_dt: datetime | None = None
+    delivered_before_dt: datetime | None = None
+    if request.delivered_after is not None:
+        delivered_after_dt = _parse_iso_datetime(
+            request.delivered_after, "delivered_after"
+        )
+    if request.delivered_before is not None:
+        delivered_before_dt = _parse_iso_datetime(
+            request.delivered_before, "delivered_before"
+        )
+    has_client_filter = (
+        delivered_after_dt is not None or delivered_before_dt is not None
+    )
+
     # Pagination strategy:
     # - If `page` is set, the caller is driving pagination manually; forward
-    #   it so PaginationTransport disables auto-pagination (see: "ANY explicit
-    #   `page` parameter in URL disables auto-pagination") and lets callers
+    #   it so PaginationTransport disables auto-pagination and lets callers
     #   walk beyond the transport's max_pages ceiling.
     # - Otherwise, when `limit` fits in a single Katana page (<=250, the API's
-    #   max page size), pass page=1 to short-circuit auto-pagination and
-    #   avoid fetching thousands of rows when the caller asked for a small
-    #   cap (see #329). Lower bound is defence-in-depth with `ge=1` on Field.
+    #   max page size) AND no client-side-only filter is active, pass page=1
+    #   to short-circuit auto-pagination. When a client-side filter IS active,
+    #   skip the short-circuit so the transport's auto-pagination can scan
+    #   enough rows to find `limit` matching ones post-filter (#341 pattern).
     if request.page is not None:
         kwargs["page"] = request.page
-    elif 1 <= request.limit <= 250:
+    elif 1 <= request.limit <= 250 and not has_client_filter:
         kwargs["page"] = 1
 
     response = await get_all_sales_orders.asyncio_detailed(**kwargs)
     attrs_list = unwrap_data(response, default=[])
+
+    # Client-side delivery_date filter (Katana has no server-side param).
+    if has_client_filter:
+
+        def _in_delivery_window(so: Any) -> bool:
+            delivery = unwrap_unset(so.delivery_date, None)
+            if not isinstance(delivery, _datetime.datetime):
+                return False
+            if delivered_after_dt is not None and delivery < delivered_after_dt:
+                return False
+            return not (
+                delivered_before_dt is not None and delivery > delivered_before_dt
+            )
+
+        attrs_list = [so for so in attrs_list if _in_delivery_window(so)]
+
     # Safety net: cap to request.limit post-pagination so we never return more
     # than the caller asked for, regardless of how the transport behaved.
     attrs_list = attrs_list[: request.limit]
@@ -592,7 +727,7 @@ async def _list_sales_orders_impl(
 async def list_sales_orders(
     request: Annotated[ListSalesOrdersRequest, Unpack()], context: Context
 ) -> ToolResult:
-    """List sales orders with filters.
+    """List sales orders with filters (list-tool pattern v2).
 
     Use this for discovery workflows — find recent orders, orders needing work
     orders, orders for a specific customer, etc. Returns summary info (order_no,
@@ -602,6 +737,14 @@ async def list_sales_orders(
     - `needs_work_orders=true` — orders with no MOs yet (production_status=NONE)
     - `status="NOT_SHIPPED"` — unshipped orders
     - `customer_id=N` — orders for a specific customer
+
+    **Time windows:**
+    - `created_after` / `created_before` — server-side bounds on `created_at`
+    - `updated_after` / `updated_before` — server-side bounds on `updated_at`
+    - `delivered_after` / `delivered_before` — client-side bounds on
+      `delivery_date` (Katana has no server-side filter). When set, the tool
+      skips the page=1 short-circuit so auto-pagination can scan enough rows
+      to find `limit` matching results post-filter.
 
     For full line-item details on a specific order, use `get_sales_order` next.
     """

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -891,3 +891,341 @@ async def test_create_manufacturing_order_make_to_order_with_subassemblies():
 
     assert result.is_preview is True
     assert "subassemblies" in result.message
+
+
+# ============================================================================
+# list_manufacturing_orders — pattern v2
+# ============================================================================
+
+_MO_GET_ALL = (
+    "katana_public_api_client.api.manufacturing_order.get_all_manufacturing_orders"
+)
+_MO_UNWRAP_DATA = "katana_public_api_client.utils.unwrap_data"
+
+
+def _make_mock_mo(
+    *,
+    id: int = 1,
+    order_no: str | None = "MO-1",
+    status: str | None = "NOT_STARTED",
+    variant_id: int | None = 100,
+    planned_quantity: float | None = 5.0,
+    actual_quantity: float | None = None,
+    location_id: int | None = 1,
+    order_created_date: datetime | None = None,
+    production_deadline_date: datetime | None = None,
+    done_date: datetime | None = None,
+    is_linked_to_sales_order: bool | None = False,
+    sales_order_id: int | None = None,
+    total_cost: float | None = 999.0,
+) -> MagicMock:
+    """Build a mock ManufacturingOrder attrs object for tests."""
+    mo = MagicMock()
+    mo.id = id
+    mo.order_no = order_no if order_no is not None else UNSET
+    mo.status = status if status is not None else UNSET
+    mo.variant_id = variant_id if variant_id is not None else UNSET
+    mo.planned_quantity = planned_quantity if planned_quantity is not None else UNSET
+    mo.actual_quantity = actual_quantity if actual_quantity is not None else UNSET
+    mo.location_id = location_id if location_id is not None else UNSET
+    mo.order_created_date = (
+        order_created_date if order_created_date is not None else UNSET
+    )
+    mo.production_deadline_date = (
+        production_deadline_date if production_deadline_date is not None else UNSET
+    )
+    mo.done_date = done_date if done_date is not None else UNSET
+    mo.is_linked_to_sales_order = (
+        is_linked_to_sales_order if is_linked_to_sales_order is not None else UNSET
+    )
+    mo.sales_order_id = sales_order_id if sales_order_id is not None else UNSET
+    mo.total_cost = total_cost if total_cost is not None else UNSET
+    return mo
+
+
+@pytest.mark.asyncio
+async def test_list_manufacturing_orders_server_side_filters_pass_through():
+    """Server-side filters forward to the API kwargs when set."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListManufacturingOrdersRequest,
+        _list_manufacturing_orders_impl,
+    )
+
+    from katana_public_api_client.models import GetAllManufacturingOrdersStatus
+
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    request = ListManufacturingOrdersRequest(
+        ids=[1, 2, 3],
+        order_no="MO-42",
+        status=GetAllManufacturingOrdersStatus.IN_PROGRESS,
+        location_id=7,
+        is_linked_to_sales_order=True,
+        include_deleted=False,
+        limit=25,
+    )
+
+    with (
+        patch(f"{_MO_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_MO_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_manufacturing_orders_impl(request, context)
+
+    assert captured["ids"] == [1, 2, 3]
+    assert captured["order_no"] == "MO-42"
+    assert captured["status"] == GetAllManufacturingOrdersStatus.IN_PROGRESS
+    assert captured["location_id"] == 7
+    assert captured["is_linked_to_sales_order"] is True
+    assert captured["include_deleted"] is False
+    assert captured["limit"] == 25
+
+
+@pytest.mark.asyncio
+async def test_list_manufacturing_orders_page_short_circuit_single_page():
+    """limit <= 250 with no client-side filter adds page=1."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListManufacturingOrdersRequest,
+        _list_manufacturing_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_MO_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_MO_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_manufacturing_orders_impl(
+            ListManufacturingOrdersRequest(limit=10), context
+        )
+
+    assert captured["page"] == 1
+    assert captured["limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_list_manufacturing_orders_caller_page_preserved():
+    """Caller's explicit `page` overrides the short-circuit."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListManufacturingOrdersRequest,
+        _list_manufacturing_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_MO_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_MO_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_manufacturing_orders_impl(
+            ListManufacturingOrdersRequest(limit=50, page=3), context
+        )
+
+    assert captured["page"] == 3
+    assert captured["limit"] == 50
+
+
+@pytest.mark.asyncio
+async def test_list_manufacturing_orders_skips_short_circuit_when_client_filter_set():
+    """production_deadline filter (client-side) suppresses the page=1 short-circuit."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListManufacturingOrdersRequest,
+        _list_manufacturing_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_MO_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_MO_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_manufacturing_orders_impl(
+            ListManufacturingOrdersRequest(
+                limit=10, production_deadline_after="2026-04-01T00:00:00Z"
+            ),
+            context,
+        )
+
+    assert "page" not in captured
+    assert captured["limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_list_manufacturing_orders_pagination_meta_from_header():
+    """x-pagination header populates PaginationMeta when page is set."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListManufacturingOrdersRequest,
+        _list_manufacturing_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+
+    mock_response = MagicMock()
+    mock_response.headers = {
+        "x-pagination": (
+            '{"total_records":"200","total_pages":"4","offset":"0","page":"2",'
+            '"first_page":"false","last_page":"false"}'
+        )
+    }
+
+    async def fake(**kwargs):
+        return mock_response
+
+    with (
+        patch(f"{_MO_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_MO_UNWRAP_DATA, return_value=[]),
+    ):
+        result = await _list_manufacturing_orders_impl(
+            ListManufacturingOrdersRequest(page=2, limit=50), context
+        )
+
+    assert result.pagination is not None
+    assert result.pagination.total_records == 200
+    assert result.pagination.total_pages == 4
+    assert result.pagination.page == 2
+    assert result.pagination.first_page is False
+
+
+@pytest.mark.asyncio
+async def test_list_manufacturing_orders_caps_to_limit():
+    """Safety net: slice results to request.limit regardless of transport."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListManufacturingOrdersRequest,
+        _list_manufacturing_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    over_fetched = [_make_mock_mo(id=i, order_no=f"MO-{i}") for i in range(100)]
+
+    with (
+        patch(f"{_MO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_MO_UNWRAP_DATA, return_value=over_fetched),
+    ):
+        result = await _list_manufacturing_orders_impl(
+            ListManufacturingOrdersRequest(limit=25), context
+        )
+
+    assert len(result.orders) == 25
+    assert result.total_count == 25
+
+
+@pytest.mark.asyncio
+async def test_list_manufacturing_orders_limit_le_250_validation():
+    """limit > 250 is rejected at the schema boundary."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListManufacturingOrdersRequest,
+    )
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ListManufacturingOrdersRequest(limit=500)
+
+
+@pytest.mark.asyncio
+async def test_list_manufacturing_orders_invalid_date_raises():
+    """Malformed ISO-8601 for a date filter surfaces as ValueError."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListManufacturingOrdersRequest,
+        _list_manufacturing_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+
+    with (
+        patch(f"{_MO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_MO_UNWRAP_DATA, return_value=[]),
+        pytest.raises(ValueError, match=r"Invalid ISO-8601.*created_after"),
+    ):
+        await _list_manufacturing_orders_impl(
+            ListManufacturingOrdersRequest(created_after="not-a-date"), context
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_manufacturing_orders_date_z_normalization():
+    """Trailing Z and z both normalize to +00:00 and forward as datetimes."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListManufacturingOrdersRequest,
+        _list_manufacturing_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_MO_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_MO_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_manufacturing_orders_impl(
+            ListManufacturingOrdersRequest(
+                created_after="2026-01-01T00:00:00Z",
+                updated_before="2026-04-01T00:00:00z",
+            ),
+            context,
+        )
+
+    assert isinstance(captured["created_at_min"], datetime)
+    assert isinstance(captured["updated_at_max"], datetime)
+    assert captured["created_at_min"].tzinfo is not None
+    assert captured["updated_at_max"].tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_list_manufacturing_orders_production_deadline_client_side_filter():
+    """production_deadline_after/before filters post-fetch via client code."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListManufacturingOrdersRequest,
+        _list_manufacturing_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    mos = [
+        _make_mock_mo(
+            id=1,
+            order_no="MO-1",
+            production_deadline_date=datetime(2026, 4, 15, tzinfo=UTC),
+        ),
+        _make_mock_mo(
+            id=2,
+            order_no="MO-2",
+            production_deadline_date=datetime(2027, 1, 1, tzinfo=UTC),
+        ),
+    ]
+
+    with (
+        patch(f"{_MO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_MO_UNWRAP_DATA, return_value=mos),
+    ):
+        result = await _list_manufacturing_orders_impl(
+            ListManufacturingOrdersRequest(
+                production_deadline_after="2026-04-01T00:00:00Z",
+                production_deadline_before="2026-04-30T00:00:00Z",
+            ),
+            context,
+        )
+
+    assert result.total_count == 1
+    assert result.orders[0].id == 1

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -1431,3 +1431,394 @@ async def test_get_purchase_order_by_id():
     assert result.id == 12345
     assert result.order_no == "PO-BYID"
     assert len(result.rows) == 2
+
+
+# ============================================================================
+# list_purchase_orders — pattern v2
+# ============================================================================
+
+
+def _make_mock_list_po(
+    *,
+    id: int = 1,
+    order_no: str | None = "PO-1",
+    status: str | None = "NOT_RECEIVED",
+    billing_status: str | None = "NOT_BILLED",
+    entity_type: str | None = "regular",
+    supplier_id: int | None = 10,
+    location_id: int | None = 1,
+    currency: str | None = "USD",
+    order_created_date: datetime | None = None,
+    expected_arrival_date: datetime | None = None,
+    total: float | None = 999.0,
+    rows: list | None = None,
+) -> MagicMock:
+    """Build a mock purchase order attrs object for list-tool tests."""
+    po = MagicMock()
+    po.id = id
+    po.order_no = order_no if order_no is not None else UNSET
+    po.status = status if status is not None else UNSET
+    po.billing_status = billing_status if billing_status is not None else UNSET
+    po.entity_type = entity_type if entity_type is not None else UNSET
+    po.supplier_id = supplier_id if supplier_id is not None else UNSET
+    po.location_id = location_id if location_id is not None else UNSET
+    po.currency = currency if currency is not None else UNSET
+    po.order_created_date = (
+        order_created_date if order_created_date is not None else UNSET
+    )
+    po.expected_arrival_date = (
+        expected_arrival_date if expected_arrival_date is not None else UNSET
+    )
+    po.total = total if total is not None else UNSET
+    po.purchase_order_rows = rows if rows is not None else UNSET
+    return po
+
+
+def _make_mock_po_row(
+    *,
+    id: int = 1,
+    variant_id: int = 100,
+    quantity: float = 2.0,
+    price_per_unit: float = 50.0,
+    arrival_date: datetime | None = None,
+) -> MagicMock:
+    """Build a mock purchase order row."""
+    r = MagicMock()
+    r.id = id
+    r.variant_id = variant_id
+    r.quantity = quantity
+    r.price_per_unit = price_per_unit
+    r.arrival_date = arrival_date if arrival_date is not None else UNSET
+    r.received_date = UNSET
+    r.total = quantity * price_per_unit
+    return r
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_server_side_filters_pass_through():
+    """Server-side filters forward to find_purchase_orders kwargs."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    from katana_public_api_client.models import (
+        FindPurchaseOrdersBillingStatus,
+        FindPurchaseOrdersStatus,
+        PurchaseOrderEntityType,
+    )
+
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    request = ListPurchaseOrdersRequest(
+        ids=[1, 2, 3],
+        order_no="PO-42",
+        entity_type=PurchaseOrderEntityType.REGULAR,
+        status=FindPurchaseOrdersStatus.NOT_RECEIVED,
+        billing_status=FindPurchaseOrdersBillingStatus.NOT_BILLED,
+        currency="USD",
+        location_id=5,
+        supplier_id=99,
+        include_deleted=False,
+        limit=25,
+    )
+
+    with (
+        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_purchase_orders_impl(request, context)
+
+    assert captured["ids"] == [1, 2, 3]
+    assert captured["order_no"] == "PO-42"
+    assert captured["entity_type"] == PurchaseOrderEntityType.REGULAR
+    assert captured["status"] == FindPurchaseOrdersStatus.NOT_RECEIVED
+    assert captured["billing_status"] == FindPurchaseOrdersBillingStatus.NOT_BILLED
+    assert captured["currency"] == "USD"
+    assert captured["location_id"] == 5
+    assert captured["supplier_id"] == 99
+    assert captured["include_deleted"] is False
+    assert captured["limit"] == 25
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_page_short_circuit_single_page():
+    """limit <= 250 with no client-side filter adds page=1."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_purchase_orders_impl(ListPurchaseOrdersRequest(limit=10), context)
+
+    assert captured["page"] == 1
+    assert captured["limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_caller_page_preserved():
+    """Explicit page overrides the short-circuit."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_purchase_orders_impl(
+            ListPurchaseOrdersRequest(limit=50, page=2), context
+        )
+
+    assert captured["page"] == 2
+    assert captured["limit"] == 50
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_skips_short_circuit_when_client_filter_set():
+    """expected_arrival filter suppresses the page=1 short-circuit."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_purchase_orders_impl(
+            ListPurchaseOrdersRequest(
+                limit=10, expected_arrival_after="2026-04-01T00:00:00Z"
+            ),
+            context,
+        )
+
+    assert "page" not in captured
+    assert captured["limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_pagination_meta_from_header():
+    """x-pagination header populates PaginationMeta when page is set."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+
+    mock_response = MagicMock()
+    mock_response.headers = {
+        "x-pagination": (
+            '{"total_records":"200","total_pages":"4","offset":"0","page":"2",'
+            '"first_page":"false","last_page":"false"}'
+        )
+    }
+
+    async def fake(**kwargs):
+        return mock_response
+
+    with (
+        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        result = await _list_purchase_orders_impl(
+            ListPurchaseOrdersRequest(page=2, limit=50), context
+        )
+
+    assert result.pagination is not None
+    assert result.pagination.total_records == 200
+    assert result.pagination.total_pages == 4
+    assert result.pagination.page == 2
+    assert result.pagination.first_page is False
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_caps_to_limit():
+    """Safety net: slice results to request.limit."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    over_fetched = [_make_mock_list_po(id=i, order_no=f"PO-{i}") for i in range(100)]
+
+    with (
+        patch(f"{_PO_FIND}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=over_fetched),
+    ):
+        result = await _list_purchase_orders_impl(
+            ListPurchaseOrdersRequest(limit=25), context
+        )
+
+    assert len(result.orders) == 25
+    assert result.total_count == 25
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_limit_le_250_validation():
+    """limit > 250 is rejected at the schema boundary."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+    )
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ListPurchaseOrdersRequest(limit=500)
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_invalid_date_raises():
+    """Malformed ISO-8601 surfaces as ValueError."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+
+    with (
+        patch(f"{_PO_FIND}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=[]),
+        pytest.raises(ValueError, match=r"Invalid ISO-8601.*created_after"),
+    ):
+        await _list_purchase_orders_impl(
+            ListPurchaseOrdersRequest(created_after="not-a-date"), context
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_date_z_normalization():
+    """Trailing Z/z normalize to +00:00 and forward as datetimes."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_purchase_orders_impl(
+            ListPurchaseOrdersRequest(
+                created_after="2026-01-01T00:00:00Z",
+                updated_before="2026-04-01T00:00:00z",
+            ),
+            context,
+        )
+
+    assert isinstance(captured["created_at_min"], datetime)
+    assert isinstance(captured["updated_at_max"], datetime)
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_expected_arrival_client_side_filter():
+    """expected_arrival_after/before filters post-fetch."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    pos = [
+        _make_mock_list_po(
+            id=1,
+            order_no="PO-1",
+            expected_arrival_date=datetime(2026, 4, 15, tzinfo=UTC),
+        ),
+        _make_mock_list_po(
+            id=2,
+            order_no="PO-2",
+            expected_arrival_date=datetime(2027, 1, 1, tzinfo=UTC),
+        ),
+    ]
+
+    with (
+        patch(f"{_PO_FIND}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=pos),
+    ):
+        result = await _list_purchase_orders_impl(
+            ListPurchaseOrdersRequest(
+                expected_arrival_after="2026-04-01T00:00:00Z",
+                expected_arrival_before="2026-04-30T00:00:00Z",
+            ),
+            context,
+        )
+
+    assert result.total_count == 1
+    assert result.orders[0].id == 1
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_include_rows_populates_details():
+    """include_rows=True exposes per-PO line item detail."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _ = create_mock_context()
+    mock_po = _make_mock_list_po(
+        id=7,
+        rows=[
+            _make_mock_po_row(id=1, variant_id=100, quantity=5, price_per_unit=10.0),
+            _make_mock_po_row(id=2, variant_id=200, quantity=2, price_per_unit=25.0),
+        ],
+    )
+
+    with (
+        patch(f"{_PO_FIND}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=[mock_po]),
+    ):
+        result_with = await _list_purchase_orders_impl(
+            ListPurchaseOrdersRequest(include_rows=True), context
+        )
+        result_without = await _list_purchase_orders_impl(
+            ListPurchaseOrdersRequest(include_rows=False), context
+        )
+
+    assert result_with.orders[0].rows is not None
+    assert len(result_with.orders[0].rows) == 2
+    assert result_with.orders[0].row_count == 2
+    assert result_without.orders[0].rows is None
+    # row_count should still reflect the true count regardless of include_rows
+    assert result_without.orders[0].row_count == 2

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -1541,7 +1541,10 @@ async def test_list_purchase_orders_server_side_filters_pass_through():
     assert captured["billing_status"] == FindPurchaseOrdersBillingStatus.NOT_BILLED
     assert captured["currency"] == "USD"
     assert captured["location_id"] == 5
-    assert captured["supplier_id"] == 99
+    # supplier_id cast to float at the API boundary (generated-client signature
+    # uses `float` historically); the tool-facing field is `int`.
+    assert captured["supplier_id"] == 99.0
+    assert isinstance(captured["supplier_id"], float)
     assert captured["include_deleted"] is False
     assert captured["limit"] == 25
 

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -738,28 +738,6 @@ async def test_list_sales_orders_passes_page_1_when_limit_fits_single_page():
 
 
 @pytest.mark.asyncio
-async def test_list_sales_orders_omits_page_when_limit_exceeds_single_page():
-    """For limit > 250, let auto-pagination do its thing (no explicit page)."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    request = ListSalesOrdersRequest(limit=500)
-
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_sales_orders_impl(request, context)
-
-    assert "page" not in captured
-    assert captured["limit"] == 500
-
-
-@pytest.mark.asyncio
 async def test_list_sales_orders_returns_summary_rows():
     """Response rows carry order_no, totals, and row_count."""
     context, _ = create_mock_context()
@@ -861,6 +839,152 @@ async def test_list_sales_orders_no_page_leaves_pagination_none():
     # gated on the *request's* page field, not what we sent to the API.
     assert captured["page"] == 1
     assert result.pagination is None
+
+
+# ============================================================================
+# list_sales_orders — date filters + pattern v2 refinements
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_server_side_date_filters_passed_through():
+    """created_after/before + updated_after/before forward as datetime kwargs."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    request = ListSalesOrdersRequest(
+        created_after="2026-01-01T00:00:00+00:00",
+        created_before="2026-04-01T00:00:00Z",
+        updated_after="2026-02-01T00:00:00z",
+        updated_before="2026-03-31T23:59:59+00:00",
+    )
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SO_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_sales_orders_impl(request, context)
+
+    assert isinstance(captured["created_at_min"], datetime)
+    assert isinstance(captured["created_at_max"], datetime)
+    assert isinstance(captured["updated_at_min"], datetime)
+    assert isinstance(captured["updated_at_max"], datetime)
+    # Z / z normalized to +00:00
+    assert captured["created_at_max"].tzinfo is not None
+    assert captured["updated_at_min"].tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_invalid_server_date_raises():
+    """Malformed ISO-8601 for a server-side date surfaces as ValueError."""
+    context, _ = create_mock_context()
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_DATA, return_value=[]),
+        pytest.raises(ValueError, match=r"Invalid ISO-8601.*created_after"),
+    ):
+        await _list_sales_orders_impl(
+            ListSalesOrdersRequest(created_after="not-a-date"), context
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_delivered_filter_applied_client_side():
+    """delivered_after/before filter post-fetch (Katana has no server param)."""
+    context, _ = create_mock_context()
+
+    sos = [
+        _make_mock_so(id=1, order_no="SO-1"),
+        _make_mock_so(id=2, order_no="SO-2"),
+    ]
+    # SO-1 has delivery_date=2026-04-20 (from _make_mock_so default).
+    # Push SO-2 to 2027-01-01 — outside the filter window.
+    sos[1].delivery_date = datetime(2027, 1, 1, tzinfo=UTC)
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_DATA, return_value=sos),
+    ):
+        result = await _list_sales_orders_impl(
+            ListSalesOrdersRequest(
+                delivered_after="2026-04-01T00:00:00Z",
+                delivered_before="2026-04-30T00:00:00Z",
+            ),
+            context,
+        )
+
+    assert result.total_count == 1
+    assert result.orders[0].id == 1
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_skips_page1_short_circuit_when_delivered_filter_set():
+    """When a client-side delivered filter is active, don't short-circuit page=1
+    so auto-pagination can scan enough rows post-filter."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    request = ListSalesOrdersRequest(limit=10, delivered_after="2026-04-01T00:00:00Z")
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SO_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_sales_orders_impl(request, context)
+
+    # page must NOT be set because we need auto-pagination to scan enough
+    # rows to post-filter down to `limit`.
+    assert "page" not in captured
+    assert captured["limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_limit_le_250_validation():
+    """Request with limit > 250 is rejected at the schema boundary."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ListSalesOrdersRequest(limit=500)
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_page_ge_1_validation():
+    """page=0 is rejected at the schema boundary."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ListSalesOrdersRequest(page=0)
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_ids_include_deleted_pass_through():
+    """ids and include_deleted forward to API kwargs when set."""
+    context, _ = create_mock_context()
+    captured: dict = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    request = ListSalesOrdersRequest(ids=[1, 2, 3], include_deleted=True)
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
+        patch(_SO_UNWRAP_DATA, return_value=[]),
+    ):
+        await _list_sales_orders_impl(request, context)
+
+    assert captured["ids"] == [1, 2, 3]
+    assert captured["include_deleted"] is True
 
 
 # ============================================================================


### PR DESCRIPTION
## Description

Expands the scope of #333 (per user direction) to deliver three related
list-tool changes in one PR:

- **`list_sales_orders`** — adds server-side date-range filters
  (`created_after/before`, `updated_after/before`) and client-side
  `delivered_after/before` (Katana has no server-side filter for
  `delivery_date`). Picks up `le=250` on `limit` and `ge=1` on `page` to
  match the post-#341 pattern v2 refinement. Adds pass-through for
  `ids`, `invoicing_status`, `currency`, `include_deleted`.
- **`list_manufacturing_orders`** — new tool in `foundation/manufacturing_orders.py`.
  Server-side filters: `ids`, `order_no`, `status`, `location_id`,
  `is_linked_to_sales_order`, `include_deleted`, `created_at_min/max`,
  `updated_at_min/max`. Client-side date pair:
  `production_deadline_after/before`.
- **`list_purchase_orders`** — new tool in `foundation/purchase_orders.py`.
  Server-side filters: `ids`, `order_no`, `entity_type`, `status`,
  `billing_status`, `currency`, `location_id`, `tracking_location_id`,
  `supplier_id`, `include_deleted`, `created_at_min/max`,
  `updated_at_min/max`. Client-side date pair:
  `expected_arrival_after/before`. `include_rows=True` populates line-item
  detail (POs bundle rows in the list response).

All three tools follow **list-tool pattern v2**:
- `limit: int = Field(default=50, ge=1, le=250, ...)` — matches Katana's
  per-page ceiling.
- `page: int | None = Field(default=None, ge=1, ...)` — rejects invalid
  pages at the schema boundary.
- `_parse_iso_datetime` helper normalizes trailing `Z`/`z` to `+00:00`
  and raises `ValueError` with field-name context on unparseable input
  (no silent drops).
- **Short-circuit-skip-when-client-side-filter-is-active** — when a
  client-side-only filter (`delivered_*`, `production_deadline_*`,
  `expected_arrival_*`) is set, we skip the `page=1` short-circuit so
  auto-pagination can scan enough rows to find `limit` matches
  post-filter (the #341 pattern).
- Pagination meta parsed from Katana's `x-pagination` response header
  only when the caller passed `page` explicitly.
- Post-fetch `[:limit]` safety-net slice.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] I have added tests that prove the new filters and pattern
  refinements work (39 new tests across the three test files; all
  2336 tests pass via `uv run poe check`).
- [x] `uv run poe check` passes clean locally (format + lint + pyright +
  pytest + mdformat + yamllint).

## Code Quality

- [x] Follows the style guidelines (ruff + mdformat + pyright).
- [x] Self-review: filters match the exact set exposed by the generated
  client files (`get_all_sales_orders.py`,
  `get_all_manufacturing_orders.py`, `find_purchase_orders.py`).
- [x] `katana_mcp_server/src/katana_mcp/resources/help.py` updated for
  the two new tools + the new filters on `list_sales_orders`.

## Related Issues

Fixes #333

## Additional Notes

- **Cache integration is explicitly out of scope here.** Issue #342
  tracks moving these list tools to the SQLite cache after the current
  wave of MCP feature work. This PR sticks to transport-level filters.
- Phase 3 (`#332` — `include_rows` for SO) will build on the
  `include_rows` parameter already accepted by `list_purchase_orders`
  (working) and reserved on `list_manufacturing_orders`
  (Katana's list endpoint doesn't bundle recipe rows, so it's
  documented as reserved for future support via
  `get_manufacturing_order_recipe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)