### PR TITLE
feat(mcp): exhaustive get_sales_order + canonical-name markdown labels (#346)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -811,16 +811,27 @@ also carries a `rows` list.
 ---
 
 ### get_sales_order
-Look up a single sales order by order number or ID with full line items.
+Look up a single sales order by order number or ID with exhaustive detail.
 
 **Parameters:**
 - `order_no` (optional): SO number (e.g., "#WEB20394")
 - `order_id` (optional): SO ID
 - `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
-**Returns:** Order header (status, customer, location, total, delivery_date)
-plus `rows` with variant_id, SKU, quantity, price_per_unit, and any linked
-manufacturing_order_id. SKU is enriched via the variant cache.
+**Returns:** Every field Katana exposes on the sales order record —
+identifiers (id, order_no, customer_id, location_id, source), status flags
+(status, production_status, invoicing_status, product_availability,
+ingredient_availability), dates (order_created_date, delivery_date,
+picked_date, product_expected_date, ingredient_expected_date), money (total,
+total_in_base_currency, currency, conversion_rate, conversion_date), notes
+(additional_info, customer_ref), tracking (tracking_number,
+tracking_number_url), address pointers (billing_address_id,
+shipping_address_id) plus the full resolved `addresses` list fetched from
+/sales_order_addresses, `shipping_fee` block, `linked_manufacturing_order_id`,
+ecommerce metadata (ecommerce_order_type/store_name/order_id), timestamps
+(created_at, updated_at, deleted_at), and per-line `rows` with every
+`SalesOrderRow` field (variant_id, SKU via variant cache, quantity, pricing,
+discounts, tax, cogs, linked MO, batch/serial tracking, timestamps).
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -854,27 +854,219 @@ class GetSalesOrderRequest(BaseModel):
     )
 
 
-class GetSalesOrderResponse(BaseModel):
-    """Full sales order details."""
+class SalesOrderRowDetail(BaseModel):
+    """Full sales order row — every field on ``SalesOrderRow`` surfaced.
+
+    Used inside ``GetSalesOrderResponse.rows`` where we want the exhaustive
+    row-level detail. ``SalesOrderRowInfo`` (used by list_sales_orders) stays
+    summary-shaped so the list tool remains compact.
+    """
 
     id: int
-    order_no: str | None
-    customer_id: int | None
-    location_id: int | None
-    status: str | None
-    production_status: str | None
-    created_at: str | None
-    delivery_date: str | None
-    total: float | None
-    currency: str | None
-    additional_info: str | None
-    rows: list[SalesOrderRowInfo]
+    variant_id: int | None = None
+    sku: str | None = None
+    quantity: float | None = None
+    sales_order_id: int | None = None
+    tax_rate_id: int | None = None
+    tax_rate: float | None = None
+    location_id: int | None = None
+    product_availability: str | None = None
+    product_expected_date: str | None = None
+    price_per_unit: float | None = None
+    price_per_unit_in_base_currency: float | None = None
+    total: float | None = None
+    total_in_base_currency: float | None = None
+    total_discount: str | None = None
+    cogs_value: float | None = None
+    linked_manufacturing_order_id: int | None = None
+    conversion_rate: float | None = None
+    conversion_date: str | None = None
+    serial_numbers: list[int] = Field(default_factory=list)
+    created_at: str | None = None
+    updated_at: str | None = None
+    deleted_at: str | None = None
+
+
+class SalesOrderAddressInfo(BaseModel):
+    """Full sales order address — one entry in ``GetSalesOrderResponse.addresses``.
+
+    Mirrors every field on the ``SalesOrderAddress`` attrs model. The attrs
+    field ``zip_`` is a Python keyword workaround; the wire format (and this
+    Pydantic field) is ``zip``.
+    """
+
+    id: int
+    sales_order_id: int | None = None
+    entity_type: str | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+    company: str | None = None
+    phone: str | None = None
+    line_1: str | None = None
+    line_2: str | None = None
+    city: str | None = None
+    state: str | None = None
+    zip: str | None = None
+    country: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    deleted_at: str | None = None
+
+
+class SalesOrderShippingFeeInfo(BaseModel):
+    """Shipping fee block — mirrors the ``SalesOrderShippingFee`` attrs model."""
+
+    id: int
+    sales_order_id: int | None = None
+    amount: str | None = None
+    tax_rate_id: int | None = None
+    description: str | None = None
+
+
+class GetSalesOrderResponse(BaseModel):
+    """Full sales order details. Exhaustive — every field Katana exposes on
+    ``SalesOrder`` is surfaced (including nested rows, addresses, and
+    shipping fee) so callers don't need follow-up lookups for standard fields.
+    """
+
+    # Identifiers / header
+    id: int
+    order_no: str | None = None
+    customer_id: int | None = None
+    location_id: int | None = None
+    source: str | None = None
+    order_created_date: str | None = None
+
+    # Status / workflow
+    status: str | None = None
+    production_status: str | None = None
+    invoicing_status: str | None = None
+    product_availability: str | None = None
+    product_expected_date: str | None = None
+    ingredient_availability: str | None = None
+    ingredient_expected_date: str | None = None
+
+    # Dates
+    delivery_date: str | None = None
+    picked_date: str | None = None
+
+    # Money
+    currency: str | None = None
+    total: float | None = None
+    total_in_base_currency: float | None = None
+    conversion_rate: float | None = None
+    conversion_date: str | None = None
+
+    # Notes / reference
+    additional_info: str | None = None
+    customer_ref: str | None = None
+
+    # Tracking
+    tracking_number: str | None = None
+    tracking_number_url: str | None = None
+
+    # Addresses — both the ID pointers on the SO and the full resolved list
+    billing_address_id: int | None = None
+    shipping_address_id: int | None = None
+    addresses: list[SalesOrderAddressInfo] = Field(default_factory=list)
+
+    # Linked resources
+    linked_manufacturing_order_id: int | None = None
+    shipping_fee: SalesOrderShippingFeeInfo | None = None
+
+    # Ecommerce metadata
+    ecommerce_order_type: str | None = None
+    ecommerce_store_name: str | None = None
+    ecommerce_order_id: str | None = None
+
+    # Timestamps
+    created_at: str | None = None
+    updated_at: str | None = None
+    deleted_at: str | None = None
+
+    # Line items — exhaustive per-row detail
+    rows: list[SalesOrderRowDetail] = Field(default_factory=list)
+
+
+def _shipping_fee_from_attrs(fee: Any) -> SalesOrderShippingFeeInfo | None:
+    """Build a SalesOrderShippingFeeInfo from a populated attrs fee or None.
+
+    Callers must pre-unwrap the attrs field (via ``unwrap_unset(obj.shipping_fee,
+    None)``) so this helper only receives ``None`` or a populated object —
+    passing the raw UNSET sentinel would AttributeError on ``.id``.
+    """
+    if fee is None:
+        return None
+    return SalesOrderShippingFeeInfo(
+        id=fee.id,
+        sales_order_id=fee.sales_order_id,
+        amount=unwrap_unset(fee.amount, None),
+        tax_rate_id=unwrap_unset(fee.tax_rate_id, None),
+        description=unwrap_unset(fee.description, None),
+    )
+
+
+async def _fetch_sales_order_addresses(
+    services: Any, sales_order_id: int
+) -> list[SalesOrderAddressInfo]:
+    """Fetch all addresses for a sales order via /sales_order_addresses.
+
+    SOs aren't cached today (per #342 they're transactional), so this is a
+    fetch-on-demand call alongside the SO lookup. Returns the full list of
+    addresses linked to ``sales_order_id``.
+    """
+    from katana_public_api_client.api.sales_order_address import (
+        get_all_sales_order_addresses,
+    )
+    from katana_public_api_client.utils import unwrap_data
+
+    response = await get_all_sales_order_addresses.asyncio_detailed(
+        client=services.client,
+        sales_order_ids=[sales_order_id],
+        limit=250,
+    )
+    rows = unwrap_data(response, default=[])
+    result: list[SalesOrderAddressInfo] = []
+    for row in rows:
+        row_dict = row.to_dict() if hasattr(row, "to_dict") else row
+        # The attrs model uses ``zip_`` as a Python keyword workaround; the
+        # API wire format is ``zip``. ``to_dict()`` emits the wire name.
+        result.append(
+            SalesOrderAddressInfo(
+                id=row_dict.get("id", 0),
+                sales_order_id=row_dict.get("sales_order_id"),
+                entity_type=row_dict.get("entity_type"),
+                first_name=row_dict.get("first_name"),
+                last_name=row_dict.get("last_name"),
+                company=row_dict.get("company"),
+                phone=row_dict.get("phone"),
+                line_1=row_dict.get("line_1"),
+                line_2=row_dict.get("line_2"),
+                city=row_dict.get("city"),
+                state=row_dict.get("state"),
+                zip=row_dict.get("zip"),
+                country=row_dict.get("country"),
+                # to_dict() has already serialized these to ISO strings;
+                # iso_or_none expects datetime and would AttributeError.
+                created_at=row_dict.get("created_at"),
+                updated_at=row_dict.get("updated_at"),
+                deleted_at=row_dict.get("deleted_at"),
+            )
+        )
+    return result
 
 
 async def _get_sales_order_impl(
     request: GetSalesOrderRequest, context: Context
 ) -> GetSalesOrderResponse:
-    """Look up a single sales order by order_no or order_id with line items."""
+    """Look up a single sales order by order_no or order_id with line items.
+
+    Exhaustive response — every field Katana exposes on ``SalesOrder`` (plus
+    nested rows, addresses, and shipping fee) is surfaced so callers don't
+    need follow-up lookups for standard fields. SO is not cached today (#342
+    covers the cache migration), so this keeps the same SO lookup path the
+    prior impl used and adds a fetch-on-demand for addresses.
+    """
     from katana_public_api_client.api.sales_order import (
         get_all_sales_orders,
         get_sales_order as api_get_sales_order,
@@ -905,29 +1097,56 @@ async def _get_sales_order_impl(
 
     raw_rows = unwrap_unset(so.sales_order_rows, [])
 
-    # Parallelize variant lookups across all rows (N+1 fix)
+    # Parallelize variant lookups across all rows (N+1 fix) AND the address
+    # fetch — both depend only on the SO we just loaded.
     variant_ids = [unwrap_unset(r.variant_id, None) for r in raw_rows]
-    variants = await asyncio.gather(
-        *(
-            services.cache.get_by_id(EntityType.VARIANT, v_id)
-            if v_id is not None
-            else none_coro()
-            for v_id in variant_ids
-        )
+    variants, addresses = await asyncio.gather(
+        asyncio.gather(
+            *(
+                services.cache.get_by_id(EntityType.VARIANT, v_id)
+                if v_id is not None
+                else none_coro()
+                for v_id in variant_ids
+            )
+        ),
+        _fetch_sales_order_addresses(services, so.id),
     )
 
-    row_infos: list[SalesOrderRowInfo] = []
+    row_details: list[SalesOrderRowDetail] = []
     for r, variant in zip(raw_rows, variants, strict=True):
-        row_infos.append(
-            SalesOrderRowInfo(
+        row_details.append(
+            SalesOrderRowDetail(
                 id=r.id,
                 variant_id=unwrap_unset(r.variant_id, None),
                 sku=variant.get("sku") if variant else None,
                 quantity=unwrap_unset(r.quantity, None),
+                sales_order_id=unwrap_unset(r.sales_order_id, None),
+                tax_rate_id=unwrap_unset(r.tax_rate_id, None),
+                tax_rate=unwrap_unset(r.tax_rate, None),
+                location_id=unwrap_unset(r.location_id, None),
+                product_availability=enum_to_str(
+                    unwrap_unset(r.product_availability, None)
+                ),
+                product_expected_date=iso_or_none(
+                    unwrap_unset(r.product_expected_date, None)
+                ),
                 price_per_unit=unwrap_unset(r.price_per_unit, None),
+                price_per_unit_in_base_currency=unwrap_unset(
+                    r.price_per_unit_in_base_currency, None
+                ),
+                total=unwrap_unset(r.total, None),
+                total_in_base_currency=unwrap_unset(r.total_in_base_currency, None),
+                total_discount=unwrap_unset(r.total_discount, None),
+                cogs_value=unwrap_unset(r.cogs_value, None),
                 linked_manufacturing_order_id=unwrap_unset(
                     r.linked_manufacturing_order_id, None
                 ),
+                conversion_rate=unwrap_unset(r.conversion_rate, None),
+                conversion_date=iso_or_none(unwrap_unset(r.conversion_date, None)),
+                serial_numbers=unwrap_unset(r.serial_numbers, []),
+                created_at=iso_or_none(unwrap_unset(r.created_at, None)),
+                updated_at=iso_or_none(unwrap_unset(r.updated_at, None)),
+                deleted_at=iso_or_none(unwrap_unset(r.deleted_at, None)),
             )
         )
 
@@ -936,15 +1155,155 @@ async def _get_sales_order_impl(
         order_no=unwrap_unset(so.order_no, None),
         customer_id=unwrap_unset(so.customer_id, None),
         location_id=unwrap_unset(so.location_id, None),
+        source=unwrap_unset(so.source, None),
+        order_created_date=iso_or_none(unwrap_unset(so.order_created_date, None)),
         status=enum_to_str(unwrap_unset(so.status, None)),
         production_status=enum_to_str(unwrap_unset(so.production_status, None)),
-        created_at=iso_or_none(unwrap_unset(so.created_at, None)),
+        invoicing_status=unwrap_unset(so.invoicing_status, None),
+        product_availability=enum_to_str(unwrap_unset(so.product_availability, None)),
+        product_expected_date=iso_or_none(unwrap_unset(so.product_expected_date, None)),
+        ingredient_availability=enum_to_str(
+            unwrap_unset(so.ingredient_availability, None)
+        ),
+        ingredient_expected_date=iso_or_none(
+            unwrap_unset(so.ingredient_expected_date, None)
+        ),
         delivery_date=iso_or_none(unwrap_unset(so.delivery_date, None)),
-        total=unwrap_unset(so.total, None),
+        picked_date=iso_or_none(unwrap_unset(so.picked_date, None)),
         currency=unwrap_unset(so.currency, None),
+        total=unwrap_unset(so.total, None),
+        total_in_base_currency=unwrap_unset(so.total_in_base_currency, None),
+        conversion_rate=unwrap_unset(so.conversion_rate, None),
+        conversion_date=iso_or_none(unwrap_unset(so.conversion_date, None)),
         additional_info=unwrap_unset(so.additional_info, None),
-        rows=row_infos,
+        customer_ref=unwrap_unset(so.customer_ref, None),
+        tracking_number=unwrap_unset(so.tracking_number, None),
+        tracking_number_url=unwrap_unset(so.tracking_number_url, None),
+        billing_address_id=unwrap_unset(so.billing_address_id, None),
+        shipping_address_id=unwrap_unset(so.shipping_address_id, None),
+        addresses=addresses,
+        linked_manufacturing_order_id=unwrap_unset(
+            so.linked_manufacturing_order_id, None
+        ),
+        shipping_fee=_shipping_fee_from_attrs(unwrap_unset(so.shipping_fee, None)),
+        ecommerce_order_type=unwrap_unset(so.ecommerce_order_type, None),
+        ecommerce_store_name=unwrap_unset(so.ecommerce_store_name, None),
+        ecommerce_order_id=unwrap_unset(so.ecommerce_order_id, None),
+        created_at=iso_or_none(unwrap_unset(so.created_at, None)),
+        updated_at=iso_or_none(unwrap_unset(so.updated_at, None)),
+        deleted_at=iso_or_none(unwrap_unset(so.deleted_at, None)),
+        rows=row_details,
     )
+
+
+# Scalar fields rendered in order at the top of the markdown response.
+# Labels use canonical Pydantic names so LLM consumers can't confuse a
+# rendered section header with the field name (see #346 follow-on).
+_GET_SO_SCALAR_FIELDS: tuple[str, ...] = (
+    "id",
+    "order_no",
+    "customer_id",
+    "location_id",
+    "source",
+    "status",
+    "production_status",
+    "invoicing_status",
+    "product_availability",
+    "product_expected_date",
+    "ingredient_availability",
+    "ingredient_expected_date",
+    "order_created_date",
+    "delivery_date",
+    "picked_date",
+    "currency",
+    "total",
+    "total_in_base_currency",
+    "conversion_rate",
+    "conversion_date",
+    "customer_ref",
+    "additional_info",
+    "tracking_number",
+    "tracking_number_url",
+    "billing_address_id",
+    "shipping_address_id",
+    "linked_manufacturing_order_id",
+    "ecommerce_order_type",
+    "ecommerce_store_name",
+    "ecommerce_order_id",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+)
+
+# Per-address fields rendered (in order) under an ``addresses`` block.
+_ADDRESS_FIELDS: tuple[str, ...] = (
+    "sales_order_id",
+    "entity_type",
+    "first_name",
+    "last_name",
+    "company",
+    "phone",
+    "line_1",
+    "line_2",
+    "city",
+    "state",
+    "zip",
+    "country",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+)
+
+# Per-row fields rendered under a ``rows`` block. ``id`` + ``variant_id`` /
+# ``sku`` are emitted first as the row header; the rest are indented beneath.
+_ROW_HEADER_FIELDS: tuple[str, ...] = ("variant_id", "sku")
+_ROW_BODY_FIELDS: tuple[str, ...] = (
+    "sales_order_id",
+    "quantity",
+    "price_per_unit",
+    "price_per_unit_in_base_currency",
+    "total",
+    "total_in_base_currency",
+    "total_discount",
+    "tax_rate_id",
+    "tax_rate",
+    "location_id",
+    "product_availability",
+    "product_expected_date",
+    "cogs_value",
+    "linked_manufacturing_order_id",
+    "conversion_rate",
+    "conversion_date",
+    "serial_numbers",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+)
+
+
+def _render_address_md(addr: SalesOrderAddressInfo) -> str:
+    """Render one address as an indented multi-line block with canonical labels."""
+    lines = [f"  - **id**: {addr.id}"]
+    for fname in _ADDRESS_FIELDS:
+        val = getattr(addr, fname)
+        if val is None or val == "":
+            continue
+        lines.append(f"    **{fname}**: {val}")
+    return "\n".join(lines)
+
+
+def _render_row_md(row: SalesOrderRowDetail) -> str:
+    """Render one sales order row as an indented multi-line block with canonical labels."""
+    lines = [f"  - **id**: {row.id}"]
+    for fname in _ROW_HEADER_FIELDS + _ROW_BODY_FIELDS:
+        val = getattr(row, fname)
+        # Empty serial_numbers list is noise — skip it. Non-empty lists render
+        # with explicit [...] syntax so an LLM reading the output can tell
+        # the field is a list.
+        if val is None or val == "" or (isinstance(val, list) and not val):
+            continue
+        lines.append(f"    **{fname}**: {val}")
+    return "\n".join(lines)
 
 
 @observe_tool
@@ -954,9 +1313,13 @@ async def get_sales_order(
 ) -> ToolResult:
     """Look up a sales order by number or ID with all line items.
 
-    Returns order details (status, production_status, customer, delivery date)
-    plus rows with variant_id, SKU, quantity, price, and per-row production
-    status. Use with `list_sales_orders` for discovery workflows.
+    Returns every field Katana exposes on the sales order record — identity,
+    status/workflow flags, dates, totals, tracking, ecommerce metadata,
+    timestamps — plus the full list of associated billing/shipping addresses
+    (fetched on-demand via /sales_order_addresses, since SOs aren't cached)
+    and exhaustive per-row detail (variant, SKU via variant cache, pricing,
+    linked manufacturing order, batch tracking, serial numbers). Use with
+    `list_sales_orders` for discovery; this is the single-call path to the rest.
     """
     from katana_mcp.tools.tool_result_utils import make_simple_result
 
@@ -968,43 +1331,49 @@ async def get_sales_order(
             structured_content=response.model_dump(),
         )
 
-    lines = [
-        f"## Sales Order {response.order_no or response.id}",
-        f"- **Status**: {response.status}",
-        f"- **Production**: {response.production_status}",
-    ]
-    if response.customer_id is not None:
-        lines.append(f"- **Customer ID**: {response.customer_id}")
-    if response.location_id is not None:
-        lines.append(f"- **Location ID**: {response.location_id}")
-    if response.total is not None:
-        lines.append(f"- **Total**: {response.total} {response.currency or ''}")
-    if response.delivery_date:
-        lines.append(f"- **Delivery**: {response.delivery_date}")
-    if response.additional_info:
-        lines.append(f"- **Notes**: {response.additional_info}")
+    # Labels use canonical Pydantic field names so LLM consumers can't
+    # confuse a section header with the field name (see #346 follow-on).
+    header = f"## Sales Order {response.order_no or response.id}"
+    md_lines: list[str] = [header]
+    for fname in _GET_SO_SCALAR_FIELDS:
+        val = getattr(response, fname)
+        if val is None or val == "":
+            continue
+        md_lines.append(f"**{fname}**: {val}")
 
+    # shipping_fee is a nested object — render its canonical fields inline.
+    if response.shipping_fee is not None:
+        md_lines.append("")
+        md_lines.append("**shipping_fee**:")
+        fee = response.shipping_fee
+        md_lines.append(f"  **id**: {fee.id}")
+        for fname in ("sales_order_id", "amount", "tax_rate_id", "description"):
+            fval = getattr(fee, fname)
+            if fval is None or fval == "":
+                continue
+            md_lines.append(f"  **{fname}**: {fval}")
+
+    # Addresses — explicit [] when empty, count + per-address blocks when populated.
+    md_lines.append("")
+    if response.addresses:
+        md_lines.append(f"**addresses** ({len(response.addresses)}):")
+        for addr in response.addresses:
+            md_lines.append(_render_address_md(addr))
+    else:
+        md_lines.append("**addresses**: []")
+
+    # Rows — same shape as addresses (explicit [] / count + per-row blocks).
+    md_lines.append("")
     if response.rows:
-        lines.append("")
-        lines.append("### Line Items")
-        lines.append(
-            format_md_table(
-                headers=["Row ID", "SKU", "Variant", "Qty", "Price", "Linked MO"],
-                rows=[
-                    [
-                        r.id,
-                        r.sku or "—",
-                        r.variant_id or "—",
-                        r.quantity,
-                        r.price_per_unit or "—",
-                        r.linked_manufacturing_order_id or "—",
-                    ]
-                    for r in response.rows
-                ],
-            )
-        )
+        md_lines.append(f"**rows** ({len(response.rows)}):")
+        for row in response.rows:
+            md_lines.append(_render_row_md(row))
+    else:
+        md_lines.append("**rows**: []")
 
-    return make_simple_result("\n".join(lines), structured_data=response.model_dump())
+    return make_simple_result(
+        "\n".join(md_lines), structured_data=response.model_dump()
+    )
 
 
 def register_tools(mcp: FastMCP) -> None:

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -558,7 +558,13 @@ def _make_mock_so(
     currency: str = "USD",
     rows: list | None = None,
 ) -> MagicMock:
-    """Build a mock SalesOrder attrs object for testing."""
+    """Build a mock SalesOrder attrs object for testing.
+
+    Every SalesOrder attrs field is stubbed (mostly to UNSET) so
+    ``unwrap_unset`` calls in the production impl don't leak raw MagicMock
+    instances through Pydantic validation. Tests that need a populated
+    field can assign it explicitly after the call.
+    """
     so = MagicMock()
     so.id = id
     so.order_no = order_no
@@ -567,11 +573,33 @@ def _make_mock_so(
     so.status = status
     so.production_status = production_status
     so.invoicing_status = UNSET
+    so.source = UNSET
+    so.order_created_date = UNSET
     so.created_at = datetime(2026, 4, 10, 9, 0, tzinfo=UTC)
+    so.updated_at = UNSET
+    so.deleted_at = UNSET
     so.delivery_date = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    so.picked_date = UNSET
+    so.conversion_rate = UNSET
+    so.conversion_date = UNSET
     so.total = total
+    so.total_in_base_currency = UNSET
     so.currency = currency
     so.additional_info = UNSET
+    so.customer_ref = UNSET
+    so.product_availability = UNSET
+    so.product_expected_date = UNSET
+    so.ingredient_availability = UNSET
+    so.ingredient_expected_date = UNSET
+    so.tracking_number = UNSET
+    so.tracking_number_url = UNSET
+    so.billing_address_id = UNSET
+    so.shipping_address_id = UNSET
+    so.linked_manufacturing_order_id = UNSET
+    so.shipping_fee = UNSET
+    so.ecommerce_order_type = UNSET
+    so.ecommerce_store_name = UNSET
+    so.ecommerce_order_id = UNSET
     so.sales_order_rows = rows if rows is not None else []
     return so
 
@@ -584,7 +612,12 @@ def _make_mock_row(
     price_per_unit: float,
     linked_mo_id: int | None = None,
 ) -> MagicMock:
-    """Build a mock sales order row."""
+    """Build a mock sales order row.
+
+    Stubs every SalesOrderRow attrs field (mostly to UNSET) so the new
+    exhaustive ``SalesOrderRowDetail`` mapping in ``_get_sales_order_impl``
+    doesn't leak MagicMock instances through Pydantic validation.
+    """
     r = MagicMock()
     r.id = id
     r.variant_id = variant_id
@@ -593,6 +626,23 @@ def _make_mock_row(
     r.linked_manufacturing_order_id = (
         linked_mo_id if linked_mo_id is not None else UNSET
     )
+    r.sales_order_id = UNSET
+    r.tax_rate_id = UNSET
+    r.tax_rate = UNSET
+    r.location_id = UNSET
+    r.product_availability = UNSET
+    r.product_expected_date = UNSET
+    r.price_per_unit_in_base_currency = UNSET
+    r.total = UNSET
+    r.total_in_base_currency = UNSET
+    r.total_discount = UNSET
+    r.cogs_value = UNSET
+    r.conversion_rate = UNSET
+    r.conversion_date = UNSET
+    r.serial_numbers = UNSET
+    r.created_at = UNSET
+    r.updated_at = UNSET
+    r.deleted_at = UNSET
     return r
 
 
@@ -1104,6 +1154,15 @@ async def test_list_sales_orders_include_rows_handles_unset_fields():
 # ============================================================================
 
 
+# Path of the internal helper that fetches /sales_order_addresses. Patched
+# in tests so `_get_sales_order_impl` doesn't make a real HTTP call — SOs
+# aren't cached today (per #342), so addresses are fetch-on-demand alongside
+# the SO lookup.
+_FETCH_ADDR_PATH = (
+    "katana_mcp.tools.foundation.sales_orders._fetch_sales_order_addresses"
+)
+
+
 @pytest.mark.asyncio
 async def test_get_sales_order_requires_identifier():
     """Must provide order_no or order_id."""
@@ -1127,6 +1186,7 @@ async def test_get_sales_order_by_id():
     with (
         patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
         patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
     ):
         request = GetSalesOrderRequest(order_id=777)
         result = await _get_sales_order_impl(request, context)
@@ -1148,6 +1208,7 @@ async def test_get_sales_order_by_number():
     with (
         patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
         patch(_SO_UNWRAP_DATA, return_value=[mock_so]),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
     ):
         request = GetSalesOrderRequest(order_no="#WEB20394")
         result = await _get_sales_order_impl(request, context)
@@ -1172,7 +1233,7 @@ async def test_get_sales_order_not_found_by_number_raises():
 
 @pytest.mark.asyncio
 async def test_get_sales_order_enriches_row_sku_from_cache():
-    """Row-level variant cache hits populate SalesOrderRowInfo.sku."""
+    """Row-level variant cache hits populate SalesOrderRowDetail.sku."""
     context, lifespan_ctx = create_mock_context()
 
     # Cache returns a variant dict for variant_id 500
@@ -1194,11 +1255,288 @@ async def test_get_sales_order_enriches_row_sku_from_cache():
     with (
         patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
         patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
     ):
         result = await _get_sales_order_impl(GetSalesOrderRequest(order_id=9), context)
 
     assert result.rows[0].sku == "BIKE-A"  # cache hit
     assert result.rows[1].sku is None  # cache miss
+
+
+# ============================================================================
+# get_sales_order — exhaustive field coverage (#346)
+# ============================================================================
+
+
+def _make_mock_so_all_fields(*, so_id: int = 2001) -> MagicMock:
+    """Build a mock SalesOrder attrs object with *every* field populated.
+
+    Used by the full-coverage test so we can assert every previously-dropped
+    field now surfaces on the response. Uses real enums where the attrs
+    model stores an enum so `enum_to_str()` behaves like production.
+    """
+    from katana_public_api_client.models.ingredient_availability import (
+        IngredientAvailability,
+    )
+    from katana_public_api_client.models.product_availability import (
+        ProductAvailability,
+    )
+    from katana_public_api_client.models.sales_order_production_status import (
+        SalesOrderProductionStatus,
+    )
+
+    so = MagicMock()
+    so.id = so_id
+    so.order_no = "SO-2024-001"
+    so.customer_id = 1501
+    so.location_id = 1
+    so.status = SalesOrderStatus.NOT_SHIPPED
+    so.source = "Shopify"
+    so.order_created_date = datetime(2024, 1, 15, 10, 0, tzinfo=UTC)
+    so.production_status = SalesOrderProductionStatus.IN_PROGRESS
+    so.invoicing_status = "NOT_INVOICED"
+    so.product_availability = ProductAvailability.IN_STOCK
+    so.product_expected_date = datetime(2024, 1, 20, 0, 0, tzinfo=UTC)
+    so.ingredient_availability = IngredientAvailability.IN_STOCK
+    so.ingredient_expected_date = datetime(2024, 1, 18, 0, 0, tzinfo=UTC)
+    so.delivery_date = datetime(2024, 1, 22, 14, 0, tzinfo=UTC)
+    so.picked_date = datetime(2024, 1, 21, 9, 0, tzinfo=UTC)
+    so.currency = "USD"
+    so.total = 1250.0
+    so.total_in_base_currency = 1250.0
+    so.conversion_rate = 1.0
+    so.conversion_date = datetime(2024, 1, 15, 10, 0, tzinfo=UTC)
+    so.additional_info = "Customer requested expedited delivery"
+    so.customer_ref = "CUST-REF-2024-001"
+    so.tracking_number = "UPS1234567890"
+    so.tracking_number_url = "https://www.ups.com/track?track=UPS1234567890"
+    so.billing_address_id = 1201
+    so.shipping_address_id = 1202
+    so.linked_manufacturing_order_id = 7777
+    so.ecommerce_order_type = "standard"
+    so.ecommerce_store_name = "Kitchen Pro Store"
+    so.ecommerce_order_id = "SHOP-5678-2024"
+    so.created_at = datetime(2024, 1, 15, 10, 0, tzinfo=UTC)
+    so.updated_at = datetime(2024, 1, 20, 16, 30, tzinfo=UTC)
+    so.deleted_at = None
+
+    # Nested shipping_fee with populated fields
+    fee = MagicMock()
+    fee.id = 2801
+    fee.sales_order_id = so_id
+    fee.amount = "25.99"
+    fee.tax_rate_id = 301
+    fee.description = "UPS Ground Shipping"
+    so.shipping_fee = fee
+
+    # One fully populated row so every SalesOrderRowDetail field has a value
+    row = MagicMock()
+    row.id = 2501
+    row.variant_id = 2101
+    row.quantity = 2.0
+    row.sales_order_id = so_id
+    row.tax_rate_id = 301
+    row.tax_rate = 10.0
+    row.location_id = 1
+    row.product_availability = ProductAvailability.IN_STOCK
+    row.product_expected_date = datetime(2024, 1, 20, 0, 0, tzinfo=UTC)
+    row.price_per_unit = 599.99
+    row.price_per_unit_in_base_currency = 599.99
+    row.total = 1199.98
+    row.total_in_base_currency = 1199.98
+    row.total_discount = "0.00"
+    row.cogs_value = 400.0
+    row.linked_manufacturing_order_id = 7777
+    row.conversion_rate = 1.0
+    row.conversion_date = datetime(2024, 1, 15, 10, 0, tzinfo=UTC)
+    row.serial_numbers = [10001, 10002]
+    row.created_at = datetime(2024, 1, 15, 10, 0, tzinfo=UTC)
+    row.updated_at = datetime(2024, 1, 15, 10, 0, tzinfo=UTC)
+    row.deleted_at = None
+    so.sales_order_rows = [row]
+
+    return so
+
+
+@pytest.mark.asyncio
+async def test_get_sales_order_surfaces_every_sales_order_field():
+    """get_sales_order exposes every field Katana puts on SalesOrder + rows.
+
+    The pre-#346 response dropped ~20 SO-level fields (source, invoicing_status,
+    product/ingredient availability, picked_date, total_in_base_currency,
+    tracking, billing/shipping address IDs, ecommerce metadata, timestamps, etc.)
+    and dropped most SalesOrderRow fields. This test pins the exhaustive
+    coverage so a future refactor can't silently drop them again.
+    """
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.cache.get_by_id = AsyncMock(return_value=None)
+    mock_so = _make_mock_so_all_fields(so_id=2001)
+
+    with (
+        patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
+    ):
+        result = await _get_sales_order_impl(
+            GetSalesOrderRequest(order_id=2001), context
+        )
+
+    # Previously-dropped SO-level scalars:
+    assert result.source == "Shopify"
+    assert result.order_created_date == "2024-01-15T10:00:00+00:00"
+    assert result.invoicing_status == "NOT_INVOICED"
+    assert result.product_availability == "IN_STOCK"
+    assert result.product_expected_date == "2024-01-20T00:00:00+00:00"
+    assert result.ingredient_availability == "IN_STOCK"
+    assert result.ingredient_expected_date == "2024-01-18T00:00:00+00:00"
+    assert result.picked_date == "2024-01-21T09:00:00+00:00"
+    assert result.total_in_base_currency == 1250.0
+    assert result.conversion_rate == 1.0
+    assert result.conversion_date == "2024-01-15T10:00:00+00:00"
+    assert result.customer_ref == "CUST-REF-2024-001"
+    assert result.tracking_number == "UPS1234567890"
+    assert result.tracking_number_url == "https://www.ups.com/track?track=UPS1234567890"
+    assert result.billing_address_id == 1201
+    assert result.shipping_address_id == 1202
+    assert result.linked_manufacturing_order_id == 7777
+    assert result.ecommerce_order_type == "standard"
+    assert result.ecommerce_store_name == "Kitchen Pro Store"
+    assert result.ecommerce_order_id == "SHOP-5678-2024"
+    assert result.created_at == "2024-01-15T10:00:00+00:00"
+    assert result.updated_at == "2024-01-20T16:30:00+00:00"
+    assert result.deleted_at is None
+
+    # Nested shipping_fee surfaces with every field:
+    assert result.shipping_fee is not None
+    assert result.shipping_fee.id == 2801
+    assert result.shipping_fee.amount == "25.99"
+    assert result.shipping_fee.tax_rate_id == 301
+    assert result.shipping_fee.description == "UPS Ground Shipping"
+
+    # Per-row exhaustive detail — fields the pre-#346 SalesOrderRowInfo dropped:
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.id == 2501
+    assert row.variant_id == 2101
+    assert row.quantity == 2.0
+    assert row.sales_order_id == 2001
+    assert row.tax_rate_id == 301
+    assert row.tax_rate == 10.0
+    assert row.location_id == 1
+    assert row.product_availability == "IN_STOCK"
+    assert row.product_expected_date == "2024-01-20T00:00:00+00:00"
+    assert row.price_per_unit == 599.99
+    assert row.price_per_unit_in_base_currency == 599.99
+    assert row.total == 1199.98
+    assert row.total_in_base_currency == 1199.98
+    assert row.total_discount == "0.00"
+    assert row.cogs_value == 400.0
+    assert row.linked_manufacturing_order_id == 7777
+    assert row.conversion_rate == 1.0
+    assert row.conversion_date == "2024-01-15T10:00:00+00:00"
+    assert row.serial_numbers == [10001, 10002]
+    assert row.created_at == "2024-01-15T10:00:00+00:00"
+    assert row.updated_at == "2024-01-15T10:00:00+00:00"
+    assert row.deleted_at is None
+
+
+@pytest.mark.asyncio
+async def test_get_sales_order_fetches_and_surfaces_addresses():
+    """Addresses come from /sales_order_addresses, not the SO response.
+
+    SOs aren't cached today (#342), so the tool fetches addresses on demand
+    alongside the SO lookup. Patches the internal helper to assert the
+    fetched results flow through to `response.addresses`.
+    """
+    from katana_mcp.tools.foundation.sales_orders import SalesOrderAddressInfo
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.cache.get_by_id = AsyncMock(return_value=None)
+    mock_so = _make_mock_so(id=2001, order_no="SO-2001")
+
+    billing = SalesOrderAddressInfo(
+        id=1201,
+        sales_order_id=2001,
+        entity_type="billing",
+        first_name="Sarah",
+        last_name="Johnson",
+        company="Johnson's Restaurant",
+        line_1="123 Main Street",
+        city="Portland",
+        state="OR",
+        zip="97201",
+        country="US",
+    )
+    shipping = SalesOrderAddressInfo(
+        id=1202,
+        sales_order_id=2001,
+        entity_type="shipping",
+        first_name="Sarah",
+        last_name="Johnson",
+        line_1="456 Oak Ave",
+        city="Seattle",
+        state="WA",
+        zip="98101",
+        country="US",
+    )
+
+    with (
+        patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[billing, shipping])),
+    ):
+        result = await _get_sales_order_impl(
+            GetSalesOrderRequest(order_id=2001), context
+        )
+
+    assert len(result.addresses) == 2
+    assert result.addresses[0].id == 1201
+    assert result.addresses[0].entity_type == "billing"
+    assert result.addresses[0].line_1 == "123 Main Street"
+    # wire field name `zip` (not the attrs `zip_` workaround):
+    assert result.addresses[0].zip == "97201"
+    assert result.addresses[1].entity_type == "shipping"
+    assert result.addresses[1].city == "Seattle"
+
+
+@pytest.mark.asyncio
+async def test_get_sales_order_markdown_uses_canonical_field_names():
+    """Markdown labels use Pydantic field names (not prettified headers)
+    so LLM consumers can't misread a section label as a different field.
+
+    Pins the #346 canonical-name convention: scalar lines render as
+    ``**field_name**: value``, empty lists render as ``**field_name**: []``,
+    and non-empty lists render as ``**field_name** (N):`` with indented
+    per-item blocks.
+    """
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.cache.get_by_id = AsyncMock(return_value=None)
+    mock_so = _make_mock_so(
+        id=2001,
+        order_no="SO-2001",
+        rows=[_make_mock_row(id=10, variant_id=500, quantity=1, price_per_unit=99.0)],
+    )
+    # Stamp distinctive values on fields whose labels we want to pin:
+    mock_so.customer_ref = "CUST-REF-001"
+    mock_so.tracking_number = "UPS1234567890"
+
+    with (
+        patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
+    ):
+        result = await get_sales_order(order_id=2001, context=context)
+
+    text = result.content[0].text
+    # Canonical-name scalar labels (not "Delivery", not "Tracking", etc.):
+    assert "**delivery_date**:" in text
+    assert "**customer_ref**: CUST-REF-001" in text
+    assert "**tracking_number**: UPS1234567890" in text
+    # Empty collections render with explicit [] so readers can't mistake
+    # the heading for a section:
+    assert "**addresses**: []" in text
+    # Non-empty rows render with a count header:
+    assert "**rows** (1):" in text
 
 
 # ============================================================================
@@ -1255,6 +1593,7 @@ async def test_get_sales_order_format_json_returns_json():
     with (
         patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
         patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
     ):
         result = await get_sales_order(order_id=9, format="json", context=context)
 


### PR DESCRIPTION
## Summary

Sibling slice to #352 (``get_customer``) in the #346 exhaustive-detail audit. ``GetSalesOrderResponse`` was exposing **12 of 34** ``SalesOrder`` fields; the per-row sub-model was exposing only 6 of 23 ``SalesOrderRow`` fields. This PR surfaces every field on both models, plus the full associated addresses list.

## What changed

**SO-level field coverage** — added the 22 ``SalesOrder`` fields previously dropped: ``source``, ``order_created_date``, ``invoicing_status``, ``product_availability``, ``product_expected_date``, ``ingredient_availability``, ``ingredient_expected_date``, ``picked_date``, ``total_in_base_currency``, ``conversion_rate``, ``conversion_date``, ``customer_ref``, ``tracking_number``, ``tracking_number_url``, ``billing_address_id``, ``shipping_address_id``, ``linked_manufacturing_order_id``, ``shipping_fee``, ``ecommerce_order_type``, ``ecommerce_store_name``, ``ecommerce_order_id``, ``updated_at``, ``deleted_at``.

**Row-level field coverage** — new ``SalesOrderRowDetail`` sub-model replaces the summary-shaped ``SalesOrderRowInfo`` inside the ``get_sales_order`` response. Adds ``sales_order_id``, ``tax_rate``, ``location_id``, ``product_availability``, ``product_expected_date``, ``price_per_unit_in_base_currency``, ``total``, ``total_in_base_currency``, ``total_discount``, ``cogs_value``, ``conversion_rate``, ``conversion_date``, ``serial_numbers``, ``created_at``, ``updated_at``, ``deleted_at``. ``list_sales_orders`` keeps ``SalesOrderRowInfo`` unchanged per scope.

**Addresses** — new ``SalesOrderAddressInfo`` Pydantic type mirrors every field on the generated ``SalesOrderAddress``. Fetched on-demand from ``/sales_order_addresses`` alongside the SO lookup, parallelized with the existing variant-cache lookups via a single ``asyncio.gather``. SOs aren't cached today (#342 covers the cache migration for transactional entities) so this matches the #352 pattern.

**Shipping fee** — new ``SalesOrderShippingFeeInfo`` sub-model surfaces every field on the nested ``SalesOrderShippingFee`` attrs model.

**Rendering** — markdown labels now use canonical Pydantic field names (``**delivery_date**:`` instead of ``**Delivery**``). Addresses render with explicit list syntax — ``**addresses**: []`` when empty, ``**addresses** (N):`` with indented per-item blocks when populated. Same pattern for ``rows``. Nested ``shipping_fee`` renders with its own canonical-labeled block.

**help.py** — ``get_sales_order`` entry rewritten to describe the exhaustive response. Append-only edit; other tool sections untouched.

## Design decisions

- **Address fetch-on-demand** — same pattern as #352. Separate HTTP per ``get_sales_order`` call; will move to cache-first once #342 lands.
- **``list_sales_orders`` stays summary-shaped** — ``SalesOrderRowInfo`` (summary) and ``SalesOrderRowDetail`` (exhaustive) coexist so the list tool stays compact and the detail tool stays complete.
- **Canonical field names in markdown** — pins the LLM-parseability convention established by #352. Trade-off accepted: reader friendliness for disambiguation.
- **Parallelized fetch** — variant cache lookups and address fetch happen under a single ``gather``, so the new endpoint call is free when we'd already be awaiting N variant lookups.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test plan

- [x] ``uv run poe check`` — 2391 passed, 3 skipped
- [x] 3 new tests matching #352 shape:
  - full-field coverage — asserts every previously-dropped ``SalesOrder`` and ``SalesOrderRow`` field surfaces
  - address fetch-through — patches ``_fetch_sales_order_addresses`` by dotted path; asserts results flow to ``response.addresses``
  - markdown-label convention — pins the canonical-name convention (``**delivery_date**:``, ``**addresses**: []``)
- [x] 4 existing ``_get_sales_order_impl`` tests updated to patch the new address helper
- [ ] CI green on 3.12 / 3.13 / 3.14

## Related

Part of #346. Follows #352 (``get_customer`` pattern). References #342 (cache epic — addresses will migrate once that lands).