### PR TITLE
fix(ci): isolate parallel agent worktrees from pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,13 @@ logs/
 *~
 .claude/settings.local.json
 
+# Claude Code agent worktrees. Each subdir is a parallel git worktree created
+# by an Agent tool isolation=worktree invocation. They live under the main
+# repo only for locality; they're independent branches and must not leak into
+# git adds or tool scans run from the main checkout.
+.claude/worktrees/
+.claude/scheduled_tasks.lock
+
 # macOS
 .DS_Store
 .AppleDouble

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,17 @@
 #
 # See issue #134 for background on why we use local hooks.
 
+# Global exclude — Claude Code agent worktrees are parallel git checkouts
+# living under the main repo only for locality. They have their own branches
+# and pre-commit cycles; formatting/linting them from a sibling worktree's
+# hook causes cross-contamination (observed during the #346 parallel-agent
+# rollup: a fixup commit from one worktree rewrote a sibling's commit
+# message because both hooks ran in the shared .git/ dir).
+exclude: |
+  (?x)(
+    ^\.claude/worktrees/
+  )
+
 repos:
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary

Two-line infrastructure fix for the hook-collision pattern we hit during the #346 rollup.

## What was broken

Claude Code agent worktrees (Agent tool with ``isolation=worktree``) are created under ``.claude/worktrees/`` as sibling git worktrees of the main checkout. They share the main repo's ``.git/`` directory — including the ``hooks/`` directory where pre-commit installs its hook script.

During the #346 parallel-agent sweep, two concurrent fixup commits (one from a customer-branch worktree, one from a PO-branch worktree) crossed wires: the PO agent's pre-commit fixup inherited the customer commit's subject, and when the PO worktree force-pushed, it partially overwrote the customer branch. Recovered by restoring from reflog, but the class of failure is recurring every time we fan out agents.

## Fix

Two defenses, both cheap:

1. **``.gitignore``** — add ``.claude/worktrees/`` so ``git add .`` from the main checkout can never accidentally stage files from a sibling worktree's tree. Also add ``.claude/scheduled_tasks.lock`` (harness artifact, was showing untracked on every ``git status``).

2. **``.pre-commit-config.yaml``** — top-level ``exclude: ^\.claude/worktrees/`` so hooks running in any worktree never process files from a sibling. Defense-in-depth against the cross-branch contamination pattern.

Neither change affects the main repo's test/lint/format scopes. ``pytest`` already only scans ``testpaths = [\"tests\", \"katana_mcp_server/tests\"]``. ``ruff`` / ``mdformat`` hooks already only receive files from the current commit. The excludes are a safety net for the concurrency case where multiple agents race.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD

## Test plan

- [x] ``uv run poe check`` passes — 2399 tests
- [ ] No future agent cross-contamination the next time we fan out (hard to test proactively; will know from the next parallel sweep)

## Related

Postmortem context in the recovery for #352 / #357 during the #346 rollup. Unrelated to #358 (that's the MCP semantic-release branch-protection issue).