### PR TITLE
chore(client): simplify PR #361 docstrings

### DIFF
--- a/katana_public_api_client/models_pydantic/_base.py
+++ b/katana_public_api_client/models_pydantic/_base.py
@@ -43,9 +43,7 @@ class KatanaPydanticBase(SQLModel):
     Extends ``SQLModel`` (not plain ``pydantic.BaseModel``) so that subclasses
     can opt into SQLAlchemy table semantics via ``table=True`` without forking
     the generated model hierarchy. ``SQLModel`` is itself a pydantic
-    ``BaseModel`` subclass, so existing consumers that validate, serialize,
-    or round-trip these models continue to work unchanged. See #342 for the
-    cache-backed-list-tools work that motivated the unification.
+    ``BaseModel`` subclass, so existing consumers continue working unchanged.
 
     This base class provides:
     - Immutable (frozen) models for data integrity

--- a/tests/test_models_pydantic.py
+++ b/tests/test_models_pydantic.py
@@ -135,22 +135,15 @@ class TestModelConfiguration:
         assert KatanaPydanticBase.model_config.get("validate_assignment") is True
 
     def test_base_extends_sqlmodel(self) -> None:
-        """KatanaPydanticBase must extend SQLModel so subclasses can opt into
-        SQLAlchemy table mode via ``table=True`` without forking the generator
-        output (see #342). SQLModel itself is a pydantic BaseModel, so existing
-        consumers are unaffected — this canary catches accidental reverts to
-        plain ``pydantic.BaseModel``."""
-        from pydantic import BaseModel
+        """Canary: KatanaPydanticBase must stay rooted in SQLModel (#342)."""
         from sqlmodel import SQLModel
 
         from katana_public_api_client.models_pydantic._base import KatanaPydanticBase
 
         assert issubclass(KatanaPydanticBase, SQLModel)
-        assert issubclass(KatanaPydanticBase, BaseModel)
 
     def test_generated_classes_extend_sqlmodel(self) -> None:
-        """Every generated entity should inherit the SQLModel-ness through
-        KatanaPydanticBase. Sampled across a few representative domains."""
+        """Generated entities inherit SQLModel-ness via KatanaPydanticBase."""
         from sqlmodel import SQLModel
 
         from katana_public_api_client.models_pydantic._generated import (


### PR DESCRIPTION
## Summary

`/simplify` pass on the just-merged PR #361 (SQLModel foundation). Two small tightenings caught by a post-merge code review:

- **`_base.py` class docstring** — drop the trailing "See #342..." sentence. That navigation aid belongs in the commit message, not in the source docstring that people read forever after.
- **Canary test docstrings** — trim the 4-sentence intent statements to one line. The assertion + the `(#342)` reference are self-documenting. Also drop the redundant `issubclass(KatanaPydanticBase, BaseModel)` check on `test_base_extends_sqlmodel` — it's implied by the SQLModel assertion since `SQLModel` IS-A `BaseModel`.

No behavior change. `ty check` green, `uv run poe check` green.

## Test plan

- [x] `uv run poe check` passes
- [x] Canary tests still pass (verify they'd still fail if `KatanaPydanticBase` reverts to `BaseModel`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)