### PR TITLE
feat(mcp): exhaustive get_customer + canonical-name markdown labels

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
@@ -7,7 +7,7 @@ rather than exposed as a resource.
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools.tool import ToolResult
@@ -143,39 +143,189 @@ class GetCustomerRequest(BaseModel):
     )
 
 
+class CustomerAddressInfo(BaseModel):
+    """Full customer address — one entry in ``GetCustomerResponse.addresses``.
+
+    Mirrors the wire-shape of ``katana_public_api_client.models.CustomerAddress``
+    (same field names, every field surfaced) so callers don't need a follow-up
+    lookup for identity fields. Field **types** intentionally diverge from the
+    generated attrs model: enums (``entity_type``) are rendered as strings and
+    timestamps as ISO strings, matching what JSON consumers actually see on
+    the wire.
+    """
+
+    id: int
+    customer_id: int
+    entity_type: str | None = None
+    default: bool | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+    company: str | None = None
+    phone: str | None = None
+    line_1: str | None = None
+    line_2: str | None = None
+    city: str | None = None
+    state: str | None = None
+    zip: str | None = None
+    country: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    deleted_at: str | None = None
+
+
 class GetCustomerResponse(BaseModel):
-    """Response containing full customer details."""
+    """Full customer details. Exhaustive — every field Katana exposes on
+    ``Customer`` is surfaced (including nested addresses) so callers don't
+    need follow-up lookups for standard fields.
+    """
 
     id: int
     name: str
+    first_name: str | None = None
+    last_name: str | None = None
+    company: str | None = None
     email: str | None = None
     phone: str | None = None
-    currency: str | None = None
-    company: str | None = None
-    category: str | None = None
     comment: str | None = None
+    currency: str | None = None
+    reference_id: str | None = None
+    category: str | None = None
+    discount_rate: float | None = None
+    default_billing_id: int | None = None
+    default_shipping_id: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    deleted_at: str | None = None
+    addresses: list[CustomerAddressInfo] = Field(default_factory=list)
+
+
+def _iso_or_none(value: Any) -> str | None:
+    """Return an ISO-8601 string for a datetime-or-str value, else None."""
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+async def _fetch_customer_addresses(
+    services: Any, customer_id: int
+) -> list[CustomerAddressInfo]:
+    """Fetch all addresses for a customer via the /customer_addresses endpoint.
+
+    Best-effort — the cache epic (#342) will fold addresses into the cache
+    sync. Until then, a transient failure shouldn't crash ``get_customer``
+    when the cache already has the customer record. Both transport-level
+    exceptions (timeouts, connection errors, unexpected statuses) and
+    API-error response bodies degrade to an empty list.
+    """
+    import httpx
+
+    from katana_public_api_client.api.customer_address import (
+        get_all_customer_addresses,
+    )
+    from katana_public_api_client.errors import UnexpectedStatus
+    from katana_public_api_client.utils import unwrap_data
+
+    try:
+        response = await get_all_customer_addresses.asyncio_detailed(
+            client=services.client,
+            customer_ids=[customer_id],
+            limit=250,
+        )
+    except (httpx.HTTPError, UnexpectedStatus):
+        return []
+    rows = unwrap_data(response, default=[], raise_on_error=False)
+    result: list[CustomerAddressInfo] = []
+    for row in rows:
+        row_dict = row.to_dict() if hasattr(row, "to_dict") else row
+        # The attrs model uses `zip_` as a Python keyword workaround; the API
+        # wire format is `zip`. `to_dict()` emits the wire name.
+        result.append(
+            CustomerAddressInfo(
+                id=row_dict.get("id", 0),
+                customer_id=row_dict.get("customer_id", customer_id),
+                entity_type=row_dict.get("entity_type"),
+                default=row_dict.get("default"),
+                first_name=row_dict.get("first_name"),
+                last_name=row_dict.get("last_name"),
+                company=row_dict.get("company"),
+                phone=row_dict.get("phone"),
+                line_1=row_dict.get("line_1"),
+                line_2=row_dict.get("line_2"),
+                city=row_dict.get("city"),
+                state=row_dict.get("state"),
+                zip=row_dict.get("zip"),
+                country=row_dict.get("country"),
+                created_at=_iso_or_none(row_dict.get("created_at")),
+                updated_at=_iso_or_none(row_dict.get("updated_at")),
+                deleted_at=_iso_or_none(row_dict.get("deleted_at")),
+            )
+        )
+    return result
 
 
 @cache_read(EntityType.CUSTOMER)
 async def _get_customer_impl(
     request: GetCustomerRequest, context: Context
 ) -> GetCustomerResponse:
-    """Look up a customer by ID via the cache."""
+    """Look up a customer by ID via the cache, with addresses from the API."""
     services = get_services(context)
     d = await services.cache.get_by_id(EntityType.CUSTOMER, request.customer_id)
     if not d:
         raise ValueError(f"Customer with ID {request.customer_id} not found")
 
+    # Addresses live on a separate endpoint; no cache entity for them yet
+    # (tracked in #342). Fetch-on-demand — one extra HTTP call per get_customer.
+    addresses = await _fetch_customer_addresses(services, request.customer_id)
+
     return GetCustomerResponse(
         id=d.get("id", request.customer_id),
         name=d.get("name") or "",
+        first_name=d.get("first_name"),
+        last_name=d.get("last_name"),
+        company=d.get("company"),
         email=d.get("email"),
         phone=d.get("phone"),
-        currency=d.get("currency"),
-        company=d.get("company"),
-        category=d.get("category"),
         comment=d.get("comment"),
+        currency=d.get("currency"),
+        reference_id=d.get("reference_id"),
+        category=d.get("category"),
+        discount_rate=d.get("discount_rate"),
+        default_billing_id=d.get("default_billing_id"),
+        default_shipping_id=d.get("default_shipping_id"),
+        created_at=_iso_or_none(d.get("created_at")),
+        updated_at=_iso_or_none(d.get("updated_at")),
+        deleted_at=_iso_or_none(d.get("deleted_at")),
+        addresses=addresses,
     )
+
+
+def _render_address_md(addr: CustomerAddressInfo) -> str:
+    """Render a single address as a compact multi-line block.
+
+    Uses canonical field names so an LLM consuming the markdown can't mistake
+    a rendered value for a differently-labeled field.
+    """
+    lines = [f"  - **id**: {addr.id}"]
+    for fname in (
+        "entity_type",
+        "default",
+        "first_name",
+        "last_name",
+        "company",
+        "phone",
+        "line_1",
+        "line_2",
+        "city",
+        "state",
+        "zip",
+        "country",
+    ):
+        val = getattr(addr, fname)
+        if val is not None and val != "":
+            lines.append(f"    **{fname}**: {val}")
+    return "\n".join(lines)
 
 
 @observe_tool
@@ -185,8 +335,11 @@ async def get_customer(
 ) -> ToolResult:
     """Get full details for a specific customer by ID.
 
-    Returns name, email, phone, currency, category, and comments. Use
-    search_customers first to find the customer_id.
+    Returns every field Katana exposes on the customer record — identity,
+    contact details, pricing (discount_rate), default address IDs, timestamps,
+    and the full list of associated billing/shipping addresses. Use
+    search_customers first to find the customer_id; this tool is the
+    single-call path to the rest.
     """
     response = await _get_customer_impl(request, context)
 
@@ -196,19 +349,40 @@ async def get_customer(
             structured_content=response.model_dump(),
         )
 
-    md_lines = [f"## {response.name}", f"**ID**: {response.id}"]
-    if response.email:
-        md_lines.append(f"**Email**: {response.email}")
-    if response.phone:
-        md_lines.append(f"**Phone**: {response.phone}")
-    if response.currency:
-        md_lines.append(f"**Currency**: {response.currency}")
-    if response.company:
-        md_lines.append(f"**Company**: {response.company}")
-    if response.category:
-        md_lines.append(f"**Category**: {response.category}")
-    if response.comment:
-        md_lines.append(f"**Comment**: {response.comment}")
+    # Labels use the canonical Pydantic field names so LLM consumers can't
+    # confuse a section header with the field name (see #346 follow-on).
+    md_lines = [f"## {response.name}"]
+    scalar_fields = (
+        "id",
+        "first_name",
+        "last_name",
+        "company",
+        "email",
+        "phone",
+        "currency",
+        "reference_id",
+        "category",
+        "discount_rate",
+        "default_billing_id",
+        "default_shipping_id",
+        "comment",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+    )
+    for fname in scalar_fields:
+        val = getattr(response, fname)
+        if val is None or val == "":
+            continue
+        md_lines.append(f"**{fname}**: {val}")
+
+    if response.addresses:
+        md_lines.append("")
+        md_lines.append(f"**addresses** ({len(response.addresses)}):")
+        for addr in response.addresses:
+            md_lines.append(_render_address_md(addr))
+    else:
+        md_lines.append("**addresses**: []")
 
     return make_simple_result(
         "\n".join(md_lines), structured_data=response.model_dump()

--- a/katana_mcp_server/tests/tools/test_customers.py
+++ b/katana_mcp_server/tests/tools/test_customers.py
@@ -120,28 +120,115 @@ async def test_search_customers_handles_missing_fields():
 # ============================================================================
 
 
+_FETCH_ADDR_PATH = "katana_mcp.tools.foundation.customers._fetch_customer_addresses"
+
+
 @pytest.mark.asyncio
 async def test_get_customer_by_id():
-    """Test get_customer with mocked cache."""
+    """get_customer returns every Customer field the cache dict carries."""
     context, lifespan_ctx = create_mock_context()
     lifespan_ctx.cache.get_by_id = AsyncMock(
         return_value={
             "id": 42,
             "name": "Widgets Inc",
+            "first_name": "Sarah",
+            "last_name": "Johnson",
             "email": "hello@widgets.io",
+            "phone": "+1-555-0123",
+            "company": "Widgets Inc",
             "currency": "EUR",
+            "reference_id": "WGT-2024-001",
             "category": "retail",
+            "discount_rate": 5.0,
+            "default_billing_id": 3001,
+            "default_shipping_id": 3002,
+            "comment": "High-volume",
+            "created_at": "2024-01-10T09:00:00Z",
+            "updated_at": "2024-01-15T14:30:00Z",
+            "deleted_at": None,
         }
     )
 
     request = GetCustomerRequest(customer_id=42)
-    result = await _get_customer_impl(request, context)
+    with patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])):
+        result = await _get_customer_impl(request, context)
 
     assert result.id == 42
     assert result.name == "Widgets Inc"
+    # Every new field the pre-#346 response was dropping:
+    assert result.first_name == "Sarah"
+    assert result.last_name == "Johnson"
+    assert result.phone == "+1-555-0123"
+    assert result.reference_id == "WGT-2024-001"
+    assert result.discount_rate == 5.0
+    assert result.default_billing_id == 3001
+    assert result.default_shipping_id == 3002
+    assert result.created_at == "2024-01-10T09:00:00Z"
+    assert result.updated_at == "2024-01-15T14:30:00Z"
+    # Fields that were already there stay correct:
     assert result.email == "hello@widgets.io"
     assert result.currency == "EUR"
     assert result.category == "retail"
+    # Addresses default to empty list when none are registered:
+    assert result.addresses == []
+
+
+@pytest.mark.asyncio
+async def test_get_customer_fetches_and_surfaces_addresses():
+    """Addresses come from the customer_addresses endpoint, not the cache."""
+    from katana_mcp.tools.foundation.customers import CustomerAddressInfo
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.cache.get_by_id = AsyncMock(
+        return_value={"id": 42, "name": "Widgets Inc"}
+    )
+    address = CustomerAddressInfo(
+        id=3001,
+        customer_id=42,
+        entity_type="billing",
+        default=True,
+        first_name="Sarah",
+        line_1="123 Main St",
+        city="Chicago",
+        state="IL",
+        zip="60601",
+        country="US",
+    )
+
+    request = GetCustomerRequest(customer_id=42)
+    with patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[address])):
+        result = await _get_customer_impl(request, context)
+
+    assert len(result.addresses) == 1
+    assert result.addresses[0].id == 3001
+    assert result.addresses[0].line_1 == "123 Main St"
+    assert result.addresses[0].entity_type == "billing"
+
+
+@pytest.mark.asyncio
+async def test_get_customer_markdown_uses_canonical_field_names():
+    """Markdown labels use Pydantic field names (not prettified headers)
+    so LLM consumers can't misread a section label as a different field
+    (motivation: #346 follow-on, supplier_item_codes misread)."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.cache.get_by_id = AsyncMock(
+        return_value={
+            "id": 42,
+            "name": "Widgets Inc",
+            "reference_id": "WGT-2024-001",
+            "discount_rate": 5.0,
+        }
+    )
+
+    with patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])):
+        result = await get_customer(customer_id=42, context=context)
+
+    text = result.content[0].text
+    assert "**reference_id**: WGT-2024-001" in text
+    assert "**discount_rate**: 5.0" in text
+    # Empty address list renders with explicit [] syntax, not a heading
+    # that a reader might mistake for a section:
+    assert "**addresses**: []" in text
 
 
 @pytest.mark.asyncio
@@ -206,7 +293,8 @@ async def test_get_customer_format_json_returns_json():
         return_value={"id": 42, "name": "Widgets Inc", "email": "hi@widgets.io"}
     )
 
-    result = await get_customer(customer_id=42, format="json", context=context)
+    with patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])):
+        result = await get_customer(customer_id=42, format="json", context=context)
 
     data = json.loads(_content_text(result))
     assert data["id"] == 42


### PR DESCRIPTION
## Summary

First slice of #346 (exhaustive single-object get_* tools). Takes ``get_customer`` as the spike because the field drop was the clearest — ``GetCustomerResponse`` was exposing 9 of 18 ``Customer`` fields. Establishes the pattern for the other entities to follow in subsequent PRs.

## What changed

**Field coverage** — added every ``Customer`` field previously dropped: ``first_name``, ``last_name``, ``reference_id``, ``discount_rate``, ``default_billing_id``, ``default_shipping_id``, ``created_at``, ``updated_at``, ``deleted_at``. Plus the full ``addresses`` list, fetched from ``/customer_addresses`` when ``get_customer`` is called (addresses aren't in the cache today — this will move to cache-first once #342 lands).

**Rendering** — markdown labels now use canonical Pydantic field names (``**reference_id**:`` instead of ``Reference``), and list-shaped fields render with explicit list syntax. Motivated by the #346 follow-on observation: the pre-fix output had a ``Supplier Info`` header followed by bare bullets, which an LLM consuming the output misread as free-form supplier metadata rather than a structured field. Canonical names + explicit list shape prevent that class of misread.

**Nested model** — new ``CustomerAddressInfo`` Pydantic type mirrors every field on the generated ``CustomerAddress`` (16 fields). Used for both API surface (``GetCustomerResponse.addresses``) and the renderer.

## Design decisions

- **Address fetch-on-demand** — separate HTTP per ``get_customer`` call. Accepted cost for exhaustiveness; will move to cache-first under #342.
- **Field labels in markdown** — canonical Pydantic names, not prettified titles. Trades reader-friendliness for LLM-parseability, which is the caller that matters.
- **Empty list rendering** — ``**addresses**: []`` rather than omitting the field. An LLM shouldn't have to infer presence vs. absence.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (the ``Supplier Info`` ambiguity class)

## Test plan

- [x] ``uv run poe check`` — 2390 passed, 3 skipped
- [x] 3 new tests: full-field coverage, address fetch-through, markdown-label convention
- [ ] CI green on 3.12 / 3.13 / 3.14
- [ ] Follow-up PRs for the other entities — sales_order, MO, PO, variant/item, inventory_movements

## Related

Part of #346. References #342 (cache epic — addresses will migrate once that lands).