### PR TITLE
chore(client): simplify PR #363 generator transforms + tests

### DIFF
--- a/scripts/generate_pydantic_models.py
+++ b/scripts/generate_pydantic_models.py
@@ -180,18 +180,13 @@ CACHE_TABLES: set[str] = {"SalesOrder", "SalesOrderRow"}
 
 @dataclass(frozen=True)
 class CacheTableRelationship:
-    """Declares a 1:N parent→child relationship between two cache tables.
+    """1:N parent→child relationship declaration between two cache tables."""
 
-    Drives AST generation of ``Relationship()`` declarations on both the
-    parent (list field) and the child (back-reference field), plus
-    ``foreign_key="<parent_table>.id"`` on the child's existing FK column.
-    """
-
-    parent: str  # class name, e.g. "SalesOrder"
-    parent_field: str  # list field on parent, e.g. "sales_order_rows"
-    child: str  # class name, e.g. "SalesOrderRow"
-    child_back_ref: str  # back-ref field to inject on child, e.g. "sales_order"
-    child_fk_field: str  # existing int FK field on child, e.g. "sales_order_id"
+    parent: str
+    parent_field: str
+    child: str
+    child_back_ref: str
+    child_fk_field: str
 
     @property
     def parent_table(self) -> str:
@@ -755,16 +750,16 @@ def inject_primary_key_in_table_classes(classes: list[ClassInfo]) -> list[ClassI
 def inject_table_annotations(classes: list[ClassInfo]) -> list[ClassInfo]:
     """Turn CACHE_TABLES entries into SQLModel tables.
 
-    Three rewrites per class:
+    Three rewrites per class, emitted in order as the first body statements:
     1. Append ``, table=True`` to the class header bases list.
-    2. Insert ``model_config = ConfigDict(frozen=False)`` as the first class
-       body statement. SQLAlchemy's ORM mutates instances during session
-       operations; the inherited ``frozen=True`` from ``KatanaPydanticBase``
-       would otherwise raise on every attribute write.
-    3. Insert ``__tablename__`` set to the snake_case class name. Otherwise
+    2. Insert ``__tablename__`` set to the snake_case class name. Otherwise
        SQLAlchemy defaults to the raw lowercase class name (``salesorder``
        vs. ``sales_order``), which breaks FK references that use the
        readable snake_case form.
+    3. Insert ``model_config = ConfigDict(frozen=False)``. SQLAlchemy's ORM
+       mutates instances during session operations; the inherited
+       ``frozen=True`` from ``KatanaPydanticBase`` would otherwise raise on
+       every attribute write.
     """
     fixed = []
     for cls in classes:
@@ -772,34 +767,24 @@ def inject_table_annotations(classes: list[ClassInfo]) -> list[ClassInfo]:
             fixed.append(cls)
             continue
         tablename = _snake_case(cls.name)
-        # 1. Class header: `class X(Parent):` → `class X(Parent, table=True):`
-        new_source, n1 = re.subn(
-            rf"^(class {re.escape(cls.name)}\([^)]*)\):",
-            r"\1, table=True):",
+        # Single pass: append `, table=True` to the class bases and inject
+        # __tablename__ + model_config as the first body statements.
+        new_source, n = re.subn(
+            rf"^(class {re.escape(cls.name)}\([^)]*)\):\n",
+            (
+                r"\1, table=True):" + "\n"
+                rf'    __tablename__ = "{tablename}"' + "\n"
+                r"    model_config = ConfigDict(frozen=False)" + "\n\n"
+            ),
             cls.source,
             count=1,
             flags=re.MULTILINE,
         )
-        if n1 != 1:
+        if n != 1:
             msg = (
-                f"Failed to inject table=True into class header for {cls.name}. "
+                f"Failed to inject table annotations (table=True, "
+                f"__tablename__, model_config) into {cls.name}. "
                 "The class-declaration shape may have changed."
-            )
-            raise GenerationError(msg)
-        # 2 & 3. Inject __tablename__ + model_config at top of body.
-        new_source, n2 = re.subn(
-            rf"(class {re.escape(cls.name)}\([^)]*, table=True\):\n)",
-            (
-                rf'\1    __tablename__ = "{tablename}"' + "\n"
-                r"    model_config = ConfigDict(frozen=False)" + "\n\n"
-            ),
-            new_source,
-            count=1,
-        )
-        if n2 != 1:
-            msg = (
-                f"Failed to inject __tablename__/model_config into {cls.name}. "
-                "The post-header newline may be missing."
             )
             raise GenerationError(msg)
         fixed.append(
@@ -1164,8 +1149,7 @@ def generate_module_imports(
     if needs_datetime_import:
         import_lines.append("from datetime import datetime")
 
-    # Find cross-module dependencies
-    classes_in_module = {cls.name for cls in classes}
+    # Find cross-module dependencies (classes_in_module set already built above).
     needed_imports: dict[str, set[str]] = defaultdict(set)  # module -> class names
 
     for cls in classes:

--- a/tests/test_models_pydantic.py
+++ b/tests/test_models_pydantic.py
@@ -156,43 +156,43 @@ class TestModelConfiguration:
             assert issubclass(cls, SQLModel), f"{cls.__name__} is not a SQLModel"
 
     def test_cache_tables_are_sqlmodel_tables(self) -> None:
-        """Cache-target classes must have ``__table__`` with a snake_case name.
+        """Cache-target classes register tables with snake_case names and `id` PKs.
 
         Sanity-check the #342 generator pipeline: ``SalesOrder`` and
         ``SalesOrderRow`` opt into SQLModel table mode via ``table=True``.
-        Without the generator transforms, these would be plain pydantic
-        classes and ``__table__`` wouldn't exist.
+        Verified via ``SQLModel.metadata.tables`` (the typed public view of
+        the same table objects the classes' ``__table__`` attributes point
+        at) — importing the module triggers table registration; a
+        ``KeyError`` on lookup would mean a cache-target class silently
+        failed to register.
         """
+        import importlib
+
         from sqlmodel import SQLModel
 
-        from katana_public_api_client.models_pydantic._generated import (
-            SalesOrder,
-            SalesOrderRow,
+        # importlib triggers module load (registering the tables with
+        # SQLModel.metadata) without a named binding the linter will flag
+        # as unused.
+        importlib.import_module(
+            "katana_public_api_client.models_pydantic._generated.sales_orders"
         )
 
-        # ``__table__`` is synthesized by SQLModel's metaclass and invisible
-        # to the static type checker. Reach it via ``SQLModel.metadata`` —
-        # same underlying object, with a fully-typed public accessor.
         so_table = SQLModel.metadata.tables["sales_order"]
         sor_table = SQLModel.metadata.tables["sales_order_row"]
         assert so_table.name == "sales_order"
         assert sor_table.name == "sales_order_row"
         assert [c.name for c in so_table.primary_key.columns] == ["id"]
         assert [c.name for c in sor_table.primary_key.columns] == ["id"]
-        # The class-level __table__ must be the same SQLAlchemy table object
-        # — guards against SQLModel's table registration ever skipping a
-        # cache-target class.
-        assert SalesOrder is not None and SalesOrderRow is not None
 
     def test_cache_table_foreign_keys(self) -> None:
         """SalesOrderRow must declare a FK back to sales_order.id."""
+        import importlib
+
         from sqlmodel import SQLModel
 
-        # Import forces table registration; reference keeps the import
-        # meaningful to ruff/F401.
-        from katana_public_api_client.models_pydantic._generated import SalesOrderRow
-
-        assert SalesOrderRow is not None
+        importlib.import_module(
+            "katana_public_api_client.models_pydantic._generated.sales_orders"
+        )
         table = SQLModel.metadata.tables["sales_order_row"]
         fks = {fk.target_fullname for fk in table.foreign_keys}
         assert "sales_order.id" in fks


### PR DESCRIPTION
## Summary

`/simplify` pass on the just-merged PR #363 (#342 SQLModel generator). Four tightenings caught by post-merge code review:

### Bug fix — latent shadow
- **Duplicate `classes_in_module` assignment in `generate_module_imports`.** Computed once for `has_cache_tables`/`has_json_columns`, then re-assigned before the cross-module dependency scan. Same expression, but the shadow would silently break any future reader moving logic between the two blocks. Now a single assignment, reused.

### Transform simplification
- **Collapse two regex passes in `inject_table_annotations` into one.** The previous two-step (add `table=True` header → re-match modified header to inject body lines) is now a single substitution. One pattern, one guard, one error message.

### Style
- **Trim `CacheTableRelationship` docstring + field comments.** Field names are self-describing; per-field example comments added noise without insight.
- **Remove dead assertion in `test_cache_tables_are_sqlmodel_tables`.** `assert SalesOrder is not None and SalesOrderRow is not None` on imported class objects never fails. The actual table-registration guard is the `SQLModel.metadata.tables[...]` KeyError above. Also swapped the FK test's awkward "import then reference to placate F401" dance for `importlib.import_module` — cleaner way to express "load for side effects."

## Verification

- [x] `uv run poe check` (format, lint, typecheck, test)
- [x] 2429 tests pass (unchanged from PR #363)
- [x] Regenerated `_generated/` output is byte-identical to pre-cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)