### PR TITLE
docs(harness): harvest project-wide rules from local memory

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -34,6 +34,8 @@ Take a feature branch from "implementation done" to "PR open, CI green, review a
 - **HEREDOC for messages** — commit messages and PR bodies always use HEREDOC for proper formatting.
 - **File issues for deferred work** — if the self-review identifies out-of-scope problems, create a tracking issue with `gh issue create` before opening the PR.
 - **Delegate review-comment handling** — never duplicate `/review-pr`; invoke it.
+- **Run `/review-pr` before auto-merge can land** — CI-green is not the only gate. Reviewer feedback (Copilot, human, bot) is the other half. Auto-merge fires the moment CI passes, which can race ahead of unresolved comments and silently land a PR with unaddressed findings. After opening the PR, **always** invoke `/review-pr <#>` to surface and address every unresolved comment before allowing the merge to land. Applies to small cleanup PRs too — the failure mode compounds across multi-PR epics.
+- **In multi-PR epics, run `/simplify` and `/review-pr` between each PR** — after each PR in a series merges to `main`, do a cleanup pass on `main` before starting the next PR. Post-merge is the cheapest time to catch complexity accretion, drift, and review follow-ups that slipped through. Waiting until the end of the epic means the whole series carries forward whatever cruft each step introduced. Bake the pair into the plan as an explicit step between PR N and PR N+1, not a one-off step at the end. Recent epic context: applied during #342 cache-back wave and the #346 `get_*` exhaustive wave.
 
 ## STANDARD PATH
 

--- a/.github/agents/guides/shared/ARCHITECTURE_QUICK_REF.md
+++ b/.github/agents/guides/shared/ARCHITECTURE_QUICK_REF.md
@@ -73,6 +73,27 @@ fixes.
 - **Generated (DO NOT EDIT):** `api/**/*.py`, `models/**/*.py`, `client.py`
 - **Editable:** `katana_client.py`, `log_setup.py`, tests, docs
 
+**Generator-rewrite philosophy: regex first, libcst when the pattern grows, never
+jinja.**
+
+`scripts/generate_pydantic_models.py` runs *on top of* `datamodel-codegen`'s output.
+datamodel-codegen already does the hard work (OpenAPI → pydantic, type inference,
+discriminated unions, validators); our job is purely additive — inject SQLModel
+annotations, add `Cached<Name>` siblings, attach `Column(JSON)` on JSON-typed list
+fields, etc. For that scope, **regex-based source rewrites on top of the generated
+output are the right tool**: auditable, minimal, fast, and the failure mode (failed
+substitution) is loud (`raise GenerationError`).
+
+Triggers to upgrade the rewriting layer:
+
+- More than ~5 additional transforms accumulate, *or*
+- Recurring whitespace/formatting edge cases bite repeated transforms
+
+→ migrate to **libcst** (preserves formatting exactly, structured idempotent rewrites).
+**Do not** swap in jinja or hand-roll a new code-generation framework — full
+template-replacement of datamodel-codegen is out of scope and would multiply the surface
+area we have to keep in sync with the spec.
+
 **📄 ADR:**
 [ADR-002: OpenAPI Code Generation](../../../katana_public_api_client/docs/adr/0002-openapi-code-generation.md)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,16 +90,52 @@ Common mistakes to avoid:
 - **Polluting the API spec/models with cache-only fields** - The OpenAPI spec at
   `docs/katana-openapi.yaml` and the generated pydantic models in
   `katana_public_api_client/models_pydantic/_generated/*.py` reflect Katana's actual
-  wire contract. **Never** add fields to the spec or inject fields into the API
-  pydantic classes to satisfy cache-schema, MCP-tool, or other consumer needs. Cache
-  schemas live on sibling `Cached<Name>` classes emitted by the same generator pass —
-  the API class stays pure pydantic, the cache class carries `table=True`, foreign
-  keys, relationships, JSON columns, and any cache-only fields. See
-  `scripts/generate_pydantic_models.py::duplicate_cache_tables_as_cached_siblings`
-  and `katana_mcp_server/src/katana_mcp/typed_cache/sync.py::_attrs_<entity>_to_cached`
-  for the conversion pattern: attrs → API pydantic (via the registry) → cache pydantic
-  (via `model_dump`/`model_validate`), with relationship fields set after construction
-  since SQLModel `Relationship` descriptors don't accept input via `__init__`.
+  wire contract. **Never** add fields to the spec or inject fields into the API pydantic
+  classes to satisfy cache-schema, MCP-tool, or other consumer needs. Cache schemas live
+  on sibling `Cached<Name>` classes emitted by the same generator pass — the API class
+  stays pure pydantic, the cache class carries `table=True`, foreign keys,
+  relationships, JSON columns, and any cache-only fields. See
+  `scripts/generate_pydantic_models.py::duplicate_cache_tables_as_cached_siblings` and
+  `katana_mcp_server/src/katana_mcp/typed_cache/sync.py::_attrs_<entity>_to_cached` for
+  the conversion pattern: attrs → API pydantic (via the registry) → cache pydantic (via
+  `model_dump`/`model_validate`), with relationship fields set after construction since
+  SQLModel `Relationship` descriptors don't accept input via `__init__`.
+- **Fix bugs at the client/generator layer when the root cause lives there** - The
+  Katana client (`katana_public_api_client`) is a published, standalone package.
+  Third-party Python users hit the same bugs we hit in MCP. When a bug surfaces in
+  `katana_mcp_server/.../typed_cache/sync.py`, in a foundation tool, or in a helper but
+  originates in generated client code (attrs, pydantic, `from_attrs`, `Cached*`
+  schemas), apply the fix to the **generator or spec** — not the consumer. Test: *"would
+  a standalone client user hit this bug?"* If yes, fix it in the client. Examples:
+  `Pydantic*.from_attrs` raising on `{}` from Katana → fix `from_attrs` codegen, not
+  `_attrs_*_to_cached`. `Column(JSON)` failing to serialize a pydantic instance → fix
+  `inject_json_columns` in `scripts/generate_pydantic_models.py`, not `sync.py`. Missing
+  enum value → patch spec + regenerate, not enum-tolerant deserialization downstream.
+- **List responses must use a `ListResponse` schema with `data` array property** -
+  Katana wraps every GET list endpoint in `{"data": [...]}`. If the OpenAPI spec defines
+  a 200 response as `type: array`, the generated parser iterates `response.json()`
+  directly — when the API returns the dict wrapper, iteration yields keys (strings) and
+  `Model.from_dict("data")` raises
+  `ValueError: dictionary update sequence element #0 has length 1; 2 is required`.
+  Always define a proper `MyListResponse` schema (`type: object`,
+  `properties.data: {type: array, items: {$ref: ...}}`) and reference it from the
+  operation. The only documented exception is `/user_info`, which returns a flat object,
+  not wrapped.
+- **Real names and emails from live API responses must never enter the repo** - When
+  testing against the live Katana API and incorporating response data into the spec,
+  examples, or test fixtures, replace real names/emails with generic placeholders
+  (`Jane Doe`, `jane.doe@example.com`, etc.). Privacy concern — real user data from
+  production accounts should not be committed.
+- **Always call functions with named/keyword arguments** - Use `func(param=value)`, not
+  `func(value)`, for all calls — including third-party constructors (especially
+  `prefab_ui` components, which only accept keyword args), API methods, and cache
+  helpers. Caught by review when positional args caused runtime errors with
+  `prefab_ui.Metric`. Explicitness > brevity.
+- **Never delete `.claude/worktrees/` directories or their contents** - Other agents may
+  be actively working inside them; deleting destroys their in-progress context. If a
+  worktree causes downstream issues (e.g., `ty` type checker scanning into it),
+  **exclude the path in tool config** — never `rm -rf` the directory. Treat
+  `.claude/worktrees/` as off-limits for destructive operations.
 
 ## Using the LSP tool
 
@@ -255,14 +291,14 @@ audits and updates.
 
 Spawn via the `Agent` tool with `subagent_type` set to the agent name.
 
-| Agent             | Model  | Purpose                                                          |
-| ----------------- | ------ | ---------------------------------------------------------------- |
-| `code-reviewer`   | sonnet | Six-dimension read-only review of the current diff               |
-| `verifier`        | haiku  | Mechanical pre-PR gate (validation, debug code, history)         |
-| `domain-advisor`  | sonnet | Read-only Q&A on Katana conventions (UNSET, unwrap, helpers)     |
-| `code-modernizer` | sonnet | Actively rewrites Katana-specific anti-patterns                  |
-| `pr-preparer`     | haiku  | Project-specific PR readiness (coverage, ADRs, help-resource)    |
-| `spec-auditor`    | sonnet | Audit local OpenAPI spec vs upstream Katana API                  |
+| Agent             | Model  | Purpose                                                       |
+| ----------------- | ------ | ------------------------------------------------------------- |
+| `code-reviewer`   | sonnet | Six-dimension read-only review of the current diff            |
+| `verifier`        | haiku  | Mechanical pre-PR gate (validation, debug code, history)      |
+| `domain-advisor`  | sonnet | Read-only Q&A on Katana conventions (UNSET, unwrap, helpers)  |
+| `code-modernizer` | sonnet | Actively rewrites Katana-specific anti-patterns               |
+| `pr-preparer`     | haiku  | Project-specific PR readiness (coverage, ADRs, help-resource) |
+| `spec-auditor`    | sonnet | Audit local OpenAPI spec vs upstream Katana API               |
 
 Recommended PR pipeline: `code-modernizer` → `verifier` → `pr-preparer` →
 `code-reviewer` → `/open-pr`.


### PR DESCRIPTION
## Summary

Migrate seven project-wide rules previously held in per-machine local memory into the harness, where they're checked in, loaded for every session, and visible to every contributor (human and agent).

The trigger: while filing #399 / #400, I rationalized one of the rules ("fix bugs at the client/generator layer when the root cause lives there") into a local memory entry. That rule applies to anyone working in the repo, not just my machine — exactly the case for the harness, not memory.

## Changes

**`CLAUDE.md` — Known Pitfalls (5 new bullets):**

- Fix bugs at the client/generator layer when the root cause lives there. Drove issues #399 and #400.
- List responses must use a `ListResponse` schema with `data` array property — Katana wraps every GET list endpoint and a raw `type: array` response yields the dict-iteration crash.
- Real names and emails from live API responses must never enter the repo (privacy).
- Always call functions with named/keyword arguments — caught by `prefab_ui` constructor failures with positional args.
- Never delete `.claude/worktrees/` directories — other agents may be working in them; exclude in tool config instead.

**`.claude/skills/open-pr/SKILL.md` — CRITICAL section (2 new bullets):**

- Run `/review-pr` before auto-merge can land — CI-green is not the only gate; reviewer feedback is the other half. Auto-merge fires the moment CI passes, racing past unresolved comments.
- In multi-PR epics, run `/simplify` and `/review-pr` between each PR — cleanup pass on `main` before starting the next. Post-merge is the cheapest time to catch complexity accretion and review follow-ups.

**`.github/agents/guides/shared/ARCHITECTURE_QUICK_REF.md` — §2 OpenAPI Code Generation:**

- New "Generator-rewrite philosophy" subsection. Regex first on top of `datamodel-codegen` output (auditable, minimal); upgrade to `libcst` when patterns accumulate. Never replace `datamodel-codegen` with jinja — out of scope.

## Why bring these to the harness

Local memory only fires for one machine and is invisible to humans reviewing the code. A rule the user has stated explicitly still gets violated by other agents and other sessions if it sits only in memory. The corollary I'm now applying: anything that begins with *"we should"* / *"this project should"* / *"always do X in this codebase"* is a harness rule, not a memory rule.

## Test plan

- [x] `uv run poe check` — 2,434 passed, 3 skipped, mdformat clean
- [x] Self-review the full diff — pure doc additions, no code paths touched, no secrets / PII / debug code
- [ ] CI green
- [ ] No reviewer comments (or all addressed via /review-pr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)