### PR TITLE
fix(mcp): Prefab UI was built but never rendered in Claude Desktop

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
-from katana_mcp.tools.tool_result_utils import make_tool_result
+from katana_mcp.tools.tool_result_utils import UI_META, make_tool_result
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.domain.converters import to_unset
 from katana_public_api_client.models import (
@@ -315,5 +315,9 @@ def register_tools(mcp: FastMCP) -> None:
         readOnlyHint=False, destructiveHint=False, openWorldHint=True
     )
 
-    mcp.tool(tags={"catalog", "write"}, annotations=_write)(create_product)
-    mcp.tool(tags={"catalog", "write"}, annotations=_write)(create_material)
+    mcp.tool(tags={"catalog", "write"}, annotations=_write, meta=UI_META)(
+        create_product
+    )
+    mcp.tool(tags={"catalog", "write"}, annotations=_write, meta=UI_META)(
+        create_material
+    )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -20,6 +20,7 @@ from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
+    UI_META,
     format_md_table,
     iso_or_none,
     make_simple_result,
@@ -1583,8 +1584,12 @@ def register_tools(mcp: FastMCP) -> None:
         openWorldHint=True,
     )
 
-    mcp.tool(tags={"inventory", "read"}, annotations=_read)(check_inventory)
-    mcp.tool(tags={"inventory", "read"}, annotations=_read)(list_low_stock_items)
+    mcp.tool(tags={"inventory", "read"}, annotations=_read, meta=UI_META)(
+        check_inventory
+    )
+    mcp.tool(tags={"inventory", "read"}, annotations=_read, meta=UI_META)(
+        list_low_stock_items
+    )
     mcp.tool(tags={"inventory", "read"}, annotations=_read)(get_inventory_movements)
     mcp.tool(tags={"inventory", "read"}, annotations=_read)(list_stock_adjustments)
     mcp.tool(tags={"inventory", "write"}, annotations=_write)(create_stock_adjustment)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -19,6 +19,7 @@ from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.tool_result_utils import (
+    UI_META,
     format_md_table,
     make_simple_result,
     make_tool_result,
@@ -1040,11 +1041,15 @@ def register_tools(mcp: FastMCP) -> None:
         openWorldHint=True,
     )
 
-    mcp.tool(tags={"catalog", "read"}, annotations=_read)(search_items)
-    mcp.tool(tags={"catalog", "write"}, annotations=_write)(create_item)
-    mcp.tool(tags={"catalog", "read"}, annotations=_read)(get_item)
-    mcp.tool(tags={"catalog", "write"}, annotations=_update)(update_item)
-    mcp.tool(tags={"catalog", "write", "destructive"}, annotations=_destructive)(
-        delete_item
+    mcp.tool(tags={"catalog", "read"}, annotations=_read, meta=UI_META)(search_items)
+    mcp.tool(tags={"catalog", "write"}, annotations=_write, meta=UI_META)(create_item)
+    mcp.tool(tags={"catalog", "read"}, annotations=_read, meta=UI_META)(get_item)
+    mcp.tool(tags={"catalog", "write"}, annotations=_update, meta=UI_META)(update_item)
+    mcp.tool(
+        tags={"catalog", "write", "destructive"},
+        annotations=_destructive,
+        meta=UI_META,
+    )(delete_item)
+    mcp.tool(tags={"catalog", "read"}, annotations=_read, meta=UI_META)(
+        get_variant_details
     )
-    mcp.tool(tags={"catalog", "read"}, annotations=_read)(get_variant_details)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -1472,12 +1472,7 @@ async def batch_update_manufacturing_order_recipes(
     markdown = _render_batch_markdown(response)
     ui = build_batch_recipe_update_ui(response.model_dump())
 
-    # Attach the response data alongside the Prefab UI envelope so programmatic
-    # clients can access structured fields.
-    prefab_json = ui.to_json()
-    prefab_json["data"] = response.model_dump()
-
-    return ToolResult(content=markdown, structured_content=prefab_json)
+    return ToolResult(content=markdown, structured_content=ui)
 
 
 # ============================================================================
@@ -1935,4 +1930,5 @@ def register_tools(mcp: FastMCP) -> None:
     mcp.tool(
         tags={"orders", "manufacturing", "write", "batch"},
         annotations=_destructive_write,
+        meta=UI_META,
     )(batch_update_manufacturing_order_recipes)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -24,6 +24,7 @@ from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
+    UI_META,
     enum_to_str,
     format_md_table,
     iso_or_none,
@@ -1909,6 +1910,7 @@ def register_tools(mcp: FastMCP) -> None:
     mcp.tool(
         tags={"orders", "manufacturing", "write"},
         annotations=_write,
+        meta=UI_META,
     )(create_manufacturing_order)
     mcp.tool(
         tags={"orders", "manufacturing", "read"},

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
-from katana_mcp.tools.tool_result_utils import make_tool_result
+from katana_mcp.tools.tool_result_utils import UI_META, make_tool_result
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.domain.converters import unwrap_unset
 from katana_public_api_client.models import (
@@ -370,4 +370,5 @@ def register_tools(mcp: FastMCP) -> None:
         annotations=ToolAnnotations(
             readOnlyHint=False, destructiveHint=True, openWorldHint=True
         ),
+        meta=UI_META,
     )(fulfill_order)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -24,6 +24,7 @@ from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
+    UI_META,
     enum_to_str,
     format_md_table,
     iso_or_none,
@@ -1464,15 +1465,21 @@ def register_tools(mcp: FastMCP) -> None:
         openWorldHint=True,
     )
 
-    mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_write)(
-        create_purchase_order
-    )
-    mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_write)(
-        receive_purchase_order
-    )
-    mcp.tool(tags={"orders", "purchasing", "read"}, annotations=_read)(
-        verify_order_document
-    )
+    mcp.tool(
+        tags={"orders", "purchasing", "write"},
+        annotations=_write,
+        meta=UI_META,
+    )(create_purchase_order)
+    mcp.tool(
+        tags={"orders", "purchasing", "write"},
+        annotations=_write,
+        meta=UI_META,
+    )(receive_purchase_order)
+    mcp.tool(
+        tags={"orders", "purchasing", "read"},
+        annotations=_read,
+        meta=UI_META,
+    )(verify_order_document)
     mcp.tool(tags={"orders", "purchasing", "read"}, annotations=_read)(
         list_purchase_orders
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -23,6 +23,7 @@ from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
+    UI_META,
     enum_to_str,
     format_md_table,
     iso_or_none,
@@ -1026,6 +1027,7 @@ def register_tools(mcp: FastMCP) -> None:
         annotations=ToolAnnotations(
             readOnlyHint=False, destructiveHint=False, openWorldHint=True
         ),
+        meta=UI_META,
     )(create_sales_order)
     mcp.tool(
         tags={"orders", "sales", "read"},

--- a/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
+++ b/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
@@ -24,15 +24,11 @@ if TYPE_CHECKING:
     from prefab_ui.app import PrefabApp
 
 
+# Opt-in marker for Prefab UI rendering. Pass as ``meta=UI_META`` in
+# ``mcp.tool(...)`` for every tool that returns a ``PrefabApp`` via
+# ``make_tool_result``. Any tool missing this marker will ship markdown only —
+# the UI will be built but silently discarded by the client.
 UI_META: dict[str, Any] = {"ui": True}
-"""Tool registration ``meta`` that opts a tool into Prefab UI rendering.
-
-Pass as ``mcp.tool(..., meta=UI_META)`` for every tool that returns a
-``ToolResult`` whose ``structured_content`` may be a ``PrefabApp``. FastMCP's
-``_maybe_apply_prefab_ui`` auto-registers the ``ui://prefab/renderer.html``
-resource and expands this flag into the full AppConfig metadata that
-MCP-Apps-capable clients (Claude Desktop) need to render the UI.
-"""
 
 
 def enum_to_str(value: Any) -> str | None:
@@ -105,6 +101,14 @@ def make_tool_result(
 
     Without ``ui``, ``structured_content`` is the Pydantic response dict so
     programmatic callers can consume fields directly.
+
+    **Contract for programmatic callers:** when ``ui`` is present, ``structured_content``
+    is the Prefab wire envelope — it does **not** include the raw response dict
+    under a stable key. The previous implementation spliced the Pydantic dump into
+    ``structured_content["data"]``; that is gone. Callers who need the response as
+    JSON should request it explicitly via the tool's ``format="json"`` parameter
+    (introduced in #334), which returns a pure Pydantic JSON dump with no UI
+    envelope — the right channel for programmatic access regardless of UI state.
 
     Args:
         response: Pydantic model response from the tool

--- a/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
+++ b/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
@@ -24,6 +24,17 @@ if TYPE_CHECKING:
     from prefab_ui.app import PrefabApp
 
 
+UI_META: dict[str, Any] = {"ui": True}
+"""Tool registration ``meta`` that opts a tool into Prefab UI rendering.
+
+Pass as ``mcp.tool(..., meta=UI_META)`` for every tool that returns a
+``ToolResult`` whose ``structured_content`` may be a ``PrefabApp``. FastMCP's
+``_maybe_apply_prefab_ui`` auto-registers the ``ui://prefab/renderer.html``
+resource and expands this flag into the full AppConfig metadata that
+MCP-Apps-capable clients (Claude Desktop) need to render the UI.
+"""
+
+
 def enum_to_str(value: Any) -> str | None:
     """Extract the string value from an enum, or return as-is.
 
@@ -84,45 +95,37 @@ def make_tool_result(
     ui: PrefabApp | None = None,
     **template_vars: Any,
 ) -> ToolResult:
-    """Create a ToolResult with markdown, structured content, and optional Prefab UI.
+    """Create a ToolResult with markdown content and optional Prefab UI.
 
-    The structured_content is either:
-    - A PrefabApp JSON envelope (if ``ui`` is provided) — rendered by Claude Desktop
-    - The Pydantic model dict (fallback for programmatic access)
+    When ``ui`` is provided, the PrefabApp is passed through ``structured_content``
+    as-is — FastMCP's ``ToolResult.__init__`` detects it and converts to the wire
+    envelope via ``_prefab_to_json``. Combined with ``meta={"ui": True}`` on the
+    tool registration, this causes MCP-Apps-capable clients (Claude Desktop) to
+    render the Prefab UI. Non-Prefab clients still see the markdown fallback.
 
-    Markdown content from templates is always included for non-Prefab clients.
+    Without ``ui``, ``structured_content`` is the Pydantic response dict so
+    programmatic callers can consume fields directly.
 
     Args:
         response: Pydantic model response from the tool
         template_name: Name of the markdown template (without .md extension)
-        ui: Optional PrefabApp to use as structured_content for Prefab-capable hosts
+        ui: Optional PrefabApp for MCP-Apps rendering
         **template_vars: Variables for template rendering
 
     Returns:
-        ToolResult with markdown content and structured_content (Prefab or dict)
+        ToolResult with markdown content and structured_content
     """
-    # Render markdown from template using provided vars
     try:
         markdown = format_template(template_name, **template_vars)
     except (FileNotFoundError, KeyError) as e:
-        # Fallback to structured data as markdown if template fails
         markdown = (
             f"# Response\n\n```json\n{response.model_dump_json(indent=2)}\n```\n\n"
             f"Template error: {e}"
         )
 
-    # When Prefab UI is provided, include both the UI envelope and the response
-    # data so programmatic MCP clients can still access structured fields
-    if ui is not None:
-        prefab_json = ui.to_json()
-        prefab_json["data"] = response.model_dump()
-        structured_data = prefab_json
-    else:
-        structured_data = response.model_dump()
-
     return ToolResult(
         content=markdown,
-        structured_content=structured_data,
+        structured_content=ui if ui is not None else response.model_dump(),
     )
 
 

--- a/katana_mcp_server/tests/tools/test_tool_result_utils.py
+++ b/katana_mcp_server/tests/tools/test_tool_result_utils.py
@@ -1,0 +1,62 @@
+"""Tests for tool_result_utils — specifically the make_tool_result contract
+around Prefab UI delivery.
+
+make_tool_result is load-bearing for every tool that emits a Prefab UI:
+- when ``ui`` is None, structured_content must be the Pydantic model dump
+  so programmatic callers can read fields directly
+- when ``ui`` is a PrefabApp, structured_content must end up as a dict that
+  represents the Prefab wire envelope (FastMCP's ToolResult.__init__ handles
+  the conversion via _prefab_to_json on isinstance check)
+
+A regression in either shape would silently break MCP-Apps rendering in
+Claude Desktop — exactly the class of bug that #350 fixed.
+"""
+
+from __future__ import annotations
+
+from katana_mcp.tools.tool_result_utils import UI_META, make_tool_result
+from prefab_ui.app import PrefabApp
+from prefab_ui.components import Text
+from pydantic import BaseModel
+
+
+class _StubResponse(BaseModel):
+    id: int
+    label: str
+
+
+def _make_response() -> _StubResponse:
+    return _StubResponse(id=42, label="hello")
+
+
+def test_make_tool_result_without_ui_sets_pydantic_dump_as_structured_content():
+    response = _make_response()
+    result = make_tool_result(response, template_name="nonexistent_template_fallback")
+
+    assert result.structured_content == {"id": 42, "label": "hello"}
+
+
+def test_make_tool_result_with_ui_converts_prefab_to_envelope_dict():
+    response = _make_response()
+    with PrefabApp(state={"label": response.label}) as app:
+        Text(content="{{ label }}")
+
+    result = make_tool_result(
+        response,
+        template_name="nonexistent_template_fallback",
+        ui=app,
+    )
+
+    # FastMCP's ToolResult.__init__ detects the PrefabApp and converts it to
+    # the wire-format envelope (dict). The resulting shape is not the Pydantic
+    # dump — it's the Prefab app's JSON representation.
+    assert isinstance(result.structured_content, dict)
+    assert result.structured_content != {"id": 42, "label": "hello"}
+    # The envelope carries the view definition; check one known Prefab key.
+    assert "view" in result.structured_content
+
+
+def test_ui_meta_is_the_opt_in_marker_for_prefab_rendering():
+    # Keep UI_META's shape stable — tools pass it by reference to mcp.tool(meta=...)
+    # and FastMCP's _maybe_apply_prefab_ui looks up meta.get("ui") == True.
+    assert UI_META == {"ui": True}


### PR DESCRIPTION
## Summary

Every tool that constructed a Prefab UI via ``build_variant_details_ui``, ``build_search_results_ui``, etc. built the UI correctly but delivered it in a shape Claude Desktop's MCP-Apps renderer doesn't consume. Users saw raw markdown instead of the intended UI cards.

## Root cause

Two things had to line up, and neither did:

1. **A resource at ``ui://...`` with MIME ``text/html;profile=mcp-app``.** FastMCP auto-registers ``ui://prefab/renderer.html`` when triggered — but not here. Checked: there were zero ``ui://`` resources in the server at startup.

2. **Tool ``meta`` containing the expanded AppConfig** pointing at that resource. FastMCP's ``_maybe_apply_prefab_ui`` expands ``meta={"ui": True}`` into the full config. No tool had ``ui`` in its meta.

Meanwhile ``make_tool_result`` was manually calling ``ui.to_json()`` and stuffing the result into ``structured_content``. FastMCP's own ``ToolResult.__init__`` already does that conversion automatically when it sees a raw ``PrefabApp`` — the manual path produced the same shape but prevented the meta-expansion hook from triggering.

## Fix

- **``tool_result_utils.make_tool_result``**: pass the raw ``PrefabApp`` as ``structured_content``. FastMCP converts via ``_prefab_to_json``. Drop the ``prefab_json["data"] = response.model_dump()`` splice — redundant, since Prefab apps carry their data via ``state={...}`` at construction time.
- **``UI_META = {"ui": True}``**: new constant in ``tool_result_utils`` as the shared opt-in marker.
- **16 tool registrations** updated to pass ``meta=UI_META``:

  | File | Tools |
  | --- | --- |
  | ``items.py`` | search_items, create_item, get_item, update_item, delete_item, get_variant_details |
  | ``inventory.py`` | check_inventory, list_low_stock_items |
  | ``catalog.py`` | create_product, create_material |
  | ``sales_orders.py`` | create_sales_order |
  | ``manufacturing_orders.py`` | create_manufacturing_order |
  | ``purchase_orders.py`` | create_purchase_order, receive_purchase_order, verify_order_document |
  | ``orders.py`` | fulfill_order |

## Verification

Ran a startup probe against a freshly-registered FastMCP instance:

```
=== ui:// resources ===
  ui://prefab/renderer.html  mime=text/html;profile=mcp-app  name=Prefab Renderer
  total ui:// resources: 1

=== tools with expanded ui meta: 16 ===
  check_inventory  -> ui://prefab/renderer.html
  create_item  -> ui://prefab/renderer.html
  ... (14 more) ...
```

The renderer resource is now present with the correct MIME type; all 16 UI-emitting tools have their meta expanded to point at it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] ``uv run poe check`` — 2385 passed, 3 skipped
- [x] Runtime probe confirms resource registration + meta expansion
- [ ] Live Claude Desktop session (requires user to pull the branch into their local config and confirm UI renders — see ``MCP_CURSOR_SETUP.md`` / stdio config)

## Test plan

- [ ] CI green on 3.12 / 3.13 / 3.14
- [ ] Semgrep / CodeQL / security-scan green
- [ ] Live test: open Claude Desktop against this branch, call ``get_variant_details(sku=<any>)`` or ``search_items(query=<any>)``. The UI card should render (not raw markdown).

## Related

Fixes #350. Adjacent to #311 (Prefab UI extension) which presumed the delivery path worked.