### PR TITLE
feat(mcp): migrate list_sales_orders to cache-backed query (#368)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -9,7 +9,6 @@ These tools provide:
 from __future__ import annotations
 
 import asyncio
-import datetime as _datetime
 from datetime import UTC, datetime
 from typing import Annotated, Any, Literal
 
@@ -30,7 +29,6 @@ from katana_mcp.tools.tool_result_utils import (
     make_tool_result,
     none_coro,
     parse_iso_datetime,
-    parse_pagination_header,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.client_types import UNSET, Unset
@@ -509,164 +507,212 @@ class ListSalesOrdersResponse(BaseModel):
     pagination: PaginationMeta | None = Field(
         default=None,
         description=(
-            "Pagination cursor populated from the API's `x-pagination` header when "
-            "the caller requested a specific page. `None` when auto-paginating."
+            "Pagination metadata — populated when the caller requests a "
+            "specific `page`. Computed locally from `SELECT COUNT(*)` "
+            "against the typed cache (post-#342); `None` when the caller "
+            "does not drive paging explicitly."
         ),
     )
+
+
+def _naive_utc(dt: datetime | None) -> datetime | None:
+    """Normalize a datetime to naive UTC for comparison against the cache.
+
+    The typed cache stores timestamps as naive UTC (SQLite's default
+    DateTime column doesn't preserve tzinfo). Tz-aware filter datetimes
+    are converted to naive UTC so SQLAlchemy comparisons don't raise
+    "can't compare offset-naive and offset-aware".
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is not None:
+        return dt.astimezone(UTC).replace(tzinfo=None)
+    return dt
+
+
+def _apply_sales_order_filters(stmt: Any, request: ListSalesOrdersRequest) -> Any:
+    """Translate request filters into WHERE clauses on a ``SalesOrder`` query.
+
+    Shared by both the data SELECT and the COUNT SELECT used for
+    ``PaginationMeta`` — keeps the two queries in sync so pagination
+    totals reflect the same filter set.
+    """
+    from katana_public_api_client.models_pydantic._generated import (
+        SalesOrder as CachedSalesOrder,
+        SalesOrderProductionStatus,
+        SalesOrderStatus,
+    )
+
+    production_status = request.production_status
+    if production_status is None and request.needs_work_orders:
+        production_status = "NONE"
+
+    if request.order_no is not None:
+        stmt = stmt.where(CachedSalesOrder.order_no == request.order_no)
+    if request.ids is not None:
+        stmt = stmt.where(CachedSalesOrder.id.in_(request.ids))
+    if request.customer_id is not None:
+        stmt = stmt.where(CachedSalesOrder.customer_id == request.customer_id)
+    if request.location_id is not None:
+        stmt = stmt.where(CachedSalesOrder.location_id == request.location_id)
+    # Enum-typed filters: validate + coerce to the actual enum members so
+    # invalid input raises loudly instead of returning an empty result set.
+    # Enum-column comparisons in SQLAlchemy are safest when both sides are
+    # the enum member; string equality happens to work for StrEnum today
+    # but the coercion makes the contract explicit.
+    if request.status is not None:
+        try:
+            status_enum = SalesOrderStatus(request.status)
+        except ValueError as e:
+            valid = ", ".join(s.value for s in SalesOrderStatus)
+            msg = f"Invalid status {request.status!r}. Valid: {valid}"
+            raise ValueError(msg) from e
+        stmt = stmt.where(CachedSalesOrder.status == status_enum)
+    if production_status is not None:
+        try:
+            prod_enum = SalesOrderProductionStatus(production_status)
+        except ValueError as e:
+            valid = ", ".join(s.value for s in SalesOrderProductionStatus)
+            msg = f"Invalid production_status {production_status!r}. Valid: {valid}"
+            raise ValueError(msg) from e
+        stmt = stmt.where(CachedSalesOrder.production_status == prod_enum)
+    if request.invoicing_status is not None:
+        stmt = stmt.where(CachedSalesOrder.invoicing_status == request.invoicing_status)
+    if request.currency is not None:
+        stmt = stmt.where(CachedSalesOrder.currency == request.currency)
+    if not request.include_deleted:
+        stmt = stmt.where(CachedSalesOrder.deleted_at.is_(None))
+
+    # Date windows — all indexed SQL range queries. No more split
+    # server-side/client-side distinction; ``delivery_date`` filters
+    # that previously ran post-fetch now run inline.
+    if request.created_after is not None:
+        stmt = stmt.where(
+            CachedSalesOrder.created_at
+            >= _naive_utc(parse_iso_datetime(request.created_after, "created_after"))
+        )
+    if request.created_before is not None:
+        stmt = stmt.where(
+            CachedSalesOrder.created_at
+            <= _naive_utc(parse_iso_datetime(request.created_before, "created_before"))
+        )
+    if request.updated_after is not None:
+        stmt = stmt.where(
+            CachedSalesOrder.updated_at
+            >= _naive_utc(parse_iso_datetime(request.updated_after, "updated_after"))
+        )
+    if request.updated_before is not None:
+        stmt = stmt.where(
+            CachedSalesOrder.updated_at
+            <= _naive_utc(parse_iso_datetime(request.updated_before, "updated_before"))
+        )
+    if request.delivered_after is not None:
+        stmt = stmt.where(
+            CachedSalesOrder.delivery_date
+            >= _naive_utc(
+                parse_iso_datetime(request.delivered_after, "delivered_after")
+            )
+        )
+    if request.delivered_before is not None:
+        stmt = stmt.where(
+            CachedSalesOrder.delivery_date
+            <= _naive_utc(
+                parse_iso_datetime(request.delivered_before, "delivered_before")
+            )
+        )
+
+    return stmt
 
 
 async def _list_sales_orders_impl(
     request: ListSalesOrdersRequest, context: Context
 ) -> ListSalesOrdersResponse:
-    """List sales orders with filters (list-tool pattern v2)."""
-    from katana_public_api_client.api.sales_order import get_all_sales_orders
-    from katana_public_api_client.utils import unwrap_data
+    """List sales orders with filters (list-tool pattern v2, cache-backed).
+
+    Reads from the SQLModel typed cache instead of the live API.
+    ``ensure_sales_orders_synced`` runs an incremental ``updated_at_min``
+    delta on every call (near-zero cost steady-state; cold-start pulls
+    full history once); the query then translates request filters into
+    indexed SQL and returns results directly — no pagination dance, no
+    post-fetch client-side filtering. See ADR-0018 and #342.
+    """
+    from sqlalchemy.orm import selectinload
+    from sqlmodel import func, select
+
+    from katana_mcp.typed_cache import ensure_sales_orders_synced
+    from katana_public_api_client.models_pydantic._generated import (
+        SalesOrder as CachedSalesOrder,
+    )
 
     services = get_services(context)
 
-    # Pass through only the filters the caller actually set. `is not None`
-    # (not truthy) so 0-valued customer_id/location_id still filter.
-    production_status = request.production_status
-    if production_status is None and request.needs_work_orders:
-        production_status = "NONE"
-    kwargs: dict[str, Any] = {
-        "client": services.client,
-        "limit": request.limit,
-    }
-    if request.order_no is not None:
-        kwargs["order_no"] = request.order_no
-    if request.ids is not None:
-        kwargs["ids"] = request.ids
-    if request.customer_id is not None:
-        kwargs["customer_id"] = request.customer_id
-    if request.location_id is not None:
-        kwargs["location_id"] = request.location_id
-    if request.status is not None:
-        kwargs["status"] = request.status
-    if production_status is not None:
-        kwargs["production_status"] = production_status
-    if request.invoicing_status is not None:
-        kwargs["invoicing_status"] = request.invoicing_status
-    if request.currency is not None:
-        kwargs["currency"] = request.currency
-    if request.include_deleted is not None:
-        kwargs["include_deleted"] = request.include_deleted
+    # 1. Refresh the cache (incremental — near-zero cost steady state).
+    await ensure_sales_orders_synced(services.client, services.typed_cache)
 
-    # Server-side date filters
-    if request.created_after is not None:
-        kwargs["created_at_min"] = parse_iso_datetime(
-            request.created_after, "created_after"
-        )
-    if request.created_before is not None:
-        kwargs["created_at_max"] = parse_iso_datetime(
-            request.created_before, "created_before"
-        )
-    if request.updated_after is not None:
-        kwargs["updated_at_min"] = parse_iso_datetime(
-            request.updated_after, "updated_after"
-        )
-    if request.updated_before is not None:
-        kwargs["updated_at_max"] = parse_iso_datetime(
-            request.updated_before, "updated_before"
-        )
-
-    # Client-side date filters — parsed eagerly so bad input fails loudly
-    # before we spend an API call.
-    delivered_after_dt: datetime | None = None
-    delivered_before_dt: datetime | None = None
-    if request.delivered_after is not None:
-        delivered_after_dt = parse_iso_datetime(
-            request.delivered_after, "delivered_after"
-        )
-    if request.delivered_before is not None:
-        delivered_before_dt = parse_iso_datetime(
-            request.delivered_before, "delivered_before"
-        )
-    has_client_filter = (
-        delivered_after_dt is not None or delivered_before_dt is not None
+    # 2. Build the data query with filters + ordering + pagination.
+    # Eager-load rows always so we can report ``row_count`` accurately even
+    # when ``include_rows=False``, and serialize the detail when asked.
+    stmt = select(CachedSalesOrder).options(
+        selectinload(CachedSalesOrder.sales_order_rows)
     )
-
-    # Pagination strategy:
-    # - If `page` is set, the caller is driving pagination manually; forward
-    #   it so PaginationTransport disables auto-pagination and lets callers
-    #   walk beyond the transport's max_pages ceiling.
-    # - Otherwise, when `limit` fits in a single Katana page (<=250, the API's
-    #   max page size) AND no client-side-only filter is active, pass page=1
-    #   to short-circuit auto-pagination. When a client-side filter IS active,
-    #   skip the short-circuit so the transport's auto-pagination can scan
-    #   enough rows to find `limit` matching ones post-filter.
+    stmt = _apply_sales_order_filters(stmt, request)
+    stmt = stmt.order_by(CachedSalesOrder.created_at.desc(), CachedSalesOrder.id.desc())
     if request.page is not None:
-        kwargs["page"] = request.page
-    elif 1 <= request.limit <= 250 and not has_client_filter:
-        kwargs["page"] = 1
+        stmt = stmt.offset((request.page - 1) * request.limit).limit(request.limit)
+    else:
+        stmt = stmt.limit(request.limit)
 
-    response = await get_all_sales_orders.asyncio_detailed(**kwargs)
-    attrs_list = unwrap_data(response, default=[])
+    # 3. Execute data query and (when paginating) a separate COUNT for meta.
+    async with services.typed_cache.session() as session:
+        data_result = await session.exec(stmt)
+        cached_orders = list(data_result.all())
 
-    # Client-side delivery_date filter (Katana has no server-side param).
-    if has_client_filter:
-
-        def _in_delivery_window(so: Any) -> bool:
-            delivery = unwrap_unset(so.delivery_date, None)
-            if not isinstance(delivery, _datetime.datetime):
-                return False
-            if delivered_after_dt is not None and delivery < delivered_after_dt:
-                return False
-            return not (
-                delivered_before_dt is not None and delivery > delivered_before_dt
+        pagination: PaginationMeta | None = None
+        if request.page is not None:
+            count_stmt = _apply_sales_order_filters(
+                select(func.count()).select_from(CachedSalesOrder), request
+            )
+            total_records = (await session.exec(count_stmt)).one()
+            total_pages = (total_records + request.limit - 1) // request.limit
+            pagination = PaginationMeta(
+                total_records=total_records,
+                total_pages=total_pages,
+                page=request.page,
+                first_page=request.page == 1,
+                last_page=request.page >= total_pages,
             )
 
-        attrs_list = [so for so in attrs_list if _in_delivery_window(so)]
-
-    # Safety net: cap to request.limit post-pagination so we never return more
-    # than the caller asked for, regardless of how the transport behaved.
-    attrs_list = attrs_list[: request.limit]
-
-    # Surface pagination metadata from the `x-pagination` response header only
-    # when the caller is driving paging manually. During auto-pagination the
-    # header describes just the final fetched page, which would be misleading.
-    pagination: PaginationMeta | None = None
-    if request.page is not None:
-        headers = getattr(response, "headers", None)
-        if headers is not None:
-            pagination = parse_pagination_header(headers.get("x-pagination"))
-
+    # 4. Materialize summaries. ``sku`` stays None — resolving it would
+    # require a variant lookup per row and defeat the single-query win.
     orders: list[SalesOrderSummary] = []
-    for so in attrs_list:
-        rows = unwrap_unset(so.sales_order_rows, [])
-        # When include_rows is set, expose row-level detail on each summary.
-        # `sku` is left None in list context — resolving it would require a
-        # variant cache lookup per row (up to 250 rows * N variants), which
-        # defeats the "one call for 50 orders" goal. Callers that need SKUs
-        # should use `get_sales_order` on a specific order.
+    for so in cached_orders:
+        rows = so.sales_order_rows
         row_infos: list[SalesOrderRowInfo] | None = None
         if request.include_rows:
             row_infos = [
                 SalesOrderRowInfo(
                     id=r.id,
-                    variant_id=unwrap_unset(r.variant_id, None),
+                    variant_id=r.variant_id,
                     sku=None,
-                    quantity=unwrap_unset(r.quantity, None),
-                    price_per_unit=unwrap_unset(r.price_per_unit, None),
-                    linked_manufacturing_order_id=unwrap_unset(
-                        r.linked_manufacturing_order_id, None
-                    ),
+                    quantity=r.quantity,
+                    price_per_unit=r.price_per_unit,
+                    linked_manufacturing_order_id=r.linked_manufacturing_order_id,
                 )
                 for r in rows
             ]
         orders.append(
             SalesOrderSummary(
                 id=so.id,
-                order_no=unwrap_unset(so.order_no, None),
-                customer_id=unwrap_unset(so.customer_id, None),
-                location_id=unwrap_unset(so.location_id, None),
-                status=enum_to_str(unwrap_unset(so.status, None)),
-                production_status=enum_to_str(unwrap_unset(so.production_status, None)),
-                invoicing_status=enum_to_str(unwrap_unset(so.invoicing_status, None)),
-                created_at=iso_or_none(unwrap_unset(so.created_at, None)),
-                delivery_date=iso_or_none(unwrap_unset(so.delivery_date, None)),
-                total=unwrap_unset(so.total, None),
-                currency=unwrap_unset(so.currency, None),
+                order_no=so.order_no,
+                customer_id=so.customer_id,
+                location_id=so.location_id,
+                status=enum_to_str(so.status),
+                production_status=enum_to_str(so.production_status),
+                invoicing_status=so.invoicing_status,
+                created_at=iso_or_none(so.created_at),
+                delivery_date=iso_or_none(so.delivery_date),
+                total=so.total,
+                currency=so.currency,
                 row_count=len(rows),
                 rows=row_infos,
             )

--- a/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from platformdirs import user_cache_dir
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -41,18 +42,45 @@ class TypedCacheEngine:
     before kicking off a sync so concurrent callers don't fan out.
     """
 
-    def __init__(self, db_path: Path | None = None) -> None:
-        self._db_path = db_path if db_path is not None else _DEFAULT_DB_PATH
+    def __init__(
+        self,
+        db_path: Path | None = None,
+        *,
+        in_memory: bool = False,
+    ) -> None:
+        """Configure the engine but don't open it yet.
+
+        Args:
+            db_path: SQLite file path for file-backed mode. Defaults to the
+                user cache dir when ``None`` and ``in_memory`` is false.
+                Must not be provided when ``in_memory=True``.
+            in_memory: Use a ``:memory:`` SQLite backend instead of a file.
+                Intended for tests — all data lives in process memory and
+                is lost when the engine is closed. A ``StaticPool`` keeps
+                one connection alive across sessions so they share the
+                same in-memory database (the default pool would give each
+                session a fresh, empty DB). Passing ``db_path`` together
+                with ``in_memory=True`` raises ``ValueError``.
+        """
+        if in_memory and db_path is not None:
+            msg = "Pass either `db_path` or `in_memory=True`, not both."
+            raise ValueError(msg)
+        self._in_memory = in_memory
+        self._db_path: Path | None = (
+            None
+            if in_memory
+            else (db_path if db_path is not None else _DEFAULT_DB_PATH)
+        )
         self._engine: AsyncEngine | None = None
         self._locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     @property
-    def db_path(self) -> Path:
+    def db_path(self) -> Path | None:
+        """The SQLite file path, or ``None`` for in-memory engines."""
         return self._db_path
 
     async def open(self) -> None:
-        """Create the SQLite file (if needed), register cache-target tables,
-        and apply the schema via ``SQLModel.metadata.create_all``.
+        """Create/open the SQLite backend and apply the SQLModel schema.
 
         Safe to call only once per engine instance; subsequent calls raise
         ``RuntimeError``.
@@ -60,10 +88,22 @@ class TypedCacheEngine:
         if self._engine is not None:
             msg = "TypedCacheEngine.open() called on an already-open engine"
             raise RuntimeError(msg)
-        self._db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._engine = create_async_engine(
-            f"sqlite+aiosqlite:///{self._db_path}",
-        )
+        if self._in_memory:
+            # ``StaticPool`` + ``check_same_thread=False`` are the canonical
+            # pairing for async :memory: SQLite: a single shared connection
+            # that all sessions bind to, so seeded data persists across
+            # session boundaries within one engine.
+            self._engine = create_async_engine(
+                "sqlite+aiosqlite:///:memory:",
+                poolclass=StaticPool,
+                connect_args={"check_same_thread": False},
+            )
+        else:
+            assert self._db_path is not None  # guaranteed by __init__
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._engine = create_async_engine(
+                f"sqlite+aiosqlite:///{self._db_path}",
+            )
         async with self._engine.begin() as conn:
             await conn.run_sync(SQLModel.metadata.create_all)
 

--- a/katana_mcp_server/tests/conftest.py
+++ b/katana_mcp_server/tests/conftest.py
@@ -118,6 +118,46 @@ def mock_context():
     return create_mock_context()
 
 
+@pytest_asyncio.fixture
+async def typed_cache_engine():
+    """Per-test in-memory ``TypedCacheEngine``.
+
+    Uses ``in_memory=True`` — a ``:memory:`` SQLite backed by
+    ``StaticPool`` so concurrent sessions share one DB within the engine.
+    No filesystem I/O per test. Engine and schema are created fresh per
+    test function; if this pattern starts feeling slow as the suite
+    grows, upgrade to a session-scoped engine with per-test SAVEPOINT
+    rollback (SQLAlchemy's "joining an external transaction" recipe).
+    """
+    from katana_mcp.typed_cache import TypedCacheEngine
+
+    engine = TypedCacheEngine(in_memory=True)
+    await engine.open()
+    try:
+        yield engine
+    finally:
+        await engine.close()
+
+
+@pytest_asyncio.fixture
+async def context_with_typed_cache(typed_cache_engine):
+    """Mock context with a real in-memory ``TypedCacheEngine`` attached.
+
+    Cache-backed tools (``list_sales_orders`` post-#342) need a real
+    ``TypedCacheEngine`` on ``services.typed_cache`` — ``MagicMock``
+    isn't usable as an ``async with`` session. Tests that mock
+    ``get_all_sales_orders.asyncio_detailed`` have their attrs return
+    values convert + upsert into the cache via the sync helper before
+    the tool queries it.
+
+    Yields:
+        Tuple of ``(context, lifespan_context, typed_cache_engine)``.
+    """
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache = typed_cache_engine
+    yield context, lifespan_ctx, typed_cache_engine
+
+
 @pytest.fixture
 def mock_get_purchase_order():
     """Fixture for mocking get_purchase_order API call."""

--- a/katana_mcp_server/tests/test_typed_cache.py
+++ b/katana_mcp_server/tests/test_typed_cache.py
@@ -3,92 +3,93 @@
 Covers the runtime lifecycle (open/close/session/lock), SyncState
 roundtrip, and end-to-end cache interaction with the generated
 SalesOrder/SalesOrderRow tables.
+
+Most tests use the shared ``typed_cache_engine`` fixture (in-memory
+SQLite, ``StaticPool``). Tests that specifically exercise file-backed
+behavior (``test_open_creates_db_file``) use ``tmp_path`` directly.
 """
 
 from __future__ import annotations
 
 import asyncio
-import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
-import pytest_asyncio
 from katana_mcp.typed_cache import SyncState, TypedCacheEngine
 from sqlmodel import select
-
-
-@pytest_asyncio.fixture
-async def open_engine():
-    """Yield a TypedCacheEngine backed by a temporary SQLite file."""
-    with tempfile.TemporaryDirectory() as td:
-        engine = TypedCacheEngine(db_path=Path(td) / "test.db")
-        await engine.open()
-        try:
-            yield engine
-        finally:
-            await engine.close()
 
 
 class TestLifecycle:
     """Engine open/close and session behavior."""
 
     @pytest.mark.asyncio
-    async def test_open_creates_db_file(self):
-        with tempfile.TemporaryDirectory() as td:
-            db_path = Path(td) / "test.db"
-            engine = TypedCacheEngine(db_path=db_path)
-            assert not db_path.exists()
-            await engine.open()
-            try:
-                assert db_path.exists()
-            finally:
-                await engine.close()
+    async def test_open_creates_db_file(self, tmp_path: Path):
+        """Regression: file-backed engines materialize the SQLite file."""
+        db_path = tmp_path / "test.db"
+        engine = TypedCacheEngine(db_path=db_path)
+        assert not db_path.exists()
+        await engine.open()
+        try:
+            assert db_path.exists()
+        finally:
+            await engine.close()
 
     @pytest.mark.asyncio
-    async def test_double_open_raises(self):
-        with tempfile.TemporaryDirectory() as td:
-            engine = TypedCacheEngine(db_path=Path(td) / "test.db")
-            await engine.open()
-            try:
-                with pytest.raises(RuntimeError, match="already-open"):
-                    await engine.open()
-            finally:
-                await engine.close()
+    async def test_open_in_memory_skips_file(self, tmp_path: Path):
+        """``in_memory=True`` creates no file and reports ``db_path is None``."""
+        engine = TypedCacheEngine(in_memory=True)
+        assert engine.db_path is None
+        await engine.open()
+        try:
+            # Nothing landed in tmp_path (the canonical "no filesystem" check).
+            assert list(tmp_path.iterdir()) == []
+        finally:
+            await engine.close()
+
+    @pytest.mark.asyncio
+    async def test_in_memory_rejects_explicit_db_path(self):
+        """Mixing ``in_memory=True`` with ``db_path`` is a user error."""
+        with pytest.raises(ValueError, match="Pass either"):
+            TypedCacheEngine(db_path=Path("/tmp/anything.db"), in_memory=True)
+
+    @pytest.mark.asyncio
+    async def test_double_open_raises(self, typed_cache_engine):
+        with pytest.raises(RuntimeError, match="already-open"):
+            await typed_cache_engine.open()
 
     @pytest.mark.asyncio
     async def test_session_before_open_raises(self):
-        engine = TypedCacheEngine(db_path=Path("/tmp/never-created.db"))
+        engine = TypedCacheEngine(in_memory=True)
         with pytest.raises(RuntimeError, match="not open"):
             engine.session()
 
     @pytest.mark.asyncio
     async def test_close_is_idempotent(self):
-        with tempfile.TemporaryDirectory() as td:
-            engine = TypedCacheEngine(db_path=Path(td) / "test.db")
-            await engine.open()
-            await engine.close()
-            # Second close must not raise.
-            await engine.close()
+        engine = TypedCacheEngine(in_memory=True)
+        await engine.open()
+        await engine.close()
+        # Second close must not raise.
+        await engine.close()
 
 
 class TestSyncState:
     """SyncState upsert / read roundtrip."""
 
     @pytest.mark.asyncio
-    async def test_sync_state_roundtrip(self, open_engine):
+    async def test_sync_state_roundtrip(self, typed_cache_engine):
         # SQLite DateTime columns don't preserve tzinfo by default — values
         # round-trip as naive UTC. Using a naive UTC datetime here avoids a
         # comparison mismatch and matches how the sync helpers already
         # work with SyncState under the hood.
         now = datetime.now(tz=UTC).replace(tzinfo=None)
-        async with open_engine.session() as session:
+        async with typed_cache_engine.session() as session:
             session.add(
                 SyncState(entity_type="sales_order", last_synced=now, row_count=42)
             )
             await session.commit()
 
-        async with open_engine.session() as session:
+        async with typed_cache_engine.session() as session:
             fetched = await session.get(SyncState, "sales_order")
             assert fetched is not None
             assert fetched.entity_type == "sales_order"
@@ -100,7 +101,7 @@ class TestCacheTables:
     """Generated cache-target tables are available on the engine."""
 
     @pytest.mark.asyncio
-    async def test_can_insert_and_query_sales_order(self, open_engine):
+    async def test_can_insert_and_query_sales_order(self, typed_cache_engine):
         """End-to-end: insert a SalesOrder + SalesOrderRow, traverse the
         relationship, query back. Proves the generator-emitted schema is
         live against the engine's SQLModel.metadata.create_all call."""
@@ -110,7 +111,7 @@ class TestCacheTables:
             SalesOrderStatus,
         )
 
-        async with open_engine.session() as session:
+        async with typed_cache_engine.session() as session:
             session.add(
                 SalesOrder(
                     id=1,
@@ -125,7 +126,7 @@ class TestCacheTables:
             )
             await session.commit()
 
-        async with open_engine.session() as session:
+        async with typed_cache_engine.session() as session:
             stmt = select(SalesOrder).where(SalesOrder.order_no == "SO-INT-001")
             result = await session.exec(stmt)
             order = result.one()
@@ -140,23 +141,23 @@ class TestLocks:
     """Per-entity asyncio.Lock registry."""
 
     @pytest.mark.asyncio
-    async def test_same_entity_returns_same_lock(self, open_engine):
-        a = open_engine.lock_for("sales_order")
-        b = open_engine.lock_for("sales_order")
+    async def test_same_entity_returns_same_lock(self, typed_cache_engine):
+        a = typed_cache_engine.lock_for("sales_order")
+        b = typed_cache_engine.lock_for("sales_order")
         assert a is b
 
     @pytest.mark.asyncio
-    async def test_different_entities_distinct_locks(self, open_engine):
-        a = open_engine.lock_for("sales_order")
-        b = open_engine.lock_for("manufacturing_order")
+    async def test_different_entities_distinct_locks(self, typed_cache_engine):
+        a = typed_cache_engine.lock_for("sales_order")
+        b = typed_cache_engine.lock_for("manufacturing_order")
         assert a is not b
 
     @pytest.mark.asyncio
-    async def test_lock_serializes_concurrent_holders(self, open_engine):
+    async def test_lock_serializes_concurrent_holders(self, typed_cache_engine):
         """Two coroutines contending on one lock acquire it sequentially,
         not simultaneously — the critical-section invariant sync helpers
         rely on."""
-        lock = open_engine.lock_for("sales_order")
+        lock = typed_cache_engine.lock_for("sales_order")
         order: list[str] = []
 
         async def hold(label: str) -> None:

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -646,358 +646,399 @@ def _make_mock_row(
     return r
 
 
-@pytest.mark.asyncio
-async def test_list_sales_orders_passes_explicit_filters():
-    """All explicit non-None filters end up in the API kwargs."""
-    context, _ = create_mock_context()
-    captured_kwargs: dict = {}
+# ----------------------------------------------------------------------------
+# Cache-seeding helpers (list_sales_orders reads from the SQLModel typed cache
+# after #342). Tests pre-populate the cache with ``CachedSalesOrder`` rows,
+# no-op the API-side sync via the ``no_sync`` fixture, and assert on the query
+# results — mirroring how the live tool behaves in steady state (cache warm,
+# sync returns zero rows).
+# ----------------------------------------------------------------------------
 
-    async def fake_asyncio_detailed(**kwargs):
-        captured_kwargs.update(kwargs)
-        return MagicMock()
 
-    request = ListSalesOrdersRequest(
-        order_no="SO-100",
-        customer_id=42,
-        location_id=7,
-        status="PENDING",
-        limit=25,
+@pytest.fixture
+def no_sync():
+    """Patch ``ensure_sales_orders_synced`` to a no-op for cache-backed tests.
+
+    Tests that seed the cache directly don't want the sync helper to fire
+    API calls; stubbing the sync point isolates the query-side behavior we
+    care about (filters, pagination, row projection).
+    """
+
+    async def _noop(_client, _cache):
+        return None
+
+    # The impl imports ``ensure_sales_orders_synced`` inline (deferred to
+    # keep the typed_cache module out of startup-time import chains), so we
+    # patch at the source module rather than the tool module.
+    with patch(
+        "katana_mcp.typed_cache.ensure_sales_orders_synced",
+        side_effect=_noop,
+    ):
+        yield
+
+
+async def _seed_orders(typed_cache, orders):
+    """Insert pre-built SQLModel SalesOrder rows into the test cache."""
+    async with typed_cache.session() as session:
+        for order in orders:
+            session.add(order)
+        await session.commit()
+
+
+def _make_cache_so(
+    *,
+    id: int = 1,
+    order_no: str = "SO-TEST",
+    customer_id: int = 42,
+    location_id: int = 1,
+    status=None,
+    production_status: str | None = "NONE",
+    invoicing_status: str | None = None,
+    created_at: datetime | None = None,
+    delivery_date: datetime | None = None,
+    updated_at: datetime | None = None,
+    total: float | None = 999.0,
+    currency: str | None = "USD",
+    deleted_at: datetime | None = None,
+    rows=None,
+):
+    """Build a SQLModel ``SalesOrder`` for direct cache insertion.
+
+    Uses naive UTC datetimes (the typed cache stores timestamps without
+    tzinfo — SQLite's default DateTime column doesn't preserve offsets).
+    """
+    from katana_public_api_client.models_pydantic._generated import (
+        SalesOrder as CachedSalesOrder,
+        SalesOrderStatus as CachedSalesOrderStatus,
     )
 
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake_asyncio_detailed),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-    ):
-        result = await _list_sales_orders_impl(request, context)
-
-    assert captured_kwargs["order_no"] == "SO-100"
-    assert captured_kwargs["customer_id"] == 42
-    assert captured_kwargs["location_id"] == 7
-    assert captured_kwargs["status"] == "PENDING"
-    assert captured_kwargs["limit"] == 25
-    assert "production_status" not in captured_kwargs
-    assert result.total_count == 0
-
-
-@pytest.mark.asyncio
-async def test_list_sales_orders_zero_valued_filters_are_passed_through():
-    """customer_id=0 / location_id=0 must be passed as filters, not dropped."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    request = ListSalesOrdersRequest(customer_id=0, location_id=0)
-
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_sales_orders_impl(request, context)
-
-    assert captured["customer_id"] == 0
-    assert captured["location_id"] == 0
-
-
-@pytest.mark.asyncio
-async def test_list_sales_orders_needs_work_orders_shortcut():
-    """needs_work_orders=True sets production_status=NONE."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    request = ListSalesOrdersRequest(needs_work_orders=True)
-
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_sales_orders_impl(request, context)
-
-    assert captured["production_status"] == "NONE"
-
-
-@pytest.mark.asyncio
-async def test_list_sales_orders_explicit_production_status_wins_over_shortcut():
-    """Explicit production_status overrides needs_work_orders=True."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    request = ListSalesOrdersRequest(
-        production_status="IN_PROGRESS",
-        needs_work_orders=True,
+    return CachedSalesOrder(
+        id=id,
+        order_no=order_no,
+        customer_id=customer_id,
+        location_id=location_id,
+        status=status if status is not None else CachedSalesOrderStatus.not_shipped,
+        production_status=production_status,
+        invoicing_status=invoicing_status,
+        created_at=created_at if created_at is not None else datetime(2026, 4, 1),
+        updated_at=updated_at,
+        delivery_date=delivery_date,
+        total=total,
+        currency=currency,
+        deleted_at=deleted_at,
+        sales_order_rows=rows if rows is not None else [],
     )
 
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_sales_orders_impl(request, context)
 
-    assert captured["production_status"] == "IN_PROGRESS"
+def _make_cache_row(
+    *,
+    id: int,
+    sales_order_id: int,
+    variant_id: int,
+    quantity: float = 1.0,
+    price_per_unit: float | None = None,
+    linked_manufacturing_order_id: int | None = None,
+):
+    """Build a SQLModel ``SalesOrderRow`` for direct cache insertion."""
+    from katana_public_api_client.models_pydantic._generated import (
+        SalesOrderRow as CachedSalesOrderRow,
+    )
+
+    return CachedSalesOrderRow(
+        id=id,
+        sales_order_id=sales_order_id,
+        variant_id=variant_id,
+        quantity=quantity,
+        price_per_unit=price_per_unit,
+        linked_manufacturing_order_id=linked_manufacturing_order_id,
+    )
+
+
+# ============================================================================
+# list_sales_orders — filter predicates (translated from API kwargs to SQL
+# WHERE clauses post-#342)
+# ============================================================================
 
 
 @pytest.mark.asyncio
-async def test_list_sales_orders_caps_results_to_request_limit():
-    """Regression for #329: even if transport returns more rows than asked,
-    the response is sliced to request.limit."""
-    context, _ = create_mock_context()
+async def test_list_sales_orders_passes_explicit_filters(
+    context_with_typed_cache, no_sync
+):
+    """Explicit filters translate to SQL predicates that narrow the result set."""
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(
+        typed_cache,
+        [
+            _make_cache_so(id=1, order_no="SO-100", customer_id=42),
+            _make_cache_so(id=2, order_no="SO-101", customer_id=43),
+            _make_cache_so(id=3, order_no="SO-102", customer_id=44),
+        ],
+    )
 
-    # Simulate transport returning way more rows than requested (this is the
-    # #329 symptom: auto-pagination flooded the response).
-    over_fetched = [_make_mock_so(id=i, order_no=f"SO-{i}") for i in range(200)]
+    result = await _list_sales_orders_impl(
+        ListSalesOrdersRequest(customer_id=42), context
+    )
 
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_SO_UNWRAP_DATA, return_value=over_fetched),
-    ):
-        request = ListSalesOrdersRequest(limit=50)
-        result = await _list_sales_orders_impl(request, context)
+    assert result.total_count == 1
+    assert result.orders[0].customer_id == 42
+    assert result.orders[0].order_no == "SO-100"
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_zero_valued_filters_are_passed_through(
+    context_with_typed_cache, no_sync
+):
+    """customer_id=0 is a valid predicate — must not be dropped as falsy."""
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(
+        typed_cache,
+        [
+            _make_cache_so(id=1, customer_id=0),
+            _make_cache_so(id=2, customer_id=1),
+        ],
+    )
+
+    result = await _list_sales_orders_impl(
+        ListSalesOrdersRequest(customer_id=0), context
+    )
+
+    assert result.total_count == 1
+    assert result.orders[0].id == 1
+    assert result.orders[0].customer_id == 0
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_needs_work_orders_shortcut(
+    context_with_typed_cache, no_sync
+):
+    """needs_work_orders=True maps to production_status=NONE."""
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(
+        typed_cache,
+        [
+            _make_cache_so(id=1, production_status="NONE"),
+            _make_cache_so(id=2, production_status="IN_PROGRESS"),
+        ],
+    )
+
+    result = await _list_sales_orders_impl(
+        ListSalesOrdersRequest(needs_work_orders=True), context
+    )
+
+    assert result.total_count == 1
+    assert result.orders[0].id == 1
+    assert result.orders[0].production_status == "NONE"
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_explicit_production_status_wins_over_shortcut(
+    context_with_typed_cache, no_sync
+):
+    """Explicit production_status overrides the needs_work_orders shortcut."""
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(
+        typed_cache,
+        [
+            _make_cache_so(id=1, production_status="NONE"),
+            _make_cache_so(id=2, production_status="IN_PROGRESS"),
+        ],
+    )
+
+    result = await _list_sales_orders_impl(
+        ListSalesOrdersRequest(production_status="IN_PROGRESS", needs_work_orders=True),
+        context,
+    )
+
+    assert result.total_count == 1
+    assert result.orders[0].id == 2
+    assert result.orders[0].production_status == "IN_PROGRESS"
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_server_side_date_filters_passed_through(
+    context_with_typed_cache, no_sync
+):
+    """created_after / created_before bound the ``created_at`` range inclusively."""
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(
+        typed_cache,
+        [
+            _make_cache_so(id=1, created_at=datetime(2025, 12, 15)),  # before window
+            _make_cache_so(id=2, created_at=datetime(2026, 2, 15)),  # inside
+            _make_cache_so(id=3, created_at=datetime(2026, 5, 1)),  # after window
+        ],
+    )
+
+    result = await _list_sales_orders_impl(
+        ListSalesOrdersRequest(
+            created_after="2026-01-01T00:00:00+00:00",
+            created_before="2026-04-01T00:00:00Z",
+        ),
+        context,
+    )
+
+    assert result.total_count == 1
+    assert result.orders[0].id == 2
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_ids_include_deleted_pass_through(
+    context_with_typed_cache, no_sync
+):
+    """``include_deleted=True`` surfaces soft-deleted rows; default hides them."""
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(
+        typed_cache,
+        [
+            _make_cache_so(id=1, deleted_at=None),
+            _make_cache_so(id=2, deleted_at=datetime(2026, 3, 15)),
+        ],
+    )
+
+    # Default hides soft-deleted rows.
+    default_result = await _list_sales_orders_impl(ListSalesOrdersRequest(), context)
+    assert default_result.total_count == 1
+    assert default_result.orders[0].id == 1
+
+    # include_deleted=True surfaces them.
+    with_deleted = await _list_sales_orders_impl(
+        ListSalesOrdersRequest(include_deleted=True), context
+    )
+    assert with_deleted.total_count == 2
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_delivered_filter_applied_server_side(
+    context_with_typed_cache, no_sync
+):
+    """delivery_date range is now an indexed SQL predicate (post-#342).
+
+    Renamed from ``..._client_side``: the pre-cache impl filtered these
+    post-fetch; with the typed cache they're plain SQL WHERE clauses.
+    """
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(
+        typed_cache,
+        [
+            _make_cache_so(id=1, delivery_date=datetime(2026, 4, 20)),  # in window
+            _make_cache_so(id=2, delivery_date=datetime(2027, 1, 1)),  # outside
+        ],
+    )
+
+    result = await _list_sales_orders_impl(
+        ListSalesOrdersRequest(
+            delivered_after="2026-04-01T00:00:00Z",
+            delivered_before="2026-04-30T00:00:00Z",
+        ),
+        context,
+    )
+
+    assert result.total_count == 1
+    assert result.orders[0].id == 1
+
+
+# ============================================================================
+# list_sales_orders — pagination + result shaping
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_caps_results_to_request_limit(
+    context_with_typed_cache, no_sync
+):
+    """``limit`` caps the result set at the SQL level (no over-fetch)."""
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(
+        typed_cache,
+        [_make_cache_so(id=i, order_no=f"SO-{i}") for i in range(1, 201)],
+    )
+
+    result = await _list_sales_orders_impl(ListSalesOrdersRequest(limit=50), context)
 
     assert len(result.orders) == 50
     assert result.total_count == 50
 
 
 @pytest.mark.asyncio
-async def test_list_sales_orders_passes_page_1_when_limit_fits_single_page():
-    """Regression for #329: when limit <= 250 (Katana page max), pass page=1
-    so PaginationTransport skips auto-pagination."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    request = ListSalesOrdersRequest(limit=10)
-
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_sales_orders_impl(request, context)
-
-    assert captured["page"] == 1
-    assert captured["limit"] == 10
-
-
-@pytest.mark.asyncio
-async def test_list_sales_orders_returns_summary_rows():
-    """Response rows carry order_no, totals, and row_count."""
-    context, _ = create_mock_context()
-    mock_so = _make_mock_so(
-        id=42,
-        order_no="SO-42",
-        total=1234.56,
-        rows=[
-            _make_mock_row(id=1, variant_id=100, quantity=2, price_per_unit=500.0),
-            _make_mock_row(id=2, variant_id=101, quantity=1, price_per_unit=234.56),
-        ],
+async def test_list_sales_orders_returns_summary_rows(
+    context_with_typed_cache, no_sync
+):
+    """Summaries carry id, order_no, total, and row_count from the cache."""
+    context, _, typed_cache = context_with_typed_cache
+    rows = [
+        _make_cache_row(id=1, sales_order_id=42, variant_id=100, quantity=2),
+        _make_cache_row(id=2, sales_order_id=42, variant_id=101, quantity=1),
+    ]
+    await _seed_orders(
+        typed_cache,
+        [_make_cache_so(id=42, order_no="SO-42", total=1234.56, rows=rows)],
     )
 
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_SO_UNWRAP_DATA, return_value=[mock_so]),
-    ):
-        result = await _list_sales_orders_impl(ListSalesOrdersRequest(), context)
+    result = await _list_sales_orders_impl(ListSalesOrdersRequest(), context)
 
     assert result.total_count == 1
-    assert result.orders[0].id == 42
-    assert result.orders[0].order_no == "SO-42"
-    assert result.orders[0].total == 1234.56
-    assert result.orders[0].row_count == 2
+    summary = result.orders[0]
+    assert summary.id == 42
+    assert summary.order_no == "SO-42"
+    assert summary.total == 1234.56
+    assert summary.row_count == 2
 
 
 @pytest.mark.asyncio
-async def test_list_sales_orders_page_forwards_and_parses_header():
-    """Explicit page forwards to API and x-pagination header populates PaginationMeta."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    # Build a response that carries the Katana `x-pagination` header format.
-    mock_response = MagicMock()
-    mock_response.headers = {
-        "x-pagination": (
-            '{"total_records":"100","total_pages":"2","offset":"0","page":"1",'
-            '"first_page":"true","last_page":"false"}'
-        )
-    }
-
-    async def fake_asyncio_detailed(**kwargs):
-        captured.update(kwargs)
-        return mock_response
-
-    request = ListSalesOrdersRequest(page=1, limit=50)
-
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake_asyncio_detailed),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-    ):
-        result = await _list_sales_orders_impl(request, context)
-
-    # Explicit page was forwarded to the API (which disables auto-pagination).
-    assert captured["page"] == 1
-    assert captured["limit"] == 50
-
-    assert result.pagination is not None
-    assert result.pagination.total_records == 100
-    assert result.pagination.total_pages == 2
-    assert result.pagination.page == 1
-    assert result.pagination.first_page is True
-    assert result.pagination.last_page is False
-
-
-@pytest.mark.asyncio
-async def test_list_sales_orders_no_page_leaves_pagination_none():
-    """When caller did not pass `page`, response.pagination stays None even
-    if the underlying request short-circuited with page=1 and the transport
-    passed through an `x-pagination` header — that header describes a single
-    internal page and would be misleading to surface to the caller."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    mock_response = MagicMock()
-    mock_response.headers = {
-        "x-pagination": (
-            '{"total_records":"100","total_pages":"2","offset":"0","page":"1",'
-            '"first_page":"true","last_page":"false"}'
-        )
-    }
-
-    async def fake_asyncio_detailed(**kwargs):
-        captured.update(kwargs)
-        return mock_response
-
-    # limit=50 <= 250 triggers the short-circuit that forwards page=1
-    # internally (see #329). We still must not surface pagination metadata
-    # because the *caller* did not request a specific page.
-    request = ListSalesOrdersRequest(limit=50)
-
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake_asyncio_detailed),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-    ):
-        result = await _list_sales_orders_impl(request, context)
-
-    # Short-circuit forwards page=1 internally, but pagination metadata is
-    # gated on the *request's* page field, not what we sent to the API.
-    assert captured["page"] == 1
-    assert result.pagination is None
-
-
-# ============================================================================
-# list_sales_orders — date filters + pattern v2 refinements
-# ============================================================================
-
-
-@pytest.mark.asyncio
-async def test_list_sales_orders_server_side_date_filters_passed_through():
-    """created_after/before + updated_after/before forward as datetime kwargs."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    request = ListSalesOrdersRequest(
-        created_after="2026-01-01T00:00:00+00:00",
-        created_before="2026-04-01T00:00:00Z",
-        updated_after="2026-02-01T00:00:00z",
-        updated_before="2026-03-31T23:59:59+00:00",
+async def test_list_sales_orders_page_populates_pagination_meta(
+    context_with_typed_cache, no_sync
+):
+    """Explicit ``page`` populates PaginationMeta from a SQL COUNT(*)."""
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(
+        typed_cache,
+        [_make_cache_so(id=i, order_no=f"SO-{i}") for i in range(1, 31)],
     )
 
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_sales_orders_impl(request, context)
+    result = await _list_sales_orders_impl(
+        ListSalesOrdersRequest(page=2, limit=10), context
+    )
 
-    assert isinstance(captured["created_at_min"], datetime)
-    assert isinstance(captured["created_at_max"], datetime)
-    assert isinstance(captured["updated_at_min"], datetime)
-    assert isinstance(captured["updated_at_max"], datetime)
-    # Z / z normalized to +00:00
-    assert captured["created_at_max"].tzinfo is not None
-    assert captured["updated_at_min"].tzinfo is not None
+    assert result.pagination is not None
+    assert result.pagination.total_records == 30
+    assert result.pagination.total_pages == 3
+    assert result.pagination.page == 2
+    assert result.pagination.first_page is False
+    assert result.pagination.last_page is False
+    assert len(result.orders) == 10
 
 
 @pytest.mark.asyncio
-async def test_list_sales_orders_invalid_server_date_raises():
-    """Malformed ISO-8601 for a server-side date surfaces as ValueError."""
-    context, _ = create_mock_context()
+async def test_list_sales_orders_no_page_leaves_pagination_none(
+    context_with_typed_cache, no_sync
+):
+    """Without explicit ``page``, ``pagination`` stays None — the cache has
+    no equivalent of a server-side ``x-pagination`` header to leak through."""
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(typed_cache, [_make_cache_so(id=i) for i in range(1, 6)])
 
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-        pytest.raises(ValueError, match=r"Invalid ISO-8601.*created_after"),
-    ):
+    result = await _list_sales_orders_impl(ListSalesOrdersRequest(), context)
+
+    assert result.pagination is None
+    assert result.total_count == 5
+
+
+# ============================================================================
+# list_sales_orders — validation
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_sales_orders_invalid_server_date_raises(
+    context_with_typed_cache, no_sync
+):
+    """Malformed ISO-8601 in a date filter surfaces as ValueError."""
+    context, _, _ = context_with_typed_cache
+
+    with pytest.raises(ValueError, match=r"Invalid ISO-8601.*created_after"):
         await _list_sales_orders_impl(
             ListSalesOrdersRequest(created_after="not-a-date"), context
         )
-
-
-@pytest.mark.asyncio
-async def test_list_sales_orders_delivered_filter_applied_client_side():
-    """delivered_after/before filter post-fetch (Katana has no server param)."""
-    context, _ = create_mock_context()
-
-    sos = [
-        _make_mock_so(id=1, order_no="SO-1"),
-        _make_mock_so(id=2, order_no="SO-2"),
-    ]
-    # SO-1 has delivery_date=2026-04-20 (from _make_mock_so default).
-    # Push SO-2 to 2027-01-01 — outside the filter window.
-    sos[1].delivery_date = datetime(2027, 1, 1, tzinfo=UTC)
-
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_SO_UNWRAP_DATA, return_value=sos),
-    ):
-        result = await _list_sales_orders_impl(
-            ListSalesOrdersRequest(
-                delivered_after="2026-04-01T00:00:00Z",
-                delivered_before="2026-04-30T00:00:00Z",
-            ),
-            context,
-        )
-
-    assert result.total_count == 1
-    assert result.orders[0].id == 1
-
-
-@pytest.mark.asyncio
-async def test_list_sales_orders_skips_page1_short_circuit_when_delivered_filter_set():
-    """When a client-side delivered filter is active, don't short-circuit page=1
-    so auto-pagination can scan enough rows post-filter."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    request = ListSalesOrdersRequest(limit=10, delivered_after="2026-04-01T00:00:00Z")
-
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_sales_orders_impl(request, context)
-
-    # page must NOT be set because we need auto-pagination to scan enough
-    # rows to post-filter down to `limit`.
-    assert "page" not in captured
-    assert captured["limit"] == 10
 
 
 @pytest.mark.asyncio
@@ -1018,51 +1059,24 @@ async def test_list_sales_orders_page_ge_1_validation():
         ListSalesOrdersRequest(page=0)
 
 
-@pytest.mark.asyncio
-async def test_list_sales_orders_ids_include_deleted_pass_through():
-    """ids and include_deleted forward to API kwargs when set."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    request = ListSalesOrdersRequest(ids=[1, 2, 3], include_deleted=True)
-
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SO_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_sales_orders_impl(request, context)
-
-    assert captured["ids"] == [1, 2, 3]
-    assert captured["include_deleted"] is True
-
-
 # ============================================================================
 # list_sales_orders — include_rows (#332)
 # ============================================================================
 
 
 @pytest.mark.asyncio
-async def test_list_sales_orders_include_rows_default_false_leaves_rows_none():
+async def test_list_sales_orders_include_rows_default_false_leaves_rows_none(
+    context_with_typed_cache, no_sync
+):
     """By default summaries carry rows=None (only row_count is populated)."""
-    context, _ = create_mock_context()
-    mock_so = _make_mock_so(
-        id=1,
-        order_no="SO-1",
-        rows=[
-            _make_mock_row(id=10, variant_id=100, quantity=2, price_per_unit=50.0),
-            _make_mock_row(id=11, variant_id=101, quantity=1, price_per_unit=75.0),
-        ],
-    )
+    context, _, typed_cache = context_with_typed_cache
+    rows = [
+        _make_cache_row(id=10, sales_order_id=1, variant_id=100, quantity=2),
+        _make_cache_row(id=11, sales_order_id=1, variant_id=101, quantity=1),
+    ]
+    await _seed_orders(typed_cache, [_make_cache_so(id=1, order_no="SO-1", rows=rows)])
 
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_SO_UNWRAP_DATA, return_value=[mock_so]),
-    ):
-        result = await _list_sales_orders_impl(ListSalesOrdersRequest(), context)
+    result = await _list_sales_orders_impl(ListSalesOrdersRequest(), context)
 
     assert result.total_count == 1
     assert result.orders[0].row_count == 2
@@ -1070,80 +1084,78 @@ async def test_list_sales_orders_include_rows_default_false_leaves_rows_none():
 
 
 @pytest.mark.asyncio
-async def test_list_sales_orders_include_rows_true_populates_rows():
+async def test_list_sales_orders_include_rows_true_populates_rows(
+    context_with_typed_cache, no_sync
+):
     """include_rows=True surfaces per-row detail from sales_order_rows."""
-    context, _ = create_mock_context()
-    mock_so = _make_mock_so(
-        id=42,
-        order_no="SO-42",
-        rows=[
-            _make_mock_row(
-                id=10,
-                variant_id=100,
-                quantity=2,
-                price_per_unit=50.0,
-                linked_mo_id=555,
-            ),
-            _make_mock_row(id=11, variant_id=101, quantity=1, price_per_unit=75.0),
-        ],
+    context, _, typed_cache = context_with_typed_cache
+    rows = [
+        _make_cache_row(
+            id=10,
+            sales_order_id=42,
+            variant_id=100,
+            quantity=2,
+            price_per_unit=50.0,
+            linked_manufacturing_order_id=555,
+        ),
+        _make_cache_row(
+            id=11,
+            sales_order_id=42,
+            variant_id=101,
+            quantity=1,
+            price_per_unit=75.0,
+        ),
+    ]
+    await _seed_orders(
+        typed_cache, [_make_cache_so(id=42, order_no="SO-42", rows=rows)]
     )
 
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_SO_UNWRAP_DATA, return_value=[mock_so]),
-    ):
-        result = await _list_sales_orders_impl(
-            ListSalesOrdersRequest(include_rows=True), context
-        )
+    result = await _list_sales_orders_impl(
+        ListSalesOrdersRequest(include_rows=True), context
+    )
 
-    assert result.total_count == 1
     summary = result.orders[0]
-    assert summary.row_count == 2
     assert summary.rows is not None
     assert len(summary.rows) == 2
 
-    first, second = summary.rows
-    assert first.id == 10
-    assert first.variant_id == 100
-    assert first.quantity == 2
-    assert first.price_per_unit == 50.0
-    assert first.linked_manufacturing_order_id == 555
+    by_id = {r.id: r for r in summary.rows}
+    assert by_id[10].variant_id == 100
+    assert by_id[10].quantity == 2
+    assert by_id[10].price_per_unit == 50.0
+    assert by_id[10].linked_manufacturing_order_id == 555
     # sku is intentionally None in list context (get_sales_order enriches).
-    assert first.sku is None
+    assert by_id[10].sku is None
 
-    assert second.id == 11
-    assert second.variant_id == 101
-    assert second.linked_manufacturing_order_id is None
+    assert by_id[11].variant_id == 101
+    assert by_id[11].linked_manufacturing_order_id is None
 
 
 @pytest.mark.asyncio
-async def test_list_sales_orders_include_rows_handles_unset_fields():
-    """A row with UNSET optional fields surfaces as None instead of raising."""
-    context, _ = create_mock_context()
+async def test_list_sales_orders_include_rows_handles_unset_fields(
+    context_with_typed_cache, no_sync
+):
+    """Rows with None-valued optional fields serialize without crashing."""
+    context, _, typed_cache = context_with_typed_cache
+    sparse_row = _make_cache_row(
+        id=99,
+        sales_order_id=1,
+        variant_id=500,
+        quantity=1.0,
+        price_per_unit=None,
+        linked_manufacturing_order_id=None,
+    )
+    await _seed_orders(
+        typed_cache, [_make_cache_so(id=1, order_no="SO-1", rows=[sparse_row])]
+    )
 
-    # Row with UNSET price_per_unit and UNSET quantity — should map to None.
-    sparse_row = MagicMock()
-    sparse_row.id = 99
-    sparse_row.variant_id = UNSET
-    sparse_row.quantity = UNSET
-    sparse_row.price_per_unit = UNSET
-    sparse_row.linked_manufacturing_order_id = UNSET
-
-    mock_so = _make_mock_so(id=1, order_no="SO-1", rows=[sparse_row])
-
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_SO_UNWRAP_DATA, return_value=[mock_so]),
-    ):
-        result = await _list_sales_orders_impl(
-            ListSalesOrdersRequest(include_rows=True), context
-        )
+    result = await _list_sales_orders_impl(
+        ListSalesOrdersRequest(include_rows=True), context
+    )
 
     assert result.orders[0].rows is not None
     row = result.orders[0].rows[0]
     assert row.id == 99
-    assert row.variant_id is None
-    assert row.quantity is None
+    assert row.variant_id == 500
     assert row.price_per_unit is None
     assert row.linked_manufacturing_order_id is None
     assert row.sku is None
@@ -1550,16 +1562,14 @@ def _content_text(result) -> str:
 
 
 @pytest.mark.asyncio
-async def test_list_sales_orders_format_json_returns_json():
+async def test_list_sales_orders_format_json_returns_json(
+    context_with_typed_cache, no_sync
+):
     """format='json' returns JSON-parseable content."""
-    context, _ = create_mock_context()
-    mock_so = _make_mock_so(id=1, order_no="SO-1")
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(typed_cache, [_make_cache_so(id=1, order_no="SO-1")])
 
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_SO_UNWRAP_DATA, return_value=[mock_so]),
-    ):
-        result = await list_sales_orders(format="json", context=context)
+    result = await list_sales_orders(format="json", context=context)
 
     data = json.loads(_content_text(result))
     assert data["total_count"] == 1
@@ -1567,16 +1577,14 @@ async def test_list_sales_orders_format_json_returns_json():
 
 
 @pytest.mark.asyncio
-async def test_list_sales_orders_format_markdown_default():
+async def test_list_sales_orders_format_markdown_default(
+    context_with_typed_cache, no_sync
+):
     """Default markdown format produces a table."""
-    context, _ = create_mock_context()
-    mock_so = _make_mock_so(id=1, order_no="SO-1")
+    context, _, typed_cache = context_with_typed_cache
+    await _seed_orders(typed_cache, [_make_cache_so(id=1, order_no="SO-1")])
 
-    with (
-        patch(f"{_SO_GET_ALL}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_SO_UNWRAP_DATA, return_value=[mock_so]),
-    ):
-        result = await list_sales_orders(context=context)
+    result = await list_sales_orders(context=context)
 
     text = _content_text(result)
     assert "|" in text  # markdown table


### PR DESCRIPTION
## Summary

Closes #368. First tool to consume the #342 typed-cache runtime. Three moving pieces:

1. **Tool impl migration** — `_list_sales_orders_impl` reads from `services.typed_cache` via SQL instead of hitting the Katana API on every call.
2. **Test rewrite** — 18 tests that asserted on API-kwargs capture rewritten to seed the cache and assert on returned rows (the old contract wasn't meaningful for cache-backed).
3. **In-memory SQLite for tests** (Pattern 1) — `TypedCacheEngine(in_memory=True)` + `StaticPool`; `test_typed_cache.py` and the new `context_with_typed_cache` fixture converge on one pattern.

## Tool impl

- Calls `ensure_sales_orders_synced` (incremental delta via `updated_at_min`; near-zero cost steady state).
- Builds `select(SalesOrder)` with `selectinload` for rows and `_apply_sales_order_filters` for WHERE clauses. Filter helper is shared between the data SELECT and the COUNT(*) SELECT used for pagination meta, so the two stay in sync.
- `delivery_date` filters become indexed SQL range queries (previously client-side post-fetch — Katana has no server-side equivalent; the cache makes it first-class).
- `ORDER BY created_at DESC, id DESC`, `LIMIT`/`OFFSET` for pagination.
- `PaginationMeta` populated from `SELECT COUNT(*)` when `page` is set; `None` otherwise.

## Test plumbing (Pattern 1)

`TypedCacheEngine` gains an `in_memory: bool = False` kwarg. When true:

```python
create_async_engine(
    "sqlite+aiosqlite:///:memory:",
    poolclass=StaticPool,
    connect_args={"check_same_thread": False},
)
```

The `StaticPool` + `check_same_thread=False` is the canonical async `:memory:` pairing — one connection shared across sessions so seeded data persists across session boundaries within an engine.

New `typed_cache_engine` fixture replaces the per-test `tmp_path`-backed file. `context_with_typed_cache` composes on top of it. `test_typed_cache.py` migrates to the shared fixture, dropping the hand-rolled `tempfile.TemporaryDirectory` pattern; added a focused `test_open_creates_db_file` as a regression guard for the file-backed path.

**Pattern 2 follow-up tracked in #372** — session-scoped engine + per-test SAVEPOINT rollback. Right move once the cache-back epic reaches 4 more entity tools and scaling matters.

## Test rewrite summary

- **7 filter-predicate tests** rewritten: seed cache rows, call impl, assert returned rows match.
- **5 shape tests** migrated: include_rows true/false, unset handling, summary fields.
- **2 pagination tests** rewritten: page populates `PaginationMeta` with total_records / total_pages / first_page / last_page; no-page leaves `None`.
- **2 format tests** migrated (json / markdown).
- **3 validation tests** kept (pydantic bounds, invalid ISO date).
- **2 obsolete tests deleted** — pagination short-circuit logic is gone with cache-backing.

## Verification

- [x] `uv run poe check` clean
- [x] 2438 tests pass (was 2438 before; 2 deleted, 2 added — net unchanged)
- [x] `delivery_date` windowing works server-side via indexed SQL
- [x] `PaginationMeta.total_records` reflects full filter set (count uses same WHERE clauses as data query)
- [x] In-memory engine persists data across sessions within one engine (StaticPool)
- [x] Followed the established pattern from SQLModel's testing docs

## Follow-up

- **#372** — Pattern 2 (session-scoped + SAVEPOINT rollback) as suite grows
- **#370** — fat-module splits + complexity ratchet
- **#371** — small tech-debt sweep (bare except handlers, inventory TODOs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)