### PR TITLE
feat(mcp): add include_rows to list_sales_orders (#332)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -750,10 +750,17 @@ List sales orders with filters (list-tool pattern v2).
   scan enough rows to find `limit` matching results post-filter. Pair with a
   `created_at` window to keep fetched rows bounded.
 
+**Row detail:**
+- `include_rows` (optional, default false): When true, populate per-order row
+  details (variant_id, quantity, price_per_unit, linked_manufacturing_order_id)
+  on each summary. `sku` is left None in list context — use `get_sales_order`
+  for SKU-enriched rows on a specific order.
+
 **Returns:** Summary rows with order_no, status, production_status, row_count,
 total, currency, created_at, delivery_date. When `page` is set, the response
 also includes `pagination` with `total_records`, `total_pages`, current
-`page`, `first_page`, and `last_page`.
+`page`, `first_page`, and `last_page`. When `include_rows=true`, each summary
+also carries a `rows` list.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -752,9 +752,9 @@ List sales orders with filters (list-tool pattern v2).
 
 **Row detail:**
 - `include_rows` (optional, default false): When true, populate per-order row
-  details (variant_id, quantity, price_per_unit, linked_manufacturing_order_id)
-  on each summary. `sku` is left None in list context — use `get_sales_order`
-  for SKU-enriched rows on a specific order.
+  details (id, variant_id, quantity, price_per_unit,
+  linked_manufacturing_order_id) on each summary. `sku` is left None in list
+  context — use `get_sales_order` for SKU-enriched rows on a specific order.
 
 **Returns:** Summary rows with order_no, status, production_status, row_count,
 total, currency, created_at, delivery_date. When `page` is set, the response

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -448,6 +448,17 @@ class ListSalesOrdersRequest(BaseModel):
         ),
     )
 
+    # Row inclusion
+    include_rows: bool = Field(
+        default=False,
+        description=(
+            "When true, populate row-level detail (id, variant_id, quantity, "
+            "price_per_unit, linked_manufacturing_order_id) on each summary "
+            "via the `rows` field. `sku` is not resolved in list context — "
+            "use `get_sales_order` for SKU-enriched rows on a single order."
+        ),
+    )
+
 
 class PaginationMeta(BaseModel):
     """Pagination metadata extracted from Katana's `x-pagination` response header.
@@ -496,6 +507,7 @@ class SalesOrderSummary(BaseModel):
     total: float | None
     currency: str | None
     row_count: int
+    rows: list[SalesOrderRowInfo] | None = None
 
 
 class ListSalesOrdersResponse(BaseModel):
@@ -700,6 +712,26 @@ async def _list_sales_orders_impl(
     orders: list[SalesOrderSummary] = []
     for so in attrs_list:
         rows = unwrap_unset(so.sales_order_rows, [])
+        # When include_rows is set, expose row-level detail on each summary.
+        # `sku` is left None in list context — resolving it would require a
+        # variant cache lookup per row (up to 250 rows * N variants), which
+        # defeats the "one call for 50 orders" goal. Callers that need SKUs
+        # should use `get_sales_order` on a specific order.
+        row_infos: list[SalesOrderRowInfo] | None = None
+        if request.include_rows:
+            row_infos = [
+                SalesOrderRowInfo(
+                    id=r.id,
+                    variant_id=unwrap_unset(r.variant_id, None),
+                    sku=None,
+                    quantity=unwrap_unset(r.quantity, None),
+                    price_per_unit=unwrap_unset(r.price_per_unit, None),
+                    linked_manufacturing_order_id=unwrap_unset(
+                        r.linked_manufacturing_order_id, None
+                    ),
+                )
+                for r in rows
+            ]
         orders.append(
             SalesOrderSummary(
                 id=so.id,
@@ -714,6 +746,7 @@ async def _list_sales_orders_impl(
                 total=unwrap_unset(so.total, None),
                 currency=unwrap_unset(so.currency, None),
                 row_count=len(rows),
+                rows=row_infos,
             )
         )
 
@@ -746,7 +779,11 @@ async def list_sales_orders(
       skips the page=1 short-circuit so auto-pagination can scan enough rows
       to find `limit` matching results post-filter.
 
-    For full line-item details on a specific order, use `get_sales_order` next.
+    **Row detail:**
+    - `include_rows=true` — populate per-order row details (variant_id,
+      quantity, price_per_unit, linked_manufacturing_order_id). `sku` is left
+      None in list context; use `get_sales_order` for SKU-enriched rows on a
+      specific order.
     """
     from katana_mcp.tools.tool_result_utils import make_simple_result
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -780,7 +780,7 @@ async def list_sales_orders(
       to find `limit` matching results post-filter.
 
     **Row detail:**
-    - `include_rows=true` — populate per-order row details (variant_id,
+    - `include_rows=true` — populate per-order row details (id, variant_id,
       quantity, price_per_unit, linked_manufacturing_order_id). `sku` is left
       None in list context; use `get_sales_order` for SKU-enriched rows on a
       specific order.

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -988,6 +988,115 @@ async def test_list_sales_orders_ids_include_deleted_pass_through():
 
 
 # ============================================================================
+# list_sales_orders — include_rows (#332)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_include_rows_default_false_leaves_rows_none():
+    """By default summaries carry rows=None (only row_count is populated)."""
+    context, _ = create_mock_context()
+    mock_so = _make_mock_so(
+        id=1,
+        order_no="SO-1",
+        rows=[
+            _make_mock_row(id=10, variant_id=100, quantity=2, price_per_unit=50.0),
+            _make_mock_row(id=11, variant_id=101, quantity=1, price_per_unit=75.0),
+        ],
+    )
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_DATA, return_value=[mock_so]),
+    ):
+        result = await _list_sales_orders_impl(ListSalesOrdersRequest(), context)
+
+    assert result.total_count == 1
+    assert result.orders[0].row_count == 2
+    assert result.orders[0].rows is None
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_include_rows_true_populates_rows():
+    """include_rows=True surfaces per-row detail from sales_order_rows."""
+    context, _ = create_mock_context()
+    mock_so = _make_mock_so(
+        id=42,
+        order_no="SO-42",
+        rows=[
+            _make_mock_row(
+                id=10,
+                variant_id=100,
+                quantity=2,
+                price_per_unit=50.0,
+                linked_mo_id=555,
+            ),
+            _make_mock_row(id=11, variant_id=101, quantity=1, price_per_unit=75.0),
+        ],
+    )
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_DATA, return_value=[mock_so]),
+    ):
+        result = await _list_sales_orders_impl(
+            ListSalesOrdersRequest(include_rows=True), context
+        )
+
+    assert result.total_count == 1
+    summary = result.orders[0]
+    assert summary.row_count == 2
+    assert summary.rows is not None
+    assert len(summary.rows) == 2
+
+    first, second = summary.rows
+    assert first.id == 10
+    assert first.variant_id == 100
+    assert first.quantity == 2
+    assert first.price_per_unit == 50.0
+    assert first.linked_manufacturing_order_id == 555
+    # sku is intentionally None in list context (get_sales_order enriches).
+    assert first.sku is None
+
+    assert second.id == 11
+    assert second.variant_id == 101
+    assert second.linked_manufacturing_order_id is None
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_include_rows_handles_unset_fields():
+    """A row with UNSET optional fields surfaces as None instead of raising."""
+    context, _ = create_mock_context()
+
+    # Row with UNSET price_per_unit and UNSET quantity — should map to None.
+    sparse_row = MagicMock()
+    sparse_row.id = 99
+    sparse_row.variant_id = UNSET
+    sparse_row.quantity = UNSET
+    sparse_row.price_per_unit = UNSET
+    sparse_row.linked_manufacturing_order_id = UNSET
+
+    mock_so = _make_mock_so(id=1, order_no="SO-1", rows=[sparse_row])
+
+    with (
+        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_DATA, return_value=[mock_so]),
+    ):
+        result = await _list_sales_orders_impl(
+            ListSalesOrdersRequest(include_rows=True), context
+        )
+
+    assert result.orders[0].rows is not None
+    row = result.orders[0].rows[0]
+    assert row.id == 99
+    assert row.variant_id is None
+    assert row.quantity is None
+    assert row.price_per_unit is None
+    assert row.linked_manufacturing_order_id is None
+    assert row.sku is None
+
+
+# ============================================================================
 # get_sales_order tests
 # ============================================================================
 


### PR DESCRIPTION
## Description

Completes the `include_rows` surface sweep for list tools. `list_sales_orders` was the last list tool without row-level detail: phase 1 (#339/#341) baked it into `list_stock_adjustments` / `list_stock_transfers`, and phase 2 (#343) baked it into `list_manufacturing_orders` / `list_purchase_orders`. This PR rounds out the surface.

**Scope narrowed vs. plan**: the plan originally called for adding `include_rows` to MO and PO list tools too, but both already have it from #343. Stock adjustments/transfers also already have it from the wave-1 PRs. So this PR only touches `list_sales_orders`.

## Changes

- `ListSalesOrdersRequest.include_rows: bool = False`
- `SalesOrderSummary.rows: list[SalesOrderRowInfo] | None = None` (the `SalesOrderRowInfo` model already existed — used by `get_sales_order` — so no new model was needed)
- `_list_sales_orders_impl` populates `rows` from `sales_order_rows` when the flag is set. `sku` is intentionally left `None` in list context because resolving it would require up to 50 * N variant cache lookups per request, defeating the "50 orders in one call" goal. Callers who want SKU enrichment should use `get_sales_order` on a single order — which already does that lookup.
- `row_count` still populates in both modes (no regression for existing callers).
- `help.py` entry for `list_sales_orders` gains an `include_rows` bullet under a new "Row detail" heading.

## Short-circuit interaction

`include_rows` is purely a per-row expansion, not a filter, so it does **not** gate the `page=1` auto-pagination short-circuit. 50 orders * row-expand on one page is exactly what the caller asked for. The existing client-side `delivered_after/before` filter still gates it, unchanged.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Added 3 unit tests in `tests/tools/test_sales_orders.py`:
  - `test_list_sales_orders_include_rows_default_false_leaves_rows_none` — default behaviour unchanged, `rows=None` while `row_count` still populates.
  - `test_list_sales_orders_include_rows_true_populates_rows` — all SalesOrderRow fields (id, variant_id, quantity, price_per_unit, linked_manufacturing_order_id) come through; `sku` is None in list context.
  - `test_list_sales_orders_include_rows_handles_unset_fields` — rows with UNSET optional fields surface as None rather than raising.
- [x] `uv run poe check` passes cleanly (2362 passed, 3 pre-existing skips).

## Code Quality

- [x] Self-reviewed
- [x] No new warnings
- [x] ruff check + ruff format clean
- [x] No `noqa`, `type: ignore`, or `--no-verify`

## Related Issues

Fixes #332

## Additional Notes

- No cache integration (#342) was touched — out of scope per the plan.
- `format=json` (#334) is the next PR (phase 3F) and is not included here.