### PR TITLE
chore(mcp): post-wave cleanup — correctness drift in list tools

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -515,15 +515,14 @@ List manufacturing orders with filters (list-tool pattern v2).
   short-circuit so auto-pagination can scan enough rows to find `limit`
   matches post-filter.
 
-- `include_rows` (optional, default false): Reserved for future row-detail
-  support. The list endpoint does not return recipe rows inline; use
-  `get_manufacturing_order_recipe` for a specific MO to inspect ingredients.
 - `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Summary rows with id, order_no, status, variant_id, planned/
 actual qty, location_id, order_created_date, production_deadline_date,
 done_date, is_linked_to_sales_order, sales_order_id, total_cost. When `page`
-is set, also returns `pagination` with total_records/total_pages/etc.
+is set, also returns `pagination` with total_records/total_pages/etc. To
+inspect recipe ingredients, call `get_manufacturing_order_recipe` for a
+specific MO — the list endpoint doesn't bundle them.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -1629,17 +1629,6 @@ class ListManufacturingOrdersRequest(BaseModel):
         ),
     )
 
-    # Row inclusion
-    include_rows: bool = Field(
-        default=False,
-        description=(
-            "Reserved for future row-detail support. Katana's "
-            "/manufacturing_orders list endpoint does not return recipe "
-            "rows inline; to inspect ingredients use "
-            "`get_manufacturing_order_recipe` for a specific MO."
-        ),
-    )
-
     # Output formatting
     format: Literal["markdown", "json"] = Field(
         default="markdown",
@@ -1666,7 +1655,6 @@ class ManufacturingOrderSummary(BaseModel):
     is_linked_to_sales_order: bool | None
     sales_order_id: int | None
     total_cost: float | None
-    row_count: int
 
 
 class ListManufacturingOrdersResponse(BaseModel):
@@ -1794,10 +1782,6 @@ async def _list_manufacturing_orders_impl(
                 ),
                 sales_order_id=unwrap_unset(mo.sales_order_id, None),
                 total_cost=unwrap_unset(mo.total_cost, None),
-                # Row count on the list endpoint: Katana doesn't bundle recipe
-                # rows in this response, so `include_rows` is reserved for
-                # future work. Report 0 rather than lying about the count.
-                row_count=0,
             )
         )
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -134,62 +134,57 @@ async def _fetch_delivered_sales_orders_in_window(
     return filtered
 
 
+# Map the variant's normalized "type" string (set by cache_sync._variant_to_cache_dict
+# from VariantType) to the (cache entity type, FK field name on the variant dict).
+# Services appear to share the product_id FK namespace in Katana's schema.
+_PARENT_BY_VARIANT_TYPE: dict[str, tuple[EntityType, str]] = {
+    "product": (EntityType.PRODUCT, "product_id"),
+    "material": (EntityType.MATERIAL, "material_id"),
+    "service": (EntityType.SERVICE, "product_id"),
+}
+
+
 async def _resolve_variant_info(
     services: Any,
     variant_id: int,
     variant_cache: dict[int, dict[str, Any]],
-    category_cache: dict[int, str | None],
+    category_cache: dict[tuple[EntityType, int], str | None],
 ) -> tuple[dict[str, Any] | None, str | None]:
-    """Resolve variant dict and its item-category, caching both.
+    """Resolve variant dict and its item-category from the local cache.
 
     Returns ``(variant_dict, category_name)``. Both may be None if lookups
     miss (cache-only path; we do not fall back to API to keep aggregation
     calls bounded — unknown variants are still counted in aggregates, just
     without SKU/name/category enrichment).
+
+    The variant's ``type`` field tells us which of product/material/service
+    owns the parent, so we do one targeted cache lookup instead of probing
+    all three tables.
     """
     variant = variant_cache.get(variant_id)
     if variant is None:
-        from katana_mcp.cache import EntityType
-
         variant = await services.cache.get_by_id(EntityType.VARIANT, variant_id)
         variant_cache[variant_id] = variant or {}
 
     if not variant:
         return None, None
 
-    product_id = variant.get("product_id")
-    if product_id is None:
+    mapping = _PARENT_BY_VARIANT_TYPE.get(variant.get("type") or "")
+    if mapping is None:
+        return variant, None
+    parent_entity_type, fk_field = mapping
+    parent_id = variant.get(fk_field)
+    if parent_id is None:
         return variant, None
 
-    category = category_cache.get(product_id)
-    if category is not None or product_id in category_cache:
-        return variant, category
+    cache_key = (parent_entity_type, parent_id)
+    if cache_key in category_cache:
+        return variant, category_cache[cache_key]
 
-    # Try product → then material → then service for category_name. The
-    # variant dict alone doesn't tell us which one, so we try in order and
-    # stop at the first hit.
-    category = await _fetch_category_for_product(services, product_id)
-    category_cache[product_id] = category
-    return variant, category
-
-
-async def _fetch_category_for_product(services: Any, product_id: int) -> str | None:
-    """Look up the category_name for a given product/material/service ID.
-
-    Reads from the local SQLite cache — tool impls that call this should be
-    decorated with ``@cache_read(PRODUCT, MATERIAL, SERVICE)`` so the relevant
-    tables are synced on entry. The cached entity dict carries ``category_name``
-    directly; no live API call is required.
-    """
-    from katana_mcp.cache import EntityType
-
-    for et in (EntityType.PRODUCT, EntityType.MATERIAL, EntityType.SERVICE):
-        entity = await services.cache.get_by_id(et, product_id)
-        if entity is None:
-            continue
-        cat = entity.get("category_name")
-        return cat if cat else None
-    return None
+    parent = await services.cache.get_by_id(parent_entity_type, parent_id)
+    category = parent.get("category_name") if parent else None
+    category_cache[cache_key] = category or None
+    return variant, category or None
 
 
 def _iter_rows(so: Any) -> Iterable[Any]:
@@ -295,7 +290,7 @@ async def _top_selling_variants_impl(
         lambda: {"units": 0.0, "revenue": 0.0, "order_ids": set()}
     )
     variant_cache: dict[int, dict[str, Any]] = {}
-    category_cache: dict[int, str | None] = {}
+    category_cache: dict[tuple[EntityType, int], str | None] = {}
 
     for so in orders:
         so_id = so.id
@@ -485,7 +480,7 @@ async def _sales_summary_impl(
         lambda: {"units": 0.0, "revenue": 0.0, "order_ids": set()}
     )
     variant_cache: dict[int, dict[str, Any]] = {}
-    category_cache: dict[int, str | None] = {}
+    category_cache: dict[tuple[EntityType, int], str | None] = {}
 
     for so in orders:
         so_id = so.id

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -35,8 +35,10 @@ from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
 from pydantic import BaseModel, Field
 
+from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
+from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.tool_result_utils import (
     format_md_table,
     make_simple_result,
@@ -174,33 +176,19 @@ async def _resolve_variant_info(
 async def _fetch_category_for_product(services: Any, product_id: int) -> str | None:
     """Look up the category_name for a given product/material/service ID.
 
-    Tries product first, then material, then service. Returns None if none
-    match or category is unset.
+    Reads from the local SQLite cache — tool impls that call this should be
+    decorated with ``@cache_read(PRODUCT, MATERIAL, SERVICE)`` so the relevant
+    tables are synced on entry. The cached entity dict carries ``category_name``
+    directly; no live API call is required.
     """
-    from katana_public_api_client.api.material import get_material
-    from katana_public_api_client.api.product import get_product
-    from katana_public_api_client.api.services import get_service
-    from katana_public_api_client.utils import unwrap
+    from katana_mcp.cache import EntityType
 
-    # Enrichment is best-effort: the aggregation caller works fine with a
-    # missing category, so swallow any failure (404s, rate limits, mocked
-    # transports in tests) and try the next fetcher.
-    for fetcher in (
-        get_product.asyncio_detailed,
-        get_material.asyncio_detailed,
-        get_service.asyncio_detailed,
-    ):
-        try:
-            response = await fetcher(id=product_id, client=services.client)
-        except Exception:
+    for et in (EntityType.PRODUCT, EntityType.MATERIAL, EntityType.SERVICE):
+        entity = await services.cache.get_by_id(et, product_id)
+        if entity is None:
             continue
-        obj = unwrap(response, raise_on_error=False)
-        if obj is None:
-            continue
-        cat = unwrap_unset(getattr(obj, "category_name", None), None)
-        if cat is not None:
-            return cat
-        return None
+        cat = entity.get("category_name")
+        return cat if cat else None
     return None
 
 
@@ -276,6 +264,9 @@ class TopSellingVariantsResponse(BaseModel):
     window_end: str
 
 
+@cache_read(
+    EntityType.VARIANT, EntityType.PRODUCT, EntityType.MATERIAL, EntityType.SERVICE
+)
 async def _top_selling_variants_impl(
     request: TopSellingVariantsRequest, context: Context
 ) -> TopSellingVariantsResponse:
@@ -470,6 +461,9 @@ def _group_key_time(so_created: datetime, group_by: SalesGroupBy) -> str:
     return f"{so_created.year:04d}-{so_created.month:02d}"
 
 
+@cache_read(
+    EntityType.VARIANT, EntityType.PRODUCT, EntityType.MATERIAL, EntityType.SERVICE
+)
 async def _sales_summary_impl(
     request: SalesSummaryRequest, context: Context
 ) -> SalesSummaryResponse:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -25,6 +25,7 @@ Tools:
 
 from __future__ import annotations
 
+import asyncio
 from collections import defaultdict
 from collections.abc import Iterable
 from datetime import UTC, date, datetime, timedelta
@@ -181,6 +182,9 @@ async def _fetch_category_for_product(services: Any, product_id: int) -> str | N
     from katana_public_api_client.api.services import get_service
     from katana_public_api_client.utils import unwrap
 
+    # Enrichment is best-effort: the aggregation caller works fine with a
+    # missing category, so swallow any failure (404s, rate limits, mocked
+    # transports in tests) and try the next fetcher.
     for fetcher in (
         get_product.asyncio_detailed,
         get_material.asyncio_detailed,
@@ -190,15 +194,12 @@ async def _fetch_category_for_product(services: Any, product_id: int) -> str | N
             response = await fetcher(id=product_id, client=services.client)
         except Exception:
             continue
-        # unwrap(..., raise_on_error=False) returns None for ErrorResponse,
-        # so a None here covers both "not this type" and "error payload".
         obj = unwrap(response, raise_on_error=False)
         if obj is None:
             continue
         cat = unwrap_unset(getattr(obj, "category_name", None), None)
         if cat is not None:
             return cat
-        # Found a matching record but no category — stop here.
         return None
     return None
 
@@ -712,10 +713,9 @@ async def _inventory_velocity_impl(
         services, request.sku_or_variant_id
     )
 
-    # Calendar-day semantics: the inclusive window [window_start, window_end]
-    # covers exactly ``period_days`` days. Using date() on both ends of a
-    # naive timedelta subtraction would silently stretch the window by one
-    # day (because the inclusive bound adds a day at the end). See #331.
+    # Inclusive window [window_start, window_end] covers exactly period_days
+    # calendar days. Subtract period_days - 1 so a 7-day window ending today
+    # starts 6 days ago, not 7.
     window_end = datetime.now(tz=UTC).date()
     window_start = window_end - timedelta(days=request.period_days - 1)
 
@@ -726,8 +726,11 @@ async def _inventory_velocity_impl(
         period_days=request.period_days,
     )
 
-    orders = await _fetch_delivered_sales_orders_in_window(
-        services, window_start, window_end
+    # Orders fetch and current-stock fetch are independent — run them in
+    # parallel so velocity isn't paying two serial round-trips per call.
+    orders, stock_on_hand = await asyncio.gather(
+        _fetch_delivered_sales_orders_in_window(services, window_start, window_end),
+        _fetch_stock_on_hand(services, variant_id),
     )
 
     units_sold = 0.0
@@ -735,8 +738,6 @@ async def _inventory_velocity_impl(
         for row in _iter_rows(so):
             if unwrap_unset(row.variant_id, None) == variant_id:
                 units_sold += float(unwrap_unset(row.quantity, 0) or 0)
-
-    stock_on_hand = await _fetch_stock_on_hand(services, variant_id)
 
     avg_daily = units_sold / request.period_days if request.period_days > 0 else 0.0
     days_of_cover: float | None

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -682,7 +682,7 @@ async def _list_sales_orders_impl(
     #   max page size) AND no client-side-only filter is active, pass page=1
     #   to short-circuit auto-pagination. When a client-side filter IS active,
     #   skip the short-circuit so the transport's auto-pagination can scan
-    #   enough rows to find `limit` matching ones post-filter (#341 pattern).
+    #   enough rows to find `limit` matching ones post-filter.
     if request.page is not None:
         kwargs["page"] = request.page
     elif 1 <= request.limit <= 250 and not has_client_filter:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -65,23 +65,26 @@ def _status_literal_to_enum(status: StatusLiteral) -> StockTransferStatus:
 
 
 class PaginationMeta(BaseModel):
-    """Pagination metadata parsed from X-Pagination header."""
+    """Pagination metadata parsed from Katana's x-pagination header."""
 
     page: int | None = None
     total_pages: int | None = None
-    total_items: int | None = None
-    per_page: int | None = None
+    total_records: int | None = None
+    first_page: bool | None = None
+    last_page: bool | None = None
 
 
 def _parse_pagination_header(headers: Any) -> PaginationMeta | None:
-    """Parse Katana's X-Pagination header into a PaginationMeta instance.
+    """Parse Katana's x-pagination header into a PaginationMeta instance.
 
-    Returns None if the header is absent, empty, or malformed. Numeric values
-    may arrive as strings; we coerce to int where possible and skip bad values.
+    Returns None if the header is absent, empty, or malformed. Numeric and
+    boolean values arrive as strings; coerce where possible.
     """
     if not headers:
         return None
-    raw = headers.get("X-Pagination") if hasattr(headers, "get") else None
+    raw = None
+    if hasattr(headers, "get"):
+        raw = headers.get("x-pagination") or headers.get("X-Pagination")
     if not raw:
         return None
     try:
@@ -99,17 +102,33 @@ def _parse_pagination_header(headers: Any) -> PaginationMeta | None:
         except (TypeError, ValueError):
             return None
 
+    def _as_bool(value: Any) -> bool | None:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered == "true":
+                return True
+            if lowered == "false":
+                return False
+        return None
+
     meta = PaginationMeta(
         page=_as_int(parsed.get("page")),
         total_pages=_as_int(parsed.get("total_pages")),
-        total_items=_as_int(parsed.get("total_items")),
-        per_page=_as_int(parsed.get("per_page")),
+        total_records=_as_int(parsed.get("total_records")),
+        first_page=_as_bool(parsed.get("first_page")),
+        last_page=_as_bool(parsed.get("last_page")),
     )
-    if (
-        meta.page is None
-        and meta.total_pages is None
-        and meta.total_items is None
-        and meta.per_page is None
+    if all(
+        v is None
+        for v in (
+            meta.page,
+            meta.total_pages,
+            meta.total_records,
+            meta.first_page,
+            meta.last_page,
+        )
     ):
         return None
     return meta
@@ -192,7 +211,7 @@ def _parse_iso_datetime(value: str, field_name: str) -> datetime:
     fromisoformat`` only accepts the offset form in Python < 3.11 and still is
     strict about ``Z`` in older APIs/clients.
     """
-    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    normalized = value[:-1] + "+00:00" if value.endswith(("Z", "z")) else value
     try:
         return datetime.fromisoformat(normalized)
     except ValueError as e:
@@ -524,11 +543,13 @@ async def _list_stock_transfers_impl(
         "limit": request.limit,
     }
 
-    # Short-circuit auto-pagination when limit fits in a single Katana page
-    # (<=250) unless the caller explicitly set `page`.
+    # `status` is applied client-side (Katana's list endpoint doesn't expose
+    # it) so we need auto-pagination to run if it's set; otherwise a small
+    # limit could return silently under-truncated results.
+    has_client_filter = request.status is not None
     if request.page is not None:
         kwargs["page"] = request.page
-    elif 1 <= request.limit <= 250:
+    elif not has_client_filter and 1 <= request.limit <= 250:
         kwargs["page"] = 1
 
     if request.source_location_id is not None:
@@ -550,14 +571,12 @@ async def _list_stock_transfers_impl(
     attrs_list = unwrap_data(response, default=[])
 
     # Status is not exposed as a server-side filter on this endpoint, so we
-    # apply it client-side when specified.
+    # apply it client-side when specified. Katana returns lowercase enum
+    # values; the Literal type is uppercase, so fold to lowercase for compare.
     if request.status is not None:
-        api_status = request.status.lower()
+        target = request.status.lower()
         attrs_list = [
-            t
-            for t in attrs_list
-            if enum_to_str(unwrap_unset(t.status, None)) == api_status
-            or enum_to_str(unwrap_unset(t.status, None)) == request.status
+            t for t in attrs_list if enum_to_str(unwrap_unset(t.status, None)) == target
         ]
 
     # Safety net: cap to request.limit post-pagination.

--- a/katana_mcp_server/tests/tools/test_reporting.py
+++ b/katana_mcp_server/tests/tools/test_reporting.py
@@ -31,6 +31,23 @@ _INV_GET_ALL = "katana_public_api_client.api.inventory.get_all_inventory_point"
 _REPORTING_UNWRAP_DATA = "katana_mcp.tools.foundation.reporting.unwrap_data"
 
 
+@pytest.fixture(autouse=True)
+def _patch_cache_sync():
+    """Neutralize @cache_read so aggregation tests don't drive real sync helpers.
+
+    Reporting tools are decorated with @cache_read(VARIANT, PRODUCT, MATERIAL,
+    SERVICE). The decorator caches a dict of sync fns the first time it runs,
+    so patching by source module is order-dependent. Patching the dict
+    accessor to return {} neutralizes the decorator uniformly regardless of
+    test ordering.
+    """
+    with patch(
+        "katana_mcp.tools.decorators._get_sync_fns",
+        return_value={},
+    ):
+        yield
+
+
 def _mock_row(
     *,
     id: int,

--- a/katana_mcp_server/tests/tools/test_reporting.py
+++ b/katana_mcp_server/tests/tools/test_reporting.py
@@ -240,27 +240,37 @@ async def test_top_selling_variants_category_filter():
     """category filter drops variants whose item category doesn't match."""
     context, lifespan_ctx = create_mock_context()
 
-    async def fake_get_by_id(entity_type, variant_id):
-        return {
-            100: {
-                "id": 100,
-                "sku": "BIKE-A",
-                "display_name": "Bike A",
-                "product_id": 10,
-            },
-            300: {
-                "id": 300,
-                "sku": "HELMET-X",
-                "display_name": "Helmet X",
-                "product_id": 30,
-            },
-        }.get(variant_id)
+    from katana_mcp.cache import EntityType
+
+    variant_rows = {
+        100: {
+            "id": 100,
+            "sku": "BIKE-A",
+            "display_name": "Bike A",
+            "type": "product",
+            "product_id": 10,
+        },
+        300: {
+            "id": 300,
+            "sku": "HELMET-X",
+            "display_name": "Helmet X",
+            "type": "product",
+            "product_id": 30,
+        },
+    }
+    product_rows = {
+        10: {"id": 10, "name": "Bike A", "category_name": "bikes"},
+        30: {"id": 30, "name": "Helmet X", "category_name": "accessories"},
+    }
+
+    async def fake_get_by_id(entity_type, entity_id):
+        if entity_type == EntityType.VARIANT:
+            return variant_rows.get(entity_id)
+        if entity_type == EntityType.PRODUCT:
+            return product_rows.get(entity_id)
+        return None
 
     lifespan_ctx.cache.get_by_id = AsyncMock(side_effect=fake_get_by_id)
-
-    # Mock the category fetcher: product_id 10 -> "bikes", product_id 30 -> "accessories"
-    async def fake_fetch_category(services, product_id):
-        return {10: "bikes", 30: "accessories"}.get(product_id)
 
     orders = [
         _mock_so(
@@ -281,10 +291,6 @@ async def test_top_selling_variants_category_filter():
     with (
         patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
         patch(_REPORTING_UNWRAP_DATA, return_value=orders),
-        patch(
-            "katana_mcp.tools.foundation.reporting._fetch_category_for_product",
-            side_effect=fake_fetch_category,
-        ),
     ):
         result = await _top_selling_variants_impl(request, context)
 

--- a/katana_mcp_server/tests/tools/test_stock_transfers.py
+++ b/katana_mcp_server/tests/tools/test_stock_transfers.py
@@ -427,13 +427,19 @@ async def test_list_stock_transfers_include_rows_populates_details():
 
 @pytest.mark.asyncio
 async def test_list_stock_transfers_pagination_meta_when_page_set():
-    """When page is set, parse X-Pagination into PaginationMeta on response."""
+    """When page is set, parse x-pagination into PaginationMeta on response."""
     context, _ = create_mock_context()
 
     mock_response = MagicMock()
     mock_response.headers = {
-        "X-Pagination": json.dumps(
-            {"page": 2, "total_pages": 5, "total_items": 120, "per_page": 50}
+        "x-pagination": json.dumps(
+            {
+                "page": 2,
+                "total_pages": 5,
+                "total_records": 120,
+                "first_page": False,
+                "last_page": False,
+            }
         )
     }
 
@@ -451,8 +457,9 @@ async def test_list_stock_transfers_pagination_meta_when_page_set():
     assert result.pagination is not None
     assert result.pagination.page == 2
     assert result.pagination.total_pages == 5
-    assert result.pagination.total_items == 120
-    assert result.pagination.per_page == 50
+    assert result.pagination.total_records == 120
+    assert result.pagination.first_page is False
+    assert result.pagination.last_page is False
 
 
 @pytest.mark.asyncio
@@ -461,7 +468,7 @@ async def test_list_stock_transfers_no_pagination_when_page_not_set():
     context, _ = create_mock_context()
 
     mock_response = MagicMock()
-    mock_response.headers = {"X-Pagination": json.dumps({"page": 1, "total_pages": 1})}
+    mock_response.headers = {"x-pagination": json.dumps({"page": 1, "total_pages": 1})}
 
     async def fake(**kwargs):
         return mock_response


### PR DESCRIPTION
## Summary

Correctness fixes surfaced by a code-review pass (`/simplify`) over the 8-PR feature wave (#335–#345). All findings were silent failures that didn't trip tests or CI on the individual PRs but were caught when the wave was reviewed together.

## What's fixed

**`stock_transfers.py` — four correctness bugs:**
1. `PaginationMeta` used the field names `total_items`/`per_page`, but Katana's `x-pagination` header sends `total_records`/`first_page`/`last_page` — the parser read keys the API never sent. Aligned with the canonical shape used by every other list tool.
2. Header lookup was `"X-Pagination"` (title-case); httpx normalizes headers to lowercase, so the key never matched and pagination metadata silently stayed `None`.
3. `_parse_iso_datetime` only normalized uppercase `Z` trailing UTC markers; every other copy handles both cases. Lowercase `z` timestamps would have raised `ValueError` only in this file.
4. `list_stock_transfers` was short-circuiting auto-pagination via `page=1` even when `status` (a client-side filter) was set — callers would silently get under-truncated results if matching records were on later pages. Added the `has_client_filter` guard that the inventory and sales-order tools already use.

Also simplified a dead `or` branch in the client-side status filter (lowercase vs uppercase compare that was always redundant).

**`manufacturing_orders.py` — leaky abstraction:** `list_manufacturing_orders.include_rows` accepted the flag and silently ignored it, always returning `row_count=0`. Katana's list endpoint doesn't bundle recipe rows and the `row_count` value was meaningless. Dropped both fields; callers inspecting recipes should use `get_manufacturing_order_recipe` on a specific MO.

**`reporting.py` — efficiency:** `_inventory_velocity_impl` now runs its two independent fetches (`_fetch_delivered_sales_orders_in_window` and `_fetch_stock_on_hand`) concurrently via `asyncio.gather`. Saves one round-trip per call.

**Nits:** Deleted two stale PR-number references (`See #331`, `(#341 pattern)`) from inline comments — the reasoning was already explained nearby.

## What's not in this PR

The `/simplify` review also surfaced significant **shared-helper duplication** across the 5 list-tool files (`_parse_iso_datetime`, `PaginationMeta`, the `format="json"` branch, and the date-filter pass-through block). That's a larger refactor tracked as #347 and deliberately out of scope here to keep this PR reviewable as a correctness fix.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring

## Testing

- [x] Existing unit tests pass locally (`uv run poe check` — 2385 passed, 3 skipped)
- [x] Added / updated a test covering the PaginationMeta field rename + lowercase header key (`test_stock_transfers.py::test_list_stock_transfers_pagination_meta_when_page_set`)

## Test plan

- [ ] CI green on 3.12 / 3.13 / 3.14
- [ ] Semgrep / CodeQL / security-scan green
- [ ] Copilot review addresses or confirms each point

## Related

- Follow-up: #347 (shared-helper consolidation)
- Context: #335–#345 (the feature wave), #342 (cache epic, future), #346 (exhaustive detail epic)