### PR TITLE
feat(client+mcp): cache-back list_purchase_orders (#378)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -629,11 +629,17 @@ field (#346 follow-on).
 ---
 
 ### list_purchase_orders
-List purchase orders with filters (list-tool pattern v2).
+List purchase orders with filters. Cache-backed post-#378 — all filters run as
+indexed SQL queries against the SQLModel typed cache. ``PurchaseOrderBase`` shadows
+both ``RegularPurchaseOrder`` and ``OutsourcedPurchaseOrder`` as one cache table
+named ``purchase_order``; the outsourced-only ``tracking_location_id`` field is
+hoisted onto the cache row so it's queryable across both subtypes.
 
 **Paging:**
 - `limit` (optional, default 50, min 1, max 250): Max rows to return
-- `page` (optional, min 1): Page number (1-based), disables auto-pagination
+- `page` (optional, min 1): Page number (1-based); when set, the response includes
+  `pagination` metadata (total_records, total_pages) computed via SQL COUNT against
+  the same filter predicate
 
 **Domain filters:**
 - `ids` (optional): Explicit list of PO IDs
@@ -643,23 +649,18 @@ List purchase orders with filters (list-tool pattern v2).
 - `billing_status` (optional): BILLED, NOT_BILLED, PARTIALLY_BILLED
 - `currency` (optional): Currency code (e.g. "USD")
 - `location_id` (optional): Receiving location ID
-- `tracking_location_id` (optional): Tracking location ID (outsourced)
+- `tracking_location_id` (optional): Tracking location ID (outsourced POs)
 - `supplier_id` (optional): Supplier ID
 - `include_deleted` (optional): Include soft-deleted POs
 
-**Time windows (server-side):**
+**Time windows** (all run as indexed SQL date-range queries):
 - `created_after` / `created_before`: ISO-8601 bounds on `created_at`
 - `updated_after` / `updated_before`: ISO-8601 bounds on `updated_at`
-
-**Time windows (client-side — Katana has no server filter):**
 - `expected_arrival_after` / `expected_arrival_before`: bounds on
-  `expected_arrival_date`. When set, the tool skips the page=1
-  short-circuit so auto-pagination can scan enough rows to find `limit`
-  matches post-filter.
+  `expected_arrival_date` (was a client-side post-fetch filter pre-cache; now indexed SQL)
 
 - `include_rows` (optional, default false): Populate per-PO line item detail
-  (variant_id, quantity, price, arrival). The list endpoint bundles rows
-  inline, so this is free compared to `list_sales_orders`.
+  (variant_id, quantity, price, arrival).
 - `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Summary rows with id, order_no, status, billing_status,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -11,7 +11,6 @@ These tools provide:
 from __future__ import annotations
 
 import asyncio
-import datetime as _datetime
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Annotated, Any, Literal
@@ -31,8 +30,7 @@ from katana_mcp.tools.tool_result_utils import (
     iso_or_none,
     make_simple_result,
     make_tool_result,
-    parse_iso_datetime,
-    parse_pagination_header,
+    parse_request_dates,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.client_types import UNSET
@@ -1610,20 +1608,21 @@ class ListPurchaseOrdersRequest(BaseModel):
         ge=1,
         le=250,
         description=(
-            "Max rows to return (default 50, min 1, max 250 — Katana's "
-            "per-page ceiling). When `page` is set, acts as the page size."
+            "Max rows to return (default 50, min 1, max 250). When `page` "
+            "is set, acts as the page size for that request."
         ),
     )
     page: int | None = Field(
         default=None,
         ge=1,
         description=(
-            "Page number (1-based). When set, disables auto-pagination; "
-            "use with `limit` as page size."
+            "Page number (1-based). When set, the response includes "
+            "`pagination` metadata (total_records, total_pages) computed "
+            "via SQL COUNT against the same filter predicate."
         ),
     )
 
-    # Domain filters (server-side on Katana)
+    # Domain filters
     ids: list[int] | None = Field(
         default=None, description="Filter by explicit list of purchase order IDs"
     )
@@ -1652,14 +1651,20 @@ class ListPurchaseOrdersRequest(BaseModel):
         default=None, description="Filter by receiving location ID"
     )
     tracking_location_id: int | None = Field(
-        default=None, description="Filter by tracking location ID (outsourced POs)"
+        default=None,
+        description=(
+            "Filter by tracking location ID (outsourced POs). The cache "
+            "stores this as a hoisted column on every row; regular POs "
+            "match only when ``None`` is filtered, which doesn't apply "
+            "here — pair with ``entity_type='outsourced'`` to scope."
+        ),
     )
     supplier_id: int | None = Field(default=None, description="Filter by supplier ID")
     include_deleted: bool | None = Field(
         default=None, description="When true, include soft-deleted purchase orders."
     )
 
-    # Time-window filters (server-side)
+    # Time-window filters (all run as indexed SQL date-range queries)
     created_after: str | None = Field(
         default=None, description="ISO-8601 datetime lower bound on created_at."
     )
@@ -1672,22 +1677,18 @@ class ListPurchaseOrdersRequest(BaseModel):
     updated_before: str | None = Field(
         default=None, description="ISO-8601 datetime upper bound on updated_at."
     )
-
-    # Time-window filters (client-side — Katana does not expose server-side
-    # filters for expected_arrival_date).
     expected_arrival_after: str | None = Field(
         default=None,
         description=(
-            "ISO-8601 datetime lower bound on expected_arrival_date. "
-            "Applied client-side — Katana has no server-side filter. Pair "
-            "with a created_at window to keep fetched rows bounded."
+            "ISO-8601 datetime lower bound on expected_arrival_date — "
+            "indexed SQL range filter against the cache."
         ),
     )
     expected_arrival_before: str | None = Field(
         default=None,
         description=(
-            "ISO-8601 datetime upper bound on expected_arrival_date. "
-            "Applied client-side — see `expected_arrival_after`."
+            "ISO-8601 datetime upper bound on expected_arrival_date — "
+            "indexed SQL range filter against the cache."
         ),
     )
 
@@ -1696,9 +1697,7 @@ class ListPurchaseOrdersRequest(BaseModel):
         default=False,
         description=(
             "When true, populate row-level detail (variant_id, quantity, "
-            "price, arrival date) on each summary. Katana bundles "
-            "purchase_order_rows inline on the list endpoint, so this is "
-            "free compared to `list_sales_orders`."
+            "price, arrival date) on each summary."
         ),
     )
 
@@ -1750,146 +1749,207 @@ class ListPurchaseOrdersResponse(BaseModel):
     pagination: PaginationMeta | None = None
 
 
-def _po_row_summary(row: Any) -> PurchaseOrderRowSummary:
-    arrival = unwrap_unset(row.arrival_date, None)
-    received = unwrap_unset(row.received_date, None)
-    return PurchaseOrderRowSummary(
-        id=unwrap_unset(row.id, None),
-        variant_id=unwrap_unset(row.variant_id, None),
-        quantity=unwrap_unset(row.quantity, None),
-        price_per_unit=unwrap_unset(row.price_per_unit, None),
-        arrival_date=iso_or_none(arrival)
-        if isinstance(arrival, _datetime.datetime)
-        else None,
-        received_date=iso_or_none(received)
-        if isinstance(received, _datetime.datetime)
-        else None,
-        total=unwrap_unset(row.total, None),
+_PURCHASE_ORDER_DATE_FIELDS = (
+    "created_after",
+    "created_before",
+    "updated_after",
+    "updated_before",
+    "expected_arrival_after",
+    "expected_arrival_before",
+)
+
+
+def _apply_purchase_order_filters(
+    stmt: Any,
+    request: ListPurchaseOrdersRequest,
+    parsed_dates: dict[str, datetime | None],
+) -> Any:
+    """Translate request filters into WHERE clauses on a CachedPurchaseOrder query.
+
+    Shared by the data SELECT and the COUNT SELECT so pagination totals
+    reflect exactly the same filter set as the data rows.
+    """
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedPurchaseOrder,
+        PurchaseOrderBillingStatus,
+        PurchaseOrderEntityType,
+        PurchaseOrderStatus,
     )
+
+    if request.ids is not None:
+        stmt = stmt.where(CachedPurchaseOrder.id.in_(request.ids))
+    if request.order_no is not None:
+        stmt = stmt.where(CachedPurchaseOrder.order_no == request.order_no)
+    if request.entity_type is not None:
+        try:
+            entity_enum = PurchaseOrderEntityType(request.entity_type.value)
+        except ValueError as e:
+            valid = ", ".join(s.value for s in PurchaseOrderEntityType)
+            msg = f"Invalid entity_type {request.entity_type!r}. Valid: {valid}"
+            raise ValueError(msg) from e
+        stmt = stmt.where(CachedPurchaseOrder.entity_type == entity_enum)
+    if request.status is not None:
+        try:
+            status_enum = PurchaseOrderStatus(request.status.value)
+        except ValueError as e:
+            valid = ", ".join(s.value for s in PurchaseOrderStatus)
+            msg = f"Invalid status {request.status!r}. Valid: {valid}"
+            raise ValueError(msg) from e
+        stmt = stmt.where(CachedPurchaseOrder.status == status_enum)
+    if request.billing_status is not None:
+        try:
+            billing_enum = PurchaseOrderBillingStatus(request.billing_status.value)
+        except ValueError as e:
+            valid = ", ".join(s.value for s in PurchaseOrderBillingStatus)
+            msg = f"Invalid billing_status {request.billing_status!r}. Valid: {valid}"
+            raise ValueError(msg) from e
+        stmt = stmt.where(CachedPurchaseOrder.billing_status == billing_enum)
+    if request.currency is not None:
+        stmt = stmt.where(CachedPurchaseOrder.currency == request.currency)
+    if request.location_id is not None:
+        stmt = stmt.where(CachedPurchaseOrder.location_id == request.location_id)
+    if request.tracking_location_id is not None:
+        # Cache-only column hoisted from OutsourcedPurchaseOrder via
+        # CACHE_EXTRA_FIELDS — regular POs always carry None here.
+        stmt = stmt.where(
+            CachedPurchaseOrder.tracking_location_id == request.tracking_location_id
+        )
+    if request.supplier_id is not None:
+        stmt = stmt.where(CachedPurchaseOrder.supplier_id == request.supplier_id)
+    if not request.include_deleted:
+        stmt = stmt.where(CachedPurchaseOrder.deleted_at.is_(None))
+
+    date_columns: list[tuple[str, Any, str]] = [
+        ("created_after", CachedPurchaseOrder.created_at, ">="),
+        ("created_before", CachedPurchaseOrder.created_at, "<="),
+        ("updated_after", CachedPurchaseOrder.updated_at, ">="),
+        ("updated_before", CachedPurchaseOrder.updated_at, "<="),
+        (
+            "expected_arrival_after",
+            CachedPurchaseOrder.expected_arrival_date,
+            ">=",
+        ),
+        (
+            "expected_arrival_before",
+            CachedPurchaseOrder.expected_arrival_date,
+            "<=",
+        ),
+    ]
+    for name, col, comp in date_columns:
+        dt = parsed_dates[name]
+        if dt is None:
+            continue
+        stmt = stmt.where(col >= dt if comp == ">=" else col <= dt)
+
+    return stmt
 
 
 async def _list_purchase_orders_impl(
     request: ListPurchaseOrdersRequest, context: Context
 ) -> ListPurchaseOrdersResponse:
-    """List purchase orders with filters — follows list-tool pattern v2."""
-    from katana_public_api_client.api.purchase_order import find_purchase_orders
-    from katana_public_api_client.utils import unwrap_data
+    """List purchase orders with filters (cache-backed).
+
+    Reads from the SQLModel typed cache instead of the live API.
+    ``ensure_purchase_orders_synced`` runs an incremental ``updated_at_min``
+    delta on every call (near-zero cost steady state; cold-start pulls
+    full history once); the query then translates request filters into
+    indexed SQL. ``expected_arrival_date`` and ``tracking_location_id``
+    were both client-side post-fetch pre-cache; they now run as direct
+    SQL predicates. See ADR-0018 and #342.
+    """
+    from sqlalchemy.orm import selectinload
+    from sqlmodel import func, select
+
+    from katana_mcp.typed_cache import ensure_purchase_orders_synced
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedPurchaseOrder,
+        CachedPurchaseOrderRow,
+    )
 
     services = get_services(context)
 
-    kwargs: dict[str, Any] = {
-        "client": services.client,
-        "limit": request.limit,
-    }
-    if request.ids is not None:
-        kwargs["ids"] = request.ids
-    if request.order_no is not None:
-        kwargs["order_no"] = request.order_no
-    if request.entity_type is not None:
-        kwargs["entity_type"] = request.entity_type
-    if request.status is not None:
-        kwargs["status"] = request.status
-    if request.billing_status is not None:
-        kwargs["billing_status"] = request.billing_status
-    if request.currency is not None:
-        kwargs["currency"] = request.currency
-    if request.location_id is not None:
-        kwargs["location_id"] = request.location_id
-    # Generated client types these as float for historical spec reasons;
-    # cast ints we accept at the tool boundary to keep the schema consistent.
-    if request.tracking_location_id is not None:
-        kwargs["tracking_location_id"] = float(request.tracking_location_id)
-    if request.supplier_id is not None:
-        kwargs["supplier_id"] = float(request.supplier_id)
-    if request.include_deleted is not None:
-        kwargs["include_deleted"] = request.include_deleted
+    # 1. Refresh the cache (incremental — near-zero cost steady state).
+    await ensure_purchase_orders_synced(services.client, services.typed_cache)
 
-    # Server-side date filters
-    if request.created_after is not None:
-        kwargs["created_at_min"] = parse_iso_datetime(
-            request.created_after, "created_after"
-        )
-    if request.created_before is not None:
-        kwargs["created_at_max"] = parse_iso_datetime(
-            request.created_before, "created_before"
-        )
-    if request.updated_after is not None:
-        kwargs["updated_at_min"] = parse_iso_datetime(
-            request.updated_after, "updated_after"
-        )
-    if request.updated_before is not None:
-        kwargs["updated_at_max"] = parse_iso_datetime(
-            request.updated_before, "updated_before"
-        )
+    # 2. Parse date filters once so the data SELECT and the (optional)
+    # COUNT SELECT don't each re-parse the same ISO-8601 strings.
+    parsed_dates = parse_request_dates(request, _PURCHASE_ORDER_DATE_FIELDS)
 
-    # Client-side filter parsing (eager — bad input fails loudly)
-    arrival_after_dt: datetime | None = None
-    arrival_before_dt: datetime | None = None
-    if request.expected_arrival_after is not None:
-        arrival_after_dt = parse_iso_datetime(
-            request.expected_arrival_after, "expected_arrival_after"
-        )
-    if request.expected_arrival_before is not None:
-        arrival_before_dt = parse_iso_datetime(
-            request.expected_arrival_before, "expected_arrival_before"
-        )
-    has_client_filter = arrival_after_dt is not None or arrival_before_dt is not None
-
-    # Pagination — skip short-circuit when client-side filter active.
+    # 3. Build the data query. Pair each row with a scalar-subquery
+    # ``row_count`` so the common ``include_rows=False`` case doesn't pay
+    # the selectinload cost.
+    row_count_subq = (
+        select(func.count(CachedPurchaseOrderRow.id))
+        .where(CachedPurchaseOrderRow.purchase_order_id == CachedPurchaseOrder.id)
+        .correlate(CachedPurchaseOrder)
+        .scalar_subquery()
+        .label("row_count")
+    )
+    stmt = select(CachedPurchaseOrder, row_count_subq)
+    if request.include_rows:
+        stmt = stmt.options(selectinload(CachedPurchaseOrder.purchase_order_rows))
+    stmt = _apply_purchase_order_filters(stmt, request, parsed_dates)
+    stmt = stmt.order_by(
+        CachedPurchaseOrder.created_at.desc(), CachedPurchaseOrder.id.desc()
+    )
     if request.page is not None:
-        kwargs["page"] = request.page
-    elif 1 <= request.limit <= 250 and not has_client_filter:
-        kwargs["page"] = 1
+        stmt = stmt.offset((request.page - 1) * request.limit).limit(request.limit)
+    else:
+        stmt = stmt.limit(request.limit)
 
-    response = await find_purchase_orders.asyncio_detailed(**kwargs)
-    attrs_list = unwrap_data(response, default=[])
+    # 4. Execute data query and (when paginating) a separate COUNT for meta.
+    async with services.typed_cache.session() as session:
+        data_result = await session.exec(stmt)
+        orders_with_counts: list[tuple[CachedPurchaseOrder, int]] = data_result.all()
 
-    if has_client_filter:
+        pagination: PaginationMeta | None = None
+        if request.page is not None:
+            count_stmt = _apply_purchase_order_filters(
+                select(func.count()).select_from(CachedPurchaseOrder),
+                request,
+                parsed_dates,
+            )
+            total_records = (await session.exec(count_stmt)).one()
+            total_pages = (total_records + request.limit - 1) // request.limit
+            pagination = PaginationMeta(
+                total_records=total_records,
+                total_pages=total_pages,
+                page=request.page,
+                first_page=request.page == 1,
+                last_page=request.page >= total_pages,
+            )
 
-        def _in_arrival_window(po: Any) -> bool:
-            arrival = unwrap_unset(po.expected_arrival_date, None)
-            if not isinstance(arrival, _datetime.datetime):
-                return False
-            if arrival_after_dt is not None and arrival < arrival_after_dt:
-                return False
-            return not (arrival_before_dt is not None and arrival > arrival_before_dt)
-
-        attrs_list = [po for po in attrs_list if _in_arrival_window(po)]
-
-    # Safety net: cap to request.limit post-pagination.
-    attrs_list = attrs_list[: request.limit]
-
-    # Pagination meta — only when caller set `page` explicitly.
-    pagination: PaginationMeta | None = None
-    if request.page is not None:
-        headers = getattr(response, "headers", None)
-        if headers is not None:
-            pagination = parse_pagination_header(headers.get("x-pagination"))
-
+    # 5. Materialize summaries.
     summaries: list[PurchaseOrderSummary] = []
-    for po in attrs_list:
-        raw_rows = unwrap_unset(po.purchase_order_rows, None) or []
-        rows = [_po_row_summary(r) for r in raw_rows] if request.include_rows else None
-        created_date = unwrap_unset(po.order_created_date, None)
-        expected = unwrap_unset(po.expected_arrival_date, None)
+    for po, row_count in orders_with_counts:
+        rows: list[PurchaseOrderRowSummary] | None = None
+        if request.include_rows:
+            rows = [
+                PurchaseOrderRowSummary(
+                    id=r.id,
+                    variant_id=r.variant_id,
+                    quantity=r.quantity,
+                    price_per_unit=r.price_per_unit,
+                    arrival_date=iso_or_none(r.arrival_date),
+                    received_date=iso_or_none(r.received_date),
+                    total=r.total,
+                )
+                for r in po.purchase_order_rows
+            ]
         summaries.append(
             PurchaseOrderSummary(
                 id=po.id,
-                order_no=unwrap_unset(po.order_no, None),
-                status=enum_to_str(unwrap_unset(po.status, None)),
-                billing_status=enum_to_str(unwrap_unset(po.billing_status, None)),
-                entity_type=enum_to_str(unwrap_unset(po.entity_type, None)),
-                supplier_id=unwrap_unset(po.supplier_id, None),
-                location_id=unwrap_unset(po.location_id, None),
-                currency=unwrap_unset(po.currency, None),
-                created_date=iso_or_none(created_date)
-                if isinstance(created_date, _datetime.datetime)
-                else None,
-                expected_arrival_date=iso_or_none(expected)
-                if isinstance(expected, _datetime.datetime)
-                else None,
-                total=unwrap_unset(po.total, None),
-                row_count=len(raw_rows),
+                order_no=po.order_no,
+                status=enum_to_str(po.status),
+                billing_status=enum_to_str(po.billing_status),
+                entity_type=enum_to_str(po.entity_type),
+                supplier_id=po.supplier_id,
+                location_id=po.location_id,
+                currency=po.currency,
+                created_date=iso_or_none(po.order_created_date),
+                expected_arrival_date=iso_or_none(po.expected_arrival_date),
+                total=po.total,
+                row_count=row_count,
                 rows=rows,
             )
         )
@@ -1904,7 +1964,7 @@ async def _list_purchase_orders_impl(
 async def list_purchase_orders(
     request: Annotated[ListPurchaseOrdersRequest, Unpack()], context: Context
 ) -> ToolResult:
-    """List purchase orders with filters (list-tool pattern v2).
+    """List purchase orders with filters (cache-backed).
 
     Use this for discovery workflows — find POs by supplier, status, location,
     or within a date window. Returns summary info (order_no, status, supplier,
@@ -1914,14 +1974,21 @@ async def list_purchase_orders(
     - `status="NOT_RECEIVED"` — open POs awaiting delivery
     - `supplier_id=N` — POs for a specific supplier
     - `billing_status="NOT_BILLED"` — unbilled POs
+    - `entity_type="outsourced"` — outsourced POs only
+    - `tracking_location_id=N` — outsourced POs at a tracking location
 
-    **Time windows:**
-    - `created_after` / `created_before` — server-side bounds on `created_at`
-    - `updated_after` / `updated_before` — server-side bounds on `updated_at`
-    - `expected_arrival_after` / `expected_arrival_before` — client-side
-      bounds on `expected_arrival_date` (Katana has no server-side filter).
-      When set, the tool skips the page=1 short-circuit so auto-pagination
-      can scan enough rows to find `limit` matches post-filter.
+    **Time windows** (all run as indexed SQL date-range queries):
+    - `created_after` / `created_before` — bounds on `created_at`
+    - `updated_after` / `updated_before` — bounds on `updated_at`
+    - `expected_arrival_after` / `expected_arrival_before` — bounds on
+      `expected_arrival_date` (was a client-side post-fetch filter
+      pre-cache; now indexed SQL)
+
+    **Paging:**
+    - `limit` caps the number of rows (default 50, min 1).
+    - `page=N` returns a single page; the response includes `pagination`
+      metadata (total_records, total_pages, first/last flags) computed
+      via SQL COUNT against the same filter predicate.
 
     Pass `include_rows=True` to populate per-PO line item details.
     For full details on a specific PO, use `get_purchase_order`.

--- a/katana_mcp_server/src/katana_mcp/typed_cache/__init__.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/__init__.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from .engine import TypedCacheEngine
 from .sync import (
     ensure_manufacturing_orders_synced,
+    ensure_purchase_orders_synced,
     ensure_sales_orders_synced,
     ensure_stock_adjustments_synced,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "SyncState",
     "TypedCacheEngine",
     "ensure_manufacturing_orders_synced",
+    "ensure_purchase_orders_synced",
     "ensure_sales_orders_synced",
     "ensure_stock_adjustments_synced",
 ]

--- a/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
@@ -24,6 +24,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from katana_mcp.typed_cache import sync_state as _sync_state_mod
 from katana_public_api_client.models_pydantic._generated import (
     manufacturing as _manufacturing_mod,
+    purchase_orders as _purchase_orders_mod,
     sales_orders as _sales_orders_mod,
     stock as _stock_mod,
 )
@@ -32,6 +33,7 @@ assert _sync_state_mod is not None
 assert _sales_orders_mod is not None
 assert _stock_mod is not None
 assert _manufacturing_mod is not None
+assert _purchase_orders_mod is not None
 
 _DEFAULT_DB_PATH = Path(user_cache_dir("katana-mcp")) / "typed_cache.db"
 

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -19,15 +19,19 @@ from typing import TYPE_CHECKING
 from katana_public_api_client.api.manufacturing_order import (
     get_all_manufacturing_orders,
 )
+from katana_public_api_client.api.purchase_order import find_purchase_orders
 from katana_public_api_client.api.sales_order import get_all_sales_orders
 from katana_public_api_client.api.stock_adjustment import get_all_stock_adjustments
 from katana_public_api_client.models_pydantic._generated import (
     CachedManufacturingOrder,
+    CachedPurchaseOrder,
+    CachedPurchaseOrderRow,
     CachedSalesOrder,
     CachedSalesOrderRow,
     CachedStockAdjustment,
     CachedStockAdjustmentRow,
     ManufacturingOrder as PydanticManufacturingOrder,
+    PurchaseOrderBase as PydanticPurchaseOrderBase,
     SalesOrder as PydanticSalesOrder,
     StockAdjustment as PydanticStockAdjustment,
 )
@@ -256,6 +260,100 @@ async def ensure_manufacturing_orders_synced(
                     entity_type="manufacturing_order",
                     last_synced=datetime.now(tz=UTC).replace(tzinfo=None),
                     row_count=len(cached_orders),
+                )
+            )
+            await session.commit()
+
+
+def _attrs_purchase_order_to_cached(
+    attrs_po: object,
+) -> tuple[CachedPurchaseOrder, list[CachedPurchaseOrderRow]]:
+    """Convert one attrs ``PurchaseOrder`` (regular | outsourced) to cache rows.
+
+    Three-step:
+    1. Pick the right API pydantic class from the attrs subtype: regular
+       and outsourced POs share ``PurchaseOrderBase`` fields but differ in
+       ``entity_type`` literal and the outsourced-only
+       ``tracking_location_id`` / ``ingredient_*`` fields.
+    2. Dump the API model and re-validate into ``CachedPurchaseOrder`` —
+       the cache class shadows ``PurchaseOrderBase`` (renamed via
+       ``CACHE_TABLE_RENAMES``) and carries an extra
+       ``tracking_location_id`` column hoisted from the outsourced
+       subclass via ``CACHE_EXTRA_FIELDS``. The dump captures it
+       automatically when the source is an outsourced PO.
+    3. Build child rows with ``purchase_order_id`` set explicitly from the
+       parent, mirroring the stock-adjustment shape.
+    """
+    # Dispatch by attrs class via the model registry so we round-trip the
+    # right subclass (regular/outsourced) — calling
+    # ``PydanticPurchaseOrderBase.from_attrs`` directly would lose the
+    # outsourced-only fields (``tracking_location_id`` etc.).
+    from katana_public_api_client.models_pydantic._registry import get_pydantic_class
+
+    api_class = get_pydantic_class(type(attrs_po))
+    if api_class is None:
+        msg = (
+            f"No pydantic class registered for attrs purchase order "
+            f"type {type(attrs_po).__name__}"
+        )
+        raise RuntimeError(msg)
+    api_po: PydanticPurchaseOrderBase = api_class.from_attrs(attrs_po)
+
+    parent_data = api_po.model_dump(exclude={"purchase_order_rows"})
+    cached_parent = CachedPurchaseOrder.model_validate(parent_data)
+
+    child_rows: list[CachedPurchaseOrderRow] = []
+    api_rows = api_po.purchase_order_rows or []
+    for api_row in api_rows:
+        row_data = api_row.model_dump()
+        # Re-assert from the parent. Katana already returns
+        # ``purchase_order_id`` on rows, but the parent's id is the
+        # source of truth on insert.
+        row_data["purchase_order_id"] = api_po.id
+        child_rows.append(CachedPurchaseOrderRow.model_validate(row_data))
+    return cached_parent, child_rows
+
+
+async def ensure_purchase_orders_synced(
+    client: KatanaClient, cache: TypedCacheEngine
+) -> None:
+    """Pull updated purchase orders from Katana and upsert into the cache.
+
+    Mirror of :func:`ensure_sales_orders_synced` for the ``PurchaseOrder``
+    discriminated-union entity. Cold-start fetches full history; subsequent
+    calls pass ``updated_at_min``. Per-entity lock keeps cold-start fan-out
+    single-flight.
+    """
+    async with cache.lock_for("purchase_order"):
+        async with cache.session() as session:
+            state = await session.get(SyncState, "purchase_order")
+            last_synced = state.last_synced if state is not None else None
+
+        kwargs = (
+            {"updated_at_min": last_synced.replace(tzinfo=UTC)}
+            if last_synced is not None
+            else {}
+        )
+        response = await find_purchase_orders.asyncio_detailed(client=client, **kwargs)
+        attrs_orders = unwrap_data(response, default=[])
+
+        cached_parents: list[CachedPurchaseOrder] = []
+        cached_children: list[CachedPurchaseOrderRow] = []
+        for attrs_po in attrs_orders:
+            parent, children = _attrs_purchase_order_to_cached(attrs_po)
+            cached_parents.append(parent)
+            cached_children.extend(children)
+
+        async with cache.session() as session:
+            for parent in cached_parents:
+                await session.merge(parent)
+            for child in cached_children:
+                await session.merge(child)
+            await session.merge(
+                SyncState(
+                    entity_type="purchase_order",
+                    last_synced=datetime.now(tz=UTC).replace(tzinfo=None),
+                    row_count=len(cached_parents),
                 )
             )
             await session.commit()

--- a/katana_mcp_server/tests/factories.py
+++ b/katana_mcp_server/tests/factories.py
@@ -21,11 +21,15 @@ if TYPE_CHECKING:
 
     from katana_public_api_client.models_pydantic._generated import (
         CachedManufacturingOrder,
+        CachedPurchaseOrder,
+        CachedPurchaseOrderRow,
         CachedSalesOrder,
         CachedSalesOrderRow,
         CachedStockAdjustment,
         CachedStockAdjustmentRow,
         ManufacturingOrderStatus,
+        PurchaseOrderEntityType,
+        PurchaseOrderStatus,
         SalesOrderProductionStatus,
         SalesOrderStatus,
     )
@@ -271,4 +275,104 @@ def make_manufacturing_order(
         created_at=naive_utc(created_at) or datetime(2026, 4, 1),
         updated_at=naive_utc(updated_at),
         deleted_at=naive_utc(deleted_at),
+    )
+
+
+# ----------------------------------------------------------------------------
+# purchase_orders
+# ----------------------------------------------------------------------------
+
+
+def make_purchase_order(
+    *,
+    id: int = 1,
+    order_no: str = "PO-TEST",
+    entity_type: PurchaseOrderEntityType | str = "regular",
+    status: PurchaseOrderStatus | str | None = None,
+    billing_status: str | None = None,
+    supplier_id: int | None = 4001,
+    location_id: int | None = 1,
+    tracking_location_id: int | None = None,
+    currency: str | None = "USD",
+    expected_arrival_date: datetime | None = None,
+    order_created_date: datetime | None = None,
+    total: float | None = 100.0,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+    deleted_at: datetime | None = None,
+    rows: list[CachedPurchaseOrderRow] | None = None,
+) -> CachedPurchaseOrder:
+    """Build a ``CachedPurchaseOrder`` for direct cache insertion.
+
+    Same datetime-normalization contract as :func:`make_sales_order`. The
+    ``entity_type`` discriminator defaults to ``"regular"`` so tests that
+    don't care about the regular/outsourced split still build valid rows;
+    pass ``"outsourced"`` plus a ``tracking_location_id`` for outsourced
+    fixtures.
+    """
+    from katana_mcp.tools.tool_result_utils import naive_utc
+
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedPurchaseOrder as _CachedPurchaseOrder,
+        PurchaseOrderEntityType as _EntityType,
+        PurchaseOrderStatus as _Status,
+    )
+
+    resolved_entity_type = (
+        _EntityType(entity_type) if isinstance(entity_type, str) else entity_type
+    )
+    resolved_status = (
+        _Status(status)
+        if isinstance(status, str)
+        else (status if status is not None else _Status.not_received)
+    )
+
+    cached = _CachedPurchaseOrder(
+        id=id,
+        order_no=order_no,
+        entity_type=resolved_entity_type,
+        status=resolved_status,
+        billing_status=billing_status,
+        supplier_id=supplier_id,
+        location_id=location_id,
+        tracking_location_id=tracking_location_id,
+        currency=currency,
+        expected_arrival_date=naive_utc(expected_arrival_date),
+        order_created_date=naive_utc(order_created_date),
+        total=total,
+        created_at=naive_utc(created_at) or datetime(2026, 4, 1),
+        updated_at=naive_utc(updated_at),
+        deleted_at=naive_utc(deleted_at),
+    )
+    cached.purchase_order_rows = rows if rows is not None else []
+    return cached
+
+
+def make_purchase_order_row(
+    *,
+    id: int,
+    purchase_order_id: int,
+    variant_id: int,
+    quantity: float = 1.0,
+    price_per_unit: float | None = None,
+    arrival_date: datetime | None = None,
+    received_date: datetime | None = None,
+    total: float | None = None,
+) -> CachedPurchaseOrderRow:
+    """Build a ``CachedPurchaseOrderRow`` for direct cache insertion."""
+    from katana_mcp.tools.tool_result_utils import naive_utc
+
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedPurchaseOrderRow as _CachedPurchaseOrderRow,
+    )
+
+    return _CachedPurchaseOrderRow(
+        id=id,
+        purchase_order_id=purchase_order_id,
+        variant_id=variant_id,
+        quantity=quantity,
+        price_per_unit=price_per_unit,
+        arrival_date=naive_utc(arrival_date),
+        received_date=naive_utc(received_date),
+        total=total,
     )

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -31,7 +31,12 @@ from katana_public_api_client.models import (
     RegularPurchaseOrder,
 )
 from katana_public_api_client.utils import APIError
-from tests.conftest import create_mock_context
+from tests.conftest import create_mock_context, patch_typed_cache_sync
+from tests.factories import (
+    make_purchase_order,
+    make_purchase_order_row,
+    seed_cache,
+)
 
 # ============================================================================
 # Test Helpers
@@ -2051,256 +2056,11 @@ async def test_verify_order_document_embeds_po_without_nested_heading():
 # ============================================================================
 
 
-def _make_mock_list_po(
-    *,
-    id: int = 1,
-    order_no: str | None = "PO-1",
-    status: str | None = "NOT_RECEIVED",
-    billing_status: str | None = "NOT_BILLED",
-    entity_type: str | None = "regular",
-    supplier_id: int | None = 10,
-    location_id: int | None = 1,
-    currency: str | None = "USD",
-    order_created_date: datetime | None = None,
-    expected_arrival_date: datetime | None = None,
-    total: float | None = 999.0,
-    rows: list | None = None,
-) -> MagicMock:
-    """Build a mock purchase order attrs object for list-tool tests."""
-    po = MagicMock()
-    po.id = id
-    po.order_no = order_no if order_no is not None else UNSET
-    po.status = status if status is not None else UNSET
-    po.billing_status = billing_status if billing_status is not None else UNSET
-    po.entity_type = entity_type if entity_type is not None else UNSET
-    po.supplier_id = supplier_id if supplier_id is not None else UNSET
-    po.location_id = location_id if location_id is not None else UNSET
-    po.currency = currency if currency is not None else UNSET
-    po.order_created_date = (
-        order_created_date if order_created_date is not None else UNSET
-    )
-    po.expected_arrival_date = (
-        expected_arrival_date if expected_arrival_date is not None else UNSET
-    )
-    po.total = total if total is not None else UNSET
-    po.purchase_order_rows = rows if rows is not None else UNSET
-    return po
-
-
-def _make_mock_po_row(
-    *,
-    id: int = 1,
-    variant_id: int = 100,
-    quantity: float = 2.0,
-    price_per_unit: float = 50.0,
-    arrival_date: datetime | None = None,
-) -> MagicMock:
-    """Build a mock purchase order row."""
-    r = MagicMock()
-    r.id = id
-    r.variant_id = variant_id
-    r.quantity = quantity
-    r.price_per_unit = price_per_unit
-    r.arrival_date = arrival_date if arrival_date is not None else UNSET
-    r.received_date = UNSET
-    r.total = quantity * price_per_unit
-    return r
-
-
-@pytest.mark.asyncio
-async def test_list_purchase_orders_server_side_filters_pass_through():
-    """Server-side filters forward to find_purchase_orders kwargs."""
-    from katana_mcp.tools.foundation.purchase_orders import (
-        ListPurchaseOrdersRequest,
-        _list_purchase_orders_impl,
-    )
-
-    from katana_public_api_client.models import (
-        FindPurchaseOrdersBillingStatus,
-        FindPurchaseOrdersStatus,
-        PurchaseOrderEntityType,
-    )
-
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    request = ListPurchaseOrdersRequest(
-        ids=[1, 2, 3],
-        order_no="PO-42",
-        entity_type=PurchaseOrderEntityType.REGULAR,
-        status=FindPurchaseOrdersStatus.NOT_RECEIVED,
-        billing_status=FindPurchaseOrdersBillingStatus.NOT_BILLED,
-        currency="USD",
-        location_id=5,
-        supplier_id=99,
-        include_deleted=False,
-        limit=25,
-    )
-
-    with (
-        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
-        patch(_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_purchase_orders_impl(request, context)
-
-    assert captured["ids"] == [1, 2, 3]
-    assert captured["order_no"] == "PO-42"
-    assert captured["entity_type"] == PurchaseOrderEntityType.REGULAR
-    assert captured["status"] == FindPurchaseOrdersStatus.NOT_RECEIVED
-    assert captured["billing_status"] == FindPurchaseOrdersBillingStatus.NOT_BILLED
-    assert captured["currency"] == "USD"
-    assert captured["location_id"] == 5
-    # supplier_id cast to float at the API boundary (generated-client signature
-    # uses `float` historically); the tool-facing field is `int`.
-    assert captured["supplier_id"] == 99.0
-    assert isinstance(captured["supplier_id"], float)
-    assert captured["include_deleted"] is False
-    assert captured["limit"] == 25
-
-
-@pytest.mark.asyncio
-async def test_list_purchase_orders_page_short_circuit_single_page():
-    """limit <= 250 with no client-side filter adds page=1."""
-    from katana_mcp.tools.foundation.purchase_orders import (
-        ListPurchaseOrdersRequest,
-        _list_purchase_orders_impl,
-    )
-
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
-        patch(_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_purchase_orders_impl(ListPurchaseOrdersRequest(limit=10), context)
-
-    assert captured["page"] == 1
-    assert captured["limit"] == 10
-
-
-@pytest.mark.asyncio
-async def test_list_purchase_orders_caller_page_preserved():
-    """Explicit page overrides the short-circuit."""
-    from katana_mcp.tools.foundation.purchase_orders import (
-        ListPurchaseOrdersRequest,
-        _list_purchase_orders_impl,
-    )
-
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
-        patch(_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_purchase_orders_impl(
-            ListPurchaseOrdersRequest(limit=50, page=2), context
-        )
-
-    assert captured["page"] == 2
-    assert captured["limit"] == 50
-
-
-@pytest.mark.asyncio
-async def test_list_purchase_orders_skips_short_circuit_when_client_filter_set():
-    """expected_arrival filter suppresses the page=1 short-circuit."""
-    from katana_mcp.tools.foundation.purchase_orders import (
-        ListPurchaseOrdersRequest,
-        _list_purchase_orders_impl,
-    )
-
-    context, _ = create_mock_context()
-    captured: dict = {}
-
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
-        patch(_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_purchase_orders_impl(
-            ListPurchaseOrdersRequest(
-                limit=10, expected_arrival_after="2026-04-01T00:00:00Z"
-            ),
-            context,
-        )
-
-    assert "page" not in captured
-    assert captured["limit"] == 10
-
-
-@pytest.mark.asyncio
-async def test_list_purchase_orders_pagination_meta_from_header():
-    """x-pagination header populates PaginationMeta when page is set."""
-    from katana_mcp.tools.foundation.purchase_orders import (
-        ListPurchaseOrdersRequest,
-        _list_purchase_orders_impl,
-    )
-
-    context, _ = create_mock_context()
-
-    mock_response = MagicMock()
-    mock_response.headers = {
-        "x-pagination": (
-            '{"total_records":"200","total_pages":"4","offset":"0","page":"2",'
-            '"first_page":"false","last_page":"false"}'
-        )
-    }
-
-    async def fake(**kwargs):
-        return mock_response
-
-    with (
-        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
-        patch(_UNWRAP_DATA, return_value=[]),
-    ):
-        result = await _list_purchase_orders_impl(
-            ListPurchaseOrdersRequest(page=2, limit=50), context
-        )
-
-    assert result.pagination is not None
-    assert result.pagination.total_records == 200
-    assert result.pagination.total_pages == 4
-    assert result.pagination.page == 2
-    assert result.pagination.first_page is False
-
-
-@pytest.mark.asyncio
-async def test_list_purchase_orders_caps_to_limit():
-    """Safety net: slice results to request.limit."""
-    from katana_mcp.tools.foundation.purchase_orders import (
-        ListPurchaseOrdersRequest,
-        _list_purchase_orders_impl,
-    )
-
-    context, _ = create_mock_context()
-    over_fetched = [_make_mock_list_po(id=i, order_no=f"PO-{i}") for i in range(100)]
-
-    with (
-        patch(f"{_PO_FIND}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_UNWRAP_DATA, return_value=over_fetched),
-    ):
-        result = await _list_purchase_orders_impl(
-            ListPurchaseOrdersRequest(limit=25), context
-        )
-
-    assert len(result.orders) == 25
-    assert result.total_count == 25
+@pytest.fixture
+def no_po_sync():
+    """Patch ``ensure_purchase_orders_synced`` to a no-op."""
+    with patch_typed_cache_sync("purchase_orders"):
+        yield
 
 
 @pytest.mark.asyncio
@@ -2316,128 +2076,320 @@ async def test_list_purchase_orders_limit_le_250_validation():
 
 
 @pytest.mark.asyncio
-async def test_list_purchase_orders_invalid_date_raises():
+async def test_list_purchase_orders_filters_by_ids(
+    context_with_typed_cache, no_po_sync
+):
+    """`ids` restricts the returned set to specific PO IDs."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_purchase_order(id=1),
+            make_purchase_order(id=2),
+            make_purchase_order(id=3),
+        ],
+    )
+
+    result = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(ids=[1, 3]), context
+    )
+
+    assert {o.id for o in result.orders} == {1, 3}
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_filters_by_status_and_billing(
+    context_with_typed_cache, no_po_sync
+):
+    """`status` and `billing_status` apply as enum-typed column filters."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    from katana_public_api_client.models import (
+        FindPurchaseOrdersBillingStatus,
+        FindPurchaseOrdersStatus,
+    )
+
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_purchase_order(
+                id=1, status="NOT_RECEIVED", billing_status="NOT_BILLED"
+            ),
+            make_purchase_order(id=2, status="RECEIVED", billing_status="BILLED"),
+            make_purchase_order(id=3, status="NOT_RECEIVED", billing_status="BILLED"),
+        ],
+    )
+
+    result = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(
+            status=FindPurchaseOrdersStatus.NOT_RECEIVED,
+            billing_status=FindPurchaseOrdersBillingStatus.NOT_BILLED,
+        ),
+        context,
+    )
+
+    assert {o.id for o in result.orders} == {1}
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_filters_by_entity_type_and_tracking_location(
+    context_with_typed_cache, no_po_sync
+):
+    """`entity_type` filters regular vs outsourced; `tracking_location_id` is hoisted from the outsourced subclass."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    from katana_public_api_client.models import PurchaseOrderEntityType
+
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_purchase_order(id=1, entity_type="regular"),
+            make_purchase_order(
+                id=2, entity_type="outsourced", tracking_location_id=99
+            ),
+            make_purchase_order(
+                id=3, entity_type="outsourced", tracking_location_id=100
+            ),
+        ],
+    )
+
+    by_type = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(entity_type=PurchaseOrderEntityType.OUTSOURCED),
+        context,
+    )
+    assert {o.id for o in by_type.orders} == {2, 3}
+
+    by_tracking = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(tracking_location_id=99), context
+    )
+    assert {o.id for o in by_tracking.orders} == {2}
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_filters_by_supplier_currency_and_location(
+    context_with_typed_cache, no_po_sync
+):
+    """Direct column filters: supplier_id, currency, location_id."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_purchase_order(id=1, supplier_id=10, currency="USD", location_id=1),
+            make_purchase_order(id=2, supplier_id=10, currency="EUR", location_id=2),
+            make_purchase_order(id=3, supplier_id=20, currency="USD", location_id=1),
+        ],
+    )
+
+    by_supplier = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(supplier_id=10), context
+    )
+    assert {o.id for o in by_supplier.orders} == {1, 2}
+
+    by_currency = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(currency="USD"), context
+    )
+    assert {o.id for o in by_currency.orders} == {1, 3}
+
+    by_location = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(location_id=1), context
+    )
+    assert {o.id for o in by_location.orders} == {1, 3}
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_excludes_deleted_by_default(
+    context_with_typed_cache, no_po_sync
+):
+    """Soft-deleted POs are filtered unless include_deleted=True."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_purchase_order(id=1, deleted_at=None),
+            make_purchase_order(id=2, deleted_at=datetime(2026, 3, 15)),
+        ],
+    )
+
+    default = await _list_purchase_orders_impl(ListPurchaseOrdersRequest(), context)
+    assert {o.id for o in default.orders} == {1}
+
+    with_deleted = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(include_deleted=True), context
+    )
+    assert {o.id for o in with_deleted.orders} == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_date_filters(context_with_typed_cache, no_po_sync):
+    """`created_*` and `expected_arrival_*` apply as indexed range filters."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_purchase_order(
+                id=1,
+                created_at=datetime(2026, 2, 15),
+                expected_arrival_date=datetime(2026, 4, 15),
+            ),
+            make_purchase_order(
+                id=2,
+                created_at=datetime(2026, 5, 1),
+                expected_arrival_date=datetime(2027, 1, 1),
+            ),
+        ],
+    )
+
+    created = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(
+            created_after="2026-01-01T00:00:00Z",
+            created_before="2026-04-01T00:00:00Z",
+        ),
+        context,
+    )
+    assert {o.id for o in created.orders} == {1}
+
+    arrival = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(
+            expected_arrival_after="2026-04-01T00:00:00Z",
+            expected_arrival_before="2026-04-30T00:00:00Z",
+        ),
+        context,
+    )
+    assert {o.id for o in arrival.orders} == {1}
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_orders_invalid_date_raises(
+    context_with_typed_cache, no_po_sync
+):
     """Malformed ISO-8601 surfaces as ValueError."""
     from katana_mcp.tools.foundation.purchase_orders import (
         ListPurchaseOrdersRequest,
         _list_purchase_orders_impl,
     )
 
-    context, _ = create_mock_context()
+    context, _, _typed_cache = context_with_typed_cache
 
-    with (
-        patch(f"{_PO_FIND}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_UNWRAP_DATA, return_value=[]),
-        pytest.raises(ValueError, match=r"Invalid ISO-8601.*created_after"),
-    ):
+    with pytest.raises(ValueError, match=r"Invalid ISO-8601.*created_after"):
         await _list_purchase_orders_impl(
             ListPurchaseOrdersRequest(created_after="not-a-date"), context
         )
 
 
 @pytest.mark.asyncio
-async def test_list_purchase_orders_date_z_normalization():
-    """Trailing Z/z normalize to +00:00 and forward as datetimes."""
+async def test_list_purchase_orders_caps_to_limit(context_with_typed_cache, no_po_sync):
+    """`limit` caps the result size even when more rows match."""
     from katana_mcp.tools.foundation.purchase_orders import (
         ListPurchaseOrdersRequest,
         _list_purchase_orders_impl,
     )
 
-    context, _ = create_mock_context()
-    captured: dict = {}
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [make_purchase_order(id=i) for i in range(1, 31)],
+    )
 
-    async def fake(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
+    result = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(limit=5), context
+    )
 
-    with (
-        patch(f"{_PO_FIND}.asyncio_detailed", side_effect=fake),
-        patch(_UNWRAP_DATA, return_value=[]),
-    ):
-        await _list_purchase_orders_impl(
-            ListPurchaseOrdersRequest(
-                created_after="2026-01-01T00:00:00Z",
-                updated_before="2026-04-01T00:00:00z",
-            ),
-            context,
-        )
-
-    assert isinstance(captured["created_at_min"], datetime)
-    assert isinstance(captured["updated_at_max"], datetime)
+    assert len(result.orders) == 5
 
 
 @pytest.mark.asyncio
-async def test_list_purchase_orders_expected_arrival_client_side_filter():
-    """expected_arrival_after/before filters post-fetch."""
+async def test_list_purchase_orders_pagination_meta_populated_on_explicit_page(
+    context_with_typed_cache, no_po_sync
+):
+    """An explicit `page` populates `pagination` from a SQL COUNT against the same filter set."""
     from katana_mcp.tools.foundation.purchase_orders import (
         ListPurchaseOrdersRequest,
         _list_purchase_orders_impl,
     )
 
-    context, _ = create_mock_context()
-    pos = [
-        _make_mock_list_po(
-            id=1,
-            order_no="PO-1",
-            expected_arrival_date=datetime(2026, 4, 15, tzinfo=UTC),
-        ),
-        _make_mock_list_po(
-            id=2,
-            order_no="PO-2",
-            expected_arrival_date=datetime(2027, 1, 1, tzinfo=UTC),
-        ),
-    ]
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [make_purchase_order(id=i) for i in range(1, 12)],
+    )
 
-    with (
-        patch(f"{_PO_FIND}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_UNWRAP_DATA, return_value=pos),
-    ):
-        result = await _list_purchase_orders_impl(
-            ListPurchaseOrdersRequest(
-                expected_arrival_after="2026-04-01T00:00:00Z",
-                expected_arrival_before="2026-04-30T00:00:00Z",
-            ),
-            context,
-        )
+    result = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(limit=5, page=2), context
+    )
 
-    assert result.total_count == 1
-    assert result.orders[0].id == 1
+    assert result.pagination is not None
+    assert result.pagination.total_records == 11
+    assert result.pagination.total_pages == 3
+    assert result.pagination.page == 2
+    assert len(result.orders) == 5
 
 
 @pytest.mark.asyncio
-async def test_list_purchase_orders_include_rows_populates_details():
+async def test_list_purchase_orders_include_rows(context_with_typed_cache, no_po_sync):
     """include_rows=True exposes per-PO line item detail."""
     from katana_mcp.tools.foundation.purchase_orders import (
         ListPurchaseOrdersRequest,
         _list_purchase_orders_impl,
     )
 
-    context, _ = create_mock_context()
-    mock_po = _make_mock_list_po(
-        id=7,
-        rows=[
-            _make_mock_po_row(id=1, variant_id=100, quantity=5, price_per_unit=10.0),
-            _make_mock_po_row(id=2, variant_id=200, quantity=2, price_per_unit=25.0),
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_purchase_order(
+                id=7,
+                rows=[
+                    make_purchase_order_row(
+                        id=1, purchase_order_id=7, variant_id=100, quantity=5.0
+                    ),
+                    make_purchase_order_row(
+                        id=2, purchase_order_id=7, variant_id=200, quantity=2.0
+                    ),
+                ],
+            ),
         ],
     )
 
-    with (
-        patch(f"{_PO_FIND}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_UNWRAP_DATA, return_value=[mock_po]),
-    ):
-        result_with = await _list_purchase_orders_impl(
-            ListPurchaseOrdersRequest(include_rows=True), context
-        )
-        result_without = await _list_purchase_orders_impl(
-            ListPurchaseOrdersRequest(include_rows=False), context
-        )
+    with_rows = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(include_rows=True), context
+    )
+    without_rows = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(include_rows=False), context
+    )
 
-    assert result_with.orders[0].rows is not None
-    assert len(result_with.orders[0].rows) == 2
-    assert result_with.orders[0].row_count == 2
-    assert result_without.orders[0].rows is None
-    # row_count should still reflect the true count regardless of include_rows
-    assert result_without.orders[0].row_count == 2
+    assert with_rows.orders[0].rows is not None
+    assert len(with_rows.orders[0].rows) == 2
+    assert with_rows.orders[0].row_count == 2
+    assert without_rows.orders[0].rows is None
+    assert without_rows.orders[0].row_count == 2
 
 
 # ============================================================================

--- a/katana_public_api_client/models_pydantic/_generated/__init__.py
+++ b/katana_public_api_client/models_pydantic/_generated/__init__.py
@@ -222,6 +222,8 @@ from .manufacturing import (
     UpdateRecipeRowRequest,
 )
 from .purchase_orders import (
+    CachedPurchaseOrder,
+    CachedPurchaseOrderRow,
     CreateOutsourcedPurchaseOrderRecipeRowRequest,
     CreatePurchaseOrderAdditionalCostRowRequest,
     CreatePurchaseOrderInitialStatus,
@@ -409,6 +411,8 @@ __all__ = [
     "BomRow",
     "BomRowListResponse",
     "CachedManufacturingOrder",
+    "CachedPurchaseOrder",
+    "CachedPurchaseOrderRow",
     "CachedSalesOrder",
     "CachedSalesOrderRow",
     "CachedStockAdjustment",

--- a/katana_public_api_client/models_pydantic/_generated/purchase_orders.py
+++ b/katana_public_api_client/models_pydantic/_generated/purchase_orders.py
@@ -6,12 +6,16 @@ To regenerate, run:
     uv run poe generate-pydantic
 """
 
-from __future__ import annotations
-
+from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Optional
 
 from pydantic import AwareDatetime, ConfigDict, Field, RootModel
+from sqlalchemy import JSON, Column
+from sqlmodel import (
+    Field as SQLField,
+    Relationship,
+)
 
 from katana_public_api_client.models_pydantic._base import KatanaPydanticBase
 
@@ -850,3 +854,194 @@ class PurchaseOrderListResponse(KatanaPydanticBase):
         | None,
         Field(description="Array of purchase order objects"),
     ] = None
+
+
+class CachedPurchaseOrderRow(DeletableEntity, table=True):
+    __tablename__ = "purchase_order_row"
+    model_config = ConfigDict(frozen=False)
+
+    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+
+    quantity: Annotated[
+        float | None, Field(description="The quantity of items for the order line.")
+    ] = None
+    variant_id: Annotated[
+        int | None,
+        Field(description="ID of product or material variant added to the order line."),
+    ] = None
+    tax_rate_id: Annotated[
+        int | None, Field(description="ID of tax added to price per unit.")
+    ] = None
+    price_per_unit: Annotated[
+        float | None,
+        Field(
+            description="The sales price of one unit (excluding taxes) in sales order currency."
+        ),
+    ] = None
+    price_per_unit_in_base_currency: Annotated[
+        float | None, Field(description="Unit price converted to the base currency")
+    ] = None
+    purchase_uom_conversion_rate: Annotated[
+        float | None,
+        Field(
+            description="The conversion rate between the purchase and stock tracking UoMs."
+        ),
+    ] = None
+    purchase_uom: Annotated[
+        str | None,
+        Field(
+            description="The unit used to measure the quantity of the items (e.g. pcs, kg, m) you purchase. It can be different\nfrom the unit used to track stock.\n"
+        ),
+    ] = None
+    currency: Annotated[
+        str | None, Field(description="Currency used for this line item pricing")
+    ] = None
+    conversion_rate: Annotated[
+        float | None,
+        Field(
+            description="Currency rate used to convert from purchase order currency into factory base currency."
+        ),
+    ] = None
+    total: Annotated[
+        float | None,
+        Field(
+            description="The total value of the purchase order row (excluding taxes) in purchase order currency."
+        ),
+    ] = None
+    total_in_base_currency: Annotated[
+        float | None,
+        Field(
+            description="The total value of the purchase order row (excluding taxes) in base currency."
+        ),
+    ] = None
+    conversion_date: Annotated[
+        datetime | None, Field(description="The date of the conversion rate used.")
+    ] = None
+    received_date: Annotated[
+        datetime | None,
+        Field(
+            description="The date when the items on the purchase order row were received to your stock."
+        ),
+    ] = None
+    arrival_date: Annotated[
+        datetime | None,
+        Field(
+            description="The timestamp when the item on the row is expected to arrive (in full) in your warehouse. ISO 8601\nformat with time and timezone must be used.\n"
+        ),
+    ] = None
+    batch_transactions: Annotated[
+        list[BatchTransaction4] | None,
+        SQLField(
+            sa_column=Column(JSON),
+            description="An array of batch transactions and their quantities. You can receive stock for the same item in multiple\nbatches.\n",
+        ),
+    ] = None
+    purchase_order_id: Annotated[
+        int | None,
+        SQLField(
+            foreign_key="purchase_order.id",
+            description="Unique identifier of the parent purchase order",
+        ),
+    ] = None
+    landed_cost: Annotated[
+        str | float | None,
+        SQLField(
+            sa_column=Column(JSON),
+            description="Total landed cost including shipping, duties, and other charges",
+        ),
+    ] = None
+    group_id: Annotated[
+        int | None, Field(description="Grouping identifier for organizational purposes")
+    ] = None
+    purchase_order: Optional["CachedPurchaseOrder"] = Relationship(
+        back_populates="purchase_order_rows"
+    )
+
+
+class CachedPurchaseOrder(DeletableEntity, table=True):
+    __tablename__ = "purchase_order"
+    model_config = ConfigDict(frozen=False)
+
+    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+
+    status: Annotated[
+        PurchaseOrderStatus | None, Field(description="Status of the order.")
+    ] = None
+    order_no: Annotated[
+        str | None,
+        Field(
+            description="A unique, identifying string used in the UI and controlled by the user."
+        ),
+    ] = None
+    entity_type: Annotated[
+        PurchaseOrderEntityType | None,
+        Field(
+            description='Either "regular" or "outsourced", depending on the purchase order type.'
+        ),
+    ] = None
+    default_group_id: Annotated[
+        int | None,
+        Field(description="Default grouping identifier for organizational purposes"),
+    ] = None
+    supplier_id: Annotated[
+        int | None, Field(description="ID of the supplier who this order belongs to.")
+    ] = None
+    currency: Annotated[
+        str | None,
+        Field(
+            description="Currency of the purchase order. Filled with supplier currency by default."
+        ),
+    ] = None
+    expected_arrival_date: Annotated[
+        datetime | None,
+        Field(
+            description="The timestamp when the items are expected to arrive (in full) in your warehouse."
+        ),
+    ] = None
+    order_created_date: Annotated[
+        datetime | None,
+        Field(description="The timestamp of creating the document."),
+    ] = None
+    additional_info: Annotated[
+        str | None,
+        Field(
+            description="A string attached to the object to add any internal comments, links to external files, additional\ninstructions, etc.\n"
+        ),
+    ] = None
+    location_id: Annotated[
+        int | None,
+        Field(description="The ID of the location to which items are received."),
+    ] = None
+    total: Annotated[
+        float | None,
+        Field(
+            description="The total value of the order (including taxes) in purchase order currency."
+        ),
+    ] = None
+    total_in_base_currency: Annotated[
+        float | None,
+        Field(
+            description="The total value of the order (including taxes) in base currency."
+        ),
+    ] = None
+    billing_status: Annotated[
+        PurchaseOrderBillingStatus | None,
+        Field(
+            description='Indicating the status of generating the bill through accounting integration to either Xero or QuickBooks\nOnline. "PARTIALLY_BILLED" does not apply to Xero integration.\n'
+        ),
+    ] = None
+    last_document_status: Annotated[
+        DocumentSendStatus | None,
+        Field(description="Status of the last e-mail sent from (O)PO card."),
+    ] = None
+    purchase_order_rows: list["CachedPurchaseOrderRow"] = Relationship(
+        back_populates="purchase_order"
+    )
+    supplier: Annotated[
+        Supplier | None,
+        SQLField(
+            sa_column=Column(JSON),
+            description="Complete supplier information for this purchase order",
+        ),
+    ] = None
+    tracking_location_id: int | None = None

--- a/scripts/generate_pydantic_models.py
+++ b/scripts/generate_pydantic_models.py
@@ -181,6 +181,30 @@ CACHE_TABLES: set[str] = {
     "StockAdjustment",
     "StockAdjustmentRow",
     "ManufacturingOrder",
+    "PurchaseOrderBase",
+    "PurchaseOrderRow",
+}
+
+
+# Cache class name overrides — when the API class name reads awkwardly as a
+# cache class, remap. Example: ``PurchaseOrderBase`` is the API discriminated
+# union root (sibling of RegularPurchaseOrder + OutsourcedPurchaseOrder); the
+# cache class shadows it as ``CachedPurchaseOrder`` (and ``__tablename__`` is
+# ``purchase_order``, not ``purchase_order_base``).
+CACHE_TABLE_RENAMES: dict[str, str] = {
+    "PurchaseOrderBase": "PurchaseOrder",
+}
+
+
+# Cache-only fields hoisted from API subclasses into the cache base. Used when
+# a discriminated-union root (PurchaseOrderBase) is cached as one SQL table
+# but the listing tool needs to filter by a column that lives on a subclass
+# (OutsourcedPurchaseOrder.tracking_location_id). The converter copies these
+# fields out of the subclass instance when the entity_type matches.
+CACHE_EXTRA_FIELDS: dict[str, list[str]] = {
+    "PurchaseOrderBase": [
+        "    tracking_location_id: int | None = None",
+    ],
 }
 
 
@@ -196,7 +220,12 @@ class CacheTableRelationship:
 
     @property
     def parent_table(self) -> str:
-        return _snake_case(self.parent)
+        # Honor ``CACHE_TABLE_RENAMES`` so FK ``foreign_key="<table>.id"``
+        # references match the renamed tablename (e.g.,
+        # ``PurchaseOrderBase`` → ``purchase_order``, not
+        # ``purchase_order_base``).
+        renamed = CACHE_TABLE_RENAMES.get(self.parent, self.parent)
+        return _snake_case(renamed)
 
 
 def _snake_case(name: str) -> str:
@@ -210,10 +239,10 @@ def _cached_name(name: str) -> str:
     Cache rows live as ``Cached<Name>`` siblings of the API pydantic models
     so the API surface stays pure (no ``table=True``, no FK pollution) while
     the cache schema can carry SQLAlchemy machinery, FK back-pointers, and
-    relationships. Use this everywhere instead of string-formatting so the
-    convention is centralized.
+    relationships. ``CACHE_TABLE_RENAMES`` lets a class shadow under a
+    different name (``PurchaseOrderBase`` → ``CachedPurchaseOrder``).
     """
-    return f"Cached{name}"
+    return f"Cached{CACHE_TABLE_RENAMES.get(name, name)}"
 
 
 CACHE_RELATIONSHIPS: list[CacheTableRelationship] = [
@@ -231,6 +260,13 @@ CACHE_RELATIONSHIPS: list[CacheTableRelationship] = [
         child_back_ref="stock_adjustment",
         child_fk_field="stock_adjustment_id",
     ),
+    CacheTableRelationship(
+        parent="PurchaseOrderBase",
+        parent_field="purchase_order_rows",
+        child="PurchaseOrderRow",
+        child_back_ref="purchase_order",
+        child_fk_field="purchase_order_id",
+    ),
 ]
 
 
@@ -243,6 +279,12 @@ CACHE_JSON_COLUMNS: dict[str, list[str]] = {
     "SalesOrderRow": ["attributes", "batch_transactions", "serial_numbers"],
     "StockAdjustmentRow": ["batch_transactions"],
     "ManufacturingOrder": ["batch_transactions", "serial_numbers"],
+    # PurchaseOrderBase.supplier is a single nested ``Supplier`` object that
+    # SQLAlchemy can't auto-map; cache it as JSON so the row stays denormalized.
+    "PurchaseOrderBase": ["supplier"],
+    # ``landed_cost: str | float | None`` is a non-optional inner union
+    # that SQLAlchemy can't auto-type — JSON-column it instead of dropping.
+    "PurchaseOrderRow": ["batch_transactions", "landed_cost"],
 }
 
 
@@ -461,6 +503,7 @@ def parse_generated_file(
     classes = inject_foreign_keys(classes)
     classes = inject_relationship_fields(classes)
     classes = inject_json_columns(classes)
+    classes = inject_extra_cache_fields(classes)
 
     print(
         f"  Found {len(imports)} imports, {len(classes)} classes, "
@@ -1146,6 +1189,41 @@ def swap_awaredatetime_for_datetime(classes: list[ClassInfo]) -> list[ClassInfo]
         if new_source == cls.source:
             fixed.append(cls)
             continue
+        fixed.append(
+            ClassInfo(
+                name=cls.name,
+                source=new_source,
+                bases=cls.bases,
+                line_start=cls.line_start,
+                line_end=cls.line_end,
+            )
+        )
+    return fixed
+
+
+def inject_extra_cache_fields(classes: list[ClassInfo]) -> list[ClassInfo]:
+    """Append ``CACHE_EXTRA_FIELDS`` declarations to the cache class body.
+
+    For discriminated-union roots (PurchaseOrderBase) cached as a single
+    SQL table, this hoists subclass-only fields onto the cache class so
+    queries can filter by them without a UNION across two tables. The
+    converter copies the values from the API subclass instance.
+
+    Inserts each declaration line at the end of the class body. Plain
+    pydantic ``Field`` annotation is sufficient — SQLModel infers the
+    column type from the annotation. ``Optional`` types stay nullable on
+    the column.
+    """
+    cached_extras = {
+        _cached_name(name): fields for name, fields in CACHE_EXTRA_FIELDS.items()
+    }
+    fixed = []
+    for cls in classes:
+        extra_lines = cached_extras.get(cls.name)
+        if not extra_lines:
+            fixed.append(cls)
+            continue
+        new_source = cls.source.rstrip() + "\n" + "\n".join(extra_lines) + "\n"
         fixed.append(
             ClassInfo(
                 name=cls.name,


### PR DESCRIPTION
Closes #378.

## Summary

Migrates `list_purchase_orders` to read from the SQLModel typed cache via `CachedPurchaseOrder` (which shadows the API `PurchaseOrderBase` discriminated-union root).

## Polymorphic shape

`PurchaseOrderBase` is the API base for the discriminated union of `RegularPurchaseOrder` and `OutsourcedPurchaseOrder`. The cache stores both subtypes in one SQL table (`purchase_order`) keyed by `entity_type` — outsourced-only `tracking_location_id` is hoisted from the subclass via the new `CACHE_EXTRA_FIELDS` config so the listing tool can filter on it without crossing two tables. Regular POs carry `None` for the column.

## Generator additions

- `CACHE_TABLE_RENAMES` — lets a cache class shadow under a different name (`PurchaseOrderBase` → `CachedPurchaseOrder`, `__tablename__` is `purchase_order`, FKs reference `purchase_order.id`).
- `CACHE_EXTRA_FIELDS` — appends raw field declarations onto the cache class body. First use: `tracking_location_id: int | None = None` on `CachedPurchaseOrder`, hoisted from `OutsourcedPurchaseOrder`.
- Add `PurchaseOrderBase` and `PurchaseOrderRow` to `CACHE_TABLES`; `PurchaseOrderBase.supplier` (single nested `Supplier`) and `PurchaseOrderRow.landed_cost` (`str | float | None` non-optional inner union — SQLAlchemy can't auto-type) become JSON columns.

## Cache + sync runtime

- New `ensure_purchase_orders_synced` mirrors `ensure_sales_orders_synced` with a per-entity asyncio lock.
- `_attrs_purchase_order_to_cached` dispatches via the model registry (`get_pydantic_class(type(attrs_po))`) so the right subclass (regular/outsourced) round-trips and outsourced fields survive the `model_dump` → `model_validate` hop.
- Children use the existing `purchase_order_id` from the API response (no FK synthesis needed); back-pointer is set defensively from `api_po.id` on insert.

## Tool migration

- Cache-backed `_list_purchase_orders_impl` queries `CachedPurchaseOrder`. All filters (`ids`, `order_no`, `entity_type`, `status`, `billing_status`, `currency`, `location_id`, `tracking_location_id`, `supplier_id`, `include_deleted`, all date ranges including `expected_arrival_*`) run as indexed SQL.
- Status / billing_status / entity_type coerce via `.value` so the caller-facing API enums (`FindPurchaseOrders*`) decouple from the cache enums (`PurchaseOrder*`).

## Test plan

- [x] 12 cache-backed tests replace the 10 mock-API tests
- [x] `uv run poe test` — 2,436 passed, 3 skipped
- [x] `uv run poe agent-check` — green
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)