### PR TITLE
feat(client+mcp): cache-back list_stock_adjustments + emit Cached<Name> sibling classes (#376)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,19 @@ Common mistakes to avoid:
 - **None-to-UNSET conversion** - When building attrs API request models from optional
   fields, use `to_unset(value)` from `katana_public_api_client.domain.converters`
   instead of `value if value is not None else UNSET`.
+- **Polluting the API spec/models with cache-only fields** - The OpenAPI spec at
+  `docs/katana-openapi.yaml` and the generated pydantic models in
+  `katana_public_api_client/models_pydantic/_generated/*.py` reflect Katana's actual
+  wire contract. **Never** add fields to the spec or inject fields into the API
+  pydantic classes to satisfy cache-schema, MCP-tool, or other consumer needs. Cache
+  schemas live on sibling `Cached<Name>` classes emitted by the same generator pass —
+  the API class stays pure pydantic, the cache class carries `table=True`, foreign
+  keys, relationships, JSON columns, and any cache-only fields. See
+  `scripts/generate_pydantic_models.py::duplicate_cache_tables_as_cached_siblings`
+  and `katana_mcp_server/src/katana_mcp/typed_cache/sync.py::_attrs_<entity>_to_cached`
+  for the conversion pattern: attrs → API pydantic (via the registry) → cache pydantic
+  (via `model_dump`/`model_validate`), with relationship fields set after construction
+  since SQLModel `Relationship` descriptors don't accept input via `__init__`.
 
 ## Using the LSP tool
 

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -447,27 +447,23 @@ Create a stock adjustment to correct inventory levels.
 ---
 
 ### list_stock_adjustments
-List existing stock adjustments with filters, paging, and optional row detail.
+List existing stock adjustments with filters, paging, and optional row detail. Cache-backed
+post-#376 — all filters run as indexed SQL queries against the SQLModel typed cache, so
+`variant_id` finds matches regardless of how many adjustments precede them in the cache.
 
-**Parameters (server-side filters):**
+**Parameters:**
 - `limit` (optional, default 50, min 1, max 250): Max adjustments to return — also the page size when `page` is set
-- `page` (optional, min 1): Page number (1-based); when set, disables auto-pagination and the response includes `pagination` metadata
+- `page` (optional, min 1): Page number (1-based); when set, the response includes `pagination` metadata (total_records, total_pages) computed via SQL COUNT against the same filter predicate
 - `location_id` (optional): Filter by location
 - `ids` (optional): Restrict to a specific set of adjustment IDs
 - `stock_adjustment_number` (optional): Exact match on the adjustment number
 - `created_after` / `created_before` (optional): ISO-8601 datetime bounds on `created_at`
 - `updated_after` / `updated_before` (optional): ISO-8601 datetime bounds on `updated_at` (useful for incremental sync)
 - `include_deleted` (optional, default false): Include soft-deleted adjustments
-
-**Parameters (client-side filters — scan the fetched page set):**
-- `variant_id` (optional): Only adjustments whose rows touch this variant
-- `reason` (optional): Case-insensitive substring match on the `reason` field
-
-**Other:**
+- `variant_id` (optional): Only adjustments whose rows touch this variant — runs as an EXISTS subquery against the indexed FK on the rows table
+- `reason` (optional): Case-insensitive substring match on the `reason` field (SQL ILIKE)
 - `include_rows` (optional, default false): When true, populate row-level details on each summary
 - `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
-
-When a client-side filter is active, the tool skips the single-page short-circuit so auto-pagination can scan enough rows to find matches that may live on later pages.
 
 **Returns:** Summary rows with `id`, `stock_adjustment_number`, `location_id`, dates,
 `reason`, and row count (plus per-row detail when `include_rows=true`), plus optional

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -26,8 +26,7 @@ from katana_mcp.tools.tool_result_utils import (
     iso_or_none,
     make_simple_result,
     make_tool_result,
-    parse_iso_datetime,
-    parse_pagination_header,
+    parse_request_dates,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
@@ -876,21 +875,19 @@ class ListStockAdjustmentsRequest(BaseModel):
         ge=1,
         le=250,
         description=(
-            "Max adjustments to return (default 50, min 1, max 250 — Katana's "
-            "API page-size cap). When `page` is set, acts as the page size for "
-            "that request."
+            "Max adjustments to return (default 50, min 1, max 250). When "
+            "`page` is set, acts as the page size for that request."
         ),
     )
     page: int | None = Field(
         default=None,
         ge=1,
         description=(
-            "Page number (1-based). When set, returns a single page and "
-            "disables auto-pagination; `limit` becomes the page size. Invalid "
-            "pages (0, negative) are rejected at the schema boundary."
+            "Page number (1-based). When set, the response includes "
+            "pagination metadata describing total records and pages. "
+            "Invalid pages (0, negative) are rejected at the schema boundary."
         ),
     )
-    # Server-side filters (forwarded to Katana's GET /stock_adjustments)
     location_id: int | None = Field(default=None, description="Filter by location ID")
     ids: list[int] | None = Field(
         default=None,
@@ -920,16 +917,13 @@ class ListStockAdjustmentsRequest(BaseModel):
         description="Include soft-deleted adjustments in the result",
     )
 
-    # Client-side filters (applied post-fetch; Katana's list endpoint does not
-    # expose these server-side). When either is set the `page=1` short-circuit
-    # is skipped so auto-pagination can scan enough rows to find matches.
     variant_id: int | None = Field(
         default=None,
-        description="Filter to adjustments that touch this variant ID (client-side)",
+        description="Filter to adjustments that touch this variant ID",
     )
     reason: str | None = Field(
         default=None,
-        description="Case-insensitive substring match on the `reason` field (client-side)",
+        description="Case-insensitive substring match on the `reason` field",
     )
 
     include_rows: bool = Field(
@@ -978,134 +972,198 @@ class ListStockAdjustmentsResponse(BaseModel):
     pagination: PaginationMeta | None = Field(
         default=None,
         description=(
-            "Pagination cursor populated from the API's `x-pagination` header "
-            "when the caller requested a specific page. `None` when "
-            "auto-paginating."
+            "Pagination metadata — populated when the caller requests a "
+            "specific `page`; `None` otherwise."
         ),
     )
+
+
+_STOCK_ADJUSTMENT_DATE_FIELDS = (
+    "created_after",
+    "created_before",
+    "updated_after",
+    "updated_before",
+)
+
+
+def _apply_stock_adjustment_filters(
+    stmt: Any,
+    request: ListStockAdjustmentsRequest,
+    parsed_dates: dict[str, datetime | None],
+) -> Any:
+    """Translate request filters into WHERE clauses on a CachedStockAdjustment query.
+
+    Shared by the data SELECT and the COUNT SELECT so pagination totals
+    reflect exactly the same filter set as the data rows. ``parsed_dates``
+    must come from :func:`parse_request_dates` — keeping parsing out of
+    this function lets the paginated path avoid re-parsing on the COUNT
+    query.
+    """
+    from sqlmodel import exists, select
+
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedStockAdjustment,
+        CachedStockAdjustmentRow,
+    )
+
+    if request.location_id is not None:
+        stmt = stmt.where(CachedStockAdjustment.location_id == request.location_id)
+    if request.ids is not None:
+        stmt = stmt.where(CachedStockAdjustment.id.in_(request.ids))
+    if request.stock_adjustment_number is not None:
+        stmt = stmt.where(
+            CachedStockAdjustment.stock_adjustment_number
+            == request.stock_adjustment_number
+        )
+    if not request.include_deleted:
+        stmt = stmt.where(CachedStockAdjustment.deleted_at.is_(None))
+
+    # variant_id is a row-level field — closes the filter-breadth bug
+    # flagged in #342: previously this ran client-side after fetching one
+    # page, so an adjustment touching variant 42 on page 7 would be missed.
+    # As an EXISTS subquery it scans the indexed FK column directly.
+    if request.variant_id is not None:
+        row_filter = (
+            select(CachedStockAdjustmentRow.id)
+            .where(
+                CachedStockAdjustmentRow.stock_adjustment_id
+                == CachedStockAdjustment.id,
+                CachedStockAdjustmentRow.variant_id == request.variant_id,
+            )
+            .correlate(CachedStockAdjustment)
+        )
+        stmt = stmt.where(exists(row_filter))
+
+    if request.reason is not None:
+        # Case-insensitive substring match. SQLite's ``LIKE`` is
+        # case-insensitive for ASCII by default; ``ilike`` makes the
+        # intent explicit and works across SQLAlchemy dialects.
+        needle = request.reason.strip()
+        if needle:
+            stmt = stmt.where(CachedStockAdjustment.reason.ilike(f"%{needle}%"))
+
+    # Date windows — all indexed SQL range queries. Iterate the field
+    # tuple so adding new bounds later is one-line work.
+    date_columns: list[tuple[str, Any, str]] = [
+        ("created_after", CachedStockAdjustment.created_at, ">="),
+        ("created_before", CachedStockAdjustment.created_at, "<="),
+        ("updated_after", CachedStockAdjustment.updated_at, ">="),
+        ("updated_before", CachedStockAdjustment.updated_at, "<="),
+    ]
+    for name, col, comp in date_columns:
+        dt = parsed_dates[name]
+        if dt is None:
+            continue
+        stmt = stmt.where(col >= dt if comp == ">=" else col <= dt)
+
+    return stmt
 
 
 async def _list_stock_adjustments_impl(
     request: ListStockAdjustmentsRequest, context: Context
 ) -> ListStockAdjustmentsResponse:
-    """List stock adjustments with filters."""
-    from katana_public_api_client.api.stock_adjustment import (
-        get_all_stock_adjustments,
+    """List stock adjustments with filters (cache-backed).
+
+    Reads from the SQLModel typed cache instead of the live API.
+    ``ensure_stock_adjustments_synced`` runs an incremental
+    ``updated_at_min`` delta on every call (near-zero cost steady-state;
+    cold-start pulls full history once); the query then translates request
+    filters into indexed SQL and returns results directly — no pagination
+    dance, no post-fetch client-side filtering. ``variant_id`` runs as an
+    EXISTS subquery against the row table, closing the filter-breadth bug
+    where adjustments touching the variant on a later page were missed.
+    See ADR-0018 and #342.
+    """
+    from sqlalchemy.orm import selectinload
+    from sqlmodel import func, select
+
+    from katana_mcp.typed_cache import ensure_stock_adjustments_synced
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedStockAdjustment,
+        CachedStockAdjustmentRow,
     )
-    from katana_public_api_client.utils import unwrap_data
 
     services = get_services(context)
 
-    # Pass through server-side filters Katana supports; variant_id and reason
-    # are applied client-side below.
-    kwargs: dict[str, Any] = {
-        "client": services.client,
-        "limit": request.limit,
-    }
-    if request.location_id is not None:
-        kwargs["location_id"] = request.location_id
-    if request.ids is not None:
-        kwargs["ids"] = request.ids
-    if request.stock_adjustment_number is not None:
-        kwargs["stock_adjustment_number"] = request.stock_adjustment_number
-    if request.include_deleted:
-        kwargs["include_deleted"] = True
+    # 1. Refresh the cache (incremental — near-zero cost steady state).
+    await ensure_stock_adjustments_synced(services.client, services.typed_cache)
 
-    if request.created_after is not None:
-        kwargs["created_at_min"] = parse_iso_datetime(
-            request.created_after, "created_after"
-        )
-    if request.created_before is not None:
-        kwargs["created_at_max"] = parse_iso_datetime(
-            request.created_before, "created_before"
-        )
-    if request.updated_after is not None:
-        kwargs["updated_at_min"] = parse_iso_datetime(
-            request.updated_after, "updated_after"
-        )
-    if request.updated_before is not None:
-        kwargs["updated_at_max"] = parse_iso_datetime(
-            request.updated_before, "updated_before"
-        )
+    # 2. Parse date filters once so the data SELECT and the (optional)
+    # COUNT SELECT don't each re-parse the same ISO-8601 strings.
+    parsed_dates = parse_request_dates(request, _STOCK_ADJUSTMENT_DATE_FIELDS)
 
-    # Pagination strategy:
-    # - If `page` is set, forward it so PaginationTransport disables
-    #   auto-pagination and lets callers walk beyond max_pages.
-    # - Else if any client-side-only filter (variant_id, reason) is active,
-    #   skip the short-circuit so auto-pagination scans enough rows to find
-    #   matches; a single page would miss records on later pages.
-    # - Otherwise, when `limit` fits in a single Katana page (<=250), pass
-    #   page=1 to short-circuit auto-pagination and avoid fetching thousands
-    #   of rows. Lower bound is defence-in-depth with `ge=1` on Field.
-    has_client_filter = request.variant_id is not None or request.reason is not None
+    # 3. Build the data query. Pair each row with a scalar-subquery
+    # ``row_count`` so the common ``include_rows=False`` case doesn't pay
+    # the selectinload cost of materializing every line item just to
+    # report counts.
+    row_count_subq = (
+        select(func.count(CachedStockAdjustmentRow.id))
+        .where(CachedStockAdjustmentRow.stock_adjustment_id == CachedStockAdjustment.id)
+        .correlate(CachedStockAdjustment)
+        .scalar_subquery()
+        .label("row_count")
+    )
+    stmt = select(CachedStockAdjustment, row_count_subq)
+    if request.include_rows:
+        stmt = stmt.options(selectinload(CachedStockAdjustment.stock_adjustment_rows))
+    stmt = _apply_stock_adjustment_filters(stmt, request, parsed_dates)
+    stmt = stmt.order_by(
+        CachedStockAdjustment.created_at.desc(), CachedStockAdjustment.id.desc()
+    )
     if request.page is not None:
-        kwargs["page"] = request.page
-    elif not has_client_filter and 1 <= request.limit <= 250:
-        kwargs["page"] = 1
+        stmt = stmt.offset((request.page - 1) * request.limit).limit(request.limit)
+    else:
+        stmt = stmt.limit(request.limit)
 
-    response = await get_all_stock_adjustments.asyncio_detailed(**kwargs)
-    attrs_list = unwrap_data(response, default=[])
+    # 4. Execute data query and (when paginating) a separate COUNT for meta.
+    async with services.typed_cache.session() as session:
+        data_result = await session.exec(stmt)
+        adjustments_with_counts: list[tuple[CachedStockAdjustment, int]] = (
+            data_result.all()
+        )
 
-    # Apply client-side filters that Katana's list endpoint doesn't accept.
-    if request.variant_id is not None:
-        target_variant = request.variant_id
+        pagination: PaginationMeta | None = None
+        if request.page is not None:
+            count_stmt = _apply_stock_adjustment_filters(
+                select(func.count()).select_from(CachedStockAdjustment),
+                request,
+                parsed_dates,
+            )
+            total_records = (await session.exec(count_stmt)).one()
+            total_pages = (total_records + request.limit - 1) // request.limit
+            pagination = PaginationMeta(
+                total_records=total_records,
+                total_pages=total_pages,
+                page=request.page,
+                first_page=request.page == 1,
+                last_page=request.page >= total_pages,
+            )
 
-        def _matches_variant(adj: Any) -> bool:
-            rows = unwrap_unset(adj.stock_adjustment_rows, [])
-            return any(row.variant_id == target_variant for row in rows)
-
-        attrs_list = [adj for adj in attrs_list if _matches_variant(adj)]
-
-    if request.reason is not None:
-        reason_needle = request.reason.strip().lower()
-        if reason_needle:
-
-            def _matches_reason(adj: Any) -> bool:
-                reason_val = unwrap_unset(adj.reason, None)
-                return bool(reason_val and reason_needle in str(reason_val).lower())
-
-            attrs_list = [adj for adj in attrs_list if _matches_reason(adj)]
-
-    # Safety net: cap to request.limit post-pagination/filter so we never
-    # return more than the caller asked for.
-    attrs_list = attrs_list[: request.limit]
-
-    # Surface pagination metadata from the `x-pagination` header only when
-    # the caller is driving paging manually. During auto-pagination the header
-    # describes just the final fetched page, which would be misleading.
-    pagination: PaginationMeta | None = None
-    if request.page is not None:
-        headers = getattr(response, "headers", None)
-        if headers is not None:
-            pagination = parse_pagination_header(headers.get("x-pagination"))
-
+    # 5. Materialize summaries.
     adjustments: list[StockAdjustmentSummary] = []
-    for adj in attrs_list:
-        rows = unwrap_unset(adj.stock_adjustment_rows, [])
+    for adj, row_count in adjustments_with_counts:
         row_infos: list[StockAdjustmentRowInfo] | None = None
         if request.include_rows:
             row_infos = [
                 StockAdjustmentRowInfo(
-                    id=unwrap_unset(row.id, None),
+                    id=row.id,
                     variant_id=row.variant_id,
                     quantity=row.quantity,
-                    cost_per_unit=unwrap_unset(row.cost_per_unit, None),
+                    cost_per_unit=row.cost_per_unit,
                 )
-                for row in rows
+                for row in adj.stock_adjustment_rows
             ]
         adjustments.append(
             StockAdjustmentSummary(
                 id=adj.id,
                 stock_adjustment_number=adj.stock_adjustment_number,
                 location_id=adj.location_id,
-                stock_adjustment_date=iso_or_none(
-                    unwrap_unset(adj.stock_adjustment_date, None)
-                ),
-                created_at=iso_or_none(unwrap_unset(adj.created_at, None)),
-                updated_at=iso_or_none(unwrap_unset(adj.updated_at, None)),
-                reason=unwrap_unset(adj.reason, None),
-                additional_info=unwrap_unset(adj.additional_info, None),
-                row_count=len(rows),
+                stock_adjustment_date=iso_or_none(adj.stock_adjustment_date),
+                created_at=iso_or_none(adj.created_at),
+                updated_at=iso_or_none(adj.updated_at),
+                reason=adj.reason,
+                additional_info=adj.additional_info,
+                row_count=row_count,
                 rows=row_infos,
             )
         )
@@ -1122,7 +1180,7 @@ async def _list_stock_adjustments_impl(
 async def list_stock_adjustments(
     request: Annotated[ListStockAdjustmentsRequest, Unpack()], context: Context
 ) -> ToolResult:
-    """List stock adjustments with filters.
+    """List stock adjustments with filters (cache-backed).
 
     Use for discovery — find recent adjustments at a location, adjustments
     touching a specific variant, or adjustments matching a reason substring.
@@ -1132,15 +1190,21 @@ async def list_stock_adjustments(
 
     **Paging**
     - `limit` caps the number of rows returned (default 50, min 1).
-    - Set `page=N` for manual paging; the response includes `pagination`
-      metadata parsed from Katana's `x-pagination` header.
-    - Otherwise auto-pagination kicks in automatically (bounded by
-      `KatanaClient.max_pages`).
+    - Set `page=N` for explicit paging; the response includes `pagination`
+      metadata (total_records, total_pages, first/last flags) computed from
+      a SQL COUNT against the same filter predicate.
+    - Otherwise the response returns up to `limit` rows ordered by created_at
+      desc with no pagination metadata.
 
-    **Filters**
-    - `location_id`, `created_after`, `created_before` — server-side.
-    - `variant_id`, `reason` — applied client-side; combine with other filters
-      to narrow the result set before the client-side pass.
+    **Filters** all run as indexed SQL against the typed cache:
+    - `location_id`, `ids`, `stock_adjustment_number`, `include_deleted` —
+      direct column filters.
+    - `variant_id` — EXISTS subquery on the rows table (no page-bound
+      truncation; an adjustment touching the variant is found regardless
+      of how many other adjustments precede it).
+    - `reason` — case-insensitive `ILIKE %needle%`.
+    - `created_after`/`before`, `updated_after`/`before` — date-range
+      bounds on the corresponding columns.
     """
     response = await _list_stock_adjustments_impl(request, context)
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -528,7 +528,7 @@ def _apply_sales_order_filters(
     query.
     """
     from katana_public_api_client.models_pydantic._generated import (
-        SalesOrder as CachedSalesOrder,
+        CachedSalesOrder,
         SalesOrderProductionStatus,
         SalesOrderStatus,
     )
@@ -606,8 +606,8 @@ async def _list_sales_orders_impl(
 
     from katana_mcp.typed_cache import ensure_sales_orders_synced
     from katana_public_api_client.models_pydantic._generated import (
-        SalesOrder as CachedSalesOrder,
-        SalesOrderRow as CachedSalesOrderRow,
+        CachedSalesOrder,
+        CachedSalesOrderRow,
     )
 
     services = get_services(context)

--- a/katana_mcp_server/src/katana_mcp/typed_cache/__init__.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/__init__.py
@@ -26,11 +26,12 @@ Public API::
 from __future__ import annotations
 
 from .engine import TypedCacheEngine
-from .sync import ensure_sales_orders_synced
+from .sync import ensure_sales_orders_synced, ensure_stock_adjustments_synced
 from .sync_state import SyncState
 
 __all__ = [
     "SyncState",
     "TypedCacheEngine",
     "ensure_sales_orders_synced",
+    "ensure_stock_adjustments_synced",
 ]

--- a/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
@@ -24,10 +24,12 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from katana_mcp.typed_cache import sync_state as _sync_state_mod
 from katana_public_api_client.models_pydantic._generated import (
     sales_orders as _sales_orders_mod,
+    stock as _stock_mod,
 )
 
 assert _sync_state_mod is not None
 assert _sales_orders_mod is not None
+assert _stock_mod is not None
 
 _DEFAULT_DB_PATH = Path(user_cache_dir("katana-mcp")) / "typed_cache.db"
 

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -4,8 +4,11 @@ Each ``ensure_<entity>_synced`` helper:
 1. Takes the entity's lock to serialize concurrent sync calls.
 2. Reads the ``SyncState`` watermark and passes it to the API as
    ``updated_at_min`` so only changed rows come back on subsequent calls.
-3. Converts attrs API objects to SQLModel rows via ``from_attrs()``.
-4. Upserts rows and advances the watermark, all in one session.
+3. Converts attrs API objects to ``Cached<Entity>`` SQLModel rows via the
+   API pydantic class as an intermediary (so nested-row conversion stays
+   in one well-tested place), then re-validates into the cache sibling.
+4. Upserts parent + child rows and advances the watermark, all in one
+   session.
 """
 
 from __future__ import annotations
@@ -14,8 +17,14 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from katana_public_api_client.api.sales_order import get_all_sales_orders
+from katana_public_api_client.api.stock_adjustment import get_all_stock_adjustments
 from katana_public_api_client.models_pydantic._generated import (
+    CachedSalesOrder,
+    CachedSalesOrderRow,
+    CachedStockAdjustment,
+    CachedStockAdjustmentRow,
     SalesOrder as PydanticSalesOrder,
+    StockAdjustment as PydanticStockAdjustment,
 )
 from katana_public_api_client.utils import unwrap_data
 
@@ -25,6 +34,40 @@ if TYPE_CHECKING:
     from katana_public_api_client import KatanaClient
 
     from .engine import TypedCacheEngine
+
+
+def _attrs_sales_order_to_cached(
+    attrs_so: object,
+) -> tuple[CachedSalesOrder, list[CachedSalesOrderRow]]:
+    """Convert one attrs ``SalesOrder`` to a parent ``CachedSalesOrder`` plus
+    a flat list of ``CachedSalesOrderRow`` children with explicit FKs.
+
+    Two-step:
+    1. ``PydanticSalesOrder.from_attrs`` handles UNSET → None, enum
+       extraction, datetime coercion, and the registry-driven nested
+       conversion of each row. The result is the API pydantic model.
+    2. ``model_dump`` exports a plain dict; ``CachedSalesOrder.model_validate``
+       reconstructs the parent (excluding the ``sales_order_rows``
+       relationship — SQLModel ``Relationship`` descriptors don't accept
+       input via ``__init__``/``model_validate``). Children are re-built as
+       ``CachedSalesOrderRow`` with ``sales_order_id`` set explicitly so
+       SQLAlchemy can wire the parent→child link on insert. The caller
+       merges parents and children in separate passes.
+    """
+    api_so = PydanticSalesOrder.from_attrs(attrs_so)
+    parent_data = api_so.model_dump(exclude={"sales_order_rows"})
+    cached_parent = CachedSalesOrder.model_validate(parent_data)
+
+    child_rows: list[CachedSalesOrderRow] = []
+    api_rows = api_so.sales_order_rows or []
+    for api_row in api_rows:
+        row_data = api_row.model_dump()
+        # The API model carries ``sales_order_id`` natively (Katana returns
+        # it on rows). Re-asserting from the parent guards against the
+        # response shape silently changing.
+        row_data["sales_order_id"] = api_so.id
+        child_rows.append(CachedSalesOrderRow.model_validate(row_data))
+    return cached_parent, child_rows
 
 
 async def ensure_sales_orders_synced(
@@ -55,11 +98,19 @@ async def ensure_sales_orders_synced(
         response = await get_all_sales_orders.asyncio_detailed(client=client, **kwargs)
         attrs_orders = unwrap_data(response, default=[])
 
-        rows = [PydanticSalesOrder.from_attrs(ao) for ao in attrs_orders]
+        cached_parents: list[CachedSalesOrder] = []
+        cached_children: list[CachedSalesOrderRow] = []
+        for attrs_so in attrs_orders:
+            parent, children = _attrs_sales_order_to_cached(attrs_so)
+            cached_parents.append(parent)
+            cached_children.extend(children)
 
         async with cache.session() as session:
-            for row in rows:
-                await session.merge(row)
+            # Parents first so child FK constraints resolve on insert.
+            for parent in cached_parents:
+                await session.merge(parent)
+            for child in cached_children:
+                await session.merge(child)
             # SQLite's DateTime column doesn't preserve tzinfo, so naive
             # UTC on the write side. ``row_count`` is the last-fetch size
             # (not a cumulative total, which would drift since ``rows``
@@ -69,7 +120,78 @@ async def ensure_sales_orders_synced(
                 SyncState(
                     entity_type="sales_order",
                     last_synced=datetime.now(tz=UTC).replace(tzinfo=None),
-                    row_count=len(rows),
+                    row_count=len(cached_parents),
+                )
+            )
+            await session.commit()
+
+
+def _attrs_stock_adjustment_to_cached(
+    attrs_sa: object,
+) -> tuple[CachedStockAdjustment, list[CachedStockAdjustmentRow]]:
+    """Convert one attrs ``StockAdjustment`` to a parent + children pair.
+
+    Same shape as :func:`_attrs_sales_order_to_cached`, with one twist:
+    Katana doesn't return ``stock_adjustment_id`` on ``StockAdjustmentRow``
+    (rows are nested under the parent on the wire), so the cached row's
+    FK is set explicitly from the parent's ``id`` instead of being copied
+    from the API response.
+    """
+    api_sa = PydanticStockAdjustment.from_attrs(attrs_sa)
+    parent_data = api_sa.model_dump(exclude={"stock_adjustment_rows"})
+    cached_parent = CachedStockAdjustment.model_validate(parent_data)
+
+    child_rows: list[CachedStockAdjustmentRow] = []
+    api_rows = api_sa.stock_adjustment_rows or []
+    for api_row in api_rows:
+        row_data = api_row.model_dump()
+        row_data["stock_adjustment_id"] = api_sa.id
+        child_rows.append(CachedStockAdjustmentRow.model_validate(row_data))
+    return cached_parent, child_rows
+
+
+async def ensure_stock_adjustments_synced(
+    client: KatanaClient, cache: TypedCacheEngine
+) -> None:
+    """Pull updated stock adjustments from Katana and upsert into the cache.
+
+    Mirror of :func:`ensure_sales_orders_synced` for the ``StockAdjustment``
+    entity. Cold-start fetches the full history; subsequent calls pass
+    ``updated_at_min`` and pick up only changed rows. Per-entity lock
+    serializes concurrent calls to keep cold-start fan-out single-flight.
+    """
+    async with cache.lock_for("stock_adjustment"):
+        async with cache.session() as session:
+            state = await session.get(SyncState, "stock_adjustment")
+            last_synced = state.last_synced if state is not None else None
+
+        kwargs = (
+            {"updated_at_min": last_synced.replace(tzinfo=UTC)}
+            if last_synced is not None
+            else {}
+        )
+        response = await get_all_stock_adjustments.asyncio_detailed(
+            client=client, **kwargs
+        )
+        attrs_adjustments = unwrap_data(response, default=[])
+
+        cached_parents: list[CachedStockAdjustment] = []
+        cached_children: list[CachedStockAdjustmentRow] = []
+        for attrs_sa in attrs_adjustments:
+            parent, children = _attrs_stock_adjustment_to_cached(attrs_sa)
+            cached_parents.append(parent)
+            cached_children.extend(children)
+
+        async with cache.session() as session:
+            for parent in cached_parents:
+                await session.merge(parent)
+            for child in cached_children:
+                await session.merge(child)
+            await session.merge(
+                SyncState(
+                    entity_type="stock_adjustment",
+                    last_synced=datetime.now(tz=UTC).replace(tzinfo=None),
+                    row_count=len(cached_parents),
                 )
             )
             await session.commit()

--- a/katana_mcp_server/tests/factories.py
+++ b/katana_mcp_server/tests/factories.py
@@ -20,10 +20,12 @@ if TYPE_CHECKING:
     from katana_mcp.typed_cache import TypedCacheEngine
 
     from katana_public_api_client.models_pydantic._generated import (
-        SalesOrder as CachedSalesOrder,
+        CachedSalesOrder,
+        CachedSalesOrderRow,
+        CachedStockAdjustment,
+        CachedStockAdjustmentRow,
         SalesOrderProductionStatus,
-        SalesOrderRow as CachedSalesOrderRow,
-        SalesOrderStatus as CachedSalesOrderStatus,
+        SalesOrderStatus,
     )
 
 
@@ -51,7 +53,7 @@ def make_sales_order(
     order_no: str = "SO-TEST",
     customer_id: int = 42,
     location_id: int = 1,
-    status: CachedSalesOrderStatus | str | None = None,
+    status: SalesOrderStatus | str | None = None,
     production_status: SalesOrderProductionStatus | str | None = "NONE",
     invoicing_status: str | None = None,
     created_at: datetime | None = None,
@@ -62,7 +64,7 @@ def make_sales_order(
     deleted_at: datetime | None = None,
     rows: list[CachedSalesOrderRow] | None = None,
 ) -> CachedSalesOrder:
-    """Build a SQLModel ``SalesOrder`` for direct cache insertion.
+    """Build a ``CachedSalesOrder`` for direct cache insertion.
 
     Datetime args are normalized to naive UTC (the typed cache stores
     timestamps without tzinfo — SQLite's default ``DateTime`` column
@@ -75,15 +77,15 @@ def make_sales_order(
     from katana_mcp.tools.tool_result_utils import naive_utc
 
     from katana_public_api_client.models_pydantic._generated import (
-        SalesOrder as CachedSalesOrder,
+        CachedSalesOrder as _CachedSalesOrder,
         SalesOrderProductionStatus as _ProductionStatus,
-        SalesOrderStatus as CachedSalesOrderStatus,
+        SalesOrderStatus as _SalesOrderStatus,
     )
 
     resolved_status = (
-        CachedSalesOrderStatus(status)
+        _SalesOrderStatus(status)
         if isinstance(status, str)
-        else (status if status is not None else CachedSalesOrderStatus.not_shipped)
+        else (status if status is not None else _SalesOrderStatus.not_shipped)
     )
     resolved_prod_status = (
         _ProductionStatus(production_status)
@@ -91,7 +93,7 @@ def make_sales_order(
         else production_status
     )
 
-    return CachedSalesOrder(
+    cached = _CachedSalesOrder(
         id=id,
         order_no=order_no,
         customer_id=customer_id,
@@ -105,8 +107,11 @@ def make_sales_order(
         total=total,
         currency=currency,
         deleted_at=naive_utc(deleted_at),
-        sales_order_rows=rows if rows is not None else [],
     )
+    # ``sales_order_rows`` is a SQLModel ``Relationship`` — set after
+    # construction since the descriptor doesn't accept input via __init__.
+    cached.sales_order_rows = rows if rows is not None else []
+    return cached
 
 
 def make_sales_order_row(
@@ -118,16 +123,85 @@ def make_sales_order_row(
     price_per_unit: float | None = None,
     linked_manufacturing_order_id: int | None = None,
 ) -> CachedSalesOrderRow:
-    """Build a SQLModel ``SalesOrderRow`` for direct cache insertion."""
+    """Build a ``CachedSalesOrderRow`` for direct cache insertion."""
     from katana_public_api_client.models_pydantic._generated import (
-        SalesOrderRow as CachedSalesOrderRow,
+        CachedSalesOrderRow as _CachedSalesOrderRow,
     )
 
-    return CachedSalesOrderRow(
+    return _CachedSalesOrderRow(
         id=id,
         sales_order_id=sales_order_id,
         variant_id=variant_id,
         quantity=quantity,
         price_per_unit=price_per_unit,
         linked_manufacturing_order_id=linked_manufacturing_order_id,
+    )
+
+
+# ----------------------------------------------------------------------------
+# stock_adjustments
+# ----------------------------------------------------------------------------
+
+
+def make_stock_adjustment(
+    *,
+    id: int = 1,
+    stock_adjustment_number: str = "SA-TEST",
+    location_id: int = 1,
+    stock_adjustment_date: datetime | None = None,
+    reason: str | None = None,
+    additional_info: str | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+    deleted_at: datetime | None = None,
+    rows: list[CachedStockAdjustmentRow] | None = None,
+) -> CachedStockAdjustment:
+    """Build a ``CachedStockAdjustment`` for direct cache insertion.
+
+    Same datetime-normalization contract as :func:`make_sales_order` —
+    callers may pass tz-aware datetimes; the factory routes everything
+    through ``naive_utc`` so cache filter comparisons work either way.
+    ``created_at`` defaults to 2026-04-01 to match the sales-order builder
+    so cross-entity date-window tests share a baseline.
+    """
+    from katana_mcp.tools.tool_result_utils import naive_utc
+
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedStockAdjustment as _CachedStockAdjustment,
+    )
+
+    cached = _CachedStockAdjustment(
+        id=id,
+        stock_adjustment_number=stock_adjustment_number,
+        location_id=location_id,
+        stock_adjustment_date=naive_utc(stock_adjustment_date),
+        reason=reason,
+        additional_info=additional_info,
+        created_at=naive_utc(created_at) or datetime(2026, 4, 1),
+        updated_at=naive_utc(updated_at),
+        deleted_at=naive_utc(deleted_at),
+    )
+    cached.stock_adjustment_rows = rows if rows is not None else []
+    return cached
+
+
+def make_stock_adjustment_row(
+    *,
+    id: int,
+    stock_adjustment_id: int,
+    variant_id: int,
+    quantity: float = 1.0,
+    cost_per_unit: float | None = None,
+) -> CachedStockAdjustmentRow:
+    """Build a ``CachedStockAdjustmentRow`` for direct cache insertion."""
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedStockAdjustmentRow as _CachedStockAdjustmentRow,
+    )
+
+    return _CachedStockAdjustmentRow(
+        id=id,
+        stock_adjustment_id=stock_adjustment_id,
+        variant_id=variant_id,
+        quantity=quantity,
+        cost_per_unit=cost_per_unit,
     )

--- a/katana_mcp_server/tests/test_typed_cache.py
+++ b/katana_mcp_server/tests/test_typed_cache.py
@@ -102,18 +102,18 @@ class TestCacheTables:
 
     @pytest.mark.asyncio
     async def test_can_insert_and_query_sales_order(self, typed_cache_engine):
-        """End-to-end: insert a SalesOrder + SalesOrderRow, traverse the
-        relationship, query back. Proves the generator-emitted schema is
-        live against the engine's SQLModel.metadata.create_all call."""
+        """End-to-end: insert a CachedSalesOrder + CachedSalesOrderRow,
+        traverse the relationship, query back. Proves the generator-emitted
+        schema is live against the engine's SQLModel.metadata.create_all call."""
         from katana_public_api_client.models_pydantic._generated import (
-            SalesOrder,
-            SalesOrderRow,
+            CachedSalesOrder,
+            CachedSalesOrderRow,
             SalesOrderStatus,
         )
 
         async with typed_cache_engine.session() as session:
             session.add(
-                SalesOrder(
+                CachedSalesOrder(
                     id=1,
                     customer_id=42,
                     location_id=1,
@@ -122,12 +122,16 @@ class TestCacheTables:
                 )
             )
             session.add(
-                SalesOrderRow(id=1, sales_order_id=1, variant_id=100, quantity=2.0)
+                CachedSalesOrderRow(
+                    id=1, sales_order_id=1, variant_id=100, quantity=2.0
+                )
             )
             await session.commit()
 
         async with typed_cache_engine.session() as session:
-            stmt = select(SalesOrder).where(SalesOrder.order_no == "SO-INT-001")
+            stmt = select(CachedSalesOrder).where(
+                CachedSalesOrder.order_no == "SO-INT-001"
+            )
             result = await session.exec(stmt)
             order = result.one()
             assert order.customer_id == 42

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -37,7 +37,12 @@ from katana_mcp.tools.foundation.items import (
 from pydantic import ValidationError
 
 from katana_public_api_client.client_types import UNSET
-from tests.conftest import create_mock_context
+from tests.conftest import create_mock_context, patch_typed_cache_sync
+from tests.factories import (
+    make_stock_adjustment,
+    make_stock_adjustment_row,
+    seed_cache,
+)
 
 
 def _content_text(result) -> str:
@@ -878,8 +883,19 @@ async def test_get_variant_details_with_timestamps():
 
 
 # ============================================================================
-# list_stock_adjustments Tests
+# list_stock_adjustments Tests (cache-backed)
 # ============================================================================
+#
+# Post-#376: list_stock_adjustments reads from the SQLModel typed cache via
+# ``_list_stock_adjustments_impl``. Tests seed ``CachedStockAdjustment`` /
+# ``CachedStockAdjustmentRow`` rows with the factories from ``tests/factories``
+# and assert the impl's filter/pagination logic against the query results.
+# The ``no_sync`` fixture stubs ``ensure_stock_adjustments_synced`` so the
+# impl never tries to talk to the API during these unit tests.
+#
+# update_stock_adjustment / delete_stock_adjustment tests further down still
+# go through the live API path (those tools call the Katana API directly),
+# so the mock-API helpers below are kept for them.
 
 _SA_GET_ALL = "katana_public_api_client.api.stock_adjustment.get_all_stock_adjustments"
 _SA_UNWRAP_DATA = "katana_public_api_client.utils.unwrap_data"
@@ -899,7 +915,8 @@ def _make_mock_adjustment(
     rows: list | None = None,
     created_at: datetime | None = None,
 ) -> MagicMock:
-    """Build a mock StockAdjustment attrs object for testing."""
+    """Build a mock StockAdjustment attrs object for live-API-path tests
+    (``update_stock_adjustment`` / ``delete_stock_adjustment``)."""
     adj = MagicMock()
     adj.id = id
     adj.stock_adjustment_number = stock_adjustment_number
@@ -922,7 +939,7 @@ def _make_mock_adjustment_row(
     quantity: float = 5.0,
     cost_per_unit: float | None = None,
 ) -> MagicMock:
-    """Build a mock StockAdjustmentRow for testing."""
+    """Build a mock StockAdjustmentRow for live-API-path tests."""
     row = MagicMock()
     row.id = id
     row.variant_id = variant_id
@@ -931,354 +948,322 @@ def _make_mock_adjustment_row(
     return row
 
 
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_short_circuits_page_for_small_limit():
-    """Small `limit` (<=250) with no explicit `page` injects page=1 to short-circuit."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SA_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(limit=25), context
-        )
-
-    assert captured["page"] == 1
-    assert captured["limit"] == 25
-
-
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_forwards_explicit_page():
-    """Explicit `page=N` is forwarded (overrides the short-circuit)."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SA_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(limit=50, page=3), context
-        )
-
-    assert captured["page"] == 3
+@pytest.fixture
+def no_sync():
+    """Patch ``ensure_stock_adjustments_synced`` to a no-op for these tests."""
+    with patch_typed_cache_sync("stock_adjustments"):
+        yield
 
 
 def test_list_stock_adjustments_rejects_limit_above_page_cap():
-    """`limit > 250` is rejected at the schema boundary (Katana's API page-size cap)."""
+    """`limit > 250` is rejected at the schema boundary."""
     with pytest.raises(ValidationError):
         ListStockAdjustmentsRequest(limit=500)
 
 
 @pytest.mark.asyncio
-async def test_list_stock_adjustments_forwards_new_server_side_filters():
-    """ids, stock_adjustment_number, updated_after/before, include_deleted forward to the API."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SA_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(
-                limit=10,
-                ids=[101, 102],
-                stock_adjustment_number="SA-00042",
-                updated_after="2026-01-01T00:00:00+00:00",
-                updated_before="2026-04-01T00:00:00+00:00",
-                include_deleted=True,
-            ),
-            context,
-        )
-
-    assert captured["ids"] == [101, 102]
-    assert captured["stock_adjustment_number"] == "SA-00042"
-    assert captured["updated_at_min"] == datetime(2026, 1, 1, tzinfo=UTC)
-    assert captured["updated_at_max"] == datetime(2026, 4, 1, tzinfo=UTC)
-    assert captured["include_deleted"] is True
-
-
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_skips_short_circuit_when_variant_id_filter_set():
-    """Client-side filters need to scan more than one page; short-circuit must be skipped."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SA_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(limit=10, variant_id=42), context
-        )
-
-    # No `page` forwarded → auto-pagination runs → can find variant_id matches
-    # on later pages. Without this, a single page would be the whole haystack.
-    assert "page" not in captured
-
-
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_skips_short_circuit_when_reason_filter_set():
-    """Same as above but for the `reason` client-side filter."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SA_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(limit=10, reason="recount"), context
-        )
-
-    assert "page" not in captured
-
-
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_pagination_meta_populated_on_explicit_page():
-    """An explicit `page` populates `pagination` from the x-pagination header."""
-    context, _ = create_mock_context()
-
-    mock_response = MagicMock()
-    mock_response.headers = {
-        "x-pagination": (
-            '{"total_records":"231","total_pages":"5","page":"2",'
-            '"first_page":"false","last_page":"false"}'
-        )
-    }
-
-    with (
-        patch(
-            f"{_SA_GET_ALL}.asyncio_detailed",
-            new=AsyncMock(return_value=mock_response),
-        ),
-        patch(_SA_UNWRAP_DATA, return_value=[]),
-    ):
-        result = await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(limit=50, page=2), context
-        )
-
-    assert result.pagination is not None
-    assert result.pagination.total_records == 231
-    assert result.pagination.total_pages == 5
-    assert result.pagination.page == 2
-    assert result.pagination.first_page is False
-    assert result.pagination.last_page is False
-
-
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_pagination_meta_none_on_auto_pagination():
-    """Without an explicit `page`, `pagination` is `None` (auto-pagination)."""
-    context, _ = create_mock_context()
-
-    mock_response = MagicMock()
-    mock_response.headers = {
-        "x-pagination": '{"total_records":"10","total_pages":"1","page":"1"}'
-    }
-
-    with (
-        patch(
-            f"{_SA_GET_ALL}.asyncio_detailed",
-            new=AsyncMock(return_value=mock_response),
-        ),
-        patch(_SA_UNWRAP_DATA, return_value=[]),
-    ):
-        result = await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(limit=50), context
-        )
-
-    assert result.pagination is None
-
-
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_date_filters_forwarded():
-    """`created_after` and `created_before` map to `created_at_min`/`_max`."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SA_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(
-                created_after="2026-01-01T00:00:00Z",
-                created_before="2026-04-01T00:00:00Z",
-            ),
-            context,
-        )
-
-    assert isinstance(captured["created_at_min"], datetime)
-    assert isinstance(captured["created_at_max"], datetime)
-
-
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_location_filter_forwarded():
-    """`location_id` is forwarded as-is to the API."""
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", side_effect=fake),
-        patch(_SA_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(location_id=7), context
-        )
-
-    assert captured["location_id"] == 7
-
-
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_variant_id_filter_clientside():
-    """`variant_id` is applied client-side against returned rows."""
-    context, _ = create_mock_context()
-
-    adj_match = _make_mock_adjustment(
-        id=1, rows=[_make_mock_adjustment_row(variant_id=777)]
-    )
-    adj_skip = _make_mock_adjustment(
-        id=2, rows=[_make_mock_adjustment_row(variant_id=888)]
-    )
-
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
-        patch(_SA_UNWRAP_DATA, return_value=[adj_match, adj_skip]),
-    ):
-        result = await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(variant_id=777), context
-        )
-
-    assert result.total_count == 1
-    assert result.adjustments[0].id == 1
-
-
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_reason_filter_clientside():
-    """`reason` applies a case-insensitive substring match client-side."""
-    context, _ = create_mock_context()
-
-    adj_match = _make_mock_adjustment(id=1, reason="Cycle count correction")
-    adj_skip = _make_mock_adjustment(id=2, reason="Sample received")
-
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
-        patch(_SA_UNWRAP_DATA, return_value=[adj_match, adj_skip]),
-    ):
-        result = await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(reason="cycle"), context
-        )
-
-    assert result.total_count == 1
-    assert result.adjustments[0].id == 1
-
-
-@pytest.mark.asyncio
-async def test_list_stock_adjustments_include_rows_false_omits_rows():
-    """With `include_rows=False`, summary rows is None."""
-    context, _ = create_mock_context()
-
-    adj = _make_mock_adjustment(
-        id=10,
-        rows=[
-            _make_mock_adjustment_row(id=1, variant_id=100, quantity=5.0),
-            _make_mock_adjustment_row(id=2, variant_id=101, quantity=-2.0),
+async def test_list_stock_adjustments_filters_by_ids(context_with_typed_cache, no_sync):
+    """`ids` restricts the returned set to the specified adjustment IDs."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_adjustment(id=1),
+            make_stock_adjustment(id=2),
+            make_stock_adjustment(id=3),
         ],
     )
 
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
-        patch(_SA_UNWRAP_DATA, return_value=[adj]),
-    ):
-        result = await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(include_rows=False), context
-        )
+    result = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(ids=[1, 3]), context
+    )
+
+    assert {a.id for a in result.adjustments} == {1, 3}
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_filters_by_stock_adjustment_number(
+    context_with_typed_cache, no_sync
+):
+    """`stock_adjustment_number` is an exact-match filter."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_adjustment(id=1, stock_adjustment_number="SA-100"),
+            make_stock_adjustment(id=2, stock_adjustment_number="SA-200"),
+        ],
+    )
+
+    result = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(stock_adjustment_number="SA-200"), context
+    )
+
+    assert len(result.adjustments) == 1
+    assert result.adjustments[0].id == 2
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_filters_by_location_id(
+    context_with_typed_cache, no_sync
+):
+    """`location_id` narrows the result to that location."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_adjustment(id=1, location_id=7),
+            make_stock_adjustment(id=2, location_id=8),
+        ],
+    )
+
+    result = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(location_id=7), context
+    )
+
+    assert len(result.adjustments) == 1
+    assert result.adjustments[0].id == 1
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_excludes_deleted_by_default(
+    context_with_typed_cache, no_sync
+):
+    """Soft-deleted adjustments are filtered out unless include_deleted=True."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_adjustment(id=1, deleted_at=None),
+            make_stock_adjustment(id=2, deleted_at=datetime(2026, 3, 15)),
+        ],
+    )
+
+    default = await _list_stock_adjustments_impl(ListStockAdjustmentsRequest(), context)
+    assert {a.id for a in default.adjustments} == {1}
+
+    with_deleted = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(include_deleted=True), context
+    )
+    assert {a.id for a in with_deleted.adjustments} == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_date_filters(context_with_typed_cache, no_sync):
+    """`created_after` / `created_before` apply as indexed range filters."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_adjustment(id=1, created_at=datetime(2025, 12, 15)),  # before
+            make_stock_adjustment(id=2, created_at=datetime(2026, 2, 15)),  # inside
+            make_stock_adjustment(id=3, created_at=datetime(2026, 5, 1)),  # after
+        ],
+    )
+
+    result = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(
+            created_after="2026-01-01T00:00:00Z",
+            created_before="2026-04-01T00:00:00Z",
+        ),
+        context,
+    )
+
+    assert {a.id for a in result.adjustments} == {2}
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_variant_id_filter_via_rows(
+    context_with_typed_cache, no_sync
+):
+    """`variant_id` matches when ANY row of the adjustment touches the variant.
+
+    This closes the filter-breadth bug from #342: the pre-cache impl ran
+    this filter client-side after a single API page, missing matches on
+    later pages. The cache-backed query uses an EXISTS subquery over the
+    indexed FK column, so depth doesn't matter.
+    """
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_adjustment(
+                id=1,
+                rows=[
+                    make_stock_adjustment_row(
+                        id=10, stock_adjustment_id=1, variant_id=777
+                    ),
+                ],
+            ),
+            make_stock_adjustment(
+                id=2,
+                rows=[
+                    make_stock_adjustment_row(
+                        id=11, stock_adjustment_id=2, variant_id=888
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    result = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(variant_id=777), context
+    )
+
+    assert {a.id for a in result.adjustments} == {1}
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_reason_filter_case_insensitive_substring(
+    context_with_typed_cache, no_sync
+):
+    """`reason` applies a case-insensitive substring (ILIKE) match."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_adjustment(id=1, reason="Cycle count correction"),
+            make_stock_adjustment(id=2, reason="Sample received"),
+        ],
+    )
+
+    result = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(reason="cycle"), context
+    )
+
+    assert {a.id for a in result.adjustments} == {1}
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_include_rows_false_omits_rows(
+    context_with_typed_cache, no_sync
+):
+    """With `include_rows=False`, summary rows is None but row_count is set."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_adjustment(
+                id=10,
+                rows=[
+                    make_stock_adjustment_row(
+                        id=1, stock_adjustment_id=10, variant_id=100, quantity=5.0
+                    ),
+                    make_stock_adjustment_row(
+                        id=2, stock_adjustment_id=10, variant_id=101, quantity=-2.0
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    result = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(include_rows=False), context
+    )
 
     assert result.adjustments[0].row_count == 2
     assert result.adjustments[0].rows is None
 
 
 @pytest.mark.asyncio
-async def test_list_stock_adjustments_include_rows_true_populates_rows():
-    """With `include_rows=True`, summary rows contains row details."""
-    context, _ = create_mock_context()
-
-    adj = _make_mock_adjustment(
-        id=11,
-        rows=[
-            _make_mock_adjustment_row(
-                id=1, variant_id=100, quantity=5.0, cost_per_unit=1.23
+async def test_list_stock_adjustments_include_rows_true_populates_rows(
+    context_with_typed_cache, no_sync
+):
+    """With `include_rows=True`, summary rows carries variant/quantity/cost."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_adjustment(
+                id=11,
+                rows=[
+                    make_stock_adjustment_row(
+                        id=1,
+                        stock_adjustment_id=11,
+                        variant_id=100,
+                        quantity=5.0,
+                        cost_per_unit=1.23,
+                    ),
+                    make_stock_adjustment_row(
+                        id=2, stock_adjustment_id=11, variant_id=101, quantity=-2.0
+                    ),
+                ],
             ),
-            _make_mock_adjustment_row(id=2, variant_id=101, quantity=-2.0),
         ],
     )
 
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
-        patch(_SA_UNWRAP_DATA, return_value=[adj]),
-    ):
-        result = await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(include_rows=True), context
-        )
+    result = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(include_rows=True), context
+    )
 
     rows = result.adjustments[0].rows
     assert rows is not None
     assert len(rows) == 2
-    assert rows[0].variant_id == 100
-    assert rows[0].quantity == 5.0
-    assert rows[0].cost_per_unit == 1.23
-    assert rows[1].variant_id == 101
-    assert rows[1].cost_per_unit is None
+    by_variant = {r.variant_id: r for r in rows}
+    assert by_variant[100].quantity == 5.0
+    assert by_variant[100].cost_per_unit == 1.23
+    assert by_variant[101].cost_per_unit is None
 
 
 @pytest.mark.asyncio
-async def test_list_stock_adjustments_limit_caps_result_size():
-    """Result list is capped at `request.limit` even when API returns more."""
-    context, _ = create_mock_context()
+async def test_list_stock_adjustments_limit_caps_result_size(
+    context_with_typed_cache, no_sync
+):
+    """Result list is capped at `request.limit` even when more rows exist."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [make_stock_adjustment(id=i) for i in range(20)],
+    )
 
-    many = [_make_mock_adjustment(id=i) for i in range(20)]
-
-    with (
-        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=AsyncMock()),
-        patch(_SA_UNWRAP_DATA, return_value=many),
-    ):
-        result = await _list_stock_adjustments_impl(
-            ListStockAdjustmentsRequest(limit=5), context
-        )
+    result = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(limit=5), context
+    )
 
     assert len(result.adjustments) == 5
     assert result.total_count == 5
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_pagination_meta_populated_on_explicit_page(
+    context_with_typed_cache, no_sync
+):
+    """An explicit `page` populates `pagination` from a SQL COUNT against the same filter set."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [make_stock_adjustment(id=i) for i in range(1, 12)],
+    )
+
+    result = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(limit=5, page=2), context
+    )
+
+    assert result.pagination is not None
+    assert result.pagination.total_records == 11
+    assert result.pagination.total_pages == 3
+    assert result.pagination.page == 2
+    assert result.pagination.first_page is False
+    assert result.pagination.last_page is False
+    assert len(result.adjustments) == 5
+
+
+@pytest.mark.asyncio
+async def test_list_stock_adjustments_pagination_meta_none_without_page(
+    context_with_typed_cache, no_sync
+):
+    """Without an explicit `page`, `pagination` is `None`."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [make_stock_adjustment(id=1)],
+    )
+
+    result = await _list_stock_adjustments_impl(
+        ListStockAdjustmentsRequest(limit=50), context
+    )
+
+    assert result.pagination is None
 
 
 # ============================================================================

--- a/katana_public_api_client/models_pydantic/_generated/__init__.py
+++ b/katana_public_api_client/models_pydantic/_generated/__init__.py
@@ -253,6 +253,8 @@ from .purchase_orders import (
 )
 from .sales_orders import (
     Address1,
+    CachedSalesOrder,
+    CachedSalesOrderRow,
     CreateSalesOrderAddressRequest,
     CreateSalesOrderFulfillmentRequest,
     CreateSalesOrderRequest,
@@ -316,6 +318,8 @@ from .stock import (
     BatchTransaction9,
     BatchTransaction10,
     BatchTransactionRequest,
+    CachedStockAdjustment,
+    CachedStockAdjustmentRow,
     CreateSerialNumberResourceType,
     CreateSerialNumbersRequest,
     CreateStockAdjustmentRequest,
@@ -403,6 +407,10 @@ __all__ = [
     "BatchTransactionRequest",
     "BomRow",
     "BomRowListResponse",
+    "CachedSalesOrder",
+    "CachedSalesOrderRow",
+    "CachedStockAdjustment",
+    "CachedStockAdjustmentRow",
     "ClearDemandForecastRequest",
     "Code",
     "Code1",

--- a/katana_public_api_client/models_pydantic/_generated/sales_orders.py
+++ b/katana_public_api_client/models_pydantic/_generated/sales_orders.py
@@ -85,18 +85,10 @@ class UpdateSalesOrderStatus(StrEnum):
     delivered = "DELIVERED"
 
 
-class SalesOrderRow(DeletableEntity, table=True):
-    __tablename__ = "sales_order_row"
-    model_config = ConfigDict(frozen=False)
-
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
-
+class SalesOrderRow(DeletableEntity):
+    id: Annotated[int, Field(description="Unique identifier for the sales order row")]
     sales_order_id: Annotated[
-        int | None,
-        SQLField(
-            foreign_key="sales_order.id",
-            description="ID of the sales order this row belongs to",
-        ),
+        int | None, Field(description="ID of the sales order this row belongs to")
     ] = None
     quantity: Annotated[
         float, Field(description="Ordered quantity of the product variant")
@@ -121,7 +113,7 @@ class SalesOrderRow(DeletableEntity, table=True):
         ),
     ] = None
     product_expected_date: Annotated[
-        datetime | None,
+        AwareDatetime | None,
         Field(
             description="Expected date when the product will be available if not currently in stock"
         ),
@@ -153,23 +145,18 @@ class SalesOrderRow(DeletableEntity, table=True):
     ] = None
     attributes: Annotated[
         list[Attribute] | None,
-        SQLField(
-            sa_column=Column(JSON),
-            description="Custom attributes associated with this sales order row",
-        ),
+        Field(description="Custom attributes associated with this sales order row"),
     ] = None
     batch_transactions: Annotated[
         list[BatchTransaction6] | None,
-        SQLField(
-            sa_column=Column(JSON),
-            description="Batch allocations for this order row when using batch tracking",
+        Field(
+            description="Batch allocations for this order row when using batch tracking"
         ),
     ] = None
     serial_numbers: Annotated[
         list[int] | None,
-        SQLField(
-            sa_column=Column(JSON),
-            description="Serial numbers allocated to this order row for serialized products",
+        Field(
+            description="Serial numbers allocated to this order row for serialized products"
         ),
     ] = None
     linked_manufacturing_order_id: Annotated[
@@ -182,12 +169,9 @@ class SalesOrderRow(DeletableEntity, table=True):
         float | None, Field(description="Currency conversion rate used for this row")
     ] = None
     conversion_date: Annotated[
-        datetime | None,
+        AwareDatetime | None,
         Field(description="Date when the currency conversion rate was applied"),
     ] = None
-    sales_order: Optional["SalesOrder"] = Relationship(
-        back_populates="sales_order_rows"
-    )
 
 
 class SalesOrderAddress(DeletableEntity):
@@ -958,12 +942,7 @@ class SalesReturnReason(KatanaPydanticBase):
     name: Annotated[str, Field(description="Return reason name")]
 
 
-class SalesOrder(DeletableEntity, table=True):
-    __tablename__ = "sales_order"
-    model_config = ConfigDict(frozen=False)
-
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
-
+class SalesOrder(DeletableEntity):
     customer_id: Annotated[
         int, Field(description="Unique identifier of the customer placing the order")
     ]
@@ -978,17 +957,17 @@ class SalesOrder(DeletableEntity, table=True):
         ),
     ] = None
     order_created_date: Annotated[
-        datetime | None,
+        AwareDatetime | None,
         Field(
             description="Date and time when the sales order was created in the system"
         ),
     ] = None
     delivery_date: Annotated[
-        datetime | None,
+        AwareDatetime | None,
         Field(description="Requested or promised delivery date for the order"),
     ] = None
     picked_date: Annotated[
-        datetime | None,
+        AwareDatetime | None,
         Field(description="Date when items were picked from inventory for shipment"),
     ] = None
     location_id: Annotated[
@@ -1015,7 +994,7 @@ class SalesOrder(DeletableEntity, table=True):
         ),
     ] = None
     conversion_date: Annotated[
-        datetime | None,
+        AwareDatetime | None,
         Field(description="Date when the currency conversion rate was applied"),
     ] = None
     invoicing_status: Annotated[
@@ -1039,7 +1018,12 @@ class SalesOrder(DeletableEntity, table=True):
         str | None,
         Field(description="Customer's reference number or purchase order number"),
     ] = None
-    sales_order_rows: list["SalesOrderRow"] = Relationship(back_populates="sales_order")
+    sales_order_rows: Annotated[
+        list[SalesOrderRow] | None,
+        Field(
+            description="Line items included in the sales order with product details and quantities"
+        ),
+    ] = None
     ecommerce_order_type: Annotated[
         str | None,
         Field(
@@ -1058,14 +1042,14 @@ class SalesOrder(DeletableEntity, table=True):
     ] = None
     product_availability: Annotated[ProductAvailability | None, Field()] = None
     product_expected_date: Annotated[
-        datetime | None,
+        AwareDatetime | None,
         Field(
             description="Expected date when products will be available for fulfillment"
         ),
     ] = None
     ingredient_availability: Annotated[IngredientAvailability | None, Field()] = None
     ingredient_expected_date: Annotated[
-        datetime | None,
+        AwareDatetime | None,
         Field(
             description="Expected date when ingredients will be available for production"
         ),
@@ -1100,17 +1084,13 @@ class SalesOrder(DeletableEntity, table=True):
     ] = None
     shipping_fee: Annotated[
         SalesOrderShippingFee | None,
-        SQLField(
-            sa_column=Column(JSON),
+        Field(
             description="Shipping fee details for this sales order",
         ),
     ] = None
     addresses: Annotated[
         list[SalesOrderAddress] | None,
-        SQLField(
-            sa_column=Column(JSON),
-            description="Complete address information for billing and shipping",
-        ),
+        Field(description="Complete address information for billing and shipping"),
     ] = None
 
 
@@ -1208,5 +1188,268 @@ class SalesOrderShippingFeeListResponse(KatanaPydanticBase):
         list[SalesOrderShippingFee] | None,
         Field(
             description="Array of shipping fee records with costs and tax information"
+        ),
+    ] = None
+
+
+class CachedSalesOrderRow(DeletableEntity, table=True):
+    __tablename__ = "sales_order_row"
+    model_config = ConfigDict(frozen=False)
+
+    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+
+    sales_order_id: Annotated[
+        int | None,
+        SQLField(
+            foreign_key="sales_order.id",
+            description="ID of the sales order this row belongs to",
+        ),
+    ] = None
+    quantity: Annotated[
+        float, Field(description="Ordered quantity of the product variant")
+    ]
+    variant_id: Annotated[
+        int, Field(description="ID of the product variant being ordered")
+    ]
+    tax_rate_id: Annotated[
+        int | None, Field(description="ID of the tax rate applied to this line item")
+    ] = None
+    tax_rate: Annotated[
+        float | None, Field(description="Tax rate percentage applied to this line item")
+    ] = None
+    location_id: Annotated[
+        int | None,
+        Field(description="Location where the product should be picked from"),
+    ] = None
+    product_availability: Annotated[
+        ProductAvailability | None,
+        Field(
+            description="Current availability status of the product for this order row",
+        ),
+    ] = None
+    product_expected_date: Annotated[
+        datetime | None,
+        Field(
+            description="Expected date when the product will be available if not currently in stock"
+        ),
+    ] = None
+    price_per_unit: Annotated[
+        float | None, Field(description="Selling price per unit in the order currency")
+    ] = None
+    price_per_unit_in_base_currency: Annotated[
+        float | None,
+        Field(
+            description="Selling price per unit converted to the base company currency"
+        ),
+    ] = None
+    total: Annotated[
+        float | None,
+        Field(
+            description="Total line amount (quantity * price_per_unit) in order currency"
+        ),
+    ] = None
+    total_in_base_currency: Annotated[
+        float | None,
+        Field(description="Total line amount converted to the base company currency"),
+    ] = None
+    total_discount: Annotated[
+        str | None, Field(description="Discount amount applied to this line item")
+    ] = None
+    cogs_value: Annotated[
+        float | None, Field(description="Cost of goods sold value for this line item")
+    ] = None
+    attributes: Annotated[
+        list[Attribute] | None,
+        SQLField(
+            sa_column=Column(JSON),
+            description="Custom attributes associated with this sales order row",
+        ),
+    ] = None
+    batch_transactions: Annotated[
+        list[BatchTransaction6] | None,
+        SQLField(
+            sa_column=Column(JSON),
+            description="Batch allocations for this order row when using batch tracking",
+        ),
+    ] = None
+    serial_numbers: Annotated[
+        list[int] | None,
+        SQLField(
+            sa_column=Column(JSON),
+            description="Serial numbers allocated to this order row for serialized products",
+        ),
+    ] = None
+    linked_manufacturing_order_id: Annotated[
+        int | None,
+        Field(
+            description="ID of the manufacturing order linked to this sales order row for make-to-order items"
+        ),
+    ] = None
+    conversion_rate: Annotated[
+        float | None, Field(description="Currency conversion rate used for this row")
+    ] = None
+    conversion_date: Annotated[
+        datetime | None,
+        Field(description="Date when the currency conversion rate was applied"),
+    ] = None
+    sales_order: Optional["CachedSalesOrder"] = Relationship(
+        back_populates="sales_order_rows"
+    )
+
+
+class CachedSalesOrder(DeletableEntity, table=True):
+    __tablename__ = "sales_order"
+    model_config = ConfigDict(frozen=False)
+
+    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+
+    customer_id: Annotated[
+        int, Field(description="Unique identifier of the customer placing the order")
+    ]
+    order_no: Annotated[
+        str,
+        Field(description="Unique order number for tracking and reference purposes"),
+    ]
+    source: Annotated[
+        str | None,
+        Field(
+            description="Source system or channel where the order originated (e.g., Shopify, manual entry)"
+        ),
+    ] = None
+    order_created_date: Annotated[
+        datetime | None,
+        Field(
+            description="Date and time when the sales order was created in the system"
+        ),
+    ] = None
+    delivery_date: Annotated[
+        datetime | None,
+        Field(description="Requested or promised delivery date for the order"),
+    ] = None
+    picked_date: Annotated[
+        datetime | None,
+        Field(description="Date when items were picked from inventory for shipment"),
+    ] = None
+    location_id: Annotated[
+        int,
+        Field(
+            description="Unique identifier of the fulfillment location for this order"
+        ),
+    ]
+    status: Annotated[
+        SalesOrderStatus,
+        Field(description="Current fulfillment status of the sales order"),
+    ]
+    currency: Annotated[
+        str | None,
+        Field(
+            description="Currency code for the order pricing (ISO 4217 format)",
+            pattern="^[A-Z]{3}$",
+        ),
+    ] = None
+    conversion_rate: Annotated[
+        float | None,
+        Field(
+            description="Exchange rate used to convert order currency to base company currency"
+        ),
+    ] = None
+    conversion_date: Annotated[
+        datetime | None,
+        Field(description="Date when the currency conversion rate was applied"),
+    ] = None
+    invoicing_status: Annotated[
+        str | None,
+        Field(description="Current invoicing status indicating billing progress"),
+    ] = None
+    total: Annotated[
+        float | None, Field(description="Total order amount in the order currency")
+    ] = None
+    total_in_base_currency: Annotated[
+        float | None,
+        Field(
+            description="Total order amount converted to the company's base currency"
+        ),
+    ] = None
+    additional_info: Annotated[
+        str | None,
+        Field(description="Additional notes or instructions for the sales order"),
+    ] = None
+    customer_ref: Annotated[
+        str | None,
+        Field(description="Customer's reference number or purchase order number"),
+    ] = None
+    sales_order_rows: list["CachedSalesOrderRow"] = Relationship(
+        back_populates="sales_order"
+    )
+    ecommerce_order_type: Annotated[
+        str | None,
+        Field(
+            description="Type of ecommerce order when imported from external platforms"
+        ),
+    ] = None
+    ecommerce_store_name: Annotated[
+        str | None,
+        Field(
+            description="Name of the ecommerce store when order originated from external platforms"
+        ),
+    ] = None
+    ecommerce_order_id: Annotated[
+        str | None,
+        Field(description="Original order ID from the external ecommerce platform"),
+    ] = None
+    product_availability: Annotated[ProductAvailability | None, Field()] = None
+    product_expected_date: Annotated[
+        datetime | None,
+        Field(
+            description="Expected date when products will be available for fulfillment"
+        ),
+    ] = None
+    ingredient_availability: Annotated[IngredientAvailability | None, Field()] = None
+    ingredient_expected_date: Annotated[
+        datetime | None,
+        Field(
+            description="Expected date when ingredients will be available for production"
+        ),
+    ] = None
+    production_status: Annotated[
+        SalesOrderProductionStatus | None,
+        Field(
+            description="Current status of production for items in this order",
+        ),
+    ] = None
+    tracking_number: Annotated[
+        str | None,
+        Field(description="Shipping carrier tracking number for package tracking"),
+    ] = None
+    tracking_number_url: Annotated[
+        str | None,
+        Field(description="URL link to track the shipment on carrier website"),
+    ] = None
+    billing_address_id: Annotated[
+        int | None,
+        Field(description="Reference to the customer address used for billing"),
+    ] = None
+    shipping_address_id: Annotated[
+        int | None,
+        Field(description="Reference to the customer address used for shipping"),
+    ] = None
+    linked_manufacturing_order_id: Annotated[
+        int | None,
+        Field(
+            description="ID of the linked manufacturing order if this sales order has associated production"
+        ),
+    ] = None
+    shipping_fee: Annotated[
+        SalesOrderShippingFee | None,
+        SQLField(
+            sa_column=Column(JSON),
+            description="Shipping fee details for this sales order",
+        ),
+    ] = None
+    addresses: Annotated[
+        list[SalesOrderAddress] | None,
+        SQLField(
+            sa_column=Column(JSON),
+            description="Complete address information for billing and shipping",
         ),
     ] = None

--- a/katana_public_api_client/models_pydantic/_generated/stock.py
+++ b/katana_public_api_client/models_pydantic/_generated/stock.py
@@ -6,12 +6,16 @@ To regenerate, run:
     uv run poe generate-pydantic
 """
 
-from __future__ import annotations
-
+from datetime import datetime
 from enum import StrEnum
-from typing import Annotated
+from typing import Annotated, Optional
 
 from pydantic import AwareDatetime, ConfigDict, Field
+from sqlalchemy import JSON, Column
+from sqlmodel import (
+    Field as SQLField,
+    Relationship,
+)
 
 from katana_public_api_client.models_pydantic._base import KatanaPydanticBase
 
@@ -903,3 +907,73 @@ class SerialNumberStockListResponse(KatanaPydanticBase):
         list[SerialNumberStock] | None,
         Field(description="Array of serial number stock items"),
     ] = None
+
+
+class CachedStockAdjustmentRow(KatanaPydanticBase, table=True):
+    __tablename__ = "stock_adjustment_row"
+    model_config = ConfigDict(frozen=False)
+
+    stock_adjustment_id: Annotated[
+        int | None,
+        SQLField(
+            foreign_key="stock_adjustment.id",
+            description="(cache-only) ID of the parent row, populated by SQLAlchemy on insert.",
+        ),
+    ] = None
+
+    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+
+    variant_id: Annotated[
+        int, Field(description="ID of the product or material variant being adjusted")
+    ]
+    quantity: Annotated[
+        float, Field(description="Quantity to adjust (positive or negative)")
+    ]
+    cost_per_unit: Annotated[
+        float | None,
+        Field(
+            description="Cost per unit for this adjustment (defaults to current average cost if not specified)"
+        ),
+    ] = None
+    batch_transactions: Annotated[
+        list[StockAdjustmentBatchTransaction] | None,
+        SQLField(
+            sa_column=Column(JSON),
+            description="Optional batch-specific adjustments for tracked inventory",
+        ),
+    ] = None
+    stock_adjustment: Optional["CachedStockAdjustment"] = Relationship(
+        back_populates="stock_adjustment_rows"
+    )
+
+
+class CachedStockAdjustment(DeletableEntity, table=True):
+    __tablename__ = "stock_adjustment"
+    model_config = ConfigDict(frozen=False)
+
+    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+
+    stock_adjustment_number: Annotated[
+        str,
+        Field(
+            description="Human-readable reference number for tracking and audit purposes"
+        ),
+    ]
+    stock_adjustment_date: Annotated[
+        datetime | None,
+        Field(description="Date and time when the adjustment was performed"),
+    ] = None
+    location_id: Annotated[
+        int,
+        Field(description="ID of the location where the stock adjustment is performed"),
+    ]
+    reason: Annotated[
+        str | None, Field(description="Reason for the stock adjustment")
+    ] = None
+    additional_info: Annotated[
+        str | None,
+        Field(description="Optional notes or comments about the adjustment reason"),
+    ] = None
+    stock_adjustment_rows: list["CachedStockAdjustmentRow"] = Relationship(
+        back_populates="stock_adjustment"
+    )

--- a/scripts/generate_pydantic_models.py
+++ b/scripts/generate_pydantic_models.py
@@ -175,7 +175,12 @@ DOMAIN_GROUPS: dict[str, list[str]] = {
 # into SQLAlchemy table semantics (`table=True`) so they double as cache row
 # schemas. Expanded incrementally per-entity as list tools get cache-backed;
 # PR 2 covers SalesOrder + SalesOrderRow as the pattern-proving pair.
-CACHE_TABLES: set[str] = {"SalesOrder", "SalesOrderRow"}
+CACHE_TABLES: set[str] = {
+    "SalesOrder",
+    "SalesOrderRow",
+    "StockAdjustment",
+    "StockAdjustmentRow",
+}
 
 
 @dataclass(frozen=True)
@@ -198,6 +203,18 @@ def _snake_case(name: str) -> str:
     return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
 
 
+def _cached_name(name: str) -> str:
+    """API class name → cache-row class name (``SalesOrder`` → ``CachedSalesOrder``).
+
+    Cache rows live as ``Cached<Name>`` siblings of the API pydantic models
+    so the API surface stays pure (no ``table=True``, no FK pollution) while
+    the cache schema can carry SQLAlchemy machinery, FK back-pointers, and
+    relationships. Use this everywhere instead of string-formatting so the
+    convention is centralized.
+    """
+    return f"Cached{name}"
+
+
 CACHE_RELATIONSHIPS: list[CacheTableRelationship] = [
     CacheTableRelationship(
         parent="SalesOrder",
@@ -205,6 +222,13 @@ CACHE_RELATIONSHIPS: list[CacheTableRelationship] = [
         child="SalesOrderRow",
         child_back_ref="sales_order",
         child_fk_field="sales_order_id",
+    ),
+    CacheTableRelationship(
+        parent="StockAdjustment",
+        parent_field="stock_adjustment_rows",
+        child="StockAdjustmentRow",
+        child_back_ref="stock_adjustment",
+        child_fk_field="stock_adjustment_id",
     ),
 ]
 
@@ -216,6 +240,7 @@ CACHE_RELATIONSHIPS: list[CacheTableRelationship] = [
 CACHE_JSON_COLUMNS: dict[str, list[str]] = {
     "SalesOrder": ["shipping_fee", "addresses"],
     "SalesOrderRow": ["attributes", "batch_transactions", "serial_numbers"],
+    "StockAdjustmentRow": ["batch_transactions"],
 }
 
 
@@ -416,13 +441,18 @@ def parse_generated_file(
     # Add extra="ignore" to BaseEntity for API response tolerance (#295)
     classes = add_base_entity_extra_ignore(classes)
 
-    # #342 cache-table transforms — opt-in SQLModel table semantics for
-    # CACHE_TABLES entries. Order matters:
-    # 1. table=True + frozen=False model_config on the class header.
-    # 2. Redeclare id with primary_key=True (depends on the model_config
-    #    line placed by step 1).
-    # 3. Swap AwareDatetime → datetime so SQLModel's type inference works.
-    # 4. FK / relationship / JSON column annotations on field declarations.
+    # #342 cache-table transforms — emit a ``Cached<Name>`` sibling for
+    # each CACHE_TABLES entry. The original API class stays pure pydantic;
+    # the cache class carries SQLModel ``table=True``, primary keys, FKs,
+    # relationships, and JSON columns. Order matters:
+    # 1. Duplicate each CACHE_TABLES API class as a ``Cached<Name>`` copy
+    #    with internal references to other cached siblings rewritten.
+    # 2. table=True + frozen=False model_config on the cached class header.
+    # 3. Redeclare id with primary_key=True (depends on the model_config
+    #    line placed by step 2).
+    # 4. Swap AwareDatetime → datetime so SQLModel's type inference works.
+    # 5. FK / relationship / JSON column annotations on field declarations.
+    classes = duplicate_cache_tables_as_cached_siblings(classes)
     classes = inject_table_annotations(classes)
     classes = inject_primary_key_in_table_classes(classes)
     classes = swap_awaredatetime_for_datetime(classes)
@@ -692,6 +722,91 @@ def add_base_entity_extra_ignore(classes: list[ClassInfo]) -> list[ClassInfo]:
 # ── #342 cache-table AST transforms ────────────────────────────────────────
 
 
+def duplicate_cache_tables_as_cached_siblings(
+    classes: list[ClassInfo],
+) -> list[ClassInfo]:
+    """For each CACHE_TABLES entry, emit a ``Cached<Name>`` sibling class.
+
+    The original API class stays pure pydantic — never gets ``table=True``,
+    FKs, or relationships. The cached sibling is a copy of the source with:
+    - The class identifier rewritten ``<Name>`` → ``Cached<Name>``.
+    - References to other cached siblings rewritten (e.g.,
+      ``list[SalesOrderRow]`` → ``list[CachedSalesOrderRow]``) so a
+      relationship between two cache tables wires up to the cache copies,
+      not the API ones.
+    - Forward-reference strings inside ``Annotated`` / type hints rewritten
+      the same way (covers cases where the type appears in a string-quoted
+      forward ref).
+
+    All subsequent inject passes target the ``Cached<Name>`` copies; the
+    originals are left untouched. References from non-cache classes
+    (``SalesOrderListResponse.data: list[SalesOrder]``) keep pointing at
+    the API classes.
+    """
+    cached_targets = {n: _cached_name(n) for n in CACHE_TABLES}
+
+    def _rewrite_internal_refs(source: str) -> str:
+        new_source = source
+        # Word-boundary swap so e.g. ``SalesOrder`` → ``CachedSalesOrder``
+        # doesn't also touch ``SalesOrderRow`` (the longer name handled in
+        # its own iteration). Iterate longest-first to avoid corrupting
+        # nested references like ``SalesOrderRow`` → ``CachedSalesOrderRow``
+        # when ``SalesOrder`` is rewritten first.
+        for original in sorted(cached_targets, key=len, reverse=True):
+            cached = cached_targets[original]
+            new_source = re.sub(rf"\b{re.escape(original)}\b", cached, new_source)
+        return new_source
+
+    cached_copies: list[ClassInfo] = []
+    for cls in classes:
+        if cls.name not in cached_targets:
+            continue
+        cached_name = cached_targets[cls.name]
+        # Replace the class header identifier first (single hit), then
+        # rewrite remaining cross-cache references in field annotations.
+        # Bases are left intact — cache classes inherit from the same base
+        # entity classes (DeletableEntity, etc.) as their API siblings.
+        new_source = re.sub(
+            rf"^class {re.escape(cls.name)}\b",
+            f"class {cached_name}",
+            cls.source,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        new_source = _rewrite_internal_refs(new_source)
+        # Strip body-level statements that the cache passes will replace
+        # with their SQL-aware equivalents. Standalone classes (extending
+        # ``KatanaPydanticBase`` directly rather than an entity base) emit
+        # their own ``model_config = ConfigDict(extra="forbid")`` plus an
+        # optional ``id`` field — both must go before ``inject_table_annotations``
+        # injects ``model_config = ConfigDict(frozen=False)`` and
+        # ``inject_primary_key_in_table_classes`` injects the primary-key
+        # ``id`` declaration. Match both single-line and multi-line forms.
+        new_source = re.sub(
+            r"    model_config = ConfigDict\([^)]*\)\n",
+            "",
+            new_source,
+        )
+        new_source = re.sub(
+            r"    id:\s*Annotated\[\s*int(?:\s*\|\s*None)?\s*,"
+            r"[^]]*\][^\n]*\n",
+            "",
+            new_source,
+            count=1,
+            flags=re.DOTALL,
+        )
+        cached_copies.append(
+            ClassInfo(
+                name=cached_name,
+                source=new_source,
+                bases=list(cls.bases),
+                line_start=cls.line_start,
+                line_end=cls.line_end,
+            )
+        )
+    return classes + cached_copies
+
+
 def inject_primary_key_in_table_classes(classes: list[ClassInfo]) -> list[ClassInfo]:
     """Redeclare ``id`` on each table class with ``primary_key=True``.
 
@@ -703,9 +818,10 @@ def inject_primary_key_in_table_classes(classes: list[ClassInfo]) -> list[ClassI
     tailored description) that overrides ``BaseEntity.id`` — we strip that
     declaration before injecting the primary-keyed form to avoid duplicates.
     """
+    cache_class_names = {_cached_name(n) for n in CACHE_TABLES}
     fixed = []
     for cls in classes:
-        if cls.name not in CACHE_TABLES:
+        if cls.name not in cache_class_names:
             fixed.append(cls)
             continue
         # Strip any existing in-body `id: Annotated[int, Field(...)]`
@@ -761,12 +877,17 @@ def inject_table_annotations(classes: list[ClassInfo]) -> list[ClassInfo]:
        ``frozen=True`` from ``KatanaPydanticBase`` would otherwise raise on
        every attribute write.
     """
+    cache_class_names = {_cached_name(n) for n in CACHE_TABLES}
     fixed = []
     for cls in classes:
-        if cls.name not in CACHE_TABLES:
+        if cls.name not in cache_class_names:
             fixed.append(cls)
             continue
-        tablename = _snake_case(cls.name)
+        # ``__tablename__`` is the snake_case of the *original* (un-prefixed)
+        # entity name so FK references like ``sales_order.id`` resolve
+        # correctly — both API consumers and cache code think of the table
+        # as "sales_order", not "cached_sales_order".
+        tablename = _snake_case(cls.name.removeprefix("Cached"))
         # Single pass: append `, table=True` to the class bases and inject
         # __tablename__ + model_config as the first body statements.
         new_source, n = re.subn(
@@ -800,16 +921,27 @@ def inject_table_annotations(classes: list[ClassInfo]) -> list[ClassInfo]:
 
 
 def inject_foreign_keys(classes: list[ClassInfo]) -> list[ClassInfo]:
-    """Add ``foreign_key="<parent_table>.id"`` to child FK columns.
+    """Add ``foreign_key="<parent_table>.id"`` to child cache-row FK columns.
 
-    The generated pydantic models already carry the int FK fields
-    (e.g., ``SalesOrderRow.sales_order_id``); we just annotate the existing
-    ``Field(...)`` call with the SQLAlchemy FK constraint.
+    Two cases:
+    1. The API model already carries the FK field (e.g.,
+       ``SalesOrderRow.sales_order_id`` — Katana returns it). Rewrite the
+       existing ``Field(...)`` call to ``SQLField(foreign_key=..., ...)``.
+    2. The API model lacks the field because Katana doesn't return one
+       (e.g., ``StockAdjustmentRow``: rows are nested under the parent on
+       the wire, no back-pointer). Insert a fresh ``SQLField`` declaration
+       — the FK is a cache-only column, populated by SQLAlchemy when the
+       parent's relationship is set on ``session.merge``.
+
+    Either way we operate exclusively on the ``Cached<Name>`` siblings;
+    the API class never gets a SQL-specific kwarg or a synthetic FK field.
     """
-    # Map child class → list of (fk_field, parent_tablename) for O(1) lookup.
+    # Map cache-class → list of (fk_field, parent_tablename). Lookup uses
+    # the cached name (``CachedSalesOrderRow``) since the API class
+    # (``SalesOrderRow``) is excluded from cache transforms.
     by_child: dict[str, list[tuple[str, str]]] = defaultdict(list)
     for rel in CACHE_RELATIONSHIPS:
-        by_child[rel.child].append((rel.child_fk_field, rel.parent_table))
+        by_child[_cached_name(rel.child)].append((rel.child_fk_field, rel.parent_table))
 
     fixed = []
     for cls in classes:
@@ -828,6 +960,37 @@ def inject_foreign_keys(classes: list[ClassInfo]) -> list[ClassInfo]:
             )
             replacement = rf'\1SQLField(foreign_key="{parent_table}.id", \2'
             new_source, n = re.subn(pattern, replacement, new_source, count=1)
+            if n == 0:
+                # Field doesn't exist in the API model — insert a fresh
+                # cache-only declaration after the model_config block. This
+                # is the StockAdjustmentRow / PurchaseOrderRow / StockTransferRow
+                # case: Katana doesn't return the parent FK on row objects;
+                # we synthesize the column so SQLAlchemy can wire the
+                # parent→child relationship on insert.
+                fk_line = (
+                    f"    {fk_field}: Annotated[\n"
+                    f"        int | None,\n"
+                    f"        SQLField(\n"
+                    f'            foreign_key="{parent_table}.id",\n'
+                    f'            description="(cache-only) ID of the parent '
+                    f'row, populated by SQLAlchemy on insert.",\n'
+                    f"        ),\n"
+                    f"    ] = None\n"
+                )
+                new_source, n = re.subn(
+                    r"(model_config = ConfigDict\(frozen=False\)\n\n)",
+                    rf"\1{fk_line}\n",
+                    new_source,
+                    count=1,
+                )
+                if n != 1:
+                    msg = (
+                        f"Failed to insert synthesized foreign_key "
+                        f"{cls.name}.{fk_field}. Expected model_config "
+                        "block on the cache class."
+                    )
+                    raise GenerationError(msg)
+                continue
             if n != 1:
                 msg = (
                     f"Failed to inject foreign_key on {cls.name}.{fk_field}. "
@@ -849,30 +1012,40 @@ def inject_foreign_keys(classes: list[ClassInfo]) -> list[ClassInfo]:
 def inject_relationship_fields(classes: list[ClassInfo]) -> list[ClassInfo]:
     """Rewrite parent list fields as ``Relationship()`` and add child back-refs.
 
+    Operates on the ``Cached<Name>`` siblings only — both sides of the
+    relationship reference cached classes so the SQLAlchemy graph doesn't
+    cross over into the pure-pydantic API surface.
+
     For each declared parent→child relationship:
-    - Parent: ``parent_field: Annotated[list[Child] | None, Field(...)] = None``
-      becomes ``parent_field: list["Child"] = Relationship(back_populates="child_back_ref")``.
-    - Child: a new field ``child_back_ref: "Parent | None" = Relationship(
-      back_populates="parent_field")`` is appended to the class body.
+    - Parent (``Cached<Parent>``): the ``Annotated[list[Child] | None,
+      Field(...)] = None`` field — note the inner type was rewritten to
+      ``Cached<Child>`` by ``duplicate_cache_tables_as_cached_siblings``
+      — becomes ``parent_field: list["Cached<Child>"] = Relationship(
+      back_populates="child_back_ref")``.
+    - Child (``Cached<Child>``): a new ``child_back_ref:
+      Optional["Cached<Parent>"] = Relationship(back_populates="parent_field")``
+      field is appended to the class body.
     """
-    by_parent = {rel.parent: rel for rel in CACHE_RELATIONSHIPS}
-    by_child = {rel.child: rel for rel in CACHE_RELATIONSHIPS}
+    by_parent = {_cached_name(rel.parent): rel for rel in CACHE_RELATIONSHIPS}
+    by_child = {_cached_name(rel.child): rel for rel in CACHE_RELATIONSHIPS}
 
     fixed = []
     for cls in classes:
         new_source = cls.source
 
-        # Parent side: replace the list field with Relationship().
+        # Parent side: replace the list field with Relationship(). The inner
+        # type was rewritten to ``Cached<Child>`` during duplication, so the
+        # match pattern uses the cached child name.
         if cls.name in by_parent:
             rel = by_parent[cls.name]
-            # Match the whole field declaration including its `= None` default.
+            cached_child = _cached_name(rel.child)
             pattern = (
                 rf"{re.escape(rel.parent_field)}:\s*Annotated\[\s*"
-                rf"list\[{re.escape(rel.child)}\]\s*\|\s*None,\s*"
+                rf"list\[{re.escape(cached_child)}\]\s*\|\s*None,\s*"
                 r"Field\([^)]*\),?\s*\]\s*=\s*None"
             )
             replacement = (
-                f'{rel.parent_field}: list["{rel.child}"] = '
+                f'{rel.parent_field}: list["{cached_child}"] = '
                 f'Relationship(back_populates="{rel.child_back_ref}")'
             )
             new_source, n = re.subn(pattern, replacement, new_source, count=1)
@@ -880,19 +1053,20 @@ def inject_relationship_fields(classes: list[ClassInfo]) -> list[ClassInfo]:
                 msg = (
                     f"Failed to rewrite list relationship on "
                     f"{cls.name}.{rel.parent_field}. Expected shape "
-                    f"`Annotated[list[{rel.child}] | None, Field(...)] = None`."
+                    f"`Annotated[list[{cached_child}] | None, Field(...)] = None`."
                 )
                 raise GenerationError(msg)
 
         # Child side: append back-reference field at end of class body.
         if cls.name in by_child:
             rel = by_child[cls.name]
+            cached_parent = _cached_name(rel.parent)
             # SA's ``relationship()`` string-form resolution can't parse
-            # ``"Parent | None"``. Use ``Optional["Parent"]`` so the outer
-            # Optional[] is evaluated at class-def time and only the inner
-            # ``"Parent"`` stays as a forward reference.
+            # ``"Cached<Parent> | None"``. Use ``Optional["Cached<Parent>"]``
+            # so the outer Optional[] is evaluated at class-def time and only
+            # the inner ``"Cached<Parent>"`` stays as a forward reference.
             backref_line = (
-                f'    {rel.child_back_ref}: Optional["{rel.parent}"] = '
+                f'    {rel.child_back_ref}: Optional["{cached_parent}"] = '
                 f'Relationship(back_populates="{rel.parent_field}")\n'
             )
             new_source = new_source.rstrip() + "\n" + backref_line
@@ -938,14 +1112,15 @@ def swap_awaredatetime_for_datetime(classes: list[ClassInfo]) -> list[ClassInfo]
     ``ValueError: AwareDatetime has no matching SQLAlchemy type`` at
     class-definition time.
 
-    Applies to CACHE_TABLES entries *and* to the shared entity base
+    Applies to ``Cached<Name>`` siblings *and* to the shared entity base
     classes (BaseEntity, UpdatableEntity, DeletableEntity, etc.) — their
     datetime fields are inherited by cache tables, so they too must speak
-    plain ``datetime``. Timezone awareness is a Katana wire-protocol
-    invariant; the extra pydantic validator was safety belt for data we
-    already trust.
+    plain ``datetime``. The pure-pydantic API classes are unaffected, but
+    swapping their inherited base ripples into them — that's accepted
+    since timezone awareness is a Katana wire-protocol invariant; the
+    extra pydantic validator was safety belt for data we already trust.
     """
-    swap_targets = CACHE_TABLES | _CACHE_BASE_CLASSES
+    swap_targets = {_cached_name(n) for n in CACHE_TABLES} | _CACHE_BASE_CLASSES
     fixed = []
     for cls in classes:
         if cls.name not in swap_targets:
@@ -975,11 +1150,16 @@ def inject_json_columns(classes: list[ClassInfo]) -> list[ClassInfo]:
     For fields listed in ``CACHE_JSON_COLUMNS`` — typically lists of
     polymorphic or non-cached nested models — this preserves the typed
     pydantic interface while telling SQLAlchemy to store them as JSON rather
-    than attempting to normalize them into child tables.
+    than attempting to normalize them into child tables. Operates on the
+    ``Cached<Name>`` siblings: ``CACHE_JSON_COLUMNS`` keys are user-facing
+    API names so the cached lookup converts via ``_cached_name``.
     """
+    cached_json_columns = {
+        _cached_name(name): fields for name, fields in CACHE_JSON_COLUMNS.items()
+    }
     fixed = []
     for cls in classes:
-        fields = CACHE_JSON_COLUMNS.get(cls.name)
+        fields = cached_json_columns.get(cls.name)
         if not fields:
             fixed.append(cls)
             continue
@@ -1017,18 +1197,23 @@ def classify_class(class_name: str) -> str:
 
     Exact matches are checked first (across all groups) before prefix matches.
     This ensures that explicit class names take priority over wildcard patterns.
+    Cached siblings (``Cached<Name>``) classify under the same group as
+    their underlying API class, so cache classes co-locate in the same
+    module file as the model they shadow.
     """
+    effective_name = class_name.removeprefix("Cached")
+
     # First pass: check for exact matches across all groups
     for group_name, patterns in DOMAIN_GROUPS.items():
         for pattern in patterns:
-            if not pattern.endswith("*") and class_name == pattern:
+            if not pattern.endswith("*") and effective_name == pattern:
                 return group_name
 
     # Second pass: check for prefix matches
     for group_name, patterns in DOMAIN_GROUPS.items():
         for pattern in patterns:
             # Prefix match: pattern ends with * and class_name starts with pattern prefix
-            if pattern.endswith("*") and class_name.startswith(pattern[:-1]):
+            if pattern.endswith("*") and effective_name.startswith(pattern[:-1]):
                 return group_name
     return "common"
 
@@ -1096,8 +1281,10 @@ def generate_module_imports(
     # generator-injected field declarations use ``SQLField``; original
     # datamodel-codegen output keeps ``Field`` from pydantic.
     classes_in_module = {cls.name for cls in classes}
-    has_cache_tables = bool(classes_in_module & CACHE_TABLES)
-    has_json_columns = any(cls.name in CACHE_JSON_COLUMNS for cls in classes)
+    cached_class_names = {_cached_name(n) for n in CACHE_TABLES}
+    has_cache_tables = bool(classes_in_module & cached_class_names)
+    cached_json_class_names = {_cached_name(n) for n in CACHE_JSON_COLUMNS}
+    has_json_columns = any(cls.name in cached_json_class_names for cls in classes)
 
     # Add standard imports from the original file
     for imp in imports:
@@ -1144,7 +1331,7 @@ def generate_module_imports(
     # modules and the base module (shared entity bases feed cache tables via
     # inheritance).
     needs_datetime_import = any(
-        cls.name in (CACHE_TABLES | _CACHE_BASE_CLASSES) for cls in classes
+        cls.name in (cached_class_names | _CACHE_BASE_CLASSES) for cls in classes
     )
     if needs_datetime_import:
         import_lines.append("from datetime import datetime")
@@ -1198,7 +1385,8 @@ def write_module_file(
     # #342: modules with cache tables must NOT use `from __future__ import
     # annotations` — SQLAlchemy's relationship type resolution needs live
     # type objects at class-definition time.
-    has_cache_tables = any(cls.name in CACHE_TABLES for cls in classes)
+    cached_class_names = {_cached_name(n) for n in CACHE_TABLES}
+    has_cache_tables = any(cls.name in cached_class_names for cls in classes)
     future_annotations_line = (
         "" if has_cache_tables else "from __future__ import annotations\n\n"
     )

--- a/tests/test_models_pydantic.py
+++ b/tests/test_models_pydantic.py
@@ -207,8 +207,8 @@ class TestModelConfiguration:
         from sqlmodel import Session, SQLModel, create_engine, select
 
         from katana_public_api_client.models_pydantic._generated import (
-            SalesOrder,
-            SalesOrderRow,
+            CachedSalesOrder,
+            CachedSalesOrderRow,
             SalesOrderStatus,
         )
 
@@ -216,19 +216,21 @@ class TestModelConfiguration:
         SQLModel.metadata.create_all(engine)
 
         with Session(engine) as session:
-            order = SalesOrder(
+            order = CachedSalesOrder(
                 id=1,
                 customer_id=42,
                 location_id=1,
                 order_no="SO-001",
                 status=SalesOrderStatus.not_shipped,
             )
-            row = SalesOrderRow(id=1, sales_order_id=1, variant_id=100, quantity=5.0)
+            row = CachedSalesOrderRow(
+                id=1, sales_order_id=1, variant_id=100, quantity=5.0
+            )
             session.add(order)
             session.add(row)
             session.commit()
 
-            fetched = session.exec(select(SalesOrder)).one()
+            fetched = session.exec(select(CachedSalesOrder)).one()
             assert fetched.order_no == "SO-001"
             assert len(fetched.sales_order_rows) == 1
             assert fetched.sales_order_rows[0].variant_id == 100


### PR DESCRIPTION
Closes #376.

## Summary

Restructures the #342 cache-back machinery so the OpenAPI spec and the generated API pydantic models stay pure (mirror Katana's wire contract); cache schemas live on a parallel `Cached<Name>` class hierarchy emitted by the same generator pass. Then migrates `list_stock_adjustments` to be cache-backed, closing the filter-breadth bug from #342.

## Why this changes the pattern

PR #373 (list_sales_orders cache-back) overlaid SQLModel onto the API pydantic class in-place. That happened to work because Katana returns `sales_order_id` on `SalesOrderRow`, so no synthetic field was needed.

Two of the four remaining cache-back migrations (`StockAdjustmentRow`, future `PurchaseOrderRow`, `StockTransferRow`) don't have a parent FK on the wire — rows nest under the parent. The in-place pattern would force adding cache-only fields to the OpenAPI spec or to the API pydantic models. That ratchets cache implementation details into the public API surface; clean separation is worth a one-time refactor.

## Generator changes (`scripts/generate_pydantic_models.py`)

- New `duplicate_cache_tables_as_cached_siblings` pass copies each `CACHE_TABLES` class to a `Cached<Name>` sibling, rewriting internal references between cache classes (`list[SalesOrderRow]` → `list[CachedSalesOrderRow]`) so the SQLAlchemy relationship graph stays inside the cache copies.
- All `inject_*` passes now target `Cached<Name>` classes; the originals are left untouched (no `table=True`, no FKs, no relationships).
- `inject_foreign_keys` synthesizes a fresh `SQLField(foreign_key=...)` declaration when the FK column isn't in the source (the `StockAdjustmentRow` / future `PurchaseOrderRow` / `StockTransferRow` case).
- `classify_class` strips a leading `Cached` prefix before pattern matching so `CachedSalesOrder` co-locates with `SalesOrder` in `sales_orders.py`, etc.

## Cache + sync runtime

- `typed_cache/sync.py` adds two-step conversion helpers (`_attrs_sales_order_to_cached`, `_attrs_stock_adjustment_to_cached`) that route through the API pydantic model (to leverage `from_attrs`'s registry-driven nested conversion), then re-validate into the cache class. Children are built with explicit FKs and merged separately because SQLModel `Relationship` descriptors don't accept input via `__init__` / `model_validate`.
- `ensure_stock_adjustments_synced` mirrors `ensure_sales_orders_synced`, including the per-entity `asyncio.Lock` for cold-start single-flight.

## list_stock_adjustments tool migration

- Cache-backed `_list_stock_adjustments_impl` queries `CachedStockAdjustment`; `variant_id` runs as an `EXISTS` subquery against `CachedStockAdjustmentRow`, closing the filter-breadth bug flagged in #342 (matches on later API pages were missed).
- All filters (`ids`, `stock_adjustment_number`, `location_id`, `include_deleted`, date ranges, `variant_id`, `reason` ILIKE) run as indexed SQL against the cache.
- Pagination metadata comes from a SQL COUNT against the same filter predicate; `parse_pagination_header` is no longer used.

## Anti-pattern documentation

Added to `CLAUDE.md`: never add fields to the OpenAPI spec or to `_generated/*.py` API classes for cache or other internal consumer needs.

## Test plan

- [x] 14 cache-backed `list_stock_adjustments` tests replace the 17 mock-API tests
- [x] `uv run poe test` — 2,436 passed, 3 skipped
- [x] `uv run poe agent-check` — green
- [ ] Copilot review
- [ ] Manual smoke against staging Katana account

🤖 Generated with [Claude Code](https://claude.com/claude-code)