### PR TITLE
chore(mcp): simplify PR #373 list_sales_orders cache-back

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -429,24 +429,15 @@ class ListSalesOrdersRequest(BaseModel):
         default=None, description="ISO-8601 datetime upper bound on updated_at."
     )
 
-    # Time-window filters (client-side — Katana does not expose
-    # delivery_date_min/max as server-side filters, so the tool applies them
-    # after fetch).
+    # Time-window filters on delivery_date (applied as indexed SQL range
+    # queries against the local cache post-#342).
     delivered_after: str | None = Field(
         default=None,
-        description=(
-            "ISO-8601 datetime lower bound on delivery_date. Applied "
-            "client-side — Katana does not expose a server-side filter "
-            "for delivery_date, so this filters post-fetch. Combine with a "
-            "created_at window to keep fetched rows bounded."
-        ),
+        description="ISO-8601 datetime lower bound on delivery_date.",
     )
     delivered_before: str | None = Field(
         default=None,
-        description=(
-            "ISO-8601 datetime upper bound on delivery_date. Applied "
-            "client-side — see `delivered_after`."
-        ),
+        description="ISO-8601 datetime upper bound on delivery_date.",
     )
 
     # Row inclusion
@@ -508,9 +499,7 @@ class ListSalesOrdersResponse(BaseModel):
         default=None,
         description=(
             "Pagination metadata — populated when the caller requests a "
-            "specific `page`. Computed locally from `SELECT COUNT(*)` "
-            "against the typed cache (post-#342); `None` when the caller "
-            "does not drive paging explicitly."
+            "specific `page`; `None` otherwise."
         ),
     )
 
@@ -530,12 +519,44 @@ def _naive_utc(dt: datetime | None) -> datetime | None:
     return dt
 
 
-def _apply_sales_order_filters(stmt: Any, request: ListSalesOrdersRequest) -> Any:
+def _parse_date_filters(
+    request: ListSalesOrdersRequest,
+) -> dict[str, datetime | None]:
+    """Parse every ISO-8601 date filter on the request to naive UTC.
+
+    Run once in the impl so repeated calls to ``_apply_sales_order_filters``
+    (data SELECT + COUNT SELECT on the paginated path) don't re-parse the
+    same strings.
+    """
+    names = (
+        "created_after",
+        "created_before",
+        "updated_after",
+        "updated_before",
+        "delivered_after",
+        "delivered_before",
+    )
+    result: dict[str, datetime | None] = {}
+    for name in names:
+        raw = getattr(request, name)
+        result[name] = (
+            _naive_utc(parse_iso_datetime(raw, name)) if raw is not None else None
+        )
+    return result
+
+
+def _apply_sales_order_filters(
+    stmt: Any,
+    request: ListSalesOrdersRequest,
+    parsed_dates: dict[str, datetime | None],
+) -> Any:
     """Translate request filters into WHERE clauses on a ``SalesOrder`` query.
 
-    Shared by both the data SELECT and the COUNT SELECT used for
-    ``PaginationMeta`` — keeps the two queries in sync so pagination
-    totals reflect the same filter set.
+    Shared by the data SELECT and the COUNT SELECT so pagination totals
+    reflect exactly the same filter set as the data rows. ``parsed_dates``
+    must come from :func:`_parse_date_filters` — keeping parsing out of
+    this function lets the paginated path avoid re-parsing on the COUNT
+    query.
     """
     from katana_public_api_client.models_pydantic._generated import (
         SalesOrder as CachedSalesOrder,
@@ -555,11 +576,8 @@ def _apply_sales_order_filters(stmt: Any, request: ListSalesOrdersRequest) -> An
         stmt = stmt.where(CachedSalesOrder.customer_id == request.customer_id)
     if request.location_id is not None:
         stmt = stmt.where(CachedSalesOrder.location_id == request.location_id)
-    # Enum-typed filters: validate + coerce to the actual enum members so
-    # invalid input raises loudly instead of returning an empty result set.
-    # Enum-column comparisons in SQLAlchemy are safest when both sides are
-    # the enum member; string equality happens to work for StrEnum today
-    # but the coercion makes the contract explicit.
+    # Enum-typed filters: validate + coerce so invalid input raises
+    # loudly instead of silently returning an empty set.
     if request.status is not None:
         try:
             status_enum = SalesOrderStatus(request.status)
@@ -583,43 +601,21 @@ def _apply_sales_order_filters(stmt: Any, request: ListSalesOrdersRequest) -> An
     if not request.include_deleted:
         stmt = stmt.where(CachedSalesOrder.deleted_at.is_(None))
 
-    # Date windows — all indexed SQL range queries. No more split
-    # server-side/client-side distinction; ``delivery_date`` filters
-    # that previously ran post-fetch now run inline.
-    if request.created_after is not None:
-        stmt = stmt.where(
-            CachedSalesOrder.created_at
-            >= _naive_utc(parse_iso_datetime(request.created_after, "created_after"))
-        )
-    if request.created_before is not None:
-        stmt = stmt.where(
-            CachedSalesOrder.created_at
-            <= _naive_utc(parse_iso_datetime(request.created_before, "created_before"))
-        )
-    if request.updated_after is not None:
-        stmt = stmt.where(
-            CachedSalesOrder.updated_at
-            >= _naive_utc(parse_iso_datetime(request.updated_after, "updated_after"))
-        )
-    if request.updated_before is not None:
-        stmt = stmt.where(
-            CachedSalesOrder.updated_at
-            <= _naive_utc(parse_iso_datetime(request.updated_before, "updated_before"))
-        )
-    if request.delivered_after is not None:
-        stmt = stmt.where(
-            CachedSalesOrder.delivery_date
-            >= _naive_utc(
-                parse_iso_datetime(request.delivered_after, "delivered_after")
-            )
-        )
-    if request.delivered_before is not None:
-        stmt = stmt.where(
-            CachedSalesOrder.delivery_date
-            <= _naive_utc(
-                parse_iso_datetime(request.delivered_before, "delivered_before")
-            )
-        )
+    # Date windows — all indexed SQL range queries. ``delivery_date``
+    # now participates (was post-fetch client-side before cache-back).
+    date_columns: list[tuple[str, Any, str]] = [
+        ("created_after", CachedSalesOrder.created_at, ">="),
+        ("created_before", CachedSalesOrder.created_at, "<="),
+        ("updated_after", CachedSalesOrder.updated_at, ">="),
+        ("updated_before", CachedSalesOrder.updated_at, "<="),
+        ("delivered_after", CachedSalesOrder.delivery_date, ">="),
+        ("delivered_before", CachedSalesOrder.delivery_date, "<="),
+    ]
+    for name, col, comp in date_columns:
+        dt = parsed_dates[name]
+        if dt is None:
+            continue
+        stmt = stmt.where(col >= dt if comp == ">=" else col <= dt)
 
     return stmt
 
@@ -642,6 +638,7 @@ async def _list_sales_orders_impl(
     from katana_mcp.typed_cache import ensure_sales_orders_synced
     from katana_public_api_client.models_pydantic._generated import (
         SalesOrder as CachedSalesOrder,
+        SalesOrderRow as CachedSalesOrderRow,
     )
 
     services = get_services(context)
@@ -649,28 +646,43 @@ async def _list_sales_orders_impl(
     # 1. Refresh the cache (incremental — near-zero cost steady state).
     await ensure_sales_orders_synced(services.client, services.typed_cache)
 
-    # 2. Build the data query with filters + ordering + pagination.
-    # Eager-load rows always so we can report ``row_count`` accurately even
-    # when ``include_rows=False``, and serialize the detail when asked.
-    stmt = select(CachedSalesOrder).options(
-        selectinload(CachedSalesOrder.sales_order_rows)
+    # 2. Parse date filters once so the data SELECT and the (optional)
+    # COUNT SELECT don't each re-parse the same ISO-8601 strings.
+    parsed_dates = _parse_date_filters(request)
+
+    # 3. Build the data query. Pair each row with a scalar-subquery
+    # ``row_count`` so the common ``include_rows=False`` case doesn't pay
+    # the selectinload cost of materializing every line item just to
+    # report counts. Only eager-load the row detail when the caller asks
+    # for it.
+    row_count_subq = (
+        select(func.count(CachedSalesOrderRow.id))
+        .where(CachedSalesOrderRow.sales_order_id == CachedSalesOrder.id)
+        .correlate(CachedSalesOrder)
+        .scalar_subquery()
+        .label("row_count")
     )
-    stmt = _apply_sales_order_filters(stmt, request)
+    stmt = select(CachedSalesOrder, row_count_subq)
+    if request.include_rows:
+        stmt = stmt.options(selectinload(CachedSalesOrder.sales_order_rows))
+    stmt = _apply_sales_order_filters(stmt, request, parsed_dates)
     stmt = stmt.order_by(CachedSalesOrder.created_at.desc(), CachedSalesOrder.id.desc())
     if request.page is not None:
         stmt = stmt.offset((request.page - 1) * request.limit).limit(request.limit)
     else:
         stmt = stmt.limit(request.limit)
 
-    # 3. Execute data query and (when paginating) a separate COUNT for meta.
+    # 4. Execute data query and (when paginating) a separate COUNT for meta.
     async with services.typed_cache.session() as session:
         data_result = await session.exec(stmt)
-        cached_orders = list(data_result.all())
+        orders_with_counts: list[tuple[CachedSalesOrder, int]] = data_result.all()
 
         pagination: PaginationMeta | None = None
         if request.page is not None:
             count_stmt = _apply_sales_order_filters(
-                select(func.count()).select_from(CachedSalesOrder), request
+                select(func.count()).select_from(CachedSalesOrder),
+                request,
+                parsed_dates,
             )
             total_records = (await session.exec(count_stmt)).one()
             total_pages = (total_records + request.limit - 1) // request.limit
@@ -682,11 +694,10 @@ async def _list_sales_orders_impl(
                 last_page=request.page >= total_pages,
             )
 
-    # 4. Materialize summaries. ``sku`` stays None — resolving it would
+    # 5. Materialize summaries. ``sku`` stays None — resolving it would
     # require a variant lookup per row and defeat the single-query win.
     orders: list[SalesOrderSummary] = []
-    for so in cached_orders:
-        rows = so.sales_order_rows
+    for so, row_count in orders_with_counts:
         row_infos: list[SalesOrderRowInfo] | None = None
         if request.include_rows:
             row_infos = [
@@ -698,7 +709,7 @@ async def _list_sales_orders_impl(
                     price_per_unit=r.price_per_unit,
                     linked_manufacturing_order_id=r.linked_manufacturing_order_id,
                 )
-                for r in rows
+                for r in so.sales_order_rows
             ]
         orders.append(
             SalesOrderSummary(
@@ -713,7 +724,7 @@ async def _list_sales_orders_impl(
                 delivery_date=iso_or_none(so.delivery_date),
                 total=so.total,
                 currency=so.currency,
-                row_count=len(rows),
+                row_count=row_count,
                 rows=row_infos,
             )
         )
@@ -739,13 +750,11 @@ async def list_sales_orders(
     - `status="NOT_SHIPPED"` — unshipped orders
     - `customer_id=N` — orders for a specific customer
 
-    **Time windows:**
-    - `created_after` / `created_before` — server-side bounds on `created_at`
-    - `updated_after` / `updated_before` — server-side bounds on `updated_at`
-    - `delivered_after` / `delivered_before` — client-side bounds on
-      `delivery_date` (Katana has no server-side filter). When set, the tool
-      skips the page=1 short-circuit so auto-pagination can scan enough rows
-      to find `limit` matching results post-filter.
+    **Time windows** — all applied as indexed SQL range queries against
+    the local cache (post-#342 cache-back):
+    - `created_after` / `created_before` — bounds on `created_at`
+    - `updated_after` / `updated_before` — bounds on `updated_at`
+    - `delivered_after` / `delivered_before` — bounds on `delivery_date`
 
     **Row detail:**
     - `include_rows=true` — populate per-order row details (id, variant_id,

--- a/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
@@ -99,10 +99,16 @@ class TypedCacheEngine:
                 connect_args={"check_same_thread": False},
             )
         else:
-            assert self._db_path is not None  # guaranteed by __init__
-            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            # ``_db_path`` is never None on this branch (``__init__`` only
+            # leaves it unset when ``in_memory`` is true), but narrow the
+            # type explicitly so static checkers see it.
+            db_path = self._db_path
+            if db_path is None:
+                msg = "TypedCacheEngine: db_path is required for file-backed mode"
+                raise RuntimeError(msg)
+            db_path.parent.mkdir(parents=True, exist_ok=True)
             self._engine = create_async_engine(
-                f"sqlite+aiosqlite:///{self._db_path}",
+                f"sqlite+aiosqlite:///{db_path}",
             )
         async with self._engine.begin() as conn:
             await conn.run_sync(SQLModel.metadata.create_all)

--- a/katana_mcp_server/tests/conftest.py
+++ b/katana_mcp_server/tests/conftest.py
@@ -144,11 +144,10 @@ async def context_with_typed_cache(typed_cache_engine):
     """Mock context with a real in-memory ``TypedCacheEngine`` attached.
 
     Cache-backed tools (``list_sales_orders`` post-#342) need a real
-    ``TypedCacheEngine`` on ``services.typed_cache`` — ``MagicMock``
-    isn't usable as an ``async with`` session. Tests that mock
-    ``get_all_sales_orders.asyncio_detailed`` have their attrs return
-    values convert + upsert into the cache via the sync helper before
-    the tool queries it.
+    engine on ``services.typed_cache`` — ``MagicMock`` isn't usable as
+    an ``async with`` session. Tests typically seed the cache directly
+    via the engine's session and patch the sync helper to a no-op so
+    the tool reads the seeded rows without attempting an API fetch.
 
     Yields:
         Tuple of ``(context, lifespan_context, typed_cache_engine)``.


### PR DESCRIPTION
## Summary

`/simplify` pass on the just-merged PR #373 (list_sales_orders cache-back). Six findings applied directly; three promotion opportunities deferred to #374.

## Fixes

### Efficiency (blocking)

**Conditional row loading + scalar `row_count` subquery.** The impl was calling `selectinload(sales_order_rows)` unconditionally — in the common `include_rows=False` case, every query fetched every line item just so the materialization loop could compute `row_count=len(rows)`. For a 50-order/3-row-avg response, that's 150 extra rows of I/O and memory on every default call.

Replaced with a correlated scalar subquery column:
```python
row_count_subq = (
    select(func.count(CachedSalesOrderRow.id))
    .where(CachedSalesOrderRow.sales_order_id == CachedSalesOrder.id)
    .correlate(CachedSalesOrder)
    .scalar_subquery()
    .label("row_count")
)
stmt = select(CachedSalesOrder, row_count_subq)
if request.include_rows:
    stmt = stmt.options(selectinload(CachedSalesOrder.sales_order_rows))
```

Result rows are now `(SalesOrder, row_count)` tuples; loop destructures directly. One round trip, no wasted row data.

### Quality (blocking)

- Dropped redundant `list(data_result.all())` — `.all()` already returns `list[T]`.
- Stripped internal references (`SELECT COUNT(*)`, `post-#342`) from the user-facing `ListSalesOrdersResponse.pagination` field description. Field descriptions appear in MCP tool schemas.

### Parse-once date filters (efficiency + quality)

New `_parse_date_filters(request)` helper runs once in the impl; `_apply_sales_order_filters` takes pre-parsed datetimes. Previously the paginated path called `_apply_sales_order_filters` twice (data SELECT + COUNT SELECT), each re-parsing the same ISO strings.

Also folded the 6 copy-paste date-range branches into a single table-driven loop.

### Other

- Replaced `assert self._db_path is not None` in `engine.py` with an explicit `raise RuntimeError` — `assert` is stripped by `-O`.
- Updated the stale `context_with_typed_cache` fixture docstring (described the old "mock attrs → sync → cache" flow; tests now seed the cache directly).

## Deferred (#374)

Three promotion opportunities caught but held for the second cache-backed tool migration (manufacturing/purchase/stock) so we design against n≥2 samples instead of premature-factoring at n=1:

- Move `_naive_utc` to `tool_result_utils`
- Generalize `no_sync` fixture (factory keyed on entity type)
- Extract `_make_cache_so` / `_make_cache_row` to `tests/factories.py`

## Verification

- [x] `uv run poe check` passes clean
- [x] 2438 tests pass (same as PR #373 baseline)
- [x] No API shape changes — request filters, response schema, pagination semantics all identical
- [x] Row counts are now computed by a single SQL subquery regardless of `include_rows`; row detail serialized only when asked

🤖 Generated with [Claude Code](https://claude.com/claude-code)