### PR TITLE
refactor(mcp): consolidate list-tool helpers + enable complexity linting (#347)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -21,10 +21,13 @@ from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
+    PaginationMeta,
     format_md_table,
     iso_or_none,
     make_simple_result,
     make_tool_result,
+    parse_iso_datetime,
+    parse_pagination_header,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
@@ -865,77 +868,6 @@ async def create_stock_adjustment(
 # ============================================================================
 
 
-class PaginationMeta(BaseModel):
-    """Pagination metadata extracted from Katana's `x-pagination` response header.
-
-    Populated on list responses only when the caller requested a specific page
-    (i.e. passed `page=N`). When auto-pagination is used, this field is `None`
-    because there is no single page to describe.
-    """
-
-    total_records: int | None = Field(
-        default=None, description="Total records across all pages"
-    )
-    total_pages: int | None = Field(default=None, description="Total number of pages")
-    page: int | None = Field(default=None, description="Current page number (1-based)")
-    first_page: bool | None = Field(
-        default=None, description="True if this is the first page"
-    )
-    last_page: bool | None = Field(
-        default=None, description="True if this is the last page"
-    )
-
-
-def _parse_pagination_header(raw: str | None) -> PaginationMeta | None:
-    """Parse Katana's `x-pagination` response header into a PaginationMeta.
-
-    Katana returns this as a JSON string with all fields as strings, e.g.:
-    `{"total_records":"2319","total_pages":"2319","offset":"0","page":"1",
-      "first_page":"true","last_page":"false"}`.
-
-    Returns `None` when the header is absent or the top-level JSON is invalid
-    (non-JSON or not a JSON object). When the header is valid JSON but
-    individual fields are missing or malformed, returns a `PaginationMeta`
-    with those specific fields set to `None` rather than discarding the
-    whole header.
-    """
-    if not raw:
-        return None
-    try:
-        data = json.loads(raw)
-    except (ValueError, TypeError):
-        return None
-    if not isinstance(data, dict):
-        return None
-
-    def _as_int(val: Any) -> int | None:
-        if val is None:
-            return None
-        try:
-            return int(val)
-        except (ValueError, TypeError):
-            return None
-
-    def _as_bool(val: Any) -> bool | None:
-        if isinstance(val, bool):
-            return val
-        if isinstance(val, str):
-            lowered = val.strip().lower()
-            if lowered == "true":
-                return True
-            if lowered == "false":
-                return False
-        return None
-
-    return PaginationMeta(
-        total_records=_as_int(data.get("total_records")),
-        total_pages=_as_int(data.get("total_pages")),
-        page=_as_int(data.get("page")),
-        first_page=_as_bool(data.get("first_page")),
-        last_page=_as_bool(data.get("last_page")),
-    )
-
-
 class ListStockAdjustmentsRequest(BaseModel):
     """Request to list/filter stock adjustments."""
 
@@ -1053,27 +985,6 @@ class ListStockAdjustmentsResponse(BaseModel):
     )
 
 
-def _parse_iso_datetime(value: str | None, field_name: str) -> datetime | None:
-    """Parse an ISO-8601 string into a datetime.
-
-    Returns ``None`` when ``value`` is ``None``/empty. Raises ``ValueError``
-    with ``field_name`` context when ``value`` is a non-empty string that can't
-    be parsed — silently dropping filters would hide caller mistakes.
-
-    Normalizes trailing ``Z`` / ``z`` (UTC) to ``+00:00`` before parsing since
-    ``fromisoformat`` is strict about uppercase ``Z`` on older Python releases.
-    """
-    if not value:
-        return None
-    normalized = value[:-1] + "+00:00" if value.endswith(("Z", "z")) else value
-    try:
-        return datetime.fromisoformat(normalized)
-    except ValueError as e:
-        raise ValueError(
-            f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
-        ) from e
-
-
 async def _list_stock_adjustments_impl(
     request: ListStockAdjustmentsRequest, context: Context
 ) -> ListStockAdjustmentsResponse:
@@ -1100,18 +1011,22 @@ async def _list_stock_adjustments_impl(
     if request.include_deleted:
         kwargs["include_deleted"] = True
 
-    created_at_min = _parse_iso_datetime(request.created_after, "created_after")
-    if created_at_min is not None:
-        kwargs["created_at_min"] = created_at_min
-    created_at_max = _parse_iso_datetime(request.created_before, "created_before")
-    if created_at_max is not None:
-        kwargs["created_at_max"] = created_at_max
-    updated_at_min = _parse_iso_datetime(request.updated_after, "updated_after")
-    if updated_at_min is not None:
-        kwargs["updated_at_min"] = updated_at_min
-    updated_at_max = _parse_iso_datetime(request.updated_before, "updated_before")
-    if updated_at_max is not None:
-        kwargs["updated_at_max"] = updated_at_max
+    if request.created_after is not None:
+        kwargs["created_at_min"] = parse_iso_datetime(
+            request.created_after, "created_after"
+        )
+    if request.created_before is not None:
+        kwargs["created_at_max"] = parse_iso_datetime(
+            request.created_before, "created_before"
+        )
+    if request.updated_after is not None:
+        kwargs["updated_at_min"] = parse_iso_datetime(
+            request.updated_after, "updated_after"
+        )
+    if request.updated_before is not None:
+        kwargs["updated_at_max"] = parse_iso_datetime(
+            request.updated_before, "updated_before"
+        )
 
     # Pagination strategy:
     # - If `page` is set, forward it so PaginationTransport disables
@@ -1162,7 +1077,7 @@ async def _list_stock_adjustments_impl(
     if request.page is not None:
         headers = getattr(response, "headers", None)
         if headers is not None:
-            pagination = _parse_pagination_header(headers.get("x-pagination"))
+            pagination = parse_pagination_header(headers.get("x-pagination"))
 
     adjustments: list[StockAdjustmentSummary] = []
     for adj in attrs_list:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import datetime as _datetime
-import json
 from datetime import datetime
 from enum import StrEnum
 from typing import Annotated, Any, Literal
@@ -25,12 +24,15 @@ from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
+    PaginationMeta,
     enum_to_str,
     format_md_table,
     iso_or_none,
     make_simple_result,
     make_tool_result,
     none_coro,
+    parse_iso_datetime,
+    parse_pagination_header,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
@@ -2072,78 +2074,6 @@ async def batch_update_manufacturing_order_recipes(
 # ============================================================================
 
 
-def _parse_iso_datetime(value: str, field_name: str) -> datetime:
-    """Parse an ISO-8601 datetime string, raising ValueError on bad input.
-
-    Normalizes trailing ``Z`` / ``z`` (UTC shorthand) to ``+00:00`` before
-    parsing. Raises ``ValueError`` with the field name on unparseable input
-    so caller mistakes surface loudly instead of being silently dropped.
-    """
-    normalized = value
-    if normalized.endswith(("Z", "z")):
-        normalized = normalized[:-1] + "+00:00"
-    try:
-        return datetime.fromisoformat(normalized)
-    except ValueError as e:
-        raise ValueError(
-            f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
-        ) from e
-
-
-class MOPaginationMeta(BaseModel):
-    """Pagination metadata parsed from Katana's ``x-pagination`` header."""
-
-    total_records: int | None = None
-    total_pages: int | None = None
-    page: int | None = None
-    first_page: bool | None = None
-    last_page: bool | None = None
-
-
-def _parse_mo_pagination_header(raw: str | None) -> MOPaginationMeta | None:
-    """Parse the ``x-pagination`` response header (JSON with stringy values).
-
-    Returns ``None`` for absent or non-JSON-object headers; partial/malformed
-    fields become ``None`` on the returned meta rather than discarding the
-    whole object.
-    """
-    if not raw:
-        return None
-    try:
-        data = json.loads(raw)
-    except (ValueError, TypeError):
-        return None
-    if not isinstance(data, dict):
-        return None
-
-    def _as_int(val: Any) -> int | None:
-        if val is None:
-            return None
-        try:
-            return int(val)
-        except (ValueError, TypeError):
-            return None
-
-    def _as_bool(val: Any) -> bool | None:
-        if isinstance(val, bool):
-            return val
-        if isinstance(val, str):
-            lowered = val.strip().lower()
-            if lowered == "true":
-                return True
-            if lowered == "false":
-                return False
-        return None
-
-    return MOPaginationMeta(
-        total_records=_as_int(data.get("total_records")),
-        total_pages=_as_int(data.get("total_pages")),
-        page=_as_int(data.get("page")),
-        first_page=_as_bool(data.get("first_page")),
-        last_page=_as_bool(data.get("last_page")),
-    )
-
-
 class ListManufacturingOrdersRequest(BaseModel):
     """Request to list/filter manufacturing orders (list-tool pattern v2)."""
 
@@ -2254,7 +2184,7 @@ class ListManufacturingOrdersResponse(BaseModel):
 
     orders: list[ManufacturingOrderSummary]
     total_count: int
-    pagination: MOPaginationMeta | None = None
+    pagination: PaginationMeta | None = None
 
 
 async def _list_manufacturing_orders_impl(
@@ -2287,19 +2217,19 @@ async def _list_manufacturing_orders_impl(
 
     # Server-side date filters
     if request.created_after is not None:
-        kwargs["created_at_min"] = _parse_iso_datetime(
+        kwargs["created_at_min"] = parse_iso_datetime(
             request.created_after, "created_after"
         )
     if request.created_before is not None:
-        kwargs["created_at_max"] = _parse_iso_datetime(
+        kwargs["created_at_max"] = parse_iso_datetime(
             request.created_before, "created_before"
         )
     if request.updated_after is not None:
-        kwargs["updated_at_min"] = _parse_iso_datetime(
+        kwargs["updated_at_min"] = parse_iso_datetime(
             request.updated_after, "updated_after"
         )
     if request.updated_before is not None:
-        kwargs["updated_at_max"] = _parse_iso_datetime(
+        kwargs["updated_at_max"] = parse_iso_datetime(
             request.updated_before, "updated_before"
         )
 
@@ -2307,11 +2237,11 @@ async def _list_manufacturing_orders_impl(
     deadline_after_dt: datetime | None = None
     deadline_before_dt: datetime | None = None
     if request.production_deadline_after is not None:
-        deadline_after_dt = _parse_iso_datetime(
+        deadline_after_dt = parse_iso_datetime(
             request.production_deadline_after, "production_deadline_after"
         )
     if request.production_deadline_before is not None:
-        deadline_before_dt = _parse_iso_datetime(
+        deadline_before_dt = parse_iso_datetime(
             request.production_deadline_before, "production_deadline_before"
         )
     has_client_filter = deadline_after_dt is not None or deadline_before_dt is not None
@@ -2345,11 +2275,11 @@ async def _list_manufacturing_orders_impl(
     attrs_list = attrs_list[: request.limit]
 
     # Pagination meta — only when caller set `page` explicitly.
-    pagination: MOPaginationMeta | None = None
+    pagination: PaginationMeta | None = None
     if request.page is not None:
         headers = getattr(response, "headers", None)
         if headers is not None:
-            pagination = _parse_mo_pagination_header(headers.get("x-pagination"))
+            pagination = parse_pagination_header(headers.get("x-pagination"))
 
     summaries: list[ManufacturingOrderSummary] = []
     for mo in attrs_list:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import asyncio
 import datetime as _datetime
-import json
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Annotated, Any, Literal
@@ -26,11 +25,14 @@ from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
+    PaginationMeta,
     enum_to_str,
     format_md_table,
     iso_or_none,
     make_simple_result,
     make_tool_result,
+    parse_iso_datetime,
+    parse_pagination_header,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.client_types import UNSET
@@ -1599,72 +1601,6 @@ async def verify_order_document(
 # ============================================================================
 
 
-def _parse_iso_datetime(value: str, field_name: str) -> datetime:
-    """Parse an ISO-8601 datetime string, raising ValueError on bad input.
-
-    Normalizes trailing ``Z`` / ``z`` (UTC shorthand) to ``+00:00`` before
-    parsing. Raises ``ValueError`` with the field name on unparseable input.
-    """
-    normalized = value
-    if normalized.endswith(("Z", "z")):
-        normalized = normalized[:-1] + "+00:00"
-    try:
-        return datetime.fromisoformat(normalized)
-    except ValueError as e:
-        raise ValueError(
-            f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
-        ) from e
-
-
-class POPaginationMeta(BaseModel):
-    """Pagination metadata parsed from Katana's ``x-pagination`` header."""
-
-    total_records: int | None = None
-    total_pages: int | None = None
-    page: int | None = None
-    first_page: bool | None = None
-    last_page: bool | None = None
-
-
-def _parse_po_pagination_header(raw: str | None) -> POPaginationMeta | None:
-    """Parse Katana's ``x-pagination`` response header into POPaginationMeta."""
-    if not raw:
-        return None
-    try:
-        data = json.loads(raw)
-    except (ValueError, TypeError):
-        return None
-    if not isinstance(data, dict):
-        return None
-
-    def _as_int(val: Any) -> int | None:
-        if val is None:
-            return None
-        try:
-            return int(val)
-        except (ValueError, TypeError):
-            return None
-
-    def _as_bool(val: Any) -> bool | None:
-        if isinstance(val, bool):
-            return val
-        if isinstance(val, str):
-            lowered = val.strip().lower()
-            if lowered == "true":
-                return True
-            if lowered == "false":
-                return False
-        return None
-
-    return POPaginationMeta(
-        total_records=_as_int(data.get("total_records")),
-        total_pages=_as_int(data.get("total_pages")),
-        page=_as_int(data.get("page")),
-        first_page=_as_bool(data.get("first_page")),
-        last_page=_as_bool(data.get("last_page")),
-    )
-
-
 class ListPurchaseOrdersRequest(BaseModel):
     """Request to list/filter purchase orders (list-tool pattern v2)."""
 
@@ -1811,7 +1747,7 @@ class ListPurchaseOrdersResponse(BaseModel):
 
     orders: list[PurchaseOrderSummary]
     total_count: int
-    pagination: POPaginationMeta | None = None
+    pagination: PaginationMeta | None = None
 
 
 def _po_row_summary(row: Any) -> PurchaseOrderRowSummary:
@@ -1870,19 +1806,19 @@ async def _list_purchase_orders_impl(
 
     # Server-side date filters
     if request.created_after is not None:
-        kwargs["created_at_min"] = _parse_iso_datetime(
+        kwargs["created_at_min"] = parse_iso_datetime(
             request.created_after, "created_after"
         )
     if request.created_before is not None:
-        kwargs["created_at_max"] = _parse_iso_datetime(
+        kwargs["created_at_max"] = parse_iso_datetime(
             request.created_before, "created_before"
         )
     if request.updated_after is not None:
-        kwargs["updated_at_min"] = _parse_iso_datetime(
+        kwargs["updated_at_min"] = parse_iso_datetime(
             request.updated_after, "updated_after"
         )
     if request.updated_before is not None:
-        kwargs["updated_at_max"] = _parse_iso_datetime(
+        kwargs["updated_at_max"] = parse_iso_datetime(
             request.updated_before, "updated_before"
         )
 
@@ -1890,11 +1826,11 @@ async def _list_purchase_orders_impl(
     arrival_after_dt: datetime | None = None
     arrival_before_dt: datetime | None = None
     if request.expected_arrival_after is not None:
-        arrival_after_dt = _parse_iso_datetime(
+        arrival_after_dt = parse_iso_datetime(
             request.expected_arrival_after, "expected_arrival_after"
         )
     if request.expected_arrival_before is not None:
-        arrival_before_dt = _parse_iso_datetime(
+        arrival_before_dt = parse_iso_datetime(
             request.expected_arrival_before, "expected_arrival_before"
         )
     has_client_filter = arrival_after_dt is not None or arrival_before_dt is not None
@@ -1924,11 +1860,11 @@ async def _list_purchase_orders_impl(
     attrs_list = attrs_list[: request.limit]
 
     # Pagination meta — only when caller set `page` explicitly.
-    pagination: POPaginationMeta | None = None
+    pagination: PaginationMeta | None = None
     if request.page is not None:
         headers = getattr(response, "headers", None)
         if headers is not None:
-            pagination = _parse_po_pagination_header(headers.get("x-pagination"))
+            pagination = parse_pagination_header(headers.get("x-pagination"))
 
     summaries: list[PurchaseOrderSummary] = []
     for po in attrs_list:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import datetime as _datetime
-import json
 from datetime import UTC, datetime
 from typing import Annotated, Any, Literal
 
@@ -24,11 +23,14 @@ from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
+    PaginationMeta,
     enum_to_str,
     format_md_table,
     iso_or_none,
     make_tool_result,
     none_coro,
+    parse_iso_datetime,
+    parse_pagination_header,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.client_types import UNSET, Unset
@@ -470,27 +472,6 @@ class ListSalesOrdersRequest(BaseModel):
     )
 
 
-class PaginationMeta(BaseModel):
-    """Pagination metadata extracted from Katana's `x-pagination` response header.
-
-    Populated on `ListSalesOrdersResponse.pagination` only when the caller requested
-    a specific page (i.e. passed `page=N`). When auto-pagination is used, this field
-    is `None` because there is no single page to describe.
-    """
-
-    total_records: int | None = Field(
-        default=None, description="Total records across all pages"
-    )
-    total_pages: int | None = Field(default=None, description="Total number of pages")
-    page: int | None = Field(default=None, description="Current page number (1-based)")
-    first_page: bool | None = Field(
-        default=None, description="True if this is the first page"
-    )
-    last_page: bool | None = Field(
-        default=None, description="True if this is the last page"
-    )
-
-
 class SalesOrderRowInfo(BaseModel):
     """Summary of a sales order line item."""
 
@@ -534,75 +515,6 @@ class ListSalesOrdersResponse(BaseModel):
     )
 
 
-def _parse_iso_datetime(value: str, field_name: str) -> datetime:
-    """Parse an ISO-8601 datetime string, raising ValueError on malformed input.
-
-    Normalizes trailing ``Z`` / ``z`` (UTC shorthand) to ``+00:00`` before
-    parsing — ``datetime.fromisoformat`` didn't accept ``Z`` before Python
-    3.11. Raises ``ValueError`` with the field name on unparseable input so
-    caller mistakes surface loudly instead of being silently dropped.
-    """
-    normalized = value
-    if normalized.endswith(("Z", "z")):
-        normalized = normalized[:-1] + "+00:00"
-    try:
-        return datetime.fromisoformat(normalized)
-    except ValueError as e:
-        raise ValueError(
-            f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
-        ) from e
-
-
-def _parse_pagination_header(raw: str | None) -> PaginationMeta | None:
-    """Parse Katana's `x-pagination` response header into a PaginationMeta.
-
-    Katana returns this as a JSON string with all fields as strings, e.g.:
-    `{"total_records":"2319","total_pages":"2319","offset":"0","page":"1",
-      "first_page":"true","last_page":"false"}`.
-
-    Returns `None` when the header is absent or the top-level JSON is invalid
-    (non-JSON or not a JSON object). When the header is valid JSON but
-    individual fields are missing or malformed, returns a `PaginationMeta`
-    with those specific fields set to `None` rather than discarding the
-    whole header.
-    """
-    if not raw:
-        return None
-    try:
-        data = json.loads(raw)
-    except (ValueError, TypeError):
-        return None
-    if not isinstance(data, dict):
-        return None
-
-    def _as_int(val: Any) -> int | None:
-        if val is None:
-            return None
-        try:
-            return int(val)
-        except (ValueError, TypeError):
-            return None
-
-    def _as_bool(val: Any) -> bool | None:
-        if isinstance(val, bool):
-            return val
-        if isinstance(val, str):
-            lowered = val.strip().lower()
-            if lowered == "true":
-                return True
-            if lowered == "false":
-                return False
-        return None
-
-    return PaginationMeta(
-        total_records=_as_int(data.get("total_records")),
-        total_pages=_as_int(data.get("total_pages")),
-        page=_as_int(data.get("page")),
-        first_page=_as_bool(data.get("first_page")),
-        last_page=_as_bool(data.get("last_page")),
-    )
-
-
 async def _list_sales_orders_impl(
     request: ListSalesOrdersRequest, context: Context
 ) -> ListSalesOrdersResponse:
@@ -642,19 +554,19 @@ async def _list_sales_orders_impl(
 
     # Server-side date filters
     if request.created_after is not None:
-        kwargs["created_at_min"] = _parse_iso_datetime(
+        kwargs["created_at_min"] = parse_iso_datetime(
             request.created_after, "created_after"
         )
     if request.created_before is not None:
-        kwargs["created_at_max"] = _parse_iso_datetime(
+        kwargs["created_at_max"] = parse_iso_datetime(
             request.created_before, "created_before"
         )
     if request.updated_after is not None:
-        kwargs["updated_at_min"] = _parse_iso_datetime(
+        kwargs["updated_at_min"] = parse_iso_datetime(
             request.updated_after, "updated_after"
         )
     if request.updated_before is not None:
-        kwargs["updated_at_max"] = _parse_iso_datetime(
+        kwargs["updated_at_max"] = parse_iso_datetime(
             request.updated_before, "updated_before"
         )
 
@@ -663,11 +575,11 @@ async def _list_sales_orders_impl(
     delivered_after_dt: datetime | None = None
     delivered_before_dt: datetime | None = None
     if request.delivered_after is not None:
-        delivered_after_dt = _parse_iso_datetime(
+        delivered_after_dt = parse_iso_datetime(
             request.delivered_after, "delivered_after"
         )
     if request.delivered_before is not None:
-        delivered_before_dt = _parse_iso_datetime(
+        delivered_before_dt = parse_iso_datetime(
             request.delivered_before, "delivered_before"
         )
     has_client_filter = (
@@ -717,7 +629,7 @@ async def _list_sales_orders_impl(
     if request.page is not None:
         headers = getattr(response, "headers", None)
         if headers is not None:
-            pagination = _parse_pagination_header(headers.get("x-pagination"))
+            pagination = parse_pagination_header(headers.get("x-pagination"))
 
     orders: list[SalesOrderSummary] = []
     for so in attrs_list:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -16,7 +16,6 @@ These tools provide:
 from __future__ import annotations
 
 import datetime as _datetime
-import json
 from datetime import UTC, datetime
 from typing import Annotated, Any, Literal
 
@@ -28,10 +27,13 @@ from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
+    PaginationMeta,
     enum_to_str,
     format_md_table,
     iso_or_none,
     make_simple_result,
+    parse_iso_datetime,
+    parse_pagination_header,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
@@ -62,76 +64,6 @@ def _status_literal_to_enum(status: StatusLiteral) -> StockTransferStatus:
 # ============================================================================
 # Shared response models
 # ============================================================================
-
-
-class PaginationMeta(BaseModel):
-    """Pagination metadata parsed from Katana's x-pagination header."""
-
-    page: int | None = None
-    total_pages: int | None = None
-    total_records: int | None = None
-    first_page: bool | None = None
-    last_page: bool | None = None
-
-
-def _parse_pagination_header(headers: Any) -> PaginationMeta | None:
-    """Parse Katana's x-pagination header into a PaginationMeta instance.
-
-    Returns None if the header is absent, empty, or malformed. Numeric and
-    boolean values arrive as strings; coerce where possible.
-    """
-    if not headers:
-        return None
-    raw = None
-    if hasattr(headers, "get"):
-        raw = headers.get("x-pagination") or headers.get("X-Pagination")
-    if not raw:
-        return None
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, TypeError):
-        return None
-    if not isinstance(parsed, dict):
-        return None
-
-    def _as_int(value: Any) -> int | None:
-        if value is None:
-            return None
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
-
-    def _as_bool(value: Any) -> bool | None:
-        if isinstance(value, bool):
-            return value
-        if isinstance(value, str):
-            lowered = value.strip().lower()
-            if lowered == "true":
-                return True
-            if lowered == "false":
-                return False
-        return None
-
-    meta = PaginationMeta(
-        page=_as_int(parsed.get("page")),
-        total_pages=_as_int(parsed.get("total_pages")),
-        total_records=_as_int(parsed.get("total_records")),
-        first_page=_as_bool(parsed.get("first_page")),
-        last_page=_as_bool(parsed.get("last_page")),
-    )
-    if all(
-        v is None
-        for v in (
-            meta.page,
-            meta.total_pages,
-            meta.total_records,
-            meta.first_page,
-            meta.last_page,
-        )
-    ):
-        return None
-    return meta
 
 
 class StockTransferRowInfo(BaseModel):
@@ -202,22 +134,6 @@ def _build_summary(transfer: Any, *, include_rows: bool) -> StockTransferSummary
         row_count=len(raw_rows),
         rows=row_infos,
     )
-
-
-def _parse_iso_datetime(value: str, field_name: str) -> datetime:
-    """Parse an ISO-8601 datetime string, raising ValueError with a clear message.
-
-    Normalizes trailing ``Z`` (UTC) to ``+00:00`` before parsing — ``datetime.
-    fromisoformat`` only accepts the offset form in Python < 3.11 and still is
-    strict about ``Z`` in older APIs/clients.
-    """
-    normalized = value[:-1] + "+00:00" if value.endswith(("Z", "z")) else value
-    try:
-        return datetime.fromisoformat(normalized)
-    except ValueError as e:
-        raise ValueError(
-            f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
-        ) from e
 
 
 # ============================================================================
@@ -559,11 +475,11 @@ async def _list_stock_transfers_impl(
     if request.stock_transfer_number is not None:
         kwargs["stock_transfer_number"] = request.stock_transfer_number
     if request.created_after is not None:
-        kwargs["created_at_min"] = _parse_iso_datetime(
+        kwargs["created_at_min"] = parse_iso_datetime(
             request.created_after, "created_after"
         )
     if request.created_before is not None:
-        kwargs["created_at_max"] = _parse_iso_datetime(
+        kwargs["created_at_max"] = parse_iso_datetime(
             request.created_before, "created_before"
         )
 
@@ -588,7 +504,9 @@ async def _list_stock_transfers_impl(
 
     pagination = None
     if request.page is not None:
-        pagination = _parse_pagination_header(getattr(response, "headers", None))
+        headers = getattr(response, "headers", None)
+        if headers is not None:
+            pagination = parse_pagination_header(headers.get("x-pagination"))
 
     return ListStockTransfersResponse(
         transfers=summaries,

--- a/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
+++ b/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
@@ -12,11 +12,12 @@ renders the Prefab UI; other clients fall back to markdown content.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from katana_mcp.templates import format_template
 
@@ -49,6 +50,99 @@ def iso_or_none(dt: datetime | None) -> str | None:
     Shorthand for `dt.isoformat() if dt else None`.
     """
     return dt.isoformat() if dt else None
+
+
+def parse_iso_datetime(value: str, field_name: str) -> datetime:
+    """Parse an ISO-8601 datetime string, raising ValueError with field context.
+
+    Normalizes trailing ``Z`` / ``z`` (UTC shorthand) to ``+00:00`` before
+    parsing — ``datetime.fromisoformat`` didn't accept ``Z`` before Python
+    3.11. Raises ``ValueError`` with the field name when input is unparseable
+    so caller mistakes surface loudly instead of being silently dropped.
+
+    Callers with optional values should guard ``if value is not None:``
+    before calling — this function requires a non-None string so the return
+    type stays narrow (``datetime``, not ``datetime | None``).
+    """
+    normalized = value
+    if normalized.endswith(("Z", "z")):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError as e:
+        msg = f"Invalid ISO-8601 datetime for {field_name!r}: {value!r}"
+        raise ValueError(msg) from e
+
+
+class PaginationMeta(BaseModel):
+    """Pagination metadata extracted from Katana's ``x-pagination`` header.
+
+    Populated on list-tool responses only when the caller requested a
+    specific page (i.e. passed ``page=N``). When auto-pagination is used,
+    this field is ``None`` because there is no single page to describe.
+    """
+
+    total_records: int | None = Field(
+        default=None, description="Total records across all pages"
+    )
+    total_pages: int | None = Field(default=None, description="Total number of pages")
+    page: int | None = Field(default=None, description="Current page number (1-based)")
+    first_page: bool | None = Field(
+        default=None, description="True if this is the first page"
+    )
+    last_page: bool | None = Field(
+        default=None, description="True if this is the last page"
+    )
+
+
+def parse_pagination_header(raw: str | None) -> PaginationMeta | None:
+    """Parse Katana's ``x-pagination`` response header into a PaginationMeta.
+
+    Katana returns this as a JSON string with stringy values, e.g.:
+    ``{"total_records":"2319","total_pages":"2319","offset":"0","page":"1",
+    "first_page":"true","last_page":"false"}``.
+
+    Returns ``None`` when the header is absent or the top-level JSON is
+    invalid (non-JSON or not a JSON object). When the header is valid JSON
+    but individual fields are missing or malformed, returns a
+    ``PaginationMeta`` with those specific fields set to ``None`` rather
+    than discarding the whole header.
+    """
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    def _as_int(val: Any) -> int | None:
+        if val is None:
+            return None
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            return None
+
+    def _as_bool(val: Any) -> bool | None:
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, str):
+            lowered = val.strip().lower()
+            if lowered == "true":
+                return True
+            if lowered == "false":
+                return False
+        return None
+
+    return PaginationMeta(
+        total_records=_as_int(data.get("total_records")),
+        total_pages=_as_int(data.get("total_pages")),
+        page=_as_int(data.get("page")),
+        first_page=_as_bool(data.get("first_page")),
+        last_page=_as_bool(data.get("last_page")),
+    )
 
 
 async def none_coro() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,21 +265,81 @@ select = [
     "I",      # isort
     "B",      # flake8-bugbear
     "C4",     # flake8-comprehensions
+    "C90",    # mccabe complexity
     "UP",     # pyupgrade
     "SIM",    # flake8-simplify
     "RUF",    # ruff-specific rules
     "PLE",    # pylint errors
     "PLW",    # pylint warnings
+    "PLR0912",  # pylint: too many branches
+    "PLR0913",  # pylint: too many arguments
+    "PLR0915",  # pylint: too many statements
 ]
 ignore = [
     "E501",   # line too long (handled by formatter)
     "B008",   # do not perform function calls in argument defaults
-    "C901",   # too complex
     "SIM108", # use ternary operator instead of if-else
 ]
 
+# Complexity thresholds — pragmatic defaults calibrated against the current
+# codebase post-#347 helper consolidation. Ratchet tighter in follow-up PRs
+# as specific modules split / get refactored. Fat legacy modules that can't
+# meet these today are handled via per-file-ignore below.
+[tool.ruff.lint.mccabe]
+max-complexity = 15  # C901 threshold (default 10 is aggressive for API-shape code)
+
+[tool.ruff.lint.pylint]
+max-args = 8        # PLR0913 (default 5)
+max-branches = 15   # PLR0912 (default 12)
+max-statements = 80 # PLR0915 (default 50)
+
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["PLR2004"]  # magic value used in comparison
+# Generated API and model files — complexity rules don't apply (emitted
+# by openapi-python-client); listed here so CI doesn't surface noise on
+# every regeneration. See `[tool.poe.tasks] regenerate-client`.
+"katana_public_api_client/api/**" = ["C90", "PLR0912", "PLR0913", "PLR0915"]
+"katana_public_api_client/models/**" = ["C90", "PLR0912", "PLR0913", "PLR0915"]
+"katana_public_api_client/client.py" = ["C90", "PLR0912", "PLR0913", "PLR0915"]
+"katana_public_api_client/models_pydantic/_generated/**" = [
+    "C90", "PLR0912", "PLR0913", "PLR0915",
+]
+
+# Tests — magic values are idiomatic; test setup/assert logic is allowed
+# to be complex without refactoring into helpers just to satisfy lint.
+# Recursive ``**`` glob to catch nested dirs like ``tests/tools/`` and
+# ``tests/integration/``.
+"tests/**" = ["PLR2004", "C90", "PLR0912", "PLR0913", "PLR0915"]
+"katana_mcp_server/tests/**" = ["PLR2004", "C90", "PLR0912", "PLR0913", "PLR0915"]
+
+# Scripts — analysis/utility scripts are one-shot tools; they get reduced
+# complexity enforcement so we can iterate on them without splitting into
+# artificial helpers.
+"scripts/**" = ["C90", "PLR0912", "PLR0913", "PLR0915"]
+
+# Generated pydantic registry — emitted by scripts/generate_pydantic_models.py
+# and intentionally flat/list-shaped; complexity rules don't apply.
+"katana_public_api_client/models_pydantic/_auto_registry.py" = [
+    "C90", "PLR0912", "PLR0913", "PLR0915",
+]
+
+# Legacy fat modules with complex functions pre-dating the complexity
+# ratchet. Split into sub-modules (rendering, batch ops, etc.) in
+# follow-ups tracked via individual issues. Don't add new violations here.
+"katana_public_api_client/katana_client.py" = ["C90", "PLR0912", "PLR0915"]
+"katana_public_api_client/utils.py" = ["C90", "PLR0912"]
+"katana_mcp_server/src/katana_mcp/unpack.py" = ["C90", "PLR0912"]
+"katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py" = [
+    "C90", "PLR0912", "PLR0913", "PLR0915",
+]
+"katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py" = [
+    "C90", "PLR0912", "PLR0913", "PLR0915",
+]
+"katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py" = [
+    "C90", "PLR0912", "PLR0913", "PLR0915",
+]
+"katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py" = [
+    "C90", "PLR0912", "PLR0913", "PLR0915",
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["katana_public_api_client"]

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.40.0"
+version = "0.41.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Closes #347. Two tightly-coupled cleanups:

### 1. Helper consolidation (-237 LOC)

Three helpers previously copy-pasted across the 5 list-tool modules are now defined once in `katana_mcp/tools/tool_result_utils.py`:

- **`PaginationMeta`** — one canonical pydantic class. Replaces `PaginationMeta` / `POPaginationMeta` / `MOPaginationMeta` (structurally identical; the prefix names were copy-paste artifacts).
- **`parse_iso_datetime(value, field_name) → datetime`** — one non-optional signature. Callers with optional values guard at the call site (explicit, narrow return type).
- **`parse_pagination_header(raw) → PaginationMeta | None`** — one implementation. Two variants dropped as unneeded (case-insensitive header fallback, "all-None → None" shortcut).

Five tool files shed ~500 lines of boilerplate; ~95 lines added to the shared module.

### 2. Complexity ruff rules (first ratchet step)

C901 was previously in the ignore list (disabled). Now enabled alongside PLR0912/0913/0915 with pragmatic initial thresholds:

| Rule | Threshold | Default |
|---|---|---|
| C90 (McCabe) | 15 | 10 |
| PLR0912 (branches) | 15 | 12 |
| PLR0913 (args) | 8 | 5 |
| PLR0915 (statements) | 80 | 50 |

Per-file-ignores scoped tightly — **generated code** (API/models/registry) drops complexity rules entirely; **tests** and **scripts** get leniency; **legacy fat modules** (`katana_client.py`, `utils.py`, `unpack.py`, the four `tools/foundation/*_orders.py` files + `inventory.py`) carry explicit per-file-ignores with rationale. The legacy ignores are a deliberate "don't add new violations here" marker — ratchet tighter as each module gets split in follow-ups.

## Verification

- [x] `uv run poe check` passes clean
- [x] 2438 tests pass (no behavioral regression)
- [x] No `noqa` markers, no `# type: ignore` — per CLAUDE.md zero-tolerance
- [x] `parse_iso_datetime` handles `Z`/`z` suffix and offset forms identically to the 5 originals
- [x] `parse_pagination_header` matches the sales_orders canonical behavior (partial-field tolerance; absent/malformed headers → None)

## Follow-up ratchets

As fat modules split into sub-modules (rendering helpers, batch ops, per-subdomain tools), the per-file-ignores can come off one at a time. Priorities:

- `manufacturing_orders.py` (2,510 LOC → split into recipe / batch / list-get sub-modules)
- `purchase_orders.py` (2,078 LOC → similar shape)
- Thresholds themselves can tighten once the legacy hot spots are resolved — `max-complexity=12` and `max-statements=60` are reasonable eventual targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)