### PR TITLE
feat(mcp): exhaustive get_purchase_order + canonical-name labels (#346)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -48,8 +48,8 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **create_purchase_order** - Create PO with preview/confirm pattern
 - **list_purchase_orders** - List POs with supplier/status/date filters
 - **receive_purchase_order** - Receive items and update inventory
-- **verify_order_document** - Verify supplier documents against POs
-- **get_purchase_order** - Look up a PO by number or ID with line items
+- **verify_order_document** - Verify supplier documents against POs (returns the full PO alongside match/discrepancy details)
+- **get_purchase_order** - Look up a PO by number or ID — exhaustive detail (every PO/row field, additional cost rows, accounting metadata)
 
 ### Manufacturing & Sales
 - **create_manufacturing_order** - Create production work orders
@@ -620,7 +620,13 @@ Verify a supplier document (invoice, packing slip) against a PO.
 - `document_items` (required): Array of items from document with sku, quantity, unit_price
 - `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
-**Returns:** Match status, discrepancies, and suggested actions.
+**Returns:** Match status, discrepancies, suggested actions, and the full
+`purchase_order` in the same exhaustive shape as `get_purchase_order` —
+so callers can trace every compared value back to a concrete PO field
+without a follow-up lookup. Markdown output uses canonical Pydantic field
+names as labels (`**matches**`, `**discrepancies**`, `**purchase_order**`)
+to keep LLM consumers from misreading a prettified header as a different
+field (#346 follow-on).
 
 ---
 
@@ -666,14 +672,31 @@ expected_arrival_date, total, row_count. When `page` is set, also returns
 ---
 
 ### get_purchase_order
-Look up a purchase order by order number or ID with all line items.
+Look up a purchase order by order number or ID — exhaustive detail.
 
 **Parameters:**
 - `order_no` (optional): PO number (e.g., "PO-1022")
 - `order_id` (optional): PO ID
 - `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
-**Returns:** Order details (status, supplier, total) plus rows with variant_id, quantity, price, arrival/received dates.
+**Returns:** Every field Katana exposes on the PO record — status, billing
+status, supplier, location, totals (including `total_in_base_currency`),
+timestamps, `last_document_status`, `tracking_location_id`,
+`additional_info`, plus:
+- `purchase_order_rows` — full line items (UOM, conversion rates,
+  landed_cost, batch_transactions, every row field)
+- `additional_cost_rows` — shipping, duties, handling (every field on
+  `PurchaseOrderAdditionalCostRow`)
+- `accounting_metadata` — bill IDs, integration type (every field on
+  `PurchaseOrderAccountingMetadata`)
+
+Two extra HTTP calls fetch the additional cost rows (by PO
+`default_group_id`) and accounting metadata (by PO id) on top of the
+PO-detail fetch. Markdown output uses canonical Pydantic field names as
+labels (`**status**`, `**purchase_order_rows** (N):`, `**additional_cost_rows**: []`)
+so LLM consumers can't misread a section header as a different field
+(#346 follow-on). Use this whenever full detail is needed; use
+`list_purchase_orders` for discovery.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -683,6 +683,9 @@ Look up a purchase order by order number or ID — exhaustive detail.
 status, supplier, location, totals (including `total_in_base_currency`),
 timestamps, `last_document_status`, `tracking_location_id`,
 `additional_info`, plus:
+- `supplier` — the full embedded supplier record when Katana attaches one
+  (every field on `Supplier`: name, email, phone, currency, comment,
+  default_address_id, addresses, timestamps)
 - `purchase_order_rows` — full line items (UOM, conversion rates,
   landed_cost, batch_transactions, every row field)
 - `additional_cost_rows` — shipping, duties, handling (every field on
@@ -692,11 +695,12 @@ timestamps, `last_document_status`, `tracking_location_id`,
 
 Two extra HTTP calls fetch the additional cost rows (by PO
 `default_group_id`) and accounting metadata (by PO id) on top of the
-PO-detail fetch. Markdown output uses canonical Pydantic field names as
-labels (`**status**`, `**purchase_order_rows** (N):`, `**additional_cost_rows**: []`)
-so LLM consumers can't misread a section header as a different field
-(#346 follow-on). Use this whenever full detail is needed; use
-`list_purchase_orders` for discovery.
+PO-detail fetch; they run concurrently via `asyncio.gather` so the extra
+wait is a single round-trip, not two. Markdown output uses canonical
+Pydantic field names as labels (`**status**`, `**purchase_order_rows** (N):`,
+`**additional_cost_rows**: []`) so LLM consumers can't misread a section
+header as a different field (#346 follow-on). Use this whenever full
+detail is needed; use `list_purchase_orders` for discovery.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -10,6 +10,7 @@ These tools provide:
 
 from __future__ import annotations
 
+import asyncio
 import datetime as _datetime
 import json
 from datetime import UTC, datetime
@@ -487,7 +488,712 @@ async def receive_purchase_order(
 
 
 # ============================================================================
-# Tool 3: verify_order_document
+# Tool: get_purchase_order
+#
+# Defined before ``verify_order_document`` so the verification tool can embed
+# the same exhaustive ``GetPurchaseOrderResponse`` shape on its response
+# (avoids a forward-reference + ``model_rebuild`` dance).
+# ============================================================================
+
+
+class GetPurchaseOrderRequest(BaseModel):
+    """Request to look up a purchase order by number or ID."""
+
+    order_no: str | None = Field(
+        default=None, description="Purchase order number (e.g., 'PO-1022')"
+    )
+    order_id: int | None = Field(default=None, description="Purchase order ID")
+    format: Literal["markdown", "json"] = Field(
+        default="markdown",
+        description=(
+            "Output format: 'markdown' (default) for human-readable tables; "
+            "'json' for structured data consumable by downstream tools/aggregations."
+        ),
+    )
+
+
+class PurchaseOrderRowInfo(BaseModel):
+    """Full purchase order line item — every field Katana exposes on
+    ``PurchaseOrderRow`` is surfaced so callers don't need follow-up lookups
+    for standard row fields (UOM conversion, currency, landed_cost, etc.).
+    """
+
+    id: int
+    created_at: str | None = None
+    updated_at: str | None = None
+    deleted_at: str | None = None
+    quantity: float | None = None
+    variant_id: int | None = None
+    tax_rate_id: int | None = None
+    price_per_unit: float | None = None
+    price_per_unit_in_base_currency: float | None = None
+    purchase_uom_conversion_rate: float | None = None
+    purchase_uom: str | None = None
+    currency: str | None = None
+    conversion_rate: float | None = None
+    total: float | None = None
+    total_in_base_currency: float | None = None
+    conversion_date: str | None = None
+    received_date: str | None = None
+    arrival_date: str | None = None
+    purchase_order_id: int | None = None
+    landed_cost: float | str | None = None
+    group_id: int | None = None
+    batch_transactions: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class PurchaseOrderAdditionalCostRowInfo(BaseModel):
+    """Full additional cost row — every field Katana exposes on
+    ``PurchaseOrderAdditionalCostRow`` (shipping, duties, handling, etc.).
+    """
+
+    id: int
+    created_at: str | None = None
+    updated_at: str | None = None
+    deleted_at: str | None = None
+    additional_cost_id: int | None = None
+    group_id: int | None = None
+    name: str | None = None
+    distribution_method: str | None = None
+    tax_rate_id: int | None = None
+    tax_rate: float | None = None
+    price: float | None = None
+    price_in_base: float | None = None
+    currency: str | None = None
+    currency_conversion_rate: float | None = None
+    currency_conversion_rate_fix_date: str | None = None
+
+
+class PurchaseOrderAccountingMetadataInfo(BaseModel):
+    """Full accounting-integration metadata — every field Katana exposes on
+    ``PurchaseOrderAccountingMetadata`` (bill IDs, integration type, etc.).
+    """
+
+    id: int
+    purchase_order_id: int
+    received_items_group_id: int | None = None
+    integration_type: str | None = None
+    bill_id: str | None = None
+    created_at: str | None = None
+
+
+class SupplierInfo(BaseModel):
+    """Embedded supplier details — every field Katana exposes on
+    ``Supplier`` when the PO payload includes the inline supplier record.
+    """
+
+    id: int
+    name: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    currency: str | None = None
+    comment: str | None = None
+    default_address_id: int | None = None
+    addresses: list[dict[str, Any]] = Field(default_factory=list)
+    created_at: str | None = None
+    updated_at: str | None = None
+    deleted_at: str | None = None
+
+
+class GetPurchaseOrderResponse(BaseModel):
+    """Full purchase-order details. Exhaustive — every field Katana exposes
+    on ``RegularPurchaseOrder`` is surfaced, plus nested inline rows and
+    fetched-on-demand additional cost rows and accounting metadata. Callers
+    don't need follow-up lookups for standard PO data.
+    """
+
+    id: int
+    created_at: str | None = None
+    updated_at: str | None = None
+    deleted_at: str | None = None
+    status: str | None = None
+    order_no: str | None = None
+    entity_type: str | None = None
+    default_group_id: int | None = None
+    supplier_id: int | None = None
+    supplier: SupplierInfo | None = None
+    currency: str | None = None
+    expected_arrival_date: str | None = None
+    order_created_date: str | None = None
+    additional_info: str | None = None
+    location_id: int | None = None
+    total: float | None = None
+    total_in_base_currency: float | None = None
+    billing_status: str | None = None
+    last_document_status: str | None = None
+    tracking_location_id: int | None = None
+    purchase_order_rows: list[PurchaseOrderRowInfo] = Field(default_factory=list)
+    additional_cost_rows: list[PurchaseOrderAdditionalCostRowInfo] = Field(
+        default_factory=list
+    )
+    accounting_metadata: list[PurchaseOrderAccountingMetadataInfo] = Field(
+        default_factory=list
+    )
+
+
+def _iso_optional(value: datetime | str | None) -> str | None:
+    """Return an ISO-8601 string for a datetime-or-str value, else None.
+
+    Callers must pre-unwrap UNSET via ``unwrap_unset(..., None)`` — this
+    helper only handles ``None``, a ``datetime``, or an already-formatted
+    string. Typed ``datetime | str | None`` so pyright catches misuse.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _po_row_info(row: Any) -> PurchaseOrderRowInfo:
+    """Extract full row info from an attrs ``PurchaseOrderRow``."""
+    # batch_transactions items are attrs models — serialize them to dicts so
+    # Pydantic can validate the list shape without cross-model coupling.
+    raw_batch = unwrap_unset(row.batch_transactions, None) or []
+    batch_dicts: list[dict[str, Any]] = []
+    for bt in raw_batch:
+        if hasattr(bt, "to_dict"):
+            batch_dicts.append(bt.to_dict())
+        elif isinstance(bt, dict):
+            batch_dicts.append(bt)
+
+    return PurchaseOrderRowInfo(
+        id=row.id,
+        created_at=_iso_optional(unwrap_unset(row.created_at, None)),
+        updated_at=_iso_optional(unwrap_unset(row.updated_at, None)),
+        deleted_at=_iso_optional(unwrap_unset(row.deleted_at, None)),
+        quantity=unwrap_unset(row.quantity, None),
+        variant_id=unwrap_unset(row.variant_id, None),
+        tax_rate_id=unwrap_unset(row.tax_rate_id, None),
+        price_per_unit=unwrap_unset(row.price_per_unit, None),
+        price_per_unit_in_base_currency=unwrap_unset(
+            row.price_per_unit_in_base_currency, None
+        ),
+        purchase_uom_conversion_rate=unwrap_unset(
+            row.purchase_uom_conversion_rate, None
+        ),
+        purchase_uom=unwrap_unset(row.purchase_uom, None),
+        currency=unwrap_unset(row.currency, None),
+        conversion_rate=unwrap_unset(row.conversion_rate, None),
+        total=unwrap_unset(row.total, None),
+        total_in_base_currency=unwrap_unset(row.total_in_base_currency, None),
+        conversion_date=_iso_optional(unwrap_unset(row.conversion_date, None)),
+        received_date=_iso_optional(unwrap_unset(row.received_date, None)),
+        arrival_date=_iso_optional(unwrap_unset(row.arrival_date, None)),
+        purchase_order_id=unwrap_unset(row.purchase_order_id, None),
+        landed_cost=unwrap_unset(row.landed_cost, None),
+        group_id=unwrap_unset(row.group_id, None),
+        batch_transactions=batch_dicts,
+    )
+
+
+def _po_additional_cost_row_info(row: Any) -> PurchaseOrderAdditionalCostRowInfo:
+    """Extract full info from an attrs ``PurchaseOrderAdditionalCostRow``."""
+    return PurchaseOrderAdditionalCostRowInfo(
+        id=row.id,
+        created_at=_iso_optional(unwrap_unset(row.created_at, None)),
+        updated_at=_iso_optional(unwrap_unset(row.updated_at, None)),
+        deleted_at=_iso_optional(unwrap_unset(row.deleted_at, None)),
+        additional_cost_id=unwrap_unset(row.additional_cost_id, None),
+        group_id=unwrap_unset(row.group_id, None),
+        name=unwrap_unset(row.name, None),
+        distribution_method=enum_to_str(unwrap_unset(row.distribution_method, None)),
+        tax_rate_id=unwrap_unset(row.tax_rate_id, None),
+        tax_rate=unwrap_unset(row.tax_rate, None),
+        price=unwrap_unset(row.price, None),
+        price_in_base=unwrap_unset(row.price_in_base, None),
+        currency=unwrap_unset(row.currency, None),
+        currency_conversion_rate=unwrap_unset(row.currency_conversion_rate, None),
+        currency_conversion_rate_fix_date=_iso_optional(
+            unwrap_unset(row.currency_conversion_rate_fix_date, None)
+        ),
+    )
+
+
+def _po_accounting_metadata_info(row: Any) -> PurchaseOrderAccountingMetadataInfo:
+    """Extract full info from an attrs ``PurchaseOrderAccountingMetadata``."""
+    return PurchaseOrderAccountingMetadataInfo(
+        id=row.id,
+        purchase_order_id=row.purchase_order_id,
+        received_items_group_id=unwrap_unset(row.received_items_group_id, None),
+        integration_type=unwrap_unset(row.integration_type, None),
+        bill_id=unwrap_unset(row.bill_id, None),
+        created_at=_iso_optional(unwrap_unset(row.created_at, None)),
+    )
+
+
+def _supplier_info(supplier: Any) -> SupplierInfo | None:
+    """Extract full info from an embedded attrs ``Supplier`` record.
+
+    Returns ``None`` when the PO payload doesn't include an inline supplier
+    (Katana only embeds the supplier on some endpoints — the exhaustive
+    response surfaces it when it's there so callers don't need a follow-up
+    lookup).
+    """
+    if supplier is None:
+        return None
+    # Addresses are attrs models — serialize to plain dicts so Pydantic can
+    # validate the list shape without cross-model coupling.
+    raw_addresses = unwrap_unset(supplier.addresses, None) or []
+    address_dicts: list[dict[str, Any]] = []
+    for addr in raw_addresses:
+        if hasattr(addr, "to_dict"):
+            address_dicts.append(addr.to_dict())
+        elif isinstance(addr, dict):
+            address_dicts.append(addr)
+
+    return SupplierInfo(
+        id=supplier.id,
+        name=unwrap_unset(supplier.name, None),
+        email=unwrap_unset(supplier.email, None),
+        phone=unwrap_unset(supplier.phone, None),
+        currency=unwrap_unset(supplier.currency, None),
+        comment=unwrap_unset(supplier.comment, None),
+        default_address_id=unwrap_unset(supplier.default_address_id, None),
+        addresses=address_dicts,
+        created_at=_iso_optional(unwrap_unset(supplier.created_at, None)),
+        updated_at=_iso_optional(unwrap_unset(supplier.updated_at, None)),
+        deleted_at=_iso_optional(unwrap_unset(supplier.deleted_at, None)),
+    )
+
+
+async def _fetch_po_additional_cost_rows(
+    services: Any, group_id: int | None
+) -> list[PurchaseOrderAdditionalCostRowInfo]:
+    """Fetch additional cost rows for a PO via its ``default_group_id``.
+
+    The ``/po_additional_cost_rows`` list endpoint filters by ``group_id``,
+    which for the PO-scope is the PO's ``default_group_id``. Returns an
+    empty list when no ``group_id`` is available (the PO has no group).
+    """
+    if group_id is None:
+        return []
+
+    import httpx
+
+    from katana_public_api_client.api.purchase_order_additional_cost_row import (
+        get_purchase_order_additional_cost_rows,
+    )
+    from katana_public_api_client.errors import UnexpectedStatus
+    from katana_public_api_client.utils import unwrap_data
+
+    # Best-effort: transport errors (httpx timeouts/connection) and unexpected
+    # statuses degrade to []. `unwrap_data(default=[])` alone only handles
+    # non-200 parsed responses, not errors raised before the response lands.
+    try:
+        # The generated client types `group_id` as float for historical spec
+        # reasons; cast at the boundary like `list_purchase_orders` does.
+        response = await get_purchase_order_additional_cost_rows.asyncio_detailed(
+            client=services.client,
+            group_id=float(group_id),
+            limit=250,
+        )
+    except (httpx.HTTPError, UnexpectedStatus):
+        return []
+    rows = unwrap_data(response, default=[], raise_on_error=False)
+    return [_po_additional_cost_row_info(r) for r in rows]
+
+
+async def _fetch_po_accounting_metadata(
+    services: Any, purchase_order_id: int
+) -> list[PurchaseOrderAccountingMetadataInfo]:
+    """Fetch accounting metadata entries for a PO.
+
+    The ``/purchase_order_accounting_metadata`` list endpoint filters by
+    ``purchase_order_id``. Returns an empty list when the PO has no
+    accounting-integration rows.
+    """
+    import httpx
+
+    from katana_public_api_client.api.purchase_order_accounting_metadata import (
+        get_all_purchase_order_accounting_metadata,
+    )
+    from katana_public_api_client.errors import UnexpectedStatus
+    from katana_public_api_client.utils import unwrap_data
+
+    # Best-effort: same pattern as _fetch_po_additional_cost_rows — transport
+    # errors don't take down get_purchase_order when the core PO was fine.
+    try:
+        # Generated client types `purchase_order_id` as float; cast at boundary.
+        response = await get_all_purchase_order_accounting_metadata.asyncio_detailed(
+            client=services.client,
+            purchase_order_id=float(purchase_order_id),
+            limit=250,
+        )
+    except (httpx.HTTPError, UnexpectedStatus):
+        return []
+    rows = unwrap_data(response, default=[], raise_on_error=False)
+    return [_po_accounting_metadata_info(r) for r in rows]
+
+
+def _build_get_purchase_order_response(
+    po: Any,
+    *,
+    additional_cost_rows: list[PurchaseOrderAdditionalCostRowInfo],
+    accounting_metadata: list[PurchaseOrderAccountingMetadataInfo],
+) -> GetPurchaseOrderResponse:
+    """Build an exhaustive response from an attrs PO plus fetched side data."""
+    raw_rows = unwrap_unset(po.purchase_order_rows, None) or []
+    rows = [_po_row_info(r) for r in raw_rows]
+    supplier = _supplier_info(unwrap_unset(po.supplier, None))
+
+    return GetPurchaseOrderResponse(
+        id=po.id,
+        created_at=_iso_optional(unwrap_unset(po.created_at, None)),
+        updated_at=_iso_optional(unwrap_unset(po.updated_at, None)),
+        deleted_at=_iso_optional(unwrap_unset(po.deleted_at, None)),
+        status=enum_to_str(unwrap_unset(po.status, None)),
+        order_no=unwrap_unset(po.order_no, None),
+        entity_type=enum_to_str(unwrap_unset(po.entity_type, None)),
+        default_group_id=unwrap_unset(po.default_group_id, None),
+        supplier_id=unwrap_unset(po.supplier_id, None),
+        supplier=supplier,
+        currency=unwrap_unset(po.currency, None),
+        expected_arrival_date=_iso_optional(
+            unwrap_unset(po.expected_arrival_date, None)
+        ),
+        order_created_date=_iso_optional(unwrap_unset(po.order_created_date, None)),
+        additional_info=unwrap_unset(po.additional_info, None),
+        location_id=unwrap_unset(po.location_id, None),
+        total=unwrap_unset(po.total, None),
+        total_in_base_currency=unwrap_unset(po.total_in_base_currency, None),
+        billing_status=enum_to_str(unwrap_unset(po.billing_status, None)),
+        last_document_status=enum_to_str(unwrap_unset(po.last_document_status, None)),
+        tracking_location_id=unwrap_unset(po.tracking_location_id, None),
+        purchase_order_rows=rows,
+        additional_cost_rows=additional_cost_rows,
+        accounting_metadata=accounting_metadata,
+    )
+
+
+async def _get_purchase_order_impl(
+    request: GetPurchaseOrderRequest, context: Context
+) -> GetPurchaseOrderResponse:
+    """Look up a PO by order_no or ID and return exhaustive details.
+
+    Additional cost rows and accounting metadata are fetched on demand from
+    separate endpoints — two extra HTTP calls per ``get_purchase_order``.
+    """
+    from katana_public_api_client.api.purchase_order import (
+        find_purchase_orders,
+        get_purchase_order as api_get_purchase_order,
+    )
+    from katana_public_api_client.models import ErrorResponse
+    from katana_public_api_client.utils import unwrap_data
+
+    # Explicit ``is None`` checks so valid-but-falsy values (``order_id=0``,
+    # ``order_no=""``) don't silently route to the wrong branch or error.
+    # Empty-string ``order_no`` is rejected up front as obviously invalid.
+    if request.order_id is None and request.order_no is None:
+        raise ValueError("Either order_no or order_id must be provided")
+    if request.order_no is not None and request.order_no == "":
+        raise ValueError("order_no must not be empty")
+
+    services = get_services(context)
+
+    if request.order_id is not None:
+        response = await api_get_purchase_order.asyncio_detailed(
+            id=request.order_id, client=services.client
+        )
+        # raise_on_error=False turns 404s and ErrorResponse payloads into None
+        # so we can raise a user-friendly ValueError instead of a raw APIError.
+        po_result = unwrap(response, raise_on_error=False)
+        if po_result is None or isinstance(po_result, ErrorResponse):
+            raise ValueError(f"Purchase order ID {request.order_id} not found")
+        po = po_result
+    else:
+        # ``order_no`` is guaranteed non-None/non-empty by the guards above.
+        assert request.order_no is not None
+        list_response = await find_purchase_orders.asyncio_detailed(
+            client=services.client, order_no=request.order_no, limit=1
+        )
+        orders = unwrap_data(list_response, default=[])
+        if not orders:
+            raise ValueError(f"Purchase order '{request.order_no}' not found")
+        po = orders[0]
+
+    # Fetch the two side-data resources concurrently — they're independent
+    # network calls (cost rows filter by group_id, accounting metadata by
+    # purchase_order_id), so gather avoids doubling end-to-end latency.
+    default_group_id = unwrap_unset(po.default_group_id, None)
+    additional_cost_rows, accounting_metadata = await asyncio.gather(
+        _fetch_po_additional_cost_rows(services, default_group_id),
+        _fetch_po_accounting_metadata(services, po.id),
+    )
+
+    return _build_get_purchase_order_response(
+        po,
+        additional_cost_rows=additional_cost_rows,
+        accounting_metadata=accounting_metadata,
+    )
+
+
+# ----------------------------------------------------------------------------
+# Markdown rendering — canonical Pydantic field names as labels so an LLM
+# consumer can't misread a section header as a differently-named field
+# (motivation: #346 follow-on).
+# ----------------------------------------------------------------------------
+
+_PO_SCALAR_FIELDS: tuple[str, ...] = (
+    "id",
+    "order_no",
+    "status",
+    "billing_status",
+    "entity_type",
+    "supplier_id",
+    "location_id",
+    "tracking_location_id",
+    "default_group_id",
+    "currency",
+    "total",
+    "total_in_base_currency",
+    "expected_arrival_date",
+    "order_created_date",
+    "last_document_status",
+    "additional_info",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+)
+
+_PO_ROW_FIELDS: tuple[str, ...] = (
+    "id",
+    "variant_id",
+    "quantity",
+    "price_per_unit",
+    "price_per_unit_in_base_currency",
+    "total",
+    "total_in_base_currency",
+    "purchase_uom",
+    "purchase_uom_conversion_rate",
+    "tax_rate_id",
+    "currency",
+    "conversion_rate",
+    "conversion_date",
+    "arrival_date",
+    "received_date",
+    "purchase_order_id",
+    "landed_cost",
+    "group_id",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+)
+
+_PO_ADDITIONAL_COST_FIELDS: tuple[str, ...] = (
+    "id",
+    "additional_cost_id",
+    "group_id",
+    "name",
+    "distribution_method",
+    "price",
+    "price_in_base",
+    "currency",
+    "currency_conversion_rate",
+    "currency_conversion_rate_fix_date",
+    "tax_rate_id",
+    "tax_rate",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+)
+
+_PO_ACCOUNTING_META_FIELDS: tuple[str, ...] = (
+    "id",
+    "purchase_order_id",
+    "received_items_group_id",
+    "integration_type",
+    "bill_id",
+    "created_at",
+)
+
+
+def _render_po_row_md(row: PurchaseOrderRowInfo) -> list[str]:
+    """Render a PO row as a multi-line block under ``purchase_order_rows``."""
+    lines = [f"  - **id**: {row.id}"]
+    for fname in _PO_ROW_FIELDS:
+        if fname == "id":
+            continue
+        val = getattr(row, fname, None)
+        if val is None or val == "":
+            continue
+        lines.append(f"    **{fname}**: {val}")
+    if row.batch_transactions:
+        lines.append(
+            f"    **batch_transactions** ({len(row.batch_transactions)}): "
+            f"{row.batch_transactions}"
+        )
+    else:
+        lines.append("    **batch_transactions**: []")
+    return lines
+
+
+def _render_po_additional_cost_row_md(
+    row: PurchaseOrderAdditionalCostRowInfo,
+) -> list[str]:
+    """Render an additional cost row under ``additional_cost_rows``."""
+    lines = [f"  - **id**: {row.id}"]
+    for fname in _PO_ADDITIONAL_COST_FIELDS:
+        if fname == "id":
+            continue
+        val = getattr(row, fname, None)
+        if val is None or val == "":
+            continue
+        lines.append(f"    **{fname}**: {val}")
+    return lines
+
+
+def _render_po_accounting_metadata_md(
+    meta: PurchaseOrderAccountingMetadataInfo,
+) -> list[str]:
+    """Render an accounting metadata entry under ``accounting_metadata``."""
+    lines = [f"  - **id**: {meta.id}"]
+    for fname in _PO_ACCOUNTING_META_FIELDS:
+        if fname == "id":
+            continue
+        val = getattr(meta, fname, None)
+        if val is None or val == "":
+            continue
+        lines.append(f"    **{fname}**: {val}")
+    return lines
+
+
+_SUPPLIER_FIELDS: tuple[str, ...] = (
+    "id",
+    "name",
+    "email",
+    "phone",
+    "currency",
+    "comment",
+    "default_address_id",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+)
+
+
+def _render_supplier_md(supplier: SupplierInfo) -> list[str]:
+    """Render an embedded supplier under ``**supplier**:`` using canonical
+    field names, matching the scheme used for rows and accounting metadata.
+    """
+    lines: list[str] = []
+    for fname in _SUPPLIER_FIELDS:
+        val = getattr(supplier, fname, None)
+        if val is None or val == "":
+            continue
+        lines.append(f"  **{fname}**: {val}")
+    if supplier.addresses:
+        lines.append(
+            f"  **addresses** ({len(supplier.addresses)}): {supplier.addresses}"
+        )
+    else:
+        lines.append("  **addresses**: []")
+    return lines
+
+
+def _render_get_purchase_order_md(
+    response: GetPurchaseOrderResponse, *, embed: bool = False
+) -> str:
+    """Render an exhaustive PO response as canonical-labeled markdown.
+
+    When ``embed=True`` the top-level ``## PO …`` heading is omitted —
+    used when the PO is rendered as a nested block under another response
+    (e.g., ``verify_order_document``) where an indented markdown heading
+    would still be parsed as a top-level heading and break intended
+    nesting (copilot feedback on #357).
+    """
+    md_lines: list[str] = []
+    if not embed:
+        md_lines.append(f"## PO {response.order_no or response.id}")
+
+    for fname in _PO_SCALAR_FIELDS:
+        val = getattr(response, fname)
+        if val is None or val == "":
+            continue
+        md_lines.append(f"**{fname}**: {val}")
+
+    # supplier: inline block under the canonical key so the LLM can trace
+    # every embedded supplier field without a separate lookup.
+    if response.supplier is not None:
+        md_lines.append("")
+        md_lines.append("**supplier**:")
+        md_lines.extend(_render_supplier_md(response.supplier))
+    else:
+        md_lines.append("**supplier**: null")
+
+    # purchase_order_rows: explicit list syntax so empty lists render as `[]`
+    # rather than a dangling section header an LLM could misread (#346).
+    if response.purchase_order_rows:
+        md_lines.append("")
+        md_lines.append(
+            f"**purchase_order_rows** ({len(response.purchase_order_rows)}):"
+        )
+        for row in response.purchase_order_rows:
+            md_lines.extend(_render_po_row_md(row))
+    else:
+        md_lines.append("**purchase_order_rows**: []")
+
+    if response.additional_cost_rows:
+        md_lines.append("")
+        md_lines.append(
+            f"**additional_cost_rows** ({len(response.additional_cost_rows)}):"
+        )
+        for row in response.additional_cost_rows:
+            md_lines.extend(_render_po_additional_cost_row_md(row))
+    else:
+        md_lines.append("**additional_cost_rows**: []")
+
+    if response.accounting_metadata:
+        md_lines.append("")
+        md_lines.append(
+            f"**accounting_metadata** ({len(response.accounting_metadata)}):"
+        )
+        for meta in response.accounting_metadata:
+            md_lines.extend(_render_po_accounting_metadata_md(meta))
+    else:
+        md_lines.append("**accounting_metadata**: []")
+
+    return "\n".join(md_lines)
+
+
+@observe_tool
+@unpack_pydantic_params
+async def get_purchase_order(
+    request: Annotated[GetPurchaseOrderRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Look up a purchase order by order number or ID — exhaustive detail.
+
+    Returns every field Katana exposes on the PO record: status, billing
+    status, supplier, location, totals (including base-currency total),
+    timestamps, document status, tracking location, additional_info, plus
+    the full list of line items with every row field (UOM, conversion
+    rates, landed_cost, batch_transactions), the full list of additional
+    cost rows (shipping, duties, handling), and accounting-integration
+    metadata (bill IDs).
+
+    Two extra HTTP calls are made on top of the PO fetch — one for
+    additional cost rows, one for accounting metadata — so callers don't
+    need follow-up lookups for standard PO data. Use this tool whenever
+    full detail is needed; use ``list_purchase_orders`` for discovery.
+
+    Provide either order_no (e.g., 'PO-1022') or order_id.
+    """
+    response = await _get_purchase_order_impl(request, context)
+
+    if request.format == "json":
+        return ToolResult(
+            content=response.model_dump_json(indent=2),
+            structured_content=response.model_dump(),
+        )
+
+    return make_simple_result(
+        _render_get_purchase_order_md(response),
+        structured_data=response.model_dump(),
+    )
+
+
+# ============================================================================
+# Tool: verify_order_document
 # ============================================================================
 
 
@@ -546,9 +1252,20 @@ class VerifyOrderDocumentRequest(BaseModel):
 
 
 class VerifyOrderDocumentResponse(BaseModel):
-    """Response from verifying an order document."""
+    """Response from verifying an order document.
+
+    Successful responses include the full ``purchase_order`` in the same
+    exhaustive shape as ``get_purchase_order`` so callers don't need a
+    follow-up lookup to see what was compared against. The field is typed
+    ``Optional`` only because the model is constructed before the PO
+    payload is assigned during ``_verify_order_document_impl``; in
+    practice consumers only observe successful responses (errors on the
+    PO fetch propagate as exceptions), so ``purchase_order`` is present
+    on every response a caller receives.
+    """
 
     order_id: int
+    purchase_order: GetPurchaseOrderResponse | None = None
     matches: list[MatchResult] = Field(default_factory=list)
     discrepancies: list[Discrepancy] = Field(default_factory=list)
     suggested_actions: list[str] = Field(default_factory=list)
@@ -556,50 +1273,95 @@ class VerifyOrderDocumentResponse(BaseModel):
     message: str
 
 
+def _render_verify_order_document_md(
+    response: VerifyOrderDocumentResponse,
+) -> str:
+    """Render a verification response as canonical-labeled markdown.
+
+    Uses Pydantic field names as labels (``**matches** (N)``,
+    ``**discrepancies** (N)``, ``**purchase_order**``) so an LLM consumer
+    can't misread a prettified header as a different field (motivation:
+    #346 follow-on). Lists render with explicit counts; empty lists render
+    as ``**field**: []`` rather than a bare section header.
+    """
+    md_lines = [
+        f"## Verification — PO {response.order_id}",
+        f"**order_id**: {response.order_id}",
+        f"**overall_status**: {response.overall_status}",
+        f"**message**: {response.message}",
+    ]
+
+    if response.matches:
+        md_lines.append("")
+        md_lines.append(f"**matches** ({len(response.matches)}):")
+        for m in response.matches:
+            price = f"${m.unit_price:.2f}" if m.unit_price is not None else "—"
+            md_lines.append(
+                f"  - **sku**: {m.sku}, **quantity**: {m.quantity}, "
+                f"**unit_price**: {price}, **status**: {m.status}"
+            )
+    else:
+        md_lines.append("**matches**: []")
+
+    if response.discrepancies:
+        md_lines.append("")
+        md_lines.append(f"**discrepancies** ({len(response.discrepancies)}):")
+        for d in response.discrepancies:
+            md_lines.append(
+                f"  - **sku**: {d.sku}, **type**: {d.type.value}, "
+                f"**expected**: {d.expected}, **actual**: {d.actual}"
+            )
+            md_lines.append(f"    **message**: {d.message}")
+    else:
+        md_lines.append("**discrepancies**: []")
+
+    if response.suggested_actions:
+        md_lines.append("")
+        md_lines.append(f"**suggested_actions** ({len(response.suggested_actions)}):")
+        for a in response.suggested_actions:
+            md_lines.append(f"  - {a}")
+    else:
+        md_lines.append("**suggested_actions**: []")
+
+    # Embed the exhaustive PO under its canonical key so the LLM can trace
+    # every compared value back to a concrete PO field. Pass ``embed=True``
+    # to omit the ``## PO …`` heading — Markdown allows up to 3 leading
+    # spaces on headings, so indenting the heading would still render as a
+    # top-level heading and break intended nesting.
+    if response.purchase_order is not None:
+        md_lines.append("")
+        md_lines.append("**purchase_order**:")
+        po_md = _render_get_purchase_order_md(response.purchase_order, embed=True)
+        for line in po_md.splitlines():
+            md_lines.append(f"  {line}" if line else "")
+    else:
+        md_lines.append("**purchase_order**: null")
+
+    return "\n".join(md_lines)
+
+
 def _verify_response_to_tool_result(
     response: VerifyOrderDocumentResponse,
 ) -> ToolResult:
-    """Convert VerifyOrderDocumentResponse to ToolResult with markdown + Prefab UI."""
+    """Convert VerifyOrderDocumentResponse to ToolResult with canonical-labeled
+    markdown + Prefab UI.
+
+    The Prefab UI (``build_verification_ui``) path is preserved for Claude
+    Desktop — it's a separate rendering track attached via
+    ``structured_content``. The text content now uses canonical Pydantic
+    field names as labels so an LLM consumer can't misread a section
+    header as a different field (#346 follow-on).
+    """
     from katana_mcp.tools.prefab_ui import build_verification_ui
 
-    # Format matches and discrepancies as text for template
-    if response.matches:
-        matches_text = "\n".join(
-            f"- **{m.sku}**: {m.quantity} units @ ${m.unit_price or 0:.2f} ({m.status})"
-            for m in response.matches
-        )
-    else:
-        matches_text = "No matches found"
-
-    if response.discrepancies:
-        discrepancies_text = "\n".join(f"- {d.message}" for d in response.discrepancies)
-    else:
-        discrepancies_text = "No discrepancies"
-
-    suggested_actions_text = "\n".join(
-        f"- {action}" for action in response.suggested_actions
-    )
-
-    # Choose template based on overall status
-    if response.overall_status == "match":
-        template_name = "order_verification_match"
-    elif response.overall_status == "partial_match":
-        template_name = "order_verification_partial"
-    else:
-        template_name = "order_verification_no_match"
-
     ui = build_verification_ui(response.model_dump())
-
-    return make_tool_result(
-        response,
-        template_name,
-        ui=ui,
-        order_id=response.order_id,
-        overall_status=response.overall_status,
-        message=response.message,
-        matches_text=matches_text,
-        discrepancies_text=discrepancies_text,
-        suggested_actions_text=suggested_actions_text,
+    markdown = _render_verify_order_document_md(response)
+    # Mirror ``make_tool_result``'s contract: when a Prefab UI is present,
+    # ``structured_content`` carries the UI envelope; otherwise it carries
+    # the Pydantic dump for programmatic callers.
+    return ToolResult(
+        content=markdown,
+        structured_content=ui if ui is not None else response.model_dump(),
     )
 
 
@@ -637,6 +1399,21 @@ async def _verify_order_document_impl(
         # unwrap_as() raises typed exceptions on error, returns typed RegularPurchaseOrder
         po = unwrap_as(po_response, RegularPurchaseOrder)
 
+        # Build the exhaustive PO structured view — same shape as
+        # get_purchase_order — so callers have full context on what was
+        # compared against. Side-data fetches run concurrently via gather
+        # to avoid doubling latency on the verify path.
+        default_group_id = unwrap_unset(po.default_group_id, None)
+        additional_cost_rows, accounting_metadata = await asyncio.gather(
+            _fetch_po_additional_cost_rows(services, default_group_id),
+            _fetch_po_accounting_metadata(services, po.id),
+        )
+        exhaustive_po = _build_get_purchase_order_response(
+            po,
+            additional_cost_rows=additional_cost_rows,
+            accounting_metadata=accounting_metadata,
+        )
+
         # Extract order number safely using unwrap_unset
         order_no = unwrap_unset(po.order_no, f"PO-{request.order_id}")
 
@@ -645,6 +1422,7 @@ async def _verify_order_document_impl(
         if not po_rows_raw:
             return VerifyOrderDocumentResponse(
                 order_id=request.order_id,
+                purchase_order=exhaustive_po,
                 matches=[],
                 discrepancies=[],
                 suggested_actions=["Verify purchase order data in Katana"],
@@ -783,6 +1561,7 @@ async def _verify_order_document_impl(
 
         return VerifyOrderDocumentResponse(
             order_id=request.order_id,
+            purchase_order=exhaustive_po,
             matches=matches,
             discrepancies=discrepancies,
             suggested_actions=suggested_actions,
@@ -813,195 +1592,6 @@ async def verify_order_document(
             structured_content=response.model_dump(),
         )
     return _verify_response_to_tool_result(response)
-
-
-# ============================================================================
-# Tool: get_purchase_order
-# ============================================================================
-
-
-class GetPurchaseOrderRequest(BaseModel):
-    """Request to look up a purchase order by number or ID."""
-
-    order_no: str | None = Field(
-        default=None, description="Purchase order number (e.g., 'PO-1022')"
-    )
-    order_id: int | None = Field(default=None, description="Purchase order ID")
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
-
-
-class PurchaseOrderRowInfo(BaseModel):
-    """Summary of a purchase order line item."""
-
-    id: int
-    variant_id: int | None
-    quantity: float | None
-    price_per_unit: float | None
-    arrival_date: str | None
-    received_date: str | None
-    total: float | None
-
-
-class GetPurchaseOrderResponse(BaseModel):
-    """Response containing purchase order details."""
-
-    id: int
-    order_no: str | None
-    status: str | None
-    supplier_id: int | None
-    location_id: int | None
-    currency: str | None
-    expected_arrival_date: str | None
-    total: float | None
-    rows: list[PurchaseOrderRowInfo]
-
-
-def _po_row_info(row: Any) -> PurchaseOrderRowInfo:
-    """Extract row info from an attrs PurchaseOrderRow."""
-    arrival = unwrap_unset(row.arrival_date, None)
-    received = unwrap_unset(row.received_date, None)
-    return PurchaseOrderRowInfo(
-        id=row.id,
-        variant_id=unwrap_unset(row.variant_id, None),
-        quantity=unwrap_unset(row.quantity, None),
-        price_per_unit=unwrap_unset(row.price_per_unit, None),
-        arrival_date=iso_or_none(arrival),
-        received_date=iso_or_none(received),
-        total=unwrap_unset(row.total, None),
-    )
-
-
-async def _get_purchase_order_impl(
-    request: GetPurchaseOrderRequest, context: Context
-) -> GetPurchaseOrderResponse:
-    """Look up a PO by order_no or ID and return structured details."""
-    from katana_public_api_client.api.purchase_order import (
-        find_purchase_orders,
-        get_purchase_order as api_get_purchase_order,
-    )
-    from katana_public_api_client.models import ErrorResponse
-    from katana_public_api_client.utils import unwrap_data
-
-    if not request.order_no and not request.order_id:
-        raise ValueError("Either order_no or order_id must be provided")
-
-    services = get_services(context)
-
-    if request.order_id:
-        response = await api_get_purchase_order.asyncio_detailed(
-            id=request.order_id, client=services.client
-        )
-        # raise_on_error=False turns 404s and ErrorResponse payloads into None
-        # so we can raise a user-friendly ValueError instead of a raw APIError.
-        po_result = unwrap(response, raise_on_error=False)
-        if po_result is None or isinstance(po_result, ErrorResponse):
-            raise ValueError(f"Purchase order ID {request.order_id} not found")
-        po = po_result
-    else:
-        if not request.order_no:
-            raise ValueError("order_no is required when order_id is not provided")
-        list_response = await find_purchase_orders.asyncio_detailed(
-            client=services.client, order_no=request.order_no, limit=1
-        )
-        orders = unwrap_data(list_response, default=[])
-        if not orders:
-            raise ValueError(f"Purchase order '{request.order_no}' not found")
-        po = orders[0]
-
-    # Extract rows
-    raw_rows = unwrap_unset(po.purchase_order_rows, [])
-    rows = [_po_row_info(r) for r in raw_rows] if raw_rows else []
-
-    expected_arrival = unwrap_unset(po.expected_arrival_date, None)
-
-    return GetPurchaseOrderResponse(
-        id=po.id,
-        order_no=unwrap_unset(po.order_no, None),
-        status=enum_to_str(unwrap_unset(po.status, None)),
-        supplier_id=unwrap_unset(po.supplier_id, None),
-        location_id=unwrap_unset(po.location_id, None),
-        currency=unwrap_unset(po.currency, None),
-        expected_arrival_date=expected_arrival.isoformat()
-        if expected_arrival
-        else None,
-        total=unwrap_unset(po.total, None),
-        rows=rows,
-    )
-
-
-@observe_tool
-@unpack_pydantic_params
-async def get_purchase_order(
-    request: Annotated[GetPurchaseOrderRequest, Unpack()], context: Context
-) -> ToolResult:
-    """Look up a purchase order by order number or ID.
-
-    Returns order details including status, supplier, location, total, and all
-    line items with variant_ids, quantities, prices, and arrival dates. Use to
-    inspect a PO before receiving, or to find the variant IDs of items on order.
-
-    Provide either order_no (e.g., 'PO-1022') or order_id.
-    """
-    from katana_mcp.tools.tool_result_utils import make_simple_result
-
-    response = await _get_purchase_order_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    lines = [
-        f"## PO {response.order_no or response.id}",
-        f"- **Status**: {response.status}",
-    ]
-    if response.supplier_id is not None:
-        lines.append(f"- **Supplier ID**: {response.supplier_id}")
-    if response.location_id is not None:
-        lines.append(f"- **Location ID**: {response.location_id}")
-    if response.total is not None:
-        lines.append(f"- **Total**: {response.total} {response.currency or ''}")
-    if response.expected_arrival_date:
-        lines.append(f"- **Expected Arrival**: {response.expected_arrival_date}")
-
-    if response.rows:
-        lines.append("")
-        lines.append("### Line Items")
-        lines.append(
-            format_md_table(
-                headers=[
-                    "Row ID",
-                    "Variant ID",
-                    "Qty",
-                    "Price",
-                    "Arrival",
-                    "Received",
-                ],
-                rows=[
-                    [
-                        r.id,
-                        r.variant_id,
-                        r.quantity,
-                        r.price_per_unit,
-                        r.arrival_date or "N/A",
-                        r.received_date or "N/A",
-                    ]
-                    for r in response.rows
-                ],
-            )
-        )
-
-    return make_simple_result(
-        "\n".join(lines),
-        structured_data=response.model_dump(),
-    )
 
 
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -1615,8 +1615,35 @@ def _make_exhaustive_mock_po() -> MagicMock:
     po.billing_status = "NOT_BILLED"
     po.last_document_status = "SENT"
     po.tracking_location_id = UNSET
+    po.supplier = UNSET
     po.purchase_order_rows = [_make_exhaustive_mock_po_row()]
     return po
+
+
+def _make_mock_supplier(
+    *,
+    id: int = 999,
+    name: str = "Acme Supplies",
+    email: str = "orders@acme.example",
+    phone: str = "+1-555-0100",
+    currency: str = "USD",
+    comment: str = "Preferred supplier",
+    default_address_id: int = 7001,
+) -> MagicMock:
+    """Build a mock embedded ``Supplier`` with every exposed field set."""
+    s = MagicMock()
+    s.id = id
+    s.name = name
+    s.email = email
+    s.phone = phone
+    s.currency = currency
+    s.comment = comment
+    s.default_address_id = default_address_id
+    s.addresses = UNSET
+    s.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    s.updated_at = datetime(2026, 1, 15, tzinfo=UTC)
+    s.deleted_at = UNSET
+    return s
 
 
 @pytest.mark.asyncio
@@ -1827,6 +1854,196 @@ async def test_get_purchase_order_markdown_uses_canonical_field_names():
     # The canonical-name convention rules out these prettified labels:
     assert "**Supplier ID**" not in text
     assert "### Line Items" not in text
+
+
+@pytest.mark.asyncio
+async def test_get_purchase_order_surfaces_embedded_supplier():
+    """When the PO payload embeds a ``Supplier``, every supplier field is
+    surfaced under ``response.supplier`` and rendered inline in markdown
+    (copilot feedback on #357 — supplier was dropped from the exhaustive
+    shape)."""
+    from katana_mcp.tools.foundation.purchase_orders import SupplierInfo
+
+    context, _ = create_mock_context()
+    mock_po = _make_exhaustive_mock_po()
+    mock_po.supplier = _make_mock_supplier()
+
+    with (
+        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP, return_value=mock_po),
+    ):
+        request = GetPurchaseOrderRequest(order_id=12345)
+        result = await _get_purchase_order_impl(request, context)
+
+    assert isinstance(result.supplier, SupplierInfo)
+    assert result.supplier.id == 999
+    assert result.supplier.name == "Acme Supplies"
+    assert result.supplier.email == "orders@acme.example"
+    assert result.supplier.phone == "+1-555-0100"
+    assert result.supplier.currency == "USD"
+    assert result.supplier.comment == "Preferred supplier"
+    assert result.supplier.default_address_id == 7001
+    assert result.supplier.created_at == "2026-01-01T00:00:00+00:00"
+    assert result.supplier.updated_at == "2026-01-15T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_get_purchase_order_markdown_renders_supplier_inline():
+    """Embedded supplier renders under a canonical ``**supplier**:`` block
+    with per-field labels, matching the convention used for rows and
+    accounting metadata."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        GetPurchaseOrderResponse,
+        SupplierInfo,
+    )
+
+    context, _ = create_mock_context()
+    response = GetPurchaseOrderResponse(
+        id=12345,
+        order_no="PO-1022",
+        supplier=SupplierInfo(
+            id=999,
+            name="Acme Supplies",
+            email="orders@acme.example",
+            default_address_id=7001,
+        ),
+    )
+
+    with patch(
+        "katana_mcp.tools.foundation.purchase_orders._get_purchase_order_impl",
+        new_callable=AsyncMock,
+        return_value=response,
+    ):
+        result = await get_purchase_order(order_id=12345, context=context)
+    text = _content_text(result)
+
+    assert "**supplier**:" in text
+    assert "**name**: Acme Supplies" in text
+    assert "**email**: orders@acme.example" in text
+    assert "**default_address_id**: 7001" in text
+
+
+@pytest.mark.asyncio
+async def test_get_purchase_order_markdown_renders_null_supplier_explicitly():
+    """When the PO payload does not embed a supplier the canonical key
+    still appears as ``**supplier**: null`` so an LLM consumer sees a
+    concrete field value rather than a missing section."""
+    from katana_mcp.tools.foundation.purchase_orders import GetPurchaseOrderResponse
+
+    context, _ = create_mock_context()
+    response = GetPurchaseOrderResponse(id=12345, order_no="PO-1022")
+
+    with patch(
+        "katana_mcp.tools.foundation.purchase_orders._get_purchase_order_impl",
+        new_callable=AsyncMock,
+        return_value=response,
+    ):
+        result = await get_purchase_order(order_id=12345, context=context)
+
+    assert "**supplier**: null" in _content_text(result)
+
+
+@pytest.mark.asyncio
+async def test_get_purchase_order_rejects_empty_order_no():
+    """Empty-string ``order_no`` is rejected up front rather than silently
+    routing to the list-by-order_no branch (copilot feedback on #357 —
+    truthiness checks misclassify valid-but-falsy inputs)."""
+    context, _ = create_mock_context()
+    request = GetPurchaseOrderRequest(order_no="")
+    with pytest.raises(ValueError, match="order_no must not be empty"):
+        await _get_purchase_order_impl(request, context)
+
+
+@pytest.mark.asyncio
+async def test_get_purchase_order_accepts_zero_order_id_via_is_none_check():
+    """``order_id=0`` is a valid-but-falsy identifier. Explicit ``is None``
+    branch selection (not truthiness) must route it to the get-by-id
+    branch (copilot feedback on #357)."""
+    context, _ = create_mock_context()
+    mock_po = _make_exhaustive_mock_po()
+    mock_po.id = 0  # the identifier under test
+
+    with (
+        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock) as mock_detailed,
+        patch(_UNWRAP, return_value=mock_po),
+    ):
+        request = GetPurchaseOrderRequest(order_id=0)
+        result = await _get_purchase_order_impl(request, context)
+
+    mock_detailed.assert_awaited_once()
+    # ``find_purchase_orders`` (the list-by-order_no branch) must NOT have
+    # been exercised — the get-by-id path was taken.
+    assert mock_detailed.await_args.kwargs["id"] == 0
+    assert result.id == 0
+
+
+@pytest.mark.asyncio
+async def test_get_purchase_order_runs_side_data_fetches_concurrently():
+    """The two side-data fetches are awaited via ``asyncio.gather`` rather
+    than sequentially (copilot feedback on #357 — independent network
+    calls shouldn't double latency)."""
+    import asyncio as _asyncio
+
+    fetch_additional = AsyncMock(return_value=[])
+    fetch_accounting = AsyncMock(return_value=[])
+
+    context, _ = create_mock_context()
+    mock_po = _make_exhaustive_mock_po()
+
+    with (
+        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP, return_value=mock_po),
+        patch(_FETCH_PO_ADDITIONAL_COSTS, fetch_additional),
+        patch(_FETCH_PO_ACCOUNTING_META, fetch_accounting),
+        patch.object(_asyncio, "gather", wraps=_asyncio.gather) as spy_gather,
+    ):
+        request = GetPurchaseOrderRequest(order_id=12345)
+        await _get_purchase_order_impl(request, context)
+
+    # gather called with two awaitables — the two side-data coroutines.
+    spy_gather.assert_called_once()
+    assert len(spy_gather.call_args.args) == 2
+
+
+@pytest.mark.asyncio
+async def test_verify_order_document_embeds_po_without_nested_heading():
+    """When the exhaustive PO is embedded under ``**purchase_order**:`` in
+    the verify response the ``## PO …`` heading must be omitted — Markdown
+    treats up-to-3-leading-spaces headings as top-level, which would break
+    intended nesting (copilot feedback on #357)."""
+    context, lifespan_ctx = create_mock_context()
+
+    po_rows = [create_mock_po_row(variant_id=1, quantity=10.0, price=5.0)]
+    mock_po = create_mock_po(order_id=1234, order_no="PO-VERIFY-001", rows=po_rows)
+    mock_po_response = MagicMock()
+    mock_po_response.status_code = 200
+    mock_po_response.parsed = mock_po
+    mock_variants = [create_mock_variant(variant_id=1, sku="WIDGET-001")]
+
+    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+
+    request = VerifyOrderDocumentRequest(
+        order_id=1234,
+        document_items=[
+            DocumentItem(sku="WIDGET-001", quantity=10.0, unit_price=5.0),
+        ],
+    )
+
+    result = await verify_order_document(
+        order_id=request.order_id,
+        document_items=[i.model_dump() for i in request.document_items],
+        context=context,
+    )
+    text = _content_text(result)
+
+    # The verify-level heading is present...
+    assert "## Verification — PO 1234" in text
+    # ...but the nested PO block does NOT reintroduce a PO heading
+    # (indented or not). No ``## PO …`` anywhere in the output.
+    assert "## PO " not in text
+    # The canonical nesting label is present.
+    assert "**purchase_order**:" in text
 
 
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -38,12 +38,69 @@ from tests.conftest import create_mock_context
 # ============================================================================
 
 
+# After #346, get_purchase_order and verify_order_document fetch additional
+# cost rows and accounting metadata via extra HTTP calls. Every test in this
+# module that exercises those impls would otherwise need to patch those
+# helpers individually — instead, autouse-default them to empty and let the
+# specific tests that care override via their own patch.
+_FETCH_PO_ADDITIONAL_COSTS = (
+    "katana_mcp.tools.foundation.purchase_orders._fetch_po_additional_cost_rows"
+)
+_FETCH_PO_ACCOUNTING_META = (
+    "katana_mcp.tools.foundation.purchase_orders._fetch_po_accounting_metadata"
+)
+
+
+@pytest.fixture(autouse=True)
+def _auto_mock_po_side_data_fetches():
+    """Default the #346 side-data fetches to empty lists for every test.
+
+    Tests that want to verify these are called override the patch locally.
+    """
+    with (
+        patch(_FETCH_PO_ADDITIONAL_COSTS, AsyncMock(return_value=[])),
+        patch(_FETCH_PO_ACCOUNTING_META, AsyncMock(return_value=[])),
+    ):
+        yield
+
+
 def create_mock_po_row(variant_id: int, quantity: float, price: float):
-    """Create a mock PO row."""
+    """Create a mock PO row.
+
+    Exhaustive response model (#346) reads many more row fields than the
+    old shape. Default them all to UNSET so Pydantic validation sees
+    ``None`` rather than a stray ``MagicMock`` instance.
+    """
     row = MagicMock()
     row.variant_id = variant_id
     row.quantity = quantity
     row.price_per_unit = price
+    # id is required on PurchaseOrderRowInfo — give it a stable default that
+    # callers can ignore.
+    row.id = 1
+    # Fields touched by _po_row_info() but not set by callers — UNSET so
+    # unwrap_unset() collapses them to None.
+    for field in (
+        "created_at",
+        "updated_at",
+        "deleted_at",
+        "tax_rate_id",
+        "price_per_unit_in_base_currency",
+        "purchase_uom_conversion_rate",
+        "purchase_uom",
+        "currency",
+        "conversion_rate",
+        "total",
+        "total_in_base_currency",
+        "conversion_date",
+        "received_date",
+        "arrival_date",
+        "purchase_order_id",
+        "landed_cost",
+        "group_id",
+        "batch_transactions",
+    ):
+        setattr(row, field, UNSET)
     return row
 
 
@@ -56,11 +113,37 @@ def create_mock_variant(variant_id: int, sku: str):
 
 
 def create_mock_po(order_id: int, order_no: str, rows: list):
-    """Create a mock RegularPurchaseOrder."""
+    """Create a mock RegularPurchaseOrder.
+
+    Exhaustive get_purchase_order (#346) reads every PurchaseOrder field.
+    Default optional ones to UNSET so Pydantic sees ``None`` rather than a
+    stray ``MagicMock`` when the response is built during verification.
+    """
     po = MagicMock(spec=RegularPurchaseOrder)
     po.id = order_id
     po.order_no = order_no
     po.purchase_order_rows = rows
+    for field in (
+        "created_at",
+        "updated_at",
+        "deleted_at",
+        "status",
+        "entity_type",
+        "default_group_id",
+        "supplier_id",
+        "currency",
+        "expected_arrival_date",
+        "order_created_date",
+        "additional_info",
+        "location_id",
+        "total",
+        "total_in_base_currency",
+        "billing_status",
+        "last_document_status",
+        "tracking_location_id",
+        "supplier",
+    ):
+        setattr(po, field, UNSET)
     return po
 
 
@@ -470,9 +553,9 @@ async def test_verify_order_document_unset_values():
     """Test verification with UNSET values in PO data."""
     context, lifespan_ctx = create_mock_context()
 
-    # Mock PO row with UNSET values
-    po_row = MagicMock()
-    po_row.variant_id = 1
+    # Mock PO row with UNSET values — start from create_mock_po_row so the
+    # exhaustive response builder (#346) doesn't trip on stray MagicMocks.
+    po_row = create_mock_po_row(variant_id=1, quantity=UNSET, price=UNSET)
     po_row.quantity = UNSET
     po_row.price_per_unit = UNSET
 
@@ -589,12 +672,12 @@ async def test_verify_order_document_unset_order_no():
     """Test verification when order_no is UNSET."""
     context, lifespan_ctx = create_mock_context()
 
-    # Mock PO with UNSET order_no
+    # Mock PO with UNSET order_no — build via create_mock_po so every
+    # exhaustive-response field defaults to UNSET instead of leaking a
+    # stray MagicMock into Pydantic validation.
     po_rows = [create_mock_po_row(variant_id=1, quantity=100.0, price=25.50)]
-    mock_po = MagicMock(spec=RegularPurchaseOrder)
-    mock_po.id = 1234
-    mock_po.order_no = UNSET  # UNSET value
-    mock_po.purchase_order_rows = po_rows
+    mock_po = create_mock_po(order_id=1234, order_no="ignored", rows=po_rows)
+    mock_po.order_no = UNSET  # UNSET value under test
 
     mock_po_response = MagicMock()
     mock_po_response.status_code = 200
@@ -1339,24 +1422,44 @@ _UNWRAP = "katana_mcp.tools.foundation.purchase_orders.unwrap"
 
 
 def _make_mock_po(order_no: str = "PO-TEST") -> MagicMock:
-    """Create a mock PO with rows."""
-    row1 = MagicMock()
-    row1.id = 7001
-    row1.variant_id = 100
-    row1.quantity = 3.0
-    row1.price_per_unit = 250.0
-    row1.arrival_date = datetime(2026, 4, 15, tzinfo=UTC)
-    row1.received_date = UNSET
-    row1.total = 750.0
+    """Create a mock PO with rows.
 
-    row2 = MagicMock()
-    row2.id = 7002
-    row2.variant_id = 101
-    row2.quantity = 3.0
-    row2.price_per_unit = 50.0
-    row2.arrival_date = datetime(2026, 4, 15, tzinfo=UTC)
-    row2.received_date = UNSET
-    row2.total = 150.0
+    After #346 every PurchaseOrder / PurchaseOrderRow field is surfaced on
+    the exhaustive response, so un-set attributes must be UNSET (not bare
+    MagicMocks) to keep Pydantic validation happy.
+    """
+
+    def _mock_row(row_id: int, variant_id: int, qty: float, price: float, total: float):
+        row = MagicMock()
+        row.id = row_id
+        row.variant_id = variant_id
+        row.quantity = qty
+        row.price_per_unit = price
+        row.arrival_date = datetime(2026, 4, 15, tzinfo=UTC)
+        row.received_date = UNSET
+        row.total = total
+        for field in (
+            "created_at",
+            "updated_at",
+            "deleted_at",
+            "tax_rate_id",
+            "price_per_unit_in_base_currency",
+            "purchase_uom_conversion_rate",
+            "purchase_uom",
+            "currency",
+            "conversion_rate",
+            "total_in_base_currency",
+            "conversion_date",
+            "purchase_order_id",
+            "landed_cost",
+            "group_id",
+            "batch_transactions",
+        ):
+            setattr(row, field, UNSET)
+        return row
+
+    row1 = _mock_row(7001, 100, 3.0, 250.0, 750.0)
+    row2 = _mock_row(7002, 101, 3.0, 50.0, 150.0)
 
     po = MagicMock()
     po.id = 12345
@@ -1368,6 +1471,21 @@ def _make_mock_po(order_no: str = "PO-TEST") -> MagicMock:
     po.expected_arrival_date = datetime(2026, 4, 15, tzinfo=UTC)
     po.total = 900.0
     po.purchase_order_rows = [row1, row2]
+    for field in (
+        "created_at",
+        "updated_at",
+        "deleted_at",
+        "entity_type",
+        "default_group_id",
+        "order_created_date",
+        "additional_info",
+        "total_in_base_currency",
+        "billing_status",
+        "last_document_status",
+        "tracking_location_id",
+        "supplier",
+    ):
+        setattr(po, field, UNSET)
     return po
 
 
@@ -1389,10 +1507,10 @@ async def test_get_purchase_order_by_number():
     assert result.supplier_id == 999
     assert result.location_id == 160411
     assert result.total == 900.0
-    assert len(result.rows) == 2
-    assert result.rows[0].id == 7001
-    assert result.rows[0].variant_id == 100
-    assert result.rows[1].variant_id == 101
+    assert len(result.purchase_order_rows) == 2
+    assert result.purchase_order_rows[0].id == 7001
+    assert result.purchase_order_rows[0].variant_id == 100
+    assert result.purchase_order_rows[1].variant_id == 101
 
 
 @pytest.mark.asyncio
@@ -1434,7 +1552,281 @@ async def test_get_purchase_order_by_id():
 
     assert result.id == 12345
     assert result.order_no == "PO-BYID"
-    assert len(result.rows) == 2
+    assert len(result.purchase_order_rows) == 2
+
+
+# ============================================================================
+# get_purchase_order exhaustive detail (#346)
+# ============================================================================
+
+
+def _make_exhaustive_mock_po_row() -> MagicMock:
+    """Build a mock PurchaseOrderRow with every field set.
+
+    Mirrors the shape ``_po_row_info`` consumes, so asserting on the
+    resulting ``PurchaseOrderRowInfo`` covers every field surfaced by
+    the exhaustive get_purchase_order response.
+    """
+    row = MagicMock()
+    row.id = 7001
+    row.created_at = datetime(2026, 1, 10, 9, 0, tzinfo=UTC)
+    row.updated_at = datetime(2026, 1, 15, 14, 30, tzinfo=UTC)
+    row.deleted_at = UNSET
+    row.quantity = 3.0
+    row.variant_id = 100
+    row.tax_rate_id = 42
+    row.price_per_unit = 250.0
+    row.price_per_unit_in_base_currency = 260.0
+    row.purchase_uom_conversion_rate = 1.0
+    row.purchase_uom = "kg"
+    row.currency = "USD"
+    row.conversion_rate = 1.0
+    row.total = 750.0
+    row.total_in_base_currency = 780.0
+    row.conversion_date = datetime(2026, 1, 10, tzinfo=UTC)
+    row.received_date = UNSET
+    row.arrival_date = datetime(2026, 4, 15, tzinfo=UTC)
+    row.purchase_order_id = 12345
+    row.landed_cost = 795.0
+    row.group_id = 8080
+    row.batch_transactions = UNSET
+    return row
+
+
+def _make_exhaustive_mock_po() -> MagicMock:
+    """Build a mock RegularPurchaseOrder with every field set."""
+    po = MagicMock()
+    po.id = 12345
+    po.created_at = datetime(2026, 1, 10, 9, 0, tzinfo=UTC)
+    po.updated_at = datetime(2026, 1, 15, 14, 30, tzinfo=UTC)
+    po.deleted_at = UNSET
+    po.status = "NOT_RECEIVED"
+    po.order_no = "PO-1022"
+    po.entity_type = "regular"
+    po.default_group_id = 8080
+    po.supplier_id = 999
+    po.currency = "USD"
+    po.expected_arrival_date = datetime(2026, 4, 15, tzinfo=UTC)
+    po.order_created_date = datetime(2026, 1, 10, 9, 0, tzinfo=UTC)
+    po.additional_info = "urgent delivery"
+    po.location_id = 160411
+    po.total = 900.0
+    po.total_in_base_currency = 930.0
+    po.billing_status = "NOT_BILLED"
+    po.last_document_status = "SENT"
+    po.tracking_location_id = UNSET
+    po.purchase_order_rows = [_make_exhaustive_mock_po_row()]
+    return po
+
+
+@pytest.mark.asyncio
+async def test_get_purchase_order_full_field_coverage():
+    """Every PurchaseOrder / PurchaseOrderRow field the cache carries
+    surfaces on the exhaustive response (#346)."""
+    context, _ = create_mock_context()
+    mock_po = _make_exhaustive_mock_po()
+
+    with (
+        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP, return_value=mock_po),
+    ):
+        request = GetPurchaseOrderRequest(order_id=12345)
+        result = await _get_purchase_order_impl(request, context)
+
+    # PO-scope scalar fields — every one Katana exposes on RegularPurchaseOrder
+    assert result.id == 12345
+    assert result.order_no == "PO-1022"
+    assert result.status == "NOT_RECEIVED"
+    assert result.entity_type == "regular"
+    assert result.default_group_id == 8080
+    assert result.supplier_id == 999
+    assert result.currency == "USD"
+    assert result.location_id == 160411
+    assert result.total == 900.0
+    assert result.total_in_base_currency == 930.0
+    assert result.billing_status == "NOT_BILLED"
+    assert result.last_document_status == "SENT"
+    assert result.additional_info == "urgent delivery"
+    assert result.expected_arrival_date == "2026-04-15T00:00:00+00:00"
+    assert result.order_created_date == "2026-01-10T09:00:00+00:00"
+    assert result.created_at == "2026-01-10T09:00:00+00:00"
+    assert result.updated_at == "2026-01-15T14:30:00+00:00"
+
+    # Row-scope — every PurchaseOrderRow field
+    assert len(result.purchase_order_rows) == 1
+    row = result.purchase_order_rows[0]
+    assert row.id == 7001
+    assert row.variant_id == 100
+    assert row.tax_rate_id == 42
+    assert row.quantity == 3.0
+    assert row.price_per_unit == 250.0
+    assert row.price_per_unit_in_base_currency == 260.0
+    assert row.purchase_uom == "kg"
+    assert row.purchase_uom_conversion_rate == 1.0
+    assert row.currency == "USD"
+    assert row.conversion_rate == 1.0
+    assert row.total == 750.0
+    assert row.total_in_base_currency == 780.0
+    assert row.arrival_date == "2026-04-15T00:00:00+00:00"
+    assert row.conversion_date == "2026-01-10T00:00:00+00:00"
+    assert row.purchase_order_id == 12345
+    assert row.landed_cost == 795.0
+    assert row.group_id == 8080
+    assert row.created_at == "2026-01-10T09:00:00+00:00"
+    assert row.updated_at == "2026-01-15T14:30:00+00:00"
+
+    # Side-data default (autouse fixture returns [])
+    assert result.additional_cost_rows == []
+    assert result.accounting_metadata == []
+
+
+@pytest.mark.asyncio
+async def test_get_purchase_order_fetches_additional_costs_and_accounting_metadata():
+    """Side-data fetches run on the PO's default_group_id / id and surface
+    into the exhaustive response (#346)."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        PurchaseOrderAccountingMetadataInfo,
+        PurchaseOrderAdditionalCostRowInfo,
+    )
+
+    context, _ = create_mock_context()
+    mock_po = _make_exhaustive_mock_po()
+
+    cost_row = PurchaseOrderAdditionalCostRowInfo(
+        id=201,
+        additional_cost_id=1,
+        group_id=8080,
+        name="International Shipping",
+        distribution_method="BY_VALUE",
+        tax_rate_id=1,
+        tax_rate=8.5,
+        price=125.0,
+        price_in_base=125.0,
+        currency="USD",
+        currency_conversion_rate=1.0,
+        currency_conversion_rate_fix_date="2026-01-10T09:00:00+00:00",
+    )
+    acc_meta = PurchaseOrderAccountingMetadataInfo(
+        id=301,
+        purchase_order_id=12345,
+        received_items_group_id=2001,
+        integration_type="quickBooks",
+        bill_id="BILL-2026-001",
+        created_at="2026-01-15T11:30:00+00:00",
+    )
+
+    with (
+        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP, return_value=mock_po),
+        # Override the module-level autouse fixture so this test can
+        # assert the fetched values flow through.
+        patch(
+            _FETCH_PO_ADDITIONAL_COSTS, AsyncMock(return_value=[cost_row])
+        ) as mock_fetch_costs,
+        patch(
+            _FETCH_PO_ACCOUNTING_META, AsyncMock(return_value=[acc_meta])
+        ) as mock_fetch_meta,
+    ):
+        request = GetPurchaseOrderRequest(order_id=12345)
+        result = await _get_purchase_order_impl(request, context)
+
+    # Side-data helpers called with the right PO-scope identifiers
+    mock_fetch_costs.assert_awaited_once()
+    assert mock_fetch_costs.await_args.args[1] == 8080  # default_group_id
+    mock_fetch_meta.assert_awaited_once()
+    assert mock_fetch_meta.await_args.args[1] == 12345  # PO id
+
+    # Fetched values flow through to the response
+    assert len(result.additional_cost_rows) == 1
+    assert result.additional_cost_rows[0].id == 201
+    assert result.additional_cost_rows[0].name == "International Shipping"
+    assert result.additional_cost_rows[0].price == 125.0
+    assert result.additional_cost_rows[0].distribution_method == "BY_VALUE"
+
+    assert len(result.accounting_metadata) == 1
+    assert result.accounting_metadata[0].id == 301
+    assert result.accounting_metadata[0].integration_type == "quickBooks"
+    assert result.accounting_metadata[0].bill_id == "BILL-2026-001"
+
+
+@pytest.mark.asyncio
+async def test_get_purchase_order_markdown_uses_canonical_field_names():
+    """Markdown labels use Pydantic field names (not prettified headers)
+    so LLM consumers can't misread a section label as a different field
+    (motivation: #346 follow-on, supplier_item_codes misread)."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        GetPurchaseOrderResponse,
+        PurchaseOrderAccountingMetadataInfo,
+        PurchaseOrderAdditionalCostRowInfo,
+        PurchaseOrderRowInfo,
+    )
+
+    context, _ = create_mock_context()
+
+    response = GetPurchaseOrderResponse(
+        id=12345,
+        order_no="PO-1022",
+        status="NOT_RECEIVED",
+        supplier_id=999,
+        location_id=160411,
+        entity_type="regular",
+        default_group_id=8080,
+        currency="USD",
+        total=900.0,
+        expected_arrival_date="2026-04-15T00:00:00+00:00",
+        purchase_order_rows=[
+            PurchaseOrderRowInfo(
+                id=7001,
+                variant_id=100,
+                quantity=3.0,
+                price_per_unit=250.0,
+                total=750.0,
+                arrival_date="2026-04-15T00:00:00+00:00",
+            )
+        ],
+        additional_cost_rows=[
+            PurchaseOrderAdditionalCostRowInfo(
+                id=201,
+                name="Shipping",
+                price=125.0,
+            )
+        ],
+        accounting_metadata=[
+            PurchaseOrderAccountingMetadataInfo(
+                id=301,
+                purchase_order_id=12345,
+                bill_id="BILL-2026-001",
+            )
+        ],
+    )
+
+    with patch(
+        "katana_mcp.tools.foundation.purchase_orders._get_purchase_order_impl",
+        new_callable=AsyncMock,
+        return_value=response,
+    ):
+        result = await get_purchase_order(order_id=12345, context=context)
+
+    text = _content_text(result)
+
+    # Scalar PO fields — canonical names appear as labels
+    assert "**order_no**: PO-1022" in text
+    assert "**status**: NOT_RECEIVED" in text
+    assert "**supplier_id**: 999" in text
+    assert "**default_group_id**: 8080" in text
+    assert "**billing_status**" not in text  # unset, should not appear
+
+    # List-shaped fields — count-labeled header, canonical key
+    assert "**purchase_order_rows** (1):" in text
+    assert "**variant_id**: 100" in text
+    assert "**additional_cost_rows** (1):" in text
+    assert "**name**: Shipping" in text
+    assert "**accounting_metadata** (1):" in text
+    assert "**bill_id**: BILL-2026-001" in text
+
+    # The canonical-name convention rules out these prettified labels:
+    assert "**Supplier ID**" not in text
+    assert "### Line Items" not in text
 
 
 # ============================================================================
@@ -1881,7 +2273,9 @@ async def test_get_purchase_order_format_json_returns_json():
             entity_type="regular",
             expected_arrival_date=None,
             total=100.0,
-            rows=[],
+            purchase_order_rows=[],
+            additional_cost_rows=[],
+            accounting_metadata=[],
         )
         result = await get_purchase_order(order_id=5, format="json", context=context)
 


### PR DESCRIPTION
## Summary

Second slice of issue #346 (exhaustive single-object `get_*` detail tools) — follows the pattern set by #352 (`get_customer`).

- **`get_purchase_order`** now surfaces every field Katana exposes on `RegularPurchaseOrder` (was 8/20), every `PurchaseOrderRow` field (UOM conversion, landed_cost, batch_transactions, etc.), full `additional_cost_rows` (fetched via `/po_additional_cost_rows?group_id=<po.default_group_id>`) and full `accounting_metadata` (fetched via `/purchase_order_accounting_metadata?purchase_order_id=<id>`). Two extra HTTP calls on top of the PO fetch.
- **`verify_order_document`** now embeds the full `purchase_order` in the same exhaustive shape — so callers can trace every compared value back to a concrete PO field without a follow-up lookup.
- **Canonical-name markdown** — both tools now label every field with its Pydantic name (`**status**:`, `**purchase_order_rows** (N):`, `**accounting_metadata**: []`). Empty lists render with explicit `: []` syntax instead of dangling section headers. Motivation: #346 follow-on ambiguity fix (LLM mistook a prettified header for a field value).

Scope boundaries: Prefab UI builders untouched; `list_purchase_orders` stays summary-shaped; `help.py` entries updated (append-only).

## Test plan

- [x] `test_get_purchase_order_full_field_coverage` — asserts every previously-dropped PO/row field surfaces
- [x] `test_get_purchase_order_fetches_additional_costs_and_accounting_metadata` — patches `_fetch_po_additional_cost_rows` and `_fetch_po_accounting_metadata`, asserts right identifiers + values flow through
- [x] `test_get_purchase_order_markdown_uses_canonical_field_names` — pins the canonical-name convention
- [x] `uv run poe check` — clean (2391 passed, 3 skipped)
- [x] Shared-mock updates so every existing `get_purchase_order` / `verify_order_document` test survives the expanded response shape (no test-logic regressions)

Refs: #346, #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)