### PR TITLE
chore(mcp): post-#342 cleanup — sync debounce, query-shape branching, helper extractions

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -447,9 +447,9 @@ Create a stock adjustment to correct inventory levels.
 ---
 
 ### list_stock_adjustments
-List existing stock adjustments with filters, paging, and optional row detail. Cache-backed
-post-#376 — all filters run as indexed SQL queries against the SQLModel typed cache, so
-`variant_id` finds matches regardless of how many adjustments precede them in the cache.
+List existing stock adjustments with filters, paging, and optional row detail. All filters
+run as indexed SQL against the typed cache, so `variant_id` finds matches regardless of
+how many adjustments precede them.
 
 **Parameters:**
 - `limit` (optional, default 50, min 1, max 250): Max adjustments to return — also the page size when `page` is set
@@ -504,9 +504,8 @@ confirming.
 ---
 
 ### list_manufacturing_orders
-List manufacturing orders with filters. Cache-backed post-#377 — all filters run as
-indexed SQL queries against the SQLModel typed cache, including `production_deadline_*`
-which was a client-side post-fetch filter pre-cache.
+List manufacturing orders with filters. All filters (including `production_deadline_*`)
+run as indexed SQL against the typed cache.
 
 **Paging:**
 - `limit` (optional, default 50, min 1, max 250): Max rows to return
@@ -629,11 +628,10 @@ field (#346 follow-on).
 ---
 
 ### list_purchase_orders
-List purchase orders with filters. Cache-backed post-#378 — all filters run as
-indexed SQL queries against the SQLModel typed cache. ``PurchaseOrderBase`` shadows
-both ``RegularPurchaseOrder`` and ``OutsourcedPurchaseOrder`` as one cache table
-named ``purchase_order``; the outsourced-only ``tracking_location_id`` field is
-hoisted onto the cache row so it's queryable across both subtypes.
+List purchase orders with filters. All filters run as indexed SQL against the typed
+cache. Both `RegularPurchaseOrder` and `OutsourcedPurchaseOrder` live in one cache table
+(`purchase_order`) keyed on `entity_type`; the outsourced-only `tracking_location_id`
+field is hoisted onto the row so it's queryable across both subtypes.
 
 **Paging:**
 - `limit` (optional, default 50, min 1, max 250): Max rows to return
@@ -656,8 +654,7 @@ hoisted onto the cache row so it's queryable across both subtypes.
 **Time windows** (all run as indexed SQL date-range queries):
 - `created_after` / `created_before`: ISO-8601 bounds on `created_at`
 - `updated_after` / `updated_before`: ISO-8601 bounds on `updated_at`
-- `expected_arrival_after` / `expected_arrival_before`: bounds on
-  `expected_arrival_date` (was a client-side post-fetch filter pre-cache; now indexed SQL)
+- `expected_arrival_after` / `expected_arrival_before`: bounds on `expected_arrival_date`
 
 - `include_rows` (optional, default false): Populate per-PO line item detail
   (variant_id, quantity, price, arrival).
@@ -813,13 +810,14 @@ Create a sales order.
 ---
 
 ### list_sales_orders
-List sales orders with filters (list-tool pattern v2).
+List sales orders with filters. All filters run as indexed SQL against the typed cache.
 
 **Paging:**
 - `limit` (optional, default 50, min 1, max 250): Max rows to return. When
   `page` is set, acts as the page size.
-- `page` (optional, min 1): Page number (1-based). When set, disables
-  auto-pagination; use with `limit` as page size.
+- `page` (optional, min 1): Page number (1-based); when set, the response includes
+  `pagination` metadata (total_records, total_pages) computed via SQL COUNT against
+  the same filter predicate.
 
 **Domain filters:**
 - `order_no` (optional): Exact order number
@@ -834,15 +832,10 @@ List sales orders with filters (list-tool pattern v2).
 - `needs_work_orders` (optional): Shortcut for `production_status="NONE"` —
   finds sales orders that haven't had manufacturing orders created yet
 
-**Time windows (server-side):**
+**Time windows** (all run as indexed SQL date-range queries):
 - `created_after` / `created_before`: ISO-8601 bounds on `created_at`
 - `updated_after` / `updated_before`: ISO-8601 bounds on `updated_at`
-
-**Time windows (client-side — Katana has no server filter):**
-- `delivered_after` / `delivered_before`: ISO-8601 bounds on `delivery_date`.
-  When set, the tool skips the page=1 short-circuit so auto-pagination can
-  scan enough rows to find `limit` matching results post-filter. Pair with a
-  `created_at` window to keep fetched rows bounded.
+- `delivered_after` / `delivered_before`: ISO-8601 bounds on `delivery_date`
 
 **Row detail:**
 - `include_rows` (optional, default false): When true, populate per-order row
@@ -921,9 +914,8 @@ Create a stock transfer moving inventory between two locations.
 ---
 
 ### list_stock_transfers
-List stock transfers with filters. Cache-backed post-#379 — all filters run as
-indexed SQL queries against the SQLModel typed cache, including `status` which
-was a client-side post-fetch filter pre-cache.
+List stock transfers with filters. All filters (including `status`) run as indexed
+SQL against the typed cache.
 
 **Parameters:**
 - `limit` (optional, default 50, min 1): Max rows to return

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -22,6 +22,7 @@ from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
     PaginationMeta,
+    apply_date_window_filters,
     format_md_table,
     iso_or_none,
     make_simple_result,
@@ -1018,10 +1019,9 @@ def _apply_stock_adjustment_filters(
     if not request.include_deleted:
         stmt = stmt.where(CachedStockAdjustment.deleted_at.is_(None))
 
-    # variant_id is a row-level field — closes the filter-breadth bug
-    # flagged in #342: previously this ran client-side after fetching one
-    # page, so an adjustment touching variant 42 on page 7 would be missed.
-    # As an EXISTS subquery it scans the indexed FK column directly.
+    # ``variant_id`` is a row-level field — EXISTS subquery scans the
+    # indexed FK directly so a match on any row of any adjustment is
+    # found regardless of pagination position.
     if request.variant_id is not None:
         row_filter = (
             select(CachedStockAdjustmentRow.id)
@@ -1035,44 +1035,34 @@ def _apply_stock_adjustment_filters(
         stmt = stmt.where(exists(row_filter))
 
     if request.reason is not None:
-        # Case-insensitive substring match. SQLite's ``LIKE`` is
-        # case-insensitive for ASCII by default; ``ilike`` makes the
-        # intent explicit and works across SQLAlchemy dialects.
         needle = request.reason.strip()
         if needle:
             stmt = stmt.where(CachedStockAdjustment.reason.ilike(f"%{needle}%"))
 
-    # Date windows — all indexed SQL range queries. Iterate the field
-    # tuple so adding new bounds later is one-line work.
-    date_columns: list[tuple[str, Any, str]] = [
-        ("created_after", CachedStockAdjustment.created_at, ">="),
-        ("created_before", CachedStockAdjustment.created_at, "<="),
-        ("updated_after", CachedStockAdjustment.updated_at, ">="),
-        ("updated_before", CachedStockAdjustment.updated_at, "<="),
-    ]
-    for name, col, comp in date_columns:
-        dt = parsed_dates[name]
-        if dt is None:
-            continue
-        stmt = stmt.where(col >= dt if comp == ">=" else col <= dt)
-
-    return stmt
+    return apply_date_window_filters(
+        stmt,
+        parsed_dates,
+        ge_pairs={
+            "created_after": CachedStockAdjustment.created_at,
+            "updated_after": CachedStockAdjustment.updated_at,
+        },
+        le_pairs={
+            "created_before": CachedStockAdjustment.created_at,
+            "updated_before": CachedStockAdjustment.updated_at,
+        },
+    )
 
 
 async def _list_stock_adjustments_impl(
     request: ListStockAdjustmentsRequest, context: Context
 ) -> ListStockAdjustmentsResponse:
-    """List stock adjustments with filters (cache-backed).
+    """List stock adjustments with filters via the typed cache.
 
-    Reads from the SQLModel typed cache instead of the live API.
     ``ensure_stock_adjustments_synced`` runs an incremental
-    ``updated_at_min`` delta on every call (near-zero cost steady-state;
-    cold-start pulls full history once); the query then translates request
-    filters into indexed SQL and returns results directly — no pagination
-    dance, no post-fetch client-side filtering. ``variant_id`` runs as an
-    EXISTS subquery against the row table, closing the filter-breadth bug
-    where adjustments touching the variant on a later page were missed.
-    See ADR-0018 and #342.
+    ``updated_at_min`` delta (debounced — see :data:`_SYNC_DEBOUNCE`).
+    Filters translate to indexed SQL; ``variant_id`` runs as an EXISTS
+    subquery against the row table so a match on any row is found
+    regardless of how many adjustments precede it. See ADR-0018.
     """
     from sqlalchemy.orm import selectinload
     from sqlmodel import func, select
@@ -1085,27 +1075,28 @@ async def _list_stock_adjustments_impl(
 
     services = get_services(context)
 
-    # 1. Refresh the cache (incremental — near-zero cost steady state).
     await ensure_stock_adjustments_synced(services.client, services.typed_cache)
 
-    # 2. Parse date filters once so the data SELECT and the (optional)
-    # COUNT SELECT don't each re-parse the same ISO-8601 strings.
     parsed_dates = parse_request_dates(request, _STOCK_ADJUSTMENT_DATE_FIELDS)
 
-    # 3. Build the data query. Pair each row with a scalar-subquery
-    # ``row_count`` so the common ``include_rows=False`` case doesn't pay
-    # the selectinload cost of materializing every line item just to
-    # report counts.
-    row_count_subq = (
-        select(func.count(CachedStockAdjustmentRow.id))
-        .where(CachedStockAdjustmentRow.stock_adjustment_id == CachedStockAdjustment.id)
-        .correlate(CachedStockAdjustment)
-        .scalar_subquery()
-        .label("row_count")
-    )
-    stmt = select(CachedStockAdjustment, row_count_subq)
+    # When ``include_rows`` is set, ``selectinload`` eager-loads the
+    # children, so ``len(adj.stock_adjustment_rows)`` is free at
+    # materialization time and we skip the correlated COUNT subquery.
     if request.include_rows:
-        stmt = stmt.options(selectinload(CachedStockAdjustment.stock_adjustment_rows))
+        stmt = select(CachedStockAdjustment).options(
+            selectinload(CachedStockAdjustment.stock_adjustment_rows)
+        )
+    else:
+        row_count_subq = (
+            select(func.count(CachedStockAdjustmentRow.id))
+            .where(
+                CachedStockAdjustmentRow.stock_adjustment_id == CachedStockAdjustment.id
+            )
+            .correlate(CachedStockAdjustment)
+            .scalar_subquery()
+            .label("row_count")
+        )
+        stmt = select(CachedStockAdjustment, row_count_subq)
     stmt = _apply_stock_adjustment_filters(stmt, request, parsed_dates)
     stmt = stmt.order_by(
         CachedStockAdjustment.created_at.desc(), CachedStockAdjustment.id.desc()
@@ -1115,12 +1106,15 @@ async def _list_stock_adjustments_impl(
     else:
         stmt = stmt.limit(request.limit)
 
-    # 4. Execute data query and (when paginating) a separate COUNT for meta.
     async with services.typed_cache.session() as session:
         data_result = await session.exec(stmt)
-        adjustments_with_counts: list[tuple[CachedStockAdjustment, int]] = (
-            data_result.all()
-        )
+        if request.include_rows:
+            cached_adjustments = list(data_result.all())
+            adjustments_with_counts: list[tuple[CachedStockAdjustment, int]] = [
+                (adj, len(adj.stock_adjustment_rows)) for adj in cached_adjustments
+            ]
+        else:
+            adjustments_with_counts = data_result.all()
 
         pagination: PaginationMeta | None = None
         if request.page is not None:
@@ -1139,7 +1133,6 @@ async def _list_stock_adjustments_impl(
                 last_page=request.page >= total_pages,
             )
 
-    # 5. Materialize summaries.
     adjustments: list[StockAdjustmentSummary] = []
     for adj, row_count in adjustments_with_counts:
         row_infos: list[StockAdjustmentRowInfo] | None = None

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -24,6 +24,8 @@ from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
     PaginationMeta,
+    apply_date_window_filters,
+    coerce_enum,
     enum_to_str,
     format_md_table,
     iso_or_none,
@@ -2213,17 +2215,13 @@ def _apply_manufacturing_order_filters(
     if request.order_no is not None:
         stmt = stmt.where(CachedManufacturingOrder.order_no == request.order_no)
     if request.status is not None:
-        # ``GetAllManufacturingOrdersStatus`` is the API filter enum;
-        # ``ManufacturingOrderStatus`` is the cache column type. Both share
-        # the same string values, so coerce by .value to avoid coupling the
-        # caller to the cache enum class directly.
-        try:
-            status_enum = ManufacturingOrderStatus(request.status.value)
-        except ValueError as e:
-            valid = ", ".join(s.value for s in ManufacturingOrderStatus)
-            msg = f"Invalid status {request.status!r}. Valid: {valid}"
-            raise ValueError(msg) from e
-        stmt = stmt.where(CachedManufacturingOrder.status == status_enum)
+        # ``GetAllManufacturingOrdersStatus`` (caller) and
+        # ``ManufacturingOrderStatus`` (cache column) share string values
+        # but are distinct types — coerce_enum round-trips through .value.
+        stmt = stmt.where(
+            CachedManufacturingOrder.status
+            == coerce_enum(request.status, ManufacturingOrderStatus, "status")
+        )
     if request.location_id is not None:
         stmt = stmt.where(CachedManufacturingOrder.location_id == request.location_id)
     if request.is_linked_to_sales_order is not None:
@@ -2234,43 +2232,31 @@ def _apply_manufacturing_order_filters(
     if not request.include_deleted:
         stmt = stmt.where(CachedManufacturingOrder.deleted_at.is_(None))
 
-    date_columns: list[tuple[str, Any, str]] = [
-        ("created_after", CachedManufacturingOrder.created_at, ">="),
-        ("created_before", CachedManufacturingOrder.created_at, "<="),
-        ("updated_after", CachedManufacturingOrder.updated_at, ">="),
-        ("updated_before", CachedManufacturingOrder.updated_at, "<="),
-        (
-            "production_deadline_after",
-            CachedManufacturingOrder.production_deadline_date,
-            ">=",
-        ),
-        (
-            "production_deadline_before",
-            CachedManufacturingOrder.production_deadline_date,
-            "<=",
-        ),
-    ]
-    for name, col, comp in date_columns:
-        dt = parsed_dates[name]
-        if dt is None:
-            continue
-        stmt = stmt.where(col >= dt if comp == ">=" else col <= dt)
-
-    return stmt
+    return apply_date_window_filters(
+        stmt,
+        parsed_dates,
+        ge_pairs={
+            "created_after": CachedManufacturingOrder.created_at,
+            "updated_after": CachedManufacturingOrder.updated_at,
+            "production_deadline_after": CachedManufacturingOrder.production_deadline_date,
+        },
+        le_pairs={
+            "created_before": CachedManufacturingOrder.created_at,
+            "updated_before": CachedManufacturingOrder.updated_at,
+            "production_deadline_before": CachedManufacturingOrder.production_deadline_date,
+        },
+    )
 
 
 async def _list_manufacturing_orders_impl(
     request: ListManufacturingOrdersRequest, context: Context
 ) -> ListManufacturingOrdersResponse:
-    """List manufacturing orders with filters (cache-backed).
+    """List manufacturing orders with filters via the typed cache.
 
-    Reads from the SQLModel typed cache instead of the live API.
     ``ensure_manufacturing_orders_synced`` runs an incremental
-    ``updated_at_min`` delta on every call (near-zero cost steady-state;
-    cold-start pulls full history once); the query then translates request
-    filters into indexed SQL. ``production_deadline_*`` was a client-side
-    post-fetch filter pre-cache; it now runs as a date-range SQL predicate
-    just like any other date column. See ADR-0018 and #342.
+    ``updated_at_min`` delta (debounced — see :data:`_SYNC_DEBOUNCE`).
+    Filters (including ``production_deadline_*``) translate to indexed
+    SQL. See ADR-0018.
     """
     from sqlmodel import func, select
 
@@ -2281,14 +2267,10 @@ async def _list_manufacturing_orders_impl(
 
     services = get_services(context)
 
-    # 1. Refresh the cache (incremental — near-zero cost steady state).
     await ensure_manufacturing_orders_synced(services.client, services.typed_cache)
 
-    # 2. Parse date filters once so the data SELECT and the (optional)
-    # COUNT SELECT don't each re-parse the same ISO-8601 strings.
     parsed_dates = parse_request_dates(request, _MANUFACTURING_ORDER_DATE_FIELDS)
 
-    # 3. Build the data query.
     stmt = select(CachedManufacturingOrder)
     stmt = _apply_manufacturing_order_filters(stmt, request, parsed_dates)
     stmt = stmt.order_by(
@@ -2300,7 +2282,6 @@ async def _list_manufacturing_orders_impl(
     else:
         stmt = stmt.limit(request.limit)
 
-    # 4. Execute data query and (when paginating) a separate COUNT for meta.
     async with services.typed_cache.session() as session:
         data_result = await session.exec(stmt)
         cached_orders: list[CachedManufacturingOrder] = list(data_result.all())
@@ -2322,7 +2303,6 @@ async def _list_manufacturing_orders_impl(
                 last_page=request.page >= total_pages,
             )
 
-    # 5. Materialize summaries.
     summaries: list[ManufacturingOrderSummary] = []
     for mo in cached_orders:
         summaries.append(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -25,6 +25,8 @@ from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
     PaginationMeta,
+    apply_date_window_filters,
+    coerce_enum,
     enum_to_str,
     format_md_table,
     iso_or_none,
@@ -1781,36 +1783,29 @@ def _apply_purchase_order_filters(
     if request.order_no is not None:
         stmt = stmt.where(CachedPurchaseOrder.order_no == request.order_no)
     if request.entity_type is not None:
-        try:
-            entity_enum = PurchaseOrderEntityType(request.entity_type.value)
-        except ValueError as e:
-            valid = ", ".join(s.value for s in PurchaseOrderEntityType)
-            msg = f"Invalid entity_type {request.entity_type!r}. Valid: {valid}"
-            raise ValueError(msg) from e
-        stmt = stmt.where(CachedPurchaseOrder.entity_type == entity_enum)
+        stmt = stmt.where(
+            CachedPurchaseOrder.entity_type
+            == coerce_enum(request.entity_type, PurchaseOrderEntityType, "entity_type")
+        )
     if request.status is not None:
-        try:
-            status_enum = PurchaseOrderStatus(request.status.value)
-        except ValueError as e:
-            valid = ", ".join(s.value for s in PurchaseOrderStatus)
-            msg = f"Invalid status {request.status!r}. Valid: {valid}"
-            raise ValueError(msg) from e
-        stmt = stmt.where(CachedPurchaseOrder.status == status_enum)
+        stmt = stmt.where(
+            CachedPurchaseOrder.status
+            == coerce_enum(request.status, PurchaseOrderStatus, "status")
+        )
     if request.billing_status is not None:
-        try:
-            billing_enum = PurchaseOrderBillingStatus(request.billing_status.value)
-        except ValueError as e:
-            valid = ", ".join(s.value for s in PurchaseOrderBillingStatus)
-            msg = f"Invalid billing_status {request.billing_status!r}. Valid: {valid}"
-            raise ValueError(msg) from e
-        stmt = stmt.where(CachedPurchaseOrder.billing_status == billing_enum)
+        stmt = stmt.where(
+            CachedPurchaseOrder.billing_status
+            == coerce_enum(
+                request.billing_status, PurchaseOrderBillingStatus, "billing_status"
+            )
+        )
     if request.currency is not None:
         stmt = stmt.where(CachedPurchaseOrder.currency == request.currency)
     if request.location_id is not None:
         stmt = stmt.where(CachedPurchaseOrder.location_id == request.location_id)
     if request.tracking_location_id is not None:
-        # Cache-only column hoisted from OutsourcedPurchaseOrder via
-        # CACHE_EXTRA_FIELDS — regular POs always carry None here.
+        # Cache-only column hoisted from OutsourcedPurchaseOrder; regular
+        # POs always carry None here, so this filter implies outsourced.
         stmt = stmt.where(
             CachedPurchaseOrder.tracking_location_id == request.tracking_location_id
         )
@@ -1819,43 +1814,32 @@ def _apply_purchase_order_filters(
     if not request.include_deleted:
         stmt = stmt.where(CachedPurchaseOrder.deleted_at.is_(None))
 
-    date_columns: list[tuple[str, Any, str]] = [
-        ("created_after", CachedPurchaseOrder.created_at, ">="),
-        ("created_before", CachedPurchaseOrder.created_at, "<="),
-        ("updated_after", CachedPurchaseOrder.updated_at, ">="),
-        ("updated_before", CachedPurchaseOrder.updated_at, "<="),
-        (
-            "expected_arrival_after",
-            CachedPurchaseOrder.expected_arrival_date,
-            ">=",
-        ),
-        (
-            "expected_arrival_before",
-            CachedPurchaseOrder.expected_arrival_date,
-            "<=",
-        ),
-    ]
-    for name, col, comp in date_columns:
-        dt = parsed_dates[name]
-        if dt is None:
-            continue
-        stmt = stmt.where(col >= dt if comp == ">=" else col <= dt)
-
-    return stmt
+    return apply_date_window_filters(
+        stmt,
+        parsed_dates,
+        ge_pairs={
+            "created_after": CachedPurchaseOrder.created_at,
+            "updated_after": CachedPurchaseOrder.updated_at,
+            "expected_arrival_after": CachedPurchaseOrder.expected_arrival_date,
+        },
+        le_pairs={
+            "created_before": CachedPurchaseOrder.created_at,
+            "updated_before": CachedPurchaseOrder.updated_at,
+            "expected_arrival_before": CachedPurchaseOrder.expected_arrival_date,
+        },
+    )
 
 
 async def _list_purchase_orders_impl(
     request: ListPurchaseOrdersRequest, context: Context
 ) -> ListPurchaseOrdersResponse:
-    """List purchase orders with filters (cache-backed).
+    """List purchase orders with filters via the typed cache.
 
-    Reads from the SQLModel typed cache instead of the live API.
-    ``ensure_purchase_orders_synced`` runs an incremental ``updated_at_min``
-    delta on every call (near-zero cost steady state; cold-start pulls
-    full history once); the query then translates request filters into
-    indexed SQL. ``expected_arrival_date`` and ``tracking_location_id``
-    were both client-side post-fetch pre-cache; they now run as direct
-    SQL predicates. See ADR-0018 and #342.
+    ``ensure_purchase_orders_synced`` runs an incremental
+    ``updated_at_min`` delta (debounced — see :data:`_SYNC_DEBOUNCE`).
+    Filters (including ``expected_arrival_date`` and the hoisted
+    outsourced-only ``tracking_location_id``) translate to indexed SQL.
+    See ADR-0018.
     """
     from sqlalchemy.orm import selectinload
     from sqlmodel import func, select
@@ -1868,26 +1852,26 @@ async def _list_purchase_orders_impl(
 
     services = get_services(context)
 
-    # 1. Refresh the cache (incremental — near-zero cost steady state).
     await ensure_purchase_orders_synced(services.client, services.typed_cache)
 
-    # 2. Parse date filters once so the data SELECT and the (optional)
-    # COUNT SELECT don't each re-parse the same ISO-8601 strings.
     parsed_dates = parse_request_dates(request, _PURCHASE_ORDER_DATE_FIELDS)
 
-    # 3. Build the data query. Pair each row with a scalar-subquery
-    # ``row_count`` so the common ``include_rows=False`` case doesn't pay
-    # the selectinload cost.
-    row_count_subq = (
-        select(func.count(CachedPurchaseOrderRow.id))
-        .where(CachedPurchaseOrderRow.purchase_order_id == CachedPurchaseOrder.id)
-        .correlate(CachedPurchaseOrder)
-        .scalar_subquery()
-        .label("row_count")
-    )
-    stmt = select(CachedPurchaseOrder, row_count_subq)
+    # When ``include_rows`` is set, ``selectinload`` eager-loads the
+    # children, so ``len(po.purchase_order_rows)`` is free at materialization
+    # time and we skip the correlated COUNT subquery.
     if request.include_rows:
-        stmt = stmt.options(selectinload(CachedPurchaseOrder.purchase_order_rows))
+        stmt = select(CachedPurchaseOrder).options(
+            selectinload(CachedPurchaseOrder.purchase_order_rows)
+        )
+    else:
+        row_count_subq = (
+            select(func.count(CachedPurchaseOrderRow.id))
+            .where(CachedPurchaseOrderRow.purchase_order_id == CachedPurchaseOrder.id)
+            .correlate(CachedPurchaseOrder)
+            .scalar_subquery()
+            .label("row_count")
+        )
+        stmt = select(CachedPurchaseOrder, row_count_subq)
     stmt = _apply_purchase_order_filters(stmt, request, parsed_dates)
     stmt = stmt.order_by(
         CachedPurchaseOrder.created_at.desc(), CachedPurchaseOrder.id.desc()
@@ -1897,10 +1881,15 @@ async def _list_purchase_orders_impl(
     else:
         stmt = stmt.limit(request.limit)
 
-    # 4. Execute data query and (when paginating) a separate COUNT for meta.
     async with services.typed_cache.session() as session:
         data_result = await session.exec(stmt)
-        orders_with_counts: list[tuple[CachedPurchaseOrder, int]] = data_result.all()
+        if request.include_rows:
+            cached_orders = list(data_result.all())
+            orders_with_counts: list[tuple[CachedPurchaseOrder, int]] = [
+                (po, len(po.purchase_order_rows)) for po in cached_orders
+            ]
+        else:
+            orders_with_counts = data_result.all()
 
         pagination: PaginationMeta | None = None
         if request.page is not None:
@@ -1919,7 +1908,6 @@ async def _list_purchase_orders_impl(
                 last_page=request.page >= total_pages,
             )
 
-    # 5. Materialize summaries.
     summaries: list[PurchaseOrderSummary] = []
     for po, row_count in orders_with_counts:
         rows: list[PurchaseOrderRowSummary] | None = None

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -23,6 +23,8 @@ from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
     PaginationMeta,
+    apply_date_window_filters,
+    coerce_enum,
     enum_to_str,
     format_md_table,
     iso_or_none,
@@ -545,24 +547,18 @@ def _apply_sales_order_filters(
         stmt = stmt.where(CachedSalesOrder.customer_id == request.customer_id)
     if request.location_id is not None:
         stmt = stmt.where(CachedSalesOrder.location_id == request.location_id)
-    # Enum-typed filters: validate + coerce so invalid input raises
-    # loudly instead of silently returning an empty set.
     if request.status is not None:
-        try:
-            status_enum = SalesOrderStatus(request.status)
-        except ValueError as e:
-            valid = ", ".join(s.value for s in SalesOrderStatus)
-            msg = f"Invalid status {request.status!r}. Valid: {valid}"
-            raise ValueError(msg) from e
-        stmt = stmt.where(CachedSalesOrder.status == status_enum)
+        stmt = stmt.where(
+            CachedSalesOrder.status
+            == coerce_enum(request.status, SalesOrderStatus, "status")
+        )
     if production_status is not None:
-        try:
-            prod_enum = SalesOrderProductionStatus(production_status)
-        except ValueError as e:
-            valid = ", ".join(s.value for s in SalesOrderProductionStatus)
-            msg = f"Invalid production_status {production_status!r}. Valid: {valid}"
-            raise ValueError(msg) from e
-        stmt = stmt.where(CachedSalesOrder.production_status == prod_enum)
+        stmt = stmt.where(
+            CachedSalesOrder.production_status
+            == coerce_enum(
+                production_status, SalesOrderProductionStatus, "production_status"
+            )
+        )
     if request.invoicing_status is not None:
         stmt = stmt.where(CachedSalesOrder.invoicing_status == request.invoicing_status)
     if request.currency is not None:
@@ -570,36 +566,31 @@ def _apply_sales_order_filters(
     if not request.include_deleted:
         stmt = stmt.where(CachedSalesOrder.deleted_at.is_(None))
 
-    # Date windows — all indexed SQL range queries. ``delivery_date``
-    # now participates (was post-fetch client-side before cache-back).
-    date_columns: list[tuple[str, Any, str]] = [
-        ("created_after", CachedSalesOrder.created_at, ">="),
-        ("created_before", CachedSalesOrder.created_at, "<="),
-        ("updated_after", CachedSalesOrder.updated_at, ">="),
-        ("updated_before", CachedSalesOrder.updated_at, "<="),
-        ("delivered_after", CachedSalesOrder.delivery_date, ">="),
-        ("delivered_before", CachedSalesOrder.delivery_date, "<="),
-    ]
-    for name, col, comp in date_columns:
-        dt = parsed_dates[name]
-        if dt is None:
-            continue
-        stmt = stmt.where(col >= dt if comp == ">=" else col <= dt)
-
-    return stmt
+    return apply_date_window_filters(
+        stmt,
+        parsed_dates,
+        ge_pairs={
+            "created_after": CachedSalesOrder.created_at,
+            "updated_after": CachedSalesOrder.updated_at,
+            "delivered_after": CachedSalesOrder.delivery_date,
+        },
+        le_pairs={
+            "created_before": CachedSalesOrder.created_at,
+            "updated_before": CachedSalesOrder.updated_at,
+            "delivered_before": CachedSalesOrder.delivery_date,
+        },
+    )
 
 
 async def _list_sales_orders_impl(
     request: ListSalesOrdersRequest, context: Context
 ) -> ListSalesOrdersResponse:
-    """List sales orders with filters (list-tool pattern v2, cache-backed).
+    """List sales orders with filters via the typed cache.
 
-    Reads from the SQLModel typed cache instead of the live API.
     ``ensure_sales_orders_synced`` runs an incremental ``updated_at_min``
-    delta on every call (near-zero cost steady-state; cold-start pulls
-    full history once); the query then translates request filters into
-    indexed SQL and returns results directly — no pagination dance, no
-    post-fetch client-side filtering. See ADR-0018 and #342.
+    delta (debounced — see :data:`_SYNC_DEBOUNCE`); the query then
+    translates request filters into indexed SQL and returns results
+    directly. See ADR-0018.
     """
     from sqlalchemy.orm import selectinload
     from sqlmodel import func, select
@@ -612,28 +603,26 @@ async def _list_sales_orders_impl(
 
     services = get_services(context)
 
-    # 1. Refresh the cache (incremental — near-zero cost steady state).
     await ensure_sales_orders_synced(services.client, services.typed_cache)
 
-    # 2. Parse date filters once so the data SELECT and the (optional)
-    # COUNT SELECT don't each re-parse the same ISO-8601 strings.
     parsed_dates = parse_request_dates(request, _SALES_ORDER_DATE_FIELDS)
 
-    # 3. Build the data query. Pair each row with a scalar-subquery
-    # ``row_count`` so the common ``include_rows=False`` case doesn't pay
-    # the selectinload cost of materializing every line item just to
-    # report counts. Only eager-load the row detail when the caller asks
-    # for it.
-    row_count_subq = (
-        select(func.count(CachedSalesOrderRow.id))
-        .where(CachedSalesOrderRow.sales_order_id == CachedSalesOrder.id)
-        .correlate(CachedSalesOrder)
-        .scalar_subquery()
-        .label("row_count")
-    )
-    stmt = select(CachedSalesOrder, row_count_subq)
+    # When ``include_rows`` is set, ``selectinload`` eager-loads the
+    # children, so ``len(so.sales_order_rows)`` is free at materialization
+    # time and we skip the correlated COUNT subquery entirely.
     if request.include_rows:
-        stmt = stmt.options(selectinload(CachedSalesOrder.sales_order_rows))
+        stmt = select(CachedSalesOrder).options(
+            selectinload(CachedSalesOrder.sales_order_rows)
+        )
+    else:
+        row_count_subq = (
+            select(func.count(CachedSalesOrderRow.id))
+            .where(CachedSalesOrderRow.sales_order_id == CachedSalesOrder.id)
+            .correlate(CachedSalesOrder)
+            .scalar_subquery()
+            .label("row_count")
+        )
+        stmt = select(CachedSalesOrder, row_count_subq)
     stmt = _apply_sales_order_filters(stmt, request, parsed_dates)
     stmt = stmt.order_by(CachedSalesOrder.created_at.desc(), CachedSalesOrder.id.desc())
     if request.page is not None:
@@ -641,13 +630,20 @@ async def _list_sales_orders_impl(
     else:
         stmt = stmt.limit(request.limit)
 
-    # 4. Execute data query and (when paginating) a separate COUNT for meta.
     async with services.typed_cache.session() as session:
         data_result = await session.exec(stmt)
-        orders_with_counts: list[tuple[CachedSalesOrder, int]] = data_result.all()
+        if request.include_rows:
+            cached_orders = list(data_result.all())
+            orders_with_counts: list[tuple[CachedSalesOrder, int]] = [
+                (so, len(so.sales_order_rows)) for so in cached_orders
+            ]
+        else:
+            orders_with_counts = data_result.all()
 
         pagination: PaginationMeta | None = None
         if request.page is not None:
+            # Re-apply the same filter predicate to the COUNT so totals
+            # never disagree with the data set.
             count_stmt = _apply_sales_order_filters(
                 select(func.count()).select_from(CachedSalesOrder),
                 request,
@@ -663,8 +659,8 @@ async def _list_sales_orders_impl(
                 last_page=request.page >= total_pages,
             )
 
-    # 5. Materialize summaries. ``sku`` stays None — resolving it would
-    # require a variant lookup per row and defeat the single-query win.
+    # ``sku`` stays None — resolving it would require a variant lookup
+    # per row and defeat the single-query win.
     orders: list[SalesOrderSummary] = []
     for so, row_count in orders_with_counts:
         row_infos: list[SalesOrderRowInfo] | None = None

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -28,6 +28,8 @@ from katana_mcp.services import get_services
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     PaginationMeta,
+    apply_date_window_filters,
+    coerce_enum,
     enum_to_str,
     format_md_table,
     iso_or_none,
@@ -458,19 +460,20 @@ def _apply_stock_transfer_filters(
     """Translate request filters into WHERE clauses on a CachedStockTransfer query.
 
     Shared by the data SELECT and the COUNT SELECT so pagination totals
-    reflect exactly the same filter set as the data rows. ``status`` was a
-    client-side post-fetch filter pre-cache (Katana's list endpoint
-    doesn't expose it server-side); it's now an indexed string-equality
-    filter against the cache column. The cache stores the lowercase value
-    Katana returns, so the request's uppercase ``Literal`` is folded to
-    lowercase before comparison.
+    reflect exactly the same filter set as the data rows. The ``status``
+    request field is the uppercase ``StatusLiteral`` (PENDING, etc.); the
+    cache column stores the lowercase value Katana returns. ``coerce_enum``
+    validates the input against ``StockTransferStatus`` (raising loudly on
+    a typo rather than silently returning zero rows) before the comparison.
     """
     from katana_public_api_client.models_pydantic._generated import (
         CachedStockTransfer,
+        StockTransferStatus,
     )
 
     if request.status is not None:
-        stmt = stmt.where(CachedStockTransfer.status == request.status.lower())
+        status_enum = coerce_enum(request.status.lower(), StockTransferStatus, "status")
+        stmt = stmt.where(CachedStockTransfer.status == status_enum.value)
     if request.source_location_id is not None:
         stmt = stmt.where(
             CachedStockTransfer.source_location_id == request.source_location_id
@@ -485,31 +488,23 @@ def _apply_stock_transfer_filters(
         )
     stmt = stmt.where(CachedStockTransfer.deleted_at.is_(None))
 
-    date_columns: list[tuple[str, Any, str]] = [
-        ("created_after", CachedStockTransfer.created_at, ">="),
-        ("created_before", CachedStockTransfer.created_at, "<="),
-    ]
-    for name, col, comp in date_columns:
-        dt = parsed_dates[name]
-        if dt is None:
-            continue
-        stmt = stmt.where(col >= dt if comp == ">=" else col <= dt)
-
-    return stmt
+    return apply_date_window_filters(
+        stmt,
+        parsed_dates,
+        ge_pairs={"created_after": CachedStockTransfer.created_at},
+        le_pairs={"created_before": CachedStockTransfer.created_at},
+    )
 
 
 async def _list_stock_transfers_impl(
     request: ListStockTransfersRequest, context: Context
 ) -> ListStockTransfersResponse:
-    """List stock transfers with filters (cache-backed).
+    """List stock transfers with filters via the typed cache.
 
-    Reads from the SQLModel typed cache instead of the live API.
-    ``ensure_stock_transfers_synced`` runs an incremental ``updated_at_min``
-    delta on every call (near-zero cost steady-state; cold-start pulls
-    full history once); the query then translates request filters into
-    indexed SQL. ``status`` was client-side pre-cache (Katana doesn't
-    expose it as a server-side filter); now it's an indexed equality
-    comparison. See ADR-0018 and #342.
+    ``ensure_stock_transfers_synced`` runs an incremental
+    ``updated_at_min`` delta (debounced — see :data:`_SYNC_DEBOUNCE`).
+    Filters (including ``status``, which Katana doesn't expose as a
+    server-side filter) translate to indexed SQL. See ADR-0018.
     """
     from sqlalchemy.orm import selectinload
     from sqlmodel import func, select
@@ -522,26 +517,26 @@ async def _list_stock_transfers_impl(
 
     services = get_services(context)
 
-    # 1. Refresh the cache (incremental — near-zero cost steady state).
     await ensure_stock_transfers_synced(services.client, services.typed_cache)
 
-    # 2. Parse date filters once so the data SELECT and the (optional)
-    # COUNT SELECT don't each re-parse the same ISO-8601 strings.
     parsed_dates = parse_request_dates(request, _STOCK_TRANSFER_DATE_FIELDS)
 
-    # 3. Build the data query. Pair each row with a scalar-subquery
-    # ``row_count`` so the common ``include_rows=False`` case doesn't pay
-    # the selectinload cost.
-    row_count_subq = (
-        select(func.count(CachedStockTransferRow.id))
-        .where(CachedStockTransferRow.stock_transfer_id == CachedStockTransfer.id)
-        .correlate(CachedStockTransfer)
-        .scalar_subquery()
-        .label("row_count")
-    )
-    stmt = select(CachedStockTransfer, row_count_subq)
+    # When ``include_rows`` is set, ``selectinload`` eager-loads the
+    # children, so ``len(transfer.stock_transfer_rows)`` is free at
+    # materialization time and we skip the correlated COUNT subquery.
     if request.include_rows:
-        stmt = stmt.options(selectinload(CachedStockTransfer.stock_transfer_rows))
+        stmt = select(CachedStockTransfer).options(
+            selectinload(CachedStockTransfer.stock_transfer_rows)
+        )
+    else:
+        row_count_subq = (
+            select(func.count(CachedStockTransferRow.id))
+            .where(CachedStockTransferRow.stock_transfer_id == CachedStockTransfer.id)
+            .correlate(CachedStockTransfer)
+            .scalar_subquery()
+            .label("row_count")
+        )
+        stmt = select(CachedStockTransfer, row_count_subq)
     stmt = _apply_stock_transfer_filters(stmt, request, parsed_dates)
     stmt = stmt.order_by(
         CachedStockTransfer.created_at.desc(), CachedStockTransfer.id.desc()
@@ -551,10 +546,15 @@ async def _list_stock_transfers_impl(
     else:
         stmt = stmt.limit(request.limit)
 
-    # 4. Execute data query and (when paginating) a separate COUNT for meta.
     async with services.typed_cache.session() as session:
         data_result = await session.exec(stmt)
-        transfers_with_counts: list[tuple[CachedStockTransfer, int]] = data_result.all()
+        if request.include_rows:
+            cached_transfers = list(data_result.all())
+            transfers_with_counts: list[tuple[CachedStockTransfer, int]] = [
+                (t, len(t.stock_transfer_rows)) for t in cached_transfers
+            ]
+        else:
+            transfers_with_counts = data_result.all()
 
         pagination: PaginationMeta | None = None
         if request.page is not None:
@@ -573,9 +573,9 @@ async def _list_stock_transfers_impl(
                 last_page=request.page >= total_pages,
             )
 
-    # 5. Materialize summaries. The cached row exposes fields directly
-    # (no UNSET sentinels) so we don't reuse ``_build_summary`` (which
-    # expects the attrs API shape with ``unwrap_unset``).
+    # Cached rows expose fields directly (no UNSET sentinels), so we
+    # don't reuse ``_build_summary`` — that helper expects the attrs API
+    # shape with ``unwrap_unset``.
     summaries: list[StockTransferSummary] = []
     for transfer, row_count in transfers_with_counts:
         row_infos: list[StockTransferRowInfo] | None = None

--- a/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
+++ b/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable
 from datetime import UTC, datetime
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from fastmcp.tools import ToolResult
@@ -110,6 +111,51 @@ def parse_request_dates(
             naive_utc(parse_iso_datetime(raw, name)) if raw is not None else None
         )
     return result
+
+
+def apply_date_window_filters(
+    stmt: Any,
+    parsed_dates: dict[str, datetime | None],
+    *,
+    ge_pairs: dict[str, Any],
+    le_pairs: dict[str, Any],
+) -> Any:
+    """Attach ``>=`` / ``<=`` WHERE clauses for a set of date-range filters.
+
+    ``ge_pairs`` maps ``request_field_name -> sql_column`` for lower bounds
+    (``created_after`` → ``CachedX.created_at``, etc.); ``le_pairs`` does
+    the same for upper bounds. ``parsed_dates`` is the dict produced by
+    :func:`parse_request_dates`; missing keys (i.e. unset filters) are
+    skipped without error.
+    """
+    for name, col in ge_pairs.items():
+        dt = parsed_dates.get(name)
+        if dt is not None:
+            stmt = stmt.where(col >= dt)
+    for name, col in le_pairs.items():
+        dt = parsed_dates.get(name)
+        if dt is not None:
+            stmt = stmt.where(col <= dt)
+    return stmt
+
+
+def coerce_enum(value: Any, enum_cls: type[Enum], field_name: str) -> Enum:
+    """Coerce a request-level value (str or peer enum) into ``enum_cls``.
+
+    Cache-backed list tools accept caller-side enums like
+    ``GetAllManufacturingOrdersStatus`` but query against the cache
+    column's own enum (``ManufacturingOrderStatus``). The two share string
+    values; this helper round-trips through ``.value`` to translate while
+    raising a ``ValueError`` with the valid choices on bad input rather
+    than silently returning an empty result set.
+    """
+    raw = value.value if hasattr(value, "value") else value
+    try:
+        return enum_cls(raw)
+    except ValueError as e:
+        valid = ", ".join(s.value for s in enum_cls)
+        msg = f"Invalid {field_name} {value!r}. Valid: {valid}"
+        raise ValueError(msg) from e
 
 
 class PaginationMeta(BaseModel):

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -13,7 +13,7 @@ Each ``ensure_<entity>_synced`` helper:
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from katana_public_api_client.api.manufacturing_order import (
@@ -42,6 +42,19 @@ from katana_public_api_client.models_pydantic._generated import (
 from katana_public_api_client.utils import unwrap_data
 
 from .sync_state import SyncState
+
+# Skip the API call when the cache was synced this recently. Mirrors the
+# legacy ``cache_sync._NO_INCREMENTAL_DEBOUNCE`` so back-to-back tool
+# calls don't each kick off an HTTP RTT for an empty delta.
+_SYNC_DEBOUNCE = timedelta(seconds=300)
+
+
+def _is_fresh(last_synced: datetime | None) -> bool:
+    """True when the cache was synced within ``_SYNC_DEBOUNCE``."""
+    if last_synced is None:
+        return False
+    return (datetime.now(tz=UTC).replace(tzinfo=None) - last_synced) < _SYNC_DEBOUNCE
+
 
 if TYPE_CHECKING:
     from katana_public_api_client import KatanaClient
@@ -98,6 +111,9 @@ async def ensure_sales_orders_synced(
         async with cache.session() as session:
             state = await session.get(SyncState, "sales_order")
             last_synced = state.last_synced if state is not None else None
+
+        if _is_fresh(last_synced):
+            return
 
         # ``last_synced`` is persisted as naive UTC (SQLite's default
         # DateTime column strips tzinfo). Re-attach UTC before sending to
@@ -178,6 +194,9 @@ async def ensure_stock_adjustments_synced(
             state = await session.get(SyncState, "stock_adjustment")
             last_synced = state.last_synced if state is not None else None
 
+        if _is_fresh(last_synced):
+            return
+
         kwargs = (
             {"updated_at_min": last_synced.replace(tzinfo=UTC)}
             if last_synced is not None
@@ -241,6 +260,9 @@ async def ensure_manufacturing_orders_synced(
         async with cache.session() as session:
             state = await session.get(SyncState, "manufacturing_order")
             last_synced = state.last_synced if state is not None else None
+
+        if _is_fresh(last_synced):
+            return
 
         kwargs = (
             {"updated_at_min": last_synced.replace(tzinfo=UTC)}
@@ -333,6 +355,9 @@ async def ensure_purchase_orders_synced(
             state = await session.get(SyncState, "purchase_order")
             last_synced = state.last_synced if state is not None else None
 
+        if _is_fresh(last_synced):
+            return
+
         kwargs = (
             {"updated_at_min": last_synced.replace(tzinfo=UTC)}
             if last_synced is not None
@@ -400,6 +425,9 @@ async def ensure_stock_transfers_synced(
         async with cache.session() as session:
             state = await session.get(SyncState, "stock_transfer")
             last_synced = state.last_synced if state is not None else None
+
+        if _is_fresh(last_synced):
+            return
 
         kwargs = (
             {"updated_at_min": last_synced.replace(tzinfo=UTC)}

--- a/scripts/generate_pydantic_models.py
+++ b/scripts/generate_pydantic_models.py
@@ -308,6 +308,22 @@ class ClassInfo:
     line_start: int
     line_end: int
 
+    def with_source(self, new_source: str) -> ClassInfo:
+        """Return a copy with a rewritten ``source`` (other fields preserved).
+
+        Used by the cache-table inject passes — each pass mutates the
+        generated source string in-place; using this helper avoids the
+        repetitive ``ClassInfo(name=cls.name, source=new_source, ...)``
+        reconstruction with four passthrough fields.
+        """
+        return ClassInfo(
+            name=self.name,
+            source=new_source,
+            bases=self.bases,
+            line_start=self.line_start,
+            line_end=self.line_end,
+        )
+
 
 @dataclass
 class TypeAliasInfo:
@@ -918,15 +934,7 @@ def inject_primary_key_in_table_classes(classes: list[ClassInfo]) -> list[ClassI
                 "model_config line may be missing or differently formatted."
             )
             raise GenerationError(msg)
-        fixed.append(
-            ClassInfo(
-                name=cls.name,
-                source=new_source,
-                bases=cls.bases,
-                line_start=cls.line_start,
-                line_end=cls.line_end,
-            )
-        )
+        fixed.append(cls.with_source(new_source))
     return fixed
 
 
@@ -975,15 +983,7 @@ def inject_table_annotations(classes: list[ClassInfo]) -> list[ClassInfo]:
                 "The class-declaration shape may have changed."
             )
             raise GenerationError(msg)
-        fixed.append(
-            ClassInfo(
-                name=cls.name,
-                source=new_source,
-                bases=cls.bases,
-                line_start=cls.line_start,
-                line_end=cls.line_end,
-            )
-        )
+        fixed.append(cls.with_source(new_source))
     return fixed
 
 
@@ -1064,15 +1064,7 @@ def inject_foreign_keys(classes: list[ClassInfo]) -> list[ClassInfo]:
                     "Expected Annotated[int | None, Field(description=...)] shape."
                 )
                 raise GenerationError(msg)
-        fixed.append(
-            ClassInfo(
-                name=cls.name,
-                source=new_source,
-                bases=cls.bases,
-                line_start=cls.line_start,
-                line_end=cls.line_end,
-            )
-        )
+        fixed.append(cls.with_source(new_source))
     return fixed
 
 
@@ -1139,15 +1131,7 @@ def inject_relationship_fields(classes: list[ClassInfo]) -> list[ClassInfo]:
             new_source = new_source.rstrip() + "\n" + backref_line
 
         if new_source != cls.source:
-            fixed.append(
-                ClassInfo(
-                    name=cls.name,
-                    source=new_source,
-                    bases=cls.bases,
-                    line_start=cls.line_start,
-                    line_end=cls.line_end,
-                )
-            )
+            fixed.append(cls.with_source(new_source))
         else:
             fixed.append(cls)
     return fixed
@@ -1199,15 +1183,7 @@ def swap_awaredatetime_for_datetime(classes: list[ClassInfo]) -> list[ClassInfo]
         if new_source == cls.source:
             fixed.append(cls)
             continue
-        fixed.append(
-            ClassInfo(
-                name=cls.name,
-                source=new_source,
-                bases=cls.bases,
-                line_start=cls.line_start,
-                line_end=cls.line_end,
-            )
-        )
+        fixed.append(cls.with_source(new_source))
     return fixed
 
 
@@ -1234,15 +1210,7 @@ def inject_extra_cache_fields(classes: list[ClassInfo]) -> list[ClassInfo]:
             fixed.append(cls)
             continue
         new_source = cls.source.rstrip() + "\n" + "\n".join(extra_lines) + "\n"
-        fixed.append(
-            ClassInfo(
-                name=cls.name,
-                source=new_source,
-                bases=cls.bases,
-                line_start=cls.line_start,
-                line_end=cls.line_end,
-            )
-        )
+        fixed.append(cls.with_source(new_source))
     return fixed
 
 
@@ -1282,15 +1250,7 @@ def inject_json_columns(classes: list[ClassInfo]) -> list[ClassInfo]:
                     f"{cls.name}.{field_name}. Field shape may have changed."
                 )
                 raise GenerationError(msg)
-        fixed.append(
-            ClassInfo(
-                name=cls.name,
-                source=new_source,
-                bases=cls.bases,
-                line_start=cls.line_start,
-                line_end=cls.line_end,
-            )
-        )
+        fixed.append(cls.with_source(new_source))
     return fixed
 
 


### PR DESCRIPTION
Slam-dunk batch from the post-epic /simplify pass. Architectural follow-ups in #389; nits in #390.

## Efficiency

- **Sync debounce** (5 helpers in `typed_cache/sync.py`): cache-backed list tools were issuing an HTTP RTT on every invocation, even for empty deltas. Now skips the API call when `last_synced` is within `_SYNC_DEBOUNCE` (300s, mirrors the legacy `cache_sync._NO_INCREMENTAL_DEBOUNCE`).
- **Drop redundant `row_count` subquery on `include_rows=True`** (4 `_list_*_impl`s). When `selectinload` eager-loads children, `len(parent.<rel>_rows)` is free at materialization; the correlated COUNT subquery was per-row work for the same number. Query shape now branches on `include_rows`.

## Quality

- **`list_stock_transfers` status coerces through the cache enum.** Previously `request.status.lower()` against a `str | None` column silently returned zero rows on a typo. Now uses `coerce_enum` against `StockTransferStatus`.

## Reuse

- **`apply_date_window_filters`** in `tool_result_utils.py` — extracts the identical date-range tuple+loop block from all five `_apply_*_filters` helpers.
- **`coerce_enum`** in `tool_result_utils.py` — extracts the `try: enum_cls(req.x.value); except: build "Invalid x. Valid: ..."` pattern from 6 sites.
- **`ClassInfo.with_source(new_source)` method** in the generator — replaces 7 sites of explicit reconstruction. Generated output is byte-identical.

## Comment hygiene

- Stripped ~25 rotting comments referencing PR numbers, "post-#NNN", "client-side post-fetch pre-cache", and numbered step narration. Kept ADR-0018 references and substantive WHY-comments.
- Standardized the five list-tool descriptions in `help.py` on a single phrasing ("All filters run as indexed SQL against the typed cache.").

## Test plan

- [x] `uv run poe test` — 2,434 passed, 3 skipped
- [x] `uv run poe agent-check` — green
- [x] `uv run poe generate-pydantic` — byte-identical output (`ClassInfo.with_source` change)
- [ ] Copilot review

## Related

- Parent epic: #342 (closed)
- Architectural follow-ups: #389
- Nits follow-ups: #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)