### PR TITLE
refactor(mcp): EntitySpec + generic ensure_synced for typed-cache sync

### DIFF
--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -1,20 +1,30 @@
 """Per-entity cache sync against the Katana API.
 
-Each ``ensure_<entity>_synced`` helper:
-1. Takes the entity's lock to serialize concurrent sync calls.
-2. Reads the ``SyncState`` watermark and passes it to the API as
-   ``updated_at_min`` so only changed rows come back on subsequent calls.
-3. Converts attrs API objects to ``Cached<Entity>`` SQLModel rows via the
-   API pydantic class as an intermediary (so nested-row conversion stays
-   in one well-tested place), then re-validates into the cache sibling.
-4. Upserts parent + child rows and advances the watermark, all in one
-   session.
+One generic ``_ensure_synced(client, cache, spec)`` drives every entity's
+sync via an :class:`EntitySpec` configuration object. Each spec wires up:
+
+- the entity-key string (used for the per-entity lock and ``SyncState`` row),
+- the ``asyncio_detailed`` API endpoint to call,
+- the cache row class (``Cached<Entity>``) and the API pydantic class
+  (used as the ``from_attrs`` intermediary so nested-row conversion stays
+  in one well-tested place),
+- optional child-rows configuration (class, parent-side field name, FK
+  field name) for entities with nested rows on the wire,
+- an optional ``pydantic_resolver`` that picks the API pydantic subclass
+  from the attrs object (used by purchase orders, where Katana returns a
+  discriminated union ``RegularPurchaseOrder | OutsourcedPurchaseOrder``).
+
+Public ``ensure_<entity>_synced(client, cache)`` functions are thin
+wrappers over ``_ensure_synced`` so existing call sites and tests don't
+need to change.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from katana_public_api_client.api.manufacturing_order import (
     get_all_manufacturing_orders,
@@ -39,6 +49,7 @@ from katana_public_api_client.models_pydantic._generated import (
     StockAdjustment as PydanticStockAdjustment,
     StockTransfer as PydanticStockTransfer,
 )
+from katana_public_api_client.models_pydantic._registry import get_pydantic_class
 from katana_public_api_client.utils import unwrap_data
 
 from .sync_state import SyncState
@@ -62,54 +73,131 @@ if TYPE_CHECKING:
     from .engine import TypedCacheEngine
 
 
-def _attrs_sales_order_to_cached(
-    attrs_so: object,
-) -> tuple[CachedSalesOrder, list[CachedSalesOrderRow]]:
-    """Convert one attrs ``SalesOrder`` to a parent ``CachedSalesOrder`` plus
-    a flat list of ``CachedSalesOrderRow`` children with explicit FKs.
+@dataclass(frozen=True)
+class EntitySpec:
+    """Per-entity sync configuration consumed by ``_ensure_synced``.
+
+    Required: ``entity_key`` (the lock + SyncState key — repeated three
+    times in the prior hand-rolled helpers, source of silent-desync bugs
+    if a typo slipped through), ``api_fn`` (the ``asyncio_detailed``-
+    bearing endpoint module), ``cache_cls`` (``Cached<Entity>``), and
+    ``pydantic_cls`` (the API pydantic class — the ``from_attrs`` /
+    ``model_dump`` intermediary).
+
+    Optional: a ``child_cls`` + ``rows_field`` + ``fk_field`` triple when
+    the entity has nested rows; without them the sync emits a parent-only
+    row pair (the manufacturing-order list endpoint shape).
+    ``pydantic_resolver`` overrides ``pydantic_cls`` per-row by dispatching
+    on the attrs subclass — used by purchase orders, where the
+    discriminated-union root would otherwise lose subclass-only fields.
+    """
+
+    entity_key: str
+    api_fn: Any
+    cache_cls: type
+    pydantic_cls: type
+    child_cls: type | None = None
+    rows_field: str | None = None
+    fk_field: str | None = None
+    pydantic_resolver: Callable[[Any], type] | None = None
+
+    def __post_init__(self) -> None:
+        # Children are configured by a ``(child_cls, rows_field, fk_field)``
+        # triple — a partial set would silently drop children at runtime
+        # because ``_convert`` only iterates when all three are present.
+        # Catch the typo at construction time instead.
+        triple = (self.child_cls, self.rows_field, self.fk_field)
+        n_set = sum(value is not None for value in triple)
+        if n_set not in (0, 3):
+            msg = (
+                "EntitySpec child_cls/rows_field/fk_field must all be "
+                "set together or all left as None"
+            )
+            raise ValueError(msg)
+
+
+def _resolve_purchase_order_class(attrs_po: Any) -> type:
+    """Pick the right pydantic subclass for a purchase-order attrs object.
+
+    ``RegularPurchaseOrder`` and ``OutsourcedPurchaseOrder`` share
+    ``PurchaseOrderBase`` fields but differ in ``entity_type`` and the
+    outsourced-only ``tracking_location_id`` / ``ingredient_*`` fields.
+    Calling ``PydanticPurchaseOrderBase.from_attrs`` directly would lose
+    those subclass-only fields; the registry keeps the subtype.
+    """
+
+    api_class = get_pydantic_class(type(attrs_po))
+    if api_class is None:
+        msg = (
+            f"No pydantic class registered for attrs purchase order "
+            f"type {type(attrs_po).__name__}"
+        )
+        raise RuntimeError(msg)
+    return api_class
+
+
+def _convert(spec: EntitySpec, attrs_obj: Any) -> tuple[Any, list[Any]]:
+    """Convert one attrs API object to a ``(parent, children)`` cache pair.
 
     Two-step:
-    1. ``PydanticSalesOrder.from_attrs`` handles UNSET → None, enum
-       extraction, datetime coercion, and the registry-driven nested
-       conversion of each row. The result is the API pydantic model.
-    2. ``model_dump`` exports a plain dict; ``CachedSalesOrder.model_validate``
-       reconstructs the parent (excluding the ``sales_order_rows``
+    1. The API pydantic class (resolved via ``pydantic_resolver`` or
+       ``spec.pydantic_cls``) handles UNSET → None, enum extraction,
+       datetime coercion, and registry-driven nested-row conversion via
+       ``from_attrs``.
+    2. ``model_dump`` exports a plain dict; the cache class's
+       ``model_validate`` reconstructs the parent (excluding the rows
        relationship — SQLModel ``Relationship`` descriptors don't accept
-       input via ``__init__``/``model_validate``). Children are re-built as
-       ``CachedSalesOrderRow`` with ``sales_order_id`` set explicitly so
-       SQLAlchemy can wire the parent→child link on insert. The caller
-       merges parents and children in separate passes.
+       input via ``__init__`` / ``model_validate``). Children, if
+       configured, are re-built as the cache row class with the FK set
+       explicitly from the parent's ``id`` so SQLAlchemy can wire the
+       link on insert.
+
+    Re-asserting the FK from the parent guards against the wire shape
+    silently changing on entities (sales orders, purchase orders) where
+    Katana already returns the FK on rows; for entities where Katana
+    nests rows under the parent without a back-pointer (stock adjustments,
+    stock transfers), the FK is synthesized here.
     """
-    api_so = PydanticSalesOrder.from_attrs(attrs_so)
-    parent_data = api_so.model_dump(exclude={"sales_order_rows"})
-    cached_parent = CachedSalesOrder.model_validate(parent_data)
+    api_cls = (
+        spec.pydantic_resolver(attrs_obj)
+        if spec.pydantic_resolver is not None
+        else spec.pydantic_cls
+    )
+    api_obj = api_cls.from_attrs(attrs_obj)
 
-    child_rows: list[CachedSalesOrderRow] = []
-    api_rows = api_so.sales_order_rows or []
-    for api_row in api_rows:
-        row_data = api_row.model_dump()
-        # The API model carries ``sales_order_id`` natively (Katana returns
-        # it on rows). Re-asserting from the parent guards against the
-        # response shape silently changing.
-        row_data["sales_order_id"] = api_so.id
-        child_rows.append(CachedSalesOrderRow.model_validate(row_data))
-    return cached_parent, child_rows
+    exclude = {spec.rows_field} if spec.rows_field else set()
+    parent = spec.cache_cls.model_validate(api_obj.model_dump(exclude=exclude))
+
+    children: list[Any] = []
+    if (
+        spec.child_cls is not None
+        and spec.rows_field is not None
+        and spec.fk_field is not None
+    ):
+        api_rows = getattr(api_obj, spec.rows_field) or []
+        for api_row in api_rows:
+            row_data = api_row.model_dump()
+            row_data[spec.fk_field] = api_obj.id
+            children.append(spec.child_cls.model_validate(row_data))
+
+    return parent, children
 
 
-async def ensure_sales_orders_synced(
-    client: KatanaClient, cache: TypedCacheEngine
+async def _ensure_synced(
+    client: KatanaClient, cache: TypedCacheEngine, spec: EntitySpec
 ) -> None:
-    """Pull updated sales orders from Katana and upsert into the typed cache.
+    """Pull updated rows for one entity from Katana and upsert into the cache.
 
-    The first call on a cold cache does a full history fetch (cost scales
-    with the shop's order count); subsequent calls pass
-    ``updated_at_min=<last_synced>`` and typically return zero rows. The
-    per-entity lock guarantees only one sync runs at a time even if
-    multiple tool calls land concurrently.
+    Cold-start fetches the full history (cost scales with row count);
+    subsequent calls pass ``updated_at_min=<last_synced>`` and typically
+    return zero rows. The per-entity lock guarantees only one sync runs
+    at a time even if multiple tool calls land concurrently. The
+    ``_SYNC_DEBOUNCE`` short-circuit avoids an HTTP RTT for back-to-back
+    tool calls.
     """
-    async with cache.lock_for("sales_order"):
+    async with cache.lock_for(spec.entity_key):
         async with cache.session() as session:
-            state = await session.get(SyncState, "sales_order")
+            state = await session.get(SyncState, spec.entity_key)
             last_synced = state.last_synced if state is not None else None
 
         if _is_fresh(last_synced):
@@ -117,20 +205,19 @@ async def ensure_sales_orders_synced(
 
         # ``last_synced`` is persisted as naive UTC (SQLite's default
         # DateTime column strips tzinfo). Re-attach UTC before sending to
-        # the API so the generated client serializes an explicit offset —
-        # matches the legacy cache_sync watermark handling.
+        # the API so the generated client serializes an explicit offset.
         kwargs = (
             {"updated_at_min": last_synced.replace(tzinfo=UTC)}
             if last_synced is not None
             else {}
         )
-        response = await get_all_sales_orders.asyncio_detailed(client=client, **kwargs)
-        attrs_orders = unwrap_data(response, default=[])
+        response = await spec.api_fn.asyncio_detailed(client=client, **kwargs)
+        attrs_objs = unwrap_data(response, default=[])
 
-        cached_parents: list[CachedSalesOrder] = []
-        cached_children: list[CachedSalesOrderRow] = []
-        for attrs_so in attrs_orders:
-            parent, children = _attrs_sales_order_to_cached(attrs_so)
+        cached_parents: list[Any] = []
+        cached_children: list[Any] = []
+        for attrs_obj in attrs_objs:
+            parent, children = _convert(spec, attrs_obj)
             cached_parents.append(parent)
             cached_children.extend(children)
 
@@ -142,12 +229,13 @@ async def ensure_sales_orders_synced(
                 await session.merge(child)
             # SQLite's DateTime column doesn't preserve tzinfo, so naive
             # UTC on the write side. ``row_count`` is the last-fetch size
-            # (not a cumulative total, which would drift since ``rows``
-            # includes re-sync duplicates); consumers needing a true
-            # total run ``SELECT COUNT(*)`` on the entity table itself.
+            # (not a cumulative total, which would drift since a re-sync
+            # that finds zero changed rows would otherwise reset the
+            # count); consumers needing a true total run ``SELECT COUNT(*)``
+            # on the entity table itself.
             await session.merge(
                 SyncState(
-                    entity_type="sales_order",
+                    entity_type=spec.entity_key,
                     last_synced=datetime.now(tz=UTC).replace(tzinfo=None),
                     row_count=len(cached_parents),
                 )
@@ -155,307 +243,109 @@ async def ensure_sales_orders_synced(
             await session.commit()
 
 
-def _attrs_stock_adjustment_to_cached(
-    attrs_sa: object,
-) -> tuple[CachedStockAdjustment, list[CachedStockAdjustmentRow]]:
-    """Convert one attrs ``StockAdjustment`` to a parent + children pair.
+# ---------------------------------------------------------------------------
+# Per-entity specs
+# ---------------------------------------------------------------------------
 
-    Same shape as :func:`_attrs_sales_order_to_cached`, with one twist:
-    Katana doesn't return ``stock_adjustment_id`` on ``StockAdjustmentRow``
-    (rows are nested under the parent on the wire), so the cached row's
-    FK is set explicitly from the parent's ``id`` instead of being copied
-    from the API response.
-    """
-    api_sa = PydanticStockAdjustment.from_attrs(attrs_sa)
-    parent_data = api_sa.model_dump(exclude={"stock_adjustment_rows"})
-    cached_parent = CachedStockAdjustment.model_validate(parent_data)
 
-    child_rows: list[CachedStockAdjustmentRow] = []
-    api_rows = api_sa.stock_adjustment_rows or []
-    for api_row in api_rows:
-        row_data = api_row.model_dump()
-        row_data["stock_adjustment_id"] = api_sa.id
-        child_rows.append(CachedStockAdjustmentRow.model_validate(row_data))
-    return cached_parent, child_rows
+_SALES_ORDER_SPEC = EntitySpec(
+    entity_key="sales_order",
+    api_fn=get_all_sales_orders,
+    cache_cls=CachedSalesOrder,
+    pydantic_cls=PydanticSalesOrder,
+    child_cls=CachedSalesOrderRow,
+    rows_field="sales_order_rows",
+    fk_field="sales_order_id",
+)
+
+
+_STOCK_ADJUSTMENT_SPEC = EntitySpec(
+    entity_key="stock_adjustment",
+    api_fn=get_all_stock_adjustments,
+    cache_cls=CachedStockAdjustment,
+    pydantic_cls=PydanticStockAdjustment,
+    child_cls=CachedStockAdjustmentRow,
+    rows_field="stock_adjustment_rows",
+    fk_field="stock_adjustment_id",
+)
+
+
+# Manufacturing orders: the list endpoint returns summary objects with no
+# nested rows. Recipe rows live at ``/manufacturing_order_recipe_rows`` and
+# aren't cached by this entity's sync — leave the child fields unset.
+_MANUFACTURING_ORDER_SPEC = EntitySpec(
+    entity_key="manufacturing_order",
+    api_fn=get_all_manufacturing_orders,
+    cache_cls=CachedManufacturingOrder,
+    pydantic_cls=PydanticManufacturingOrder,
+)
+
+
+# Purchase orders: discriminated-union entity. The cache class shadows
+# ``PurchaseOrderBase`` (renamed via ``CACHE_TABLE_RENAMES``) and carries
+# an extra ``tracking_location_id`` column hoisted from the outsourced
+# subclass via ``CACHE_EXTRA_FIELDS``. ``_resolve_purchase_order_class``
+# picks the right subtype so ``model_dump`` captures the outsourced-only
+# fields; ``CachedPurchaseOrder.model_validate`` ignores the
+# unrecognized-by-the-cache extras automatically.
+_PURCHASE_ORDER_SPEC = EntitySpec(
+    entity_key="purchase_order",
+    api_fn=find_purchase_orders,
+    cache_cls=CachedPurchaseOrder,
+    pydantic_cls=PydanticPurchaseOrderBase,
+    child_cls=CachedPurchaseOrderRow,
+    rows_field="purchase_order_rows",
+    fk_field="purchase_order_id",
+    pydantic_resolver=_resolve_purchase_order_class,
+)
+
+
+_STOCK_TRANSFER_SPEC = EntitySpec(
+    entity_key="stock_transfer",
+    api_fn=get_all_stock_transfers,
+    cache_cls=CachedStockTransfer,
+    pydantic_cls=PydanticStockTransfer,
+    child_cls=CachedStockTransferRow,
+    rows_field="stock_transfer_rows",
+    fk_field="stock_transfer_id",
+)
+
+
+# ---------------------------------------------------------------------------
+# Public per-entity wrappers
+# ---------------------------------------------------------------------------
+
+
+async def ensure_sales_orders_synced(
+    client: KatanaClient, cache: TypedCacheEngine
+) -> None:
+    """Pull updated sales orders from Katana and upsert into the typed cache."""
+    await _ensure_synced(client, cache, _SALES_ORDER_SPEC)
 
 
 async def ensure_stock_adjustments_synced(
     client: KatanaClient, cache: TypedCacheEngine
 ) -> None:
-    """Pull updated stock adjustments from Katana and upsert into the cache.
-
-    Mirror of :func:`ensure_sales_orders_synced` for the ``StockAdjustment``
-    entity. Cold-start fetches the full history; subsequent calls pass
-    ``updated_at_min`` and pick up only changed rows. Per-entity lock
-    serializes concurrent calls to keep cold-start fan-out single-flight.
-    """
-    async with cache.lock_for("stock_adjustment"):
-        async with cache.session() as session:
-            state = await session.get(SyncState, "stock_adjustment")
-            last_synced = state.last_synced if state is not None else None
-
-        if _is_fresh(last_synced):
-            return
-
-        kwargs = (
-            {"updated_at_min": last_synced.replace(tzinfo=UTC)}
-            if last_synced is not None
-            else {}
-        )
-        response = await get_all_stock_adjustments.asyncio_detailed(
-            client=client, **kwargs
-        )
-        attrs_adjustments = unwrap_data(response, default=[])
-
-        cached_parents: list[CachedStockAdjustment] = []
-        cached_children: list[CachedStockAdjustmentRow] = []
-        for attrs_sa in attrs_adjustments:
-            parent, children = _attrs_stock_adjustment_to_cached(attrs_sa)
-            cached_parents.append(parent)
-            cached_children.extend(children)
-
-        async with cache.session() as session:
-            for parent in cached_parents:
-                await session.merge(parent)
-            for child in cached_children:
-                await session.merge(child)
-            await session.merge(
-                SyncState(
-                    entity_type="stock_adjustment",
-                    last_synced=datetime.now(tz=UTC).replace(tzinfo=None),
-                    row_count=len(cached_parents),
-                )
-            )
-            await session.commit()
-
-
-def _attrs_manufacturing_order_to_cached(
-    attrs_mo: object,
-) -> CachedManufacturingOrder:
-    """Convert one attrs ``ManufacturingOrder`` to a ``CachedManufacturingOrder``.
-
-    Simpler than the sales-order / stock-adjustment converters: the
-    ``/manufacturing_orders`` list endpoint returns summary objects with
-    no nested rows (recipe rows live at ``/manufacturing_order_recipe_rows``
-    and aren't cached here), so there's only one entity to build per row.
-    JSON-typed list fields (``batch_transactions``, ``serial_numbers``)
-    survive ``model_dump`` as plain dict lists and ``model_validate``
-    routes them into the cache class's JSON column unchanged.
-    """
-    api_mo = PydanticManufacturingOrder.from_attrs(attrs_mo)
-    return CachedManufacturingOrder.model_validate(api_mo.model_dump())
+    """Pull updated stock adjustments from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _STOCK_ADJUSTMENT_SPEC)
 
 
 async def ensure_manufacturing_orders_synced(
     client: KatanaClient, cache: TypedCacheEngine
 ) -> None:
-    """Pull updated manufacturing orders from Katana and upsert into the cache.
-
-    Mirror of :func:`ensure_sales_orders_synced` for the ``ManufacturingOrder``
-    entity. Cold-start fetches the full history; subsequent calls pass
-    ``updated_at_min`` and pick up only changed rows. Per-entity lock
-    serializes concurrent calls to keep cold-start fan-out single-flight.
-    """
-    async with cache.lock_for("manufacturing_order"):
-        async with cache.session() as session:
-            state = await session.get(SyncState, "manufacturing_order")
-            last_synced = state.last_synced if state is not None else None
-
-        if _is_fresh(last_synced):
-            return
-
-        kwargs = (
-            {"updated_at_min": last_synced.replace(tzinfo=UTC)}
-            if last_synced is not None
-            else {}
-        )
-        response = await get_all_manufacturing_orders.asyncio_detailed(
-            client=client, **kwargs
-        )
-        attrs_orders = unwrap_data(response, default=[])
-
-        cached_orders = [
-            _attrs_manufacturing_order_to_cached(mo) for mo in attrs_orders
-        ]
-
-        async with cache.session() as session:
-            for order in cached_orders:
-                await session.merge(order)
-            await session.merge(
-                SyncState(
-                    entity_type="manufacturing_order",
-                    last_synced=datetime.now(tz=UTC).replace(tzinfo=None),
-                    row_count=len(cached_orders),
-                )
-            )
-            await session.commit()
-
-
-def _attrs_purchase_order_to_cached(
-    attrs_po: object,
-) -> tuple[CachedPurchaseOrder, list[CachedPurchaseOrderRow]]:
-    """Convert one attrs ``PurchaseOrder`` (regular | outsourced) to cache rows.
-
-    Three-step:
-    1. Pick the right API pydantic class from the attrs subtype: regular
-       and outsourced POs share ``PurchaseOrderBase`` fields but differ in
-       ``entity_type`` literal and the outsourced-only
-       ``tracking_location_id`` / ``ingredient_*`` fields.
-    2. Dump the API model and re-validate into ``CachedPurchaseOrder`` —
-       the cache class shadows ``PurchaseOrderBase`` (renamed via
-       ``CACHE_TABLE_RENAMES``) and carries an extra
-       ``tracking_location_id`` column hoisted from the outsourced
-       subclass via ``CACHE_EXTRA_FIELDS``. The dump captures it
-       automatically when the source is an outsourced PO.
-    3. Build child rows with ``purchase_order_id`` set explicitly from the
-       parent, mirroring the stock-adjustment shape.
-    """
-    # Dispatch by attrs class via the model registry so we round-trip the
-    # right subclass (regular/outsourced) — calling
-    # ``PydanticPurchaseOrderBase.from_attrs`` directly would lose the
-    # outsourced-only fields (``tracking_location_id`` etc.).
-    from katana_public_api_client.models_pydantic._registry import get_pydantic_class
-
-    api_class = get_pydantic_class(type(attrs_po))
-    if api_class is None:
-        msg = (
-            f"No pydantic class registered for attrs purchase order "
-            f"type {type(attrs_po).__name__}"
-        )
-        raise RuntimeError(msg)
-    api_po: PydanticPurchaseOrderBase = api_class.from_attrs(attrs_po)
-
-    parent_data = api_po.model_dump(exclude={"purchase_order_rows"})
-    cached_parent = CachedPurchaseOrder.model_validate(parent_data)
-
-    child_rows: list[CachedPurchaseOrderRow] = []
-    api_rows = api_po.purchase_order_rows or []
-    for api_row in api_rows:
-        row_data = api_row.model_dump()
-        # Re-assert from the parent. Katana already returns
-        # ``purchase_order_id`` on rows, but the parent's id is the
-        # source of truth on insert.
-        row_data["purchase_order_id"] = api_po.id
-        child_rows.append(CachedPurchaseOrderRow.model_validate(row_data))
-    return cached_parent, child_rows
+    """Pull updated manufacturing orders from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _MANUFACTURING_ORDER_SPEC)
 
 
 async def ensure_purchase_orders_synced(
     client: KatanaClient, cache: TypedCacheEngine
 ) -> None:
-    """Pull updated purchase orders from Katana and upsert into the cache.
-
-    Mirror of :func:`ensure_sales_orders_synced` for the ``PurchaseOrder``
-    discriminated-union entity. Cold-start fetches full history; subsequent
-    calls pass ``updated_at_min``. Per-entity lock keeps cold-start fan-out
-    single-flight.
-    """
-    async with cache.lock_for("purchase_order"):
-        async with cache.session() as session:
-            state = await session.get(SyncState, "purchase_order")
-            last_synced = state.last_synced if state is not None else None
-
-        if _is_fresh(last_synced):
-            return
-
-        kwargs = (
-            {"updated_at_min": last_synced.replace(tzinfo=UTC)}
-            if last_synced is not None
-            else {}
-        )
-        response = await find_purchase_orders.asyncio_detailed(client=client, **kwargs)
-        attrs_orders = unwrap_data(response, default=[])
-
-        cached_parents: list[CachedPurchaseOrder] = []
-        cached_children: list[CachedPurchaseOrderRow] = []
-        for attrs_po in attrs_orders:
-            parent, children = _attrs_purchase_order_to_cached(attrs_po)
-            cached_parents.append(parent)
-            cached_children.extend(children)
-
-        async with cache.session() as session:
-            for parent in cached_parents:
-                await session.merge(parent)
-            for child in cached_children:
-                await session.merge(child)
-            await session.merge(
-                SyncState(
-                    entity_type="purchase_order",
-                    last_synced=datetime.now(tz=UTC).replace(tzinfo=None),
-                    row_count=len(cached_parents),
-                )
-            )
-            await session.commit()
-
-
-def _attrs_stock_transfer_to_cached(
-    attrs_st: object,
-) -> tuple[CachedStockTransfer, list[CachedStockTransferRow]]:
-    """Convert one attrs ``StockTransfer`` to a cache parent + child rows.
-
-    ``StockTransferRow`` doesn't carry a parent FK on the wire (rows
-    nested under the parent in API responses), so the cache populates
-    ``stock_transfer_id`` from the parent's ``id`` on insert. Mirrors the
-    stock-adjustment converter's shape.
-    """
-    api_st = PydanticStockTransfer.from_attrs(attrs_st)
-    parent_data = api_st.model_dump(exclude={"stock_transfer_rows"})
-    cached_parent = CachedStockTransfer.model_validate(parent_data)
-
-    child_rows: list[CachedStockTransferRow] = []
-    api_rows = api_st.stock_transfer_rows or []
-    for api_row in api_rows:
-        row_data = api_row.model_dump()
-        row_data["stock_transfer_id"] = api_st.id
-        child_rows.append(CachedStockTransferRow.model_validate(row_data))
-    return cached_parent, child_rows
+    """Pull updated purchase orders from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _PURCHASE_ORDER_SPEC)
 
 
 async def ensure_stock_transfers_synced(
     client: KatanaClient, cache: TypedCacheEngine
 ) -> None:
-    """Pull updated stock transfers from Katana and upsert into the cache.
-
-    Mirror of :func:`ensure_sales_orders_synced` for the ``StockTransfer``
-    entity. Cold-start fetches the full history; subsequent calls pass
-    ``updated_at_min`` and pick up only changed rows. Per-entity lock
-    serializes concurrent calls to keep cold-start fan-out single-flight.
-    """
-    async with cache.lock_for("stock_transfer"):
-        async with cache.session() as session:
-            state = await session.get(SyncState, "stock_transfer")
-            last_synced = state.last_synced if state is not None else None
-
-        if _is_fresh(last_synced):
-            return
-
-        kwargs = (
-            {"updated_at_min": last_synced.replace(tzinfo=UTC)}
-            if last_synced is not None
-            else {}
-        )
-        response = await get_all_stock_transfers.asyncio_detailed(
-            client=client, **kwargs
-        )
-        attrs_transfers = unwrap_data(response, default=[])
-
-        cached_parents: list[CachedStockTransfer] = []
-        cached_children: list[CachedStockTransferRow] = []
-        for attrs_st in attrs_transfers:
-            parent, children = _attrs_stock_transfer_to_cached(attrs_st)
-            cached_parents.append(parent)
-            cached_children.extend(children)
-
-        async with cache.session() as session:
-            for parent in cached_parents:
-                await session.merge(parent)
-            for child in cached_children:
-                await session.merge(child)
-            await session.merge(
-                SyncState(
-                    entity_type="stock_transfer",
-                    last_synced=datetime.now(tz=UTC).replace(tzinfo=None),
-                    row_count=len(cached_parents),
-                )
-            )
-            await session.commit()
+    """Pull updated stock transfers from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _STOCK_TRANSFER_SPEC)


### PR DESCRIPTION
Closes part of #389 (Item 1).

## Summary

Replaces 5 hand-rolled `ensure_<entity>_synced` helpers + 5 `_attrs_<entity>_to_cached` converters (~470 lines) with:

- An `EntitySpec` frozen dataclass capturing per-entity sync configuration (entity-key, API endpoint, cache class, pydantic class, optional child triple, optional polymorphic resolver).
- A generic `_convert(spec, attrs_obj)` that dispatches via the optional `pydantic_resolver` (purchase orders) or falls back to `spec.pydantic_cls`.
- A generic `_ensure_synced(client, cache, spec)` that runs the same 8-step skeleton every prior helper duplicated (lock → read SyncState → debounce → fetch → convert → upsert parents → upsert children → advance watermark).
- Five module-level specs (`_SALES_ORDER_SPEC`, etc.) and thin public wrappers (`ensure_sales_orders_synced` etc.) so all existing call sites and tests work unchanged.

**Diff: −337 / +213 lines (net −124).** Public API preserved; zero call-site churn.

## Why

Each of the 5 hand-rolled helpers repeated the entity-key string three times — `cache.lock_for("X")`, `session.get(SyncState, "X")`, `SyncState(entity_type="X", ...)`. A typo would silently desync the watermark from the lock from the SyncState row: `session.get` returns `None` for an unknown key, so every call would re-do a cold-start. The spec dataclass puts the entity-key in one place per entity.

`EntitySpec.__post_init__` rejects partial child specs (e.g., `child_cls` set but `rows_field` not) at construction time so a future spec edit can't silently drop child rows.

## Special cases preserved

- **Manufacturing orders** (no nested rows on the list endpoint): spec has no `child_cls` / `rows_field` / `fk_field`. `_convert` returns `(parent, [])`.
- **Purchase orders** (discriminated union): spec has `pydantic_resolver=_resolve_purchase_order_class` to keep the `RegularPurchaseOrder | OutsourcedPurchaseOrder` subtype so `model_dump` captures outsourced-only fields.

## Test plan

- [x] `uv run poe check` — full suite passes (2,439 tests).
- [x] Existing `test_typed_cache.py` (13 tests) all pass without modification.
- [x] PR #403's regression test (`TestSyncShippingFeeEmpty`) still passes (which exercises the real `ensure_sales_orders_synced` path through a mocked API).
- [x] `code-reviewer` agent review pass: 1 suggestion applied (`__post_init__` guard against partial-child silent data loss); 1 suggestion applied (hoisted deferred `_registry` import).

## Out of scope (follow-ups in #389)

- Item 2 — generator config consolidation (`CacheTableSpec` merging `CACHE_TABLES` + `CACHE_TABLE_RENAMES` + `CACHE_EXTRA_FIELDS` + `CACHE_JSON_COLUMNS`)
- Item 3 — `CacheExtraField` dataclass

Both touch `scripts/generate_pydantic_models.py` and require a pydantic regeneration round-trip; bundled into a separate PR for cleaner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)