### PR TITLE
fix(mcp): three follow-ups from /review-pr pass on #356

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -368,13 +368,15 @@ or timestamps (including `deleted_at`).
 {"variant_ids": [12345, 12346]}
 ```
 
-**Returns:** Full variant details including pricing, barcodes, supplier codes
-(ingest-normalized so the variant's own SKU is stripped from
-`supplier_item_codes` — per #346 follow-on), configuration attributes, custom
-fields, and lifecycle timestamps. Markdown labels use the canonical Pydantic
-field names (e.g. `**supplier_item_codes**: [10654627]`) with list-shaped
-fields rendered in explicit bracket syntax so LLM consumers can't misread a
-value as a differently-labeled field. List form returned when a batch is
+**Returns:** Full variant details including pricing, barcodes,
+`supplier_item_codes` (passed through verbatim from the catalog — entries
+that match the variant's own SKU are meaningful and retained, because the
+house SKU is often the QBP/vendor SKU for retail pass-throughs),
+configuration attributes, custom fields, and lifecycle timestamps. Markdown
+labels use the canonical Pydantic field names (e.g.
+`**supplier_item_codes**: [SW7083, 10654627]`) with list-shaped fields
+rendered in explicit bracket syntax so LLM consumers can't misread a value
+as a differently-labeled field. List form returned when a batch is
 requested.
 
 ---

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -483,7 +483,13 @@ def _variant_to_summary(raw: Any) -> ItemVariantSummary | None:
         sku=d["sku"],
         sales_price=d.get("sales_price"),
         # ServiceVariant uses default_cost; Variant uses purchase_price.
-        purchase_price=d.get("purchase_price") or d.get("default_cost"),
+        # Explicit None-check — `or` would shadow a legitimate 0.0 price
+        # (free samples, gift items) with default_cost.
+        purchase_price=(
+            d["purchase_price"]
+            if d.get("purchase_price") is not None
+            else d.get("default_cost")
+        ),
         type=d.get("type") or d.get("type_"),
     )
 
@@ -602,10 +608,16 @@ def _render_variant_summary_md(v: ItemVariantSummary) -> str:
 def _render_config_md(c: ItemConfigInfo) -> str:
     """Render an ItemConfig as a compact multi-line block."""
     values = ", ".join(c.values) if c.values else ""
-    lines = [f"  - **id**: {c.id}", f"    **name**: {c.name}"]
-    if values:
-        lines.append(f"    **values**: [{values}]")
-    return "\n".join(lines)
+    # Always emit `values` with explicit brackets; empty list renders as `[]`
+    # rather than being omitted, so an LLM consumer can't confuse "absent"
+    # with "empty" (#346 follow-on convention).
+    return "\n".join(
+        [
+            f"  - **id**: {c.id}",
+            f"    **name**: {c.name}",
+            f"    **values**: [{values}]",
+        ]
+    )
 
 
 def _render_supplier_md(s: ItemSupplierInfo) -> str:

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -160,10 +160,12 @@ async def test_get_variant_details_renders_supplier_item_codes_as_explicit_list(
     """One-element supplier_item_codes renders in bracket syntax (not as a
     bare bullet that an LLM could read as a scalar supplier ID).
 
-    This pins the exact shape called out in #346 follow-on: a catalog entry
-    carrying only the true supplier part number (10654627 — SW7083's own
-    SKU having been stripped by the cache_sync normalizer) should render
-    as ``**supplier_item_codes**: [10654627]``.
+    This pins the exact shape called out in #346 follow-on: a single-entry
+    list renders as ``**supplier_item_codes**: [10654627]``. The catalog may
+    store multiple codes (including the house SKU for retail pass-throughs
+    where it equals the vendor SKU); cache_sync passes the list through
+    verbatim — no mutation, no stripping — and the renderer shows every
+    entry in explicit bracket syntax.
     """
     context, lifespan_ctx = create_mock_context()
     lifespan_ctx.cache.get_by_sku = AsyncMock(
@@ -559,3 +561,60 @@ async def test_get_item_format_json_round_trips_nested():
     assert data["variants"][0]["sku"] == "KNF-PRO-8PC-STL"
     assert data["configs"][0]["name"] == "Piece Count"
     assert data["supplier"]["email"] == "sales@acme.example"
+
+
+# ============================================================================
+# Post-review regression tests (/review-pr on #356)
+# ============================================================================
+
+
+def test_variant_to_summary_preserves_zero_purchase_price():
+    """Regression: `or` treats 0.0 as falsy and used to shadow a legitimate
+    zero-price variant with `default_cost`. Explicit None-check must keep
+    the real 0.0 rather than falling through."""
+    from katana_mcp.tools.foundation.items import _variant_to_summary
+
+    summary = _variant_to_summary(
+        {
+            "id": 501,
+            "sku": "FREE-SAMPLE",
+            "sales_price": 0.0,
+            "purchase_price": 0.0,
+            "default_cost": 99.99,
+            "type": "product",
+        }
+    )
+
+    assert summary is not None
+    assert summary.purchase_price == 0.0  # Real zero, not default_cost shadow
+
+
+def test_variant_to_summary_falls_back_to_default_cost_when_purchase_price_absent():
+    """When purchase_price is truly absent/None, default_cost is the fallback
+    (matches ServiceVariant vs Variant shape divergence)."""
+    from katana_mcp.tools.foundation.items import _variant_to_summary
+
+    summary = _variant_to_summary(
+        {
+            "id": 502,
+            "sku": "SRV-ITEM",
+            "default_cost": 50.0,
+            "type": "service",
+        }
+    )
+
+    assert summary is not None
+    assert summary.purchase_price == 50.0
+
+
+def test_render_config_md_emits_empty_values_as_explicit_brackets():
+    """Regression: empty `values` list used to be silently omitted from the
+    rendered block. Per the #346 follow-on convention, list-shaped fields
+    render `[]` explicitly so an LLM consumer can't confuse absent with empty."""
+    from katana_mcp.tools.foundation.items import ItemConfigInfo, _render_config_md
+
+    empty = ItemConfigInfo(id=1, name="Empty Config", values=[])
+    md = _render_config_md(empty)
+
+    assert "**values**: []" in md
+    assert md.count("\n") == 2  # id, name, values — three lines


### PR DESCRIPTION
## Summary

Post-merge review of #356 (exhaustive `get_variant_details` / `get_item`) surfaced three real issues. All three fixed here; they landed via #356 before the review completed.

## Findings fixed

### 1. Falsy-price shadowing

`items.py:_variant_to_summary` had:

```python
purchase_price=d.get("purchase_price") or d.get("default_cost"),
```

`or` treats `0.0` as falsy. A variant priced at $0.00 (free sample, gift-with-purchase, intro SKU) would silently fall through to `default_cost`, shadowing its real price. Switched to explicit `is not None` check.

### 2. `help.py` docstring contradicts the actual behavior

The `get_variant_details` **Returns** description in the help resource claimed `supplier_item_codes` are "ingest-normalized so the variant's own SKU is stripped." Both contradicted: (a) the explicit revert in cache_sync.py, and (b) the `test_supplier_item_codes_preserved_verbatim` test that pins the opposite contract. Per the [#346 clarification](https://github.com/dougborg/katana-openapi-client/issues/346#issuecomment-), the house SKU is frequently the QBP/vendor SKU for retail pass-throughs — entries that look like "the SKU duplicated" are real supplier data that must be retained. Docstring rewritten.

### 3. Mirror bug — same wrong claim in `test_items.py`

`test_get_variant_details_renders_supplier_item_codes_as_explicit_list` docstring said "SW7083's own SKU having been stripped by the cache_sync normalizer." Mirror of #2. The test still passes because the fixture already produces the right shape, but the docstring would mislead the next person debugging a rendering regression. Rewrote to describe the actual pass-through behavior.

### 4. Empty list drops silently

`_render_config_md` only appended `**values**: [...]` when the list was non-empty. Other list-shaped fields in the wave render `[]` explicitly per the #346 follow-on convention (so LLM consumers can't confuse "absent" with "empty"). Now always emits.

## Not fixed (deliberately)

The review also flagged `test_items.py` importing private `_get_item_impl` / `_get_variant_details_impl` symbols for internal-logic tests. Acceptable pattern — the public entrypoints are tested elsewhere, and the private-import tests exercise specific helper behavior that would be hard to reach through the public surface. Filing as tech debt isn't worthwhile.

## Type of Change

- [x] Bug fix (`purchase_price` falsy-shadowing is a real correctness issue)
- [x] Documentation update (two docstring fixes)
- [x] Code refactoring (minor consistency fix)

## Testing

- [x] `uv run poe check` — 2411 passed, 3 skipped
- [ ] CI green on 3.12 / 3.13 / 3.14

## Related

Follow-up to #356 (exhaustive get_variant_details + get_item). Parent issue: #346.