### PR TITLE
chore(mcp): simplify PR #365 typed-cache sync + engine

### DIFF
--- a/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
@@ -17,17 +17,9 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-# Static imports for table registration. These modules' import side
-# effects register the `table=True` SQLModel classes with
-# ``SQLModel.metadata`` so ``create_all`` can emit their DDL. Covers
-# both the hand-written bookkeeping table (SyncState) and the
-# generator-emitted per-entity tables. Expand as more transactional
-# types come online.
-#
-# Static rather than dynamic `importlib.import_module` on purpose —
-# Semgrep flags the dynamic form (non-literal-import) and the static
-# form is equivalent at our hardcoded whitelist of modules. The
-# ``assert`` keeps the imports from being lint-stripped as unused.
+# Side-effect imports: register table=True SQLModel classes with
+# ``SQLModel.metadata`` so ``create_all`` emits their DDL. Add new
+# entity modules here as they come online.
 from katana_mcp.typed_cache import sync_state as _sync_state_mod
 from katana_public_api_client.models_pydantic._generated import (
     sales_orders as _sales_orders_mod,

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -43,18 +43,16 @@ async def ensure_sales_orders_synced(
             state = await session.get(SyncState, "sales_order")
             last_synced = state.last_synced if state is not None else None
 
-        if last_synced is not None:
-            # ``last_synced`` is persisted as naive UTC (SQLite's default
-            # DateTime column strips tzinfo). Re-attach UTC before sending
-            # it to the API so the generated client serializes an explicit
-            # timezone offset — matches how the legacy cache_sync module
-            # handles watermarks.
-            updated_at_min = last_synced.replace(tzinfo=UTC)
-            response = await get_all_sales_orders.asyncio_detailed(
-                client=client, updated_at_min=updated_at_min
-            )
-        else:
-            response = await get_all_sales_orders.asyncio_detailed(client=client)
+        # ``last_synced`` is persisted as naive UTC (SQLite's default
+        # DateTime column strips tzinfo). Re-attach UTC before sending to
+        # the API so the generated client serializes an explicit offset —
+        # matches the legacy cache_sync watermark handling.
+        kwargs = (
+            {"updated_at_min": last_synced.replace(tzinfo=UTC)}
+            if last_synced is not None
+            else {}
+        )
+        response = await get_all_sales_orders.asyncio_detailed(client=client, **kwargs)
         attrs_orders = unwrap_data(response, default=[])
 
         rows = [PydanticSalesOrder.from_attrs(ao) for ao in attrs_orders]
@@ -62,24 +60,16 @@ async def ensure_sales_orders_synced(
         async with cache.session() as session:
             for row in rows:
                 await session.merge(row)
-            # Naive UTC on the write side too — SQLite's DateTime column
-            # doesn't preserve tzinfo.
-            now = datetime.now(tz=UTC).replace(tzinfo=None)
-            existing = await session.get(SyncState, "sales_order")
-            # ``row_count`` captures the last-fetch size (not the cumulative
-            # cached total, which would drift since ``rows`` includes updates
-            # and re-synced duplicates). Consumers that need a true total
-            # can ``SELECT COUNT(*)`` against the entity's own table.
-            if existing is None:
-                session.add(
-                    SyncState(
-                        entity_type="sales_order",
-                        last_synced=now,
-                        row_count=len(rows),
-                    )
+            # SQLite's DateTime column doesn't preserve tzinfo, so naive
+            # UTC on the write side. ``row_count`` is the last-fetch size
+            # (not a cumulative total, which would drift since ``rows``
+            # includes re-sync duplicates); consumers needing a true
+            # total run ``SELECT COUNT(*)`` on the entity table itself.
+            await session.merge(
+                SyncState(
+                    entity_type="sales_order",
+                    last_synced=datetime.now(tz=UTC).replace(tzinfo=None),
+                    row_count=len(rows),
                 )
-            else:
-                existing.last_synced = now
-                existing.row_count = len(rows)
-                session.add(existing)
+            )
             await session.commit()


### PR DESCRIPTION
## Summary

`/simplify` pass on the just-merged PR #365. Three tightenings caught post-merge:

1. **Collapse cold/warm API-call branches in `ensure_sales_orders_synced`.** Both branches called the same `asyncio_detailed` with only `updated_at_min` differing. Builds kwargs once, one call site. Important because this pattern gets copy-pasted for every future `ensure_<entity>_synced` helper (mfg, po, stock_adj, stock_transfer) — establishing the idiom now avoids drift across 4 more helpers.

2. **Replace manual SyncState get/branch/add with `session.merge`.** SyncState is a SQLModel table with a primary key; `merge` is the idempotent upsert we already use for entity rows. Consistency > 10-line specialized branch that duplicated merge semantics. Removes another copy-paste target.

3. **Trim `engine.py` import comment.** 8-line rationale > imports themselves. Core fact ("side-effect imports register `table=True` classes") survives in 3 lines; Semgrep history lives in ADR 0018 + PR #365 discussion.

## Verification

- [x] `uv run poe check` clean
- [x] All 2438 tests pass
- [x] 42 lines removed, 24 added

## Why now

PR #365 is the pattern for 5 more per-entity sync helpers. Fixing the idiom before copy-paste propagates matters more than the small diff size would suggest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)