### PR TITLE
refactor(client): consolidate cache-table generator config behind CacheTableSpec

### DIFF
--- a/katana_public_api_client/models_pydantic/_generated/purchase_orders.py
+++ b/katana_public_api_client/models_pydantic/_generated/purchase_orders.py
@@ -1046,4 +1046,9 @@ class CachedPurchaseOrder(DeletableEntity, table=True):
             description="Complete supplier information for this purchase order",
         ),
     ] = None
-    tracking_location_id: int | None = None
+    tracking_location_id: Annotated[
+        int | None,
+        Field(
+            description="(cache-only) Hoisted from OutsourcedPurchaseOrder so the single ``purchase_order`` cache table can filter by tracking location without a UNION across regular/outsourced rows."
+        ),
+    ] = None

--- a/scripts/generate_pydantic_models.py
+++ b/scripts/generate_pydantic_models.py
@@ -171,43 +171,115 @@ DOMAIN_GROUPS: dict[str, list[str]] = {
 }
 
 
+@dataclass(frozen=True)
+class CacheExtraField:
+    """A cache-only field hoisted onto a cache class.
+
+    Used when a discriminated-union root (``PurchaseOrderBase``) is cached as
+    one SQL table but the listing tool needs to filter by a column that
+    lives on a subclass (``OutsourcedPurchaseOrder.tracking_location_id``).
+    The converter copies the value out of the subclass instance.
+
+    ``render()`` emits the field declaration as a Python source line. The
+    caller pastes it into the cache class body via ``inject_extra_cache_fields``;
+    SQLModel infers the column type from the annotation (``Optional`` types
+    stay nullable). When ``description`` is set the renderer uses
+    ``Annotated[..., Field(description=...)]`` so the field is self-
+    documenting in the generated source.
+    """
+
+    name: str
+    python_type: str
+    default: str = "None"
+    description: str | None = None
+
+    def render(self) -> str:
+        if self.description is None:
+            return f"    {self.name}: {self.python_type} = {self.default}"
+        return (
+            f"    {self.name}: Annotated[\n"
+            f"        {self.python_type},\n"
+            f"        Field(description={self.description!r}),\n"
+            f"    ] = {self.default}"
+        )
+
+
+@dataclass(frozen=True)
+class CacheTableSpec:
+    """Per-class cache-table configuration.
+
+    All entry-keyed cache settings live here so a reader doesn't need to
+    consult four parallel dicts to know what one class produces.
+    ``CACHE_RELATIONSHIPS`` (list of parent→child links) stays separate
+    because it has different cardinality.
+
+    - ``name_override``: post-rename base name (no ``Cached`` prefix) used
+      to derive both the cache class name and the SQLAlchemy
+      ``__tablename__`` when the API class name reads awkwardly. Example:
+      ``PurchaseOrderBase`` sets ``name_override="PurchaseOrder"``,
+      yielding cache class ``CachedPurchaseOrder`` (via ``_cached_name``)
+      and ``__tablename__`` ``purchase_order`` (via ``_snake_case``).
+    - ``extra_fields``: cache-only fields hoisted from API subclasses
+      (e.g., outsourced-PO's ``tracking_location_id``).
+    - ``json_columns``: fields whose values stay JSON in the cache (lists
+      of polymorphic / non-cached nested models, single nested objects
+      SQLAlchemy can't auto-map).
+    """
+
+    name_override: str | None = None
+    extra_fields: tuple[CacheExtraField, ...] = ()
+    json_columns: tuple[str, ...] = ()
+
+
 # Cache-table configuration for #342 — select generated pydantic classes opt
-# into SQLAlchemy table semantics (`table=True`) so they double as cache row
-# schemas. Expanded incrementally per-entity as list tools get cache-backed;
-# PR 2 covers SalesOrder + SalesOrderRow as the pattern-proving pair.
-CACHE_TABLES: set[str] = {
-    "SalesOrder",
-    "SalesOrderRow",
-    "StockAdjustment",
-    "StockAdjustmentRow",
-    "ManufacturingOrder",
-    "ManufacturingOrderRecipeRow",
-    "PurchaseOrderBase",
-    "PurchaseOrderRow",
-    "StockTransfer",
-    "StockTransferRow",
-}
-
-
-# Cache class name overrides — when the API class name reads awkwardly as a
-# cache class, remap. Example: ``PurchaseOrderBase`` is the API discriminated
-# union root (sibling of RegularPurchaseOrder + OutsourcedPurchaseOrder); the
-# cache class shadows it as ``CachedPurchaseOrder`` (and ``__tablename__`` is
-# ``purchase_order``, not ``purchase_order_base``).
-CACHE_TABLE_RENAMES: dict[str, str] = {
-    "PurchaseOrderBase": "PurchaseOrder",
-}
-
-
-# Cache-only fields hoisted from API subclasses into the cache base. Used when
-# a discriminated-union root (PurchaseOrderBase) is cached as one SQL table
-# but the listing tool needs to filter by a column that lives on a subclass
-# (OutsourcedPurchaseOrder.tracking_location_id). The converter copies these
-# fields out of the subclass instance when the entity_type matches.
-CACHE_EXTRA_FIELDS: dict[str, list[str]] = {
-    "PurchaseOrderBase": [
-        "    tracking_location_id: int | None = None",
-    ],
+# into SQLAlchemy table semantics (``table=True``) so they double as cache
+# row schemas. Each entry's spec carries any per-class overrides; an empty
+# ``CacheTableSpec()`` means "default cache table, no overrides".
+CACHE_TABLES: dict[str, CacheTableSpec] = {
+    "SalesOrder": CacheTableSpec(
+        # ``shipping_fee`` is a single nested object; ``addresses`` is a
+        # list of nested ``SalesOrderAddress``. Both stay JSON because
+        # they're low-signal for the cache's filter workload.
+        json_columns=("shipping_fee", "addresses"),
+    ),
+    "SalesOrderRow": CacheTableSpec(
+        json_columns=("attributes", "batch_transactions", "serial_numbers"),
+    ),
+    "StockAdjustment": CacheTableSpec(),
+    "StockAdjustmentRow": CacheTableSpec(json_columns=("batch_transactions",)),
+    "ManufacturingOrder": CacheTableSpec(
+        json_columns=("batch_transactions", "serial_numbers"),
+    ),
+    "ManufacturingOrderRecipeRow": CacheTableSpec(
+        json_columns=("batch_transactions",),
+    ),
+    "PurchaseOrderBase": CacheTableSpec(
+        # API discriminated-union root (sibling of RegularPurchaseOrder +
+        # OutsourcedPurchaseOrder); cache shadows as ``CachedPurchaseOrder``
+        # (``__tablename__`` ``purchase_order``, not ``purchase_order_base``).
+        name_override="PurchaseOrder",
+        extra_fields=(
+            CacheExtraField(
+                name="tracking_location_id",
+                python_type="int | None",
+                description=(
+                    "(cache-only) Hoisted from OutsourcedPurchaseOrder so the "
+                    "single ``purchase_order`` cache table can filter by tracking "
+                    "location without a UNION across regular/outsourced rows."
+                ),
+            ),
+        ),
+        # ``supplier`` is a single nested ``Supplier`` object; SQLAlchemy
+        # can't auto-map it, JSON-column instead.
+        json_columns=("supplier",),
+    ),
+    "PurchaseOrderRow": CacheTableSpec(
+        # ``landed_cost: str | float | None`` is a non-optional inner union
+        # SQLAlchemy can't auto-type — JSON-column it instead of dropping.
+        json_columns=("batch_transactions", "landed_cost"),
+    ),
+    "StockTransfer": CacheTableSpec(),
+    "StockTransferRow": CacheTableSpec(json_columns=("batch_transactions",)),
 }
 
 
@@ -237,17 +309,27 @@ class CacheTableRelationship:
 
     @property
     def parent_table(self) -> str:
-        # Honor ``CACHE_TABLE_RENAMES`` so FK ``foreign_key="<table>.id"``
-        # references match the renamed tablename (e.g.,
-        # ``PurchaseOrderBase`` → ``purchase_order``, not
+        # Honor the cache spec's ``name_override`` so FK
+        # ``foreign_key="<table>.id"`` matches the renamed tablename
+        # (e.g., ``PurchaseOrderBase`` → ``purchase_order``, not
         # ``purchase_order_base``).
-        renamed = CACHE_TABLE_RENAMES.get(self.parent, self.parent)
-        return _snake_case(renamed)
+        return _snake_case(_resolve_cache_class(self.parent))
 
 
 def _snake_case(name: str) -> str:
     """CamelCase → snake_case — used for default SQLAlchemy tablenames."""
     return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+def _resolve_cache_class(name: str) -> str:
+    """API class name → cache class name (post-rename, no ``Cached`` prefix).
+
+    Returns the cache class's final name without the ``Cached`` prefix. Used
+    by ``_cached_name`` and by ``CacheTableRelationship.parent_table`` so
+    cache references resolve to the renamed table consistently.
+    """
+    spec = CACHE_TABLES.get(name)
+    return spec.name_override if (spec and spec.name_override is not None) else name
 
 
 def _cached_name(name: str) -> str:
@@ -256,10 +338,10 @@ def _cached_name(name: str) -> str:
     Cache rows live as ``Cached<Name>`` siblings of the API pydantic models
     so the API surface stays pure (no ``table=True``, no FK pollution) while
     the cache schema can carry SQLAlchemy machinery, FK back-pointers, and
-    relationships. ``CACHE_TABLE_RENAMES`` lets a class shadow under a
-    different name (``PurchaseOrderBase`` → ``CachedPurchaseOrder``).
+    relationships. ``CacheTableSpec.name_override`` lets a class shadow
+    under a different name (``PurchaseOrderBase`` → ``CachedPurchaseOrder``).
     """
-    return f"Cached{CACHE_TABLE_RENAMES.get(name, name)}"
+    return f"Cached{_resolve_cache_class(name)}"
 
 
 CACHE_RELATIONSHIPS: list[CacheTableRelationship] = [
@@ -309,26 +391,6 @@ CACHE_RELATIONSHIPS: list[CacheTableRelationship] = [
         cache_only_parent_field=True,
     ),
 ]
-
-
-# Fields on cache tables that contain lists of non-cached nested models (e.g.,
-# polymorphic attributes, batch transactions, serial numbers). These are stored
-# as JSON rather than exploded into child tables — they're low-signal for the
-# cache's query workload and not worth the schema churn.
-CACHE_JSON_COLUMNS: dict[str, list[str]] = {
-    "SalesOrder": ["shipping_fee", "addresses"],
-    "SalesOrderRow": ["attributes", "batch_transactions", "serial_numbers"],
-    "StockAdjustmentRow": ["batch_transactions"],
-    "ManufacturingOrder": ["batch_transactions", "serial_numbers"],
-    "ManufacturingOrderRecipeRow": ["batch_transactions"],
-    # PurchaseOrderBase.supplier is a single nested ``Supplier`` object that
-    # SQLAlchemy can't auto-map; cache it as JSON so the row stays denormalized.
-    "PurchaseOrderBase": ["supplier"],
-    # ``landed_cost: str | float | None`` is a non-optional inner union
-    # that SQLAlchemy can't auto-type — JSON-column it instead of dropping.
-    "PurchaseOrderRow": ["batch_transactions", "landed_cost"],
-    "StockTransferRow": ["batch_transactions"],
-}
 
 
 @dataclass
@@ -578,6 +640,13 @@ ENTITY_SUBTYPES = {
     "ArchivableEntity",
     "ArchivableDeletableEntity",
 }
+
+
+# Base classes whose fields propagate into cache tables via inheritance.
+# Their AwareDatetime annotations (created_at / updated_at / deleted_at /
+# archived_at) must be swapped to plain ``datetime`` too — otherwise
+# SQLModel's table-column inference on the inheriting cache class fails.
+ENTITY_BASE_CLASSES: frozenset[str] = frozenset(ENTITY_SUBTYPES | {"BaseEntity"})
 
 
 def fix_mro_issues(classes: list[ClassInfo]) -> list[ClassInfo]:
@@ -1181,21 +1250,6 @@ def inject_relationship_fields(classes: list[ClassInfo]) -> list[ClassInfo]:
     return fixed
 
 
-# Base classes whose fields propagate into cache tables via inheritance.
-# Their AwareDatetime annotations (created_at / updated_at / deleted_at /
-# archived_at) must be swapped to plain ``datetime`` too — otherwise
-# SQLModel's table-column inference on the inheriting cache class fails.
-_CACHE_BASE_CLASSES = frozenset(
-    {
-        "BaseEntity",
-        "UpdatableEntity",
-        "DeletableEntity",
-        "ArchivableEntity",
-        "ArchivableDeletableEntity",
-    }
-)
-
-
 def swap_awaredatetime_for_datetime(classes: list[ClassInfo]) -> list[ClassInfo]:
     """Rewrite ``AwareDatetime`` as ``datetime`` in cache-table fields.
 
@@ -1215,7 +1269,7 @@ def swap_awaredatetime_for_datetime(classes: list[ClassInfo]) -> list[ClassInfo]
     since timezone awareness is a Katana wire-protocol invariant; the
     extra pydantic validator was safety belt for data we already trust.
     """
-    swap_targets = {_cached_name(n) for n in CACHE_TABLES} | _CACHE_BASE_CLASSES
+    swap_targets = {_cached_name(n) for n in CACHE_TABLES} | ENTITY_BASE_CLASSES
     fixed = []
     for cls in classes:
         if cls.name not in swap_targets:
@@ -1232,7 +1286,7 @@ def swap_awaredatetime_for_datetime(classes: list[ClassInfo]) -> list[ClassInfo]
 
 
 def inject_extra_cache_fields(classes: list[ClassInfo]) -> list[ClassInfo]:
-    """Append ``CACHE_EXTRA_FIELDS`` declarations to the cache class body.
+    """Append ``CacheTableSpec.extra_fields`` declarations to the cache class body.
 
     For discriminated-union roots (PurchaseOrderBase) cached as a single
     SQL table, this hoists subclass-only fields onto the cache class so
@@ -1245,15 +1299,18 @@ def inject_extra_cache_fields(classes: list[ClassInfo]) -> list[ClassInfo]:
     the column.
     """
     cached_extras = {
-        _cached_name(name): fields for name, fields in CACHE_EXTRA_FIELDS.items()
+        _cached_name(name): spec.extra_fields
+        for name, spec in CACHE_TABLES.items()
+        if spec.extra_fields
     }
     fixed = []
     for cls in classes:
-        extra_lines = cached_extras.get(cls.name)
-        if not extra_lines:
+        extras = cached_extras.get(cls.name)
+        if not extras:
             fixed.append(cls)
             continue
-        new_source = cls.source.rstrip() + "\n" + "\n".join(extra_lines) + "\n"
+        rendered = "\n".join(extra.render() for extra in extras)
+        new_source = cls.source.rstrip() + "\n" + rendered + "\n"
         fixed.append(cls.with_source(new_source))
     return fixed
 
@@ -1261,15 +1318,17 @@ def inject_extra_cache_fields(classes: list[ClassInfo]) -> list[ClassInfo]:
 def inject_json_columns(classes: list[ClassInfo]) -> list[ClassInfo]:
     """Annotate specified list fields with ``sa_column=Column(JSON)``.
 
-    For fields listed in ``CACHE_JSON_COLUMNS`` — typically lists of
+    For fields in ``CacheTableSpec.json_columns`` — typically lists of
     polymorphic or non-cached nested models — this preserves the typed
     pydantic interface while telling SQLAlchemy to store them as JSON rather
     than attempting to normalize them into child tables. Operates on the
-    ``Cached<Name>`` siblings: ``CACHE_JSON_COLUMNS`` keys are user-facing
-    API names so the cached lookup converts via ``_cached_name``.
+    ``Cached<Name>`` siblings: spec keys are user-facing API names so the
+    cached lookup converts via ``_cached_name``.
     """
     cached_json_columns = {
-        _cached_name(name): fields for name, fields in CACHE_JSON_COLUMNS.items()
+        _cached_name(name): spec.json_columns
+        for name, spec in CACHE_TABLES.items()
+        if spec.json_columns
     }
     fixed = []
     for cls in classes:
@@ -1389,7 +1448,9 @@ def generate_module_imports(
     classes_in_module = {cls.name for cls in classes}
     cached_class_names = {_cached_name(n) for n in CACHE_TABLES}
     has_cache_tables = bool(classes_in_module & cached_class_names)
-    cached_json_class_names = {_cached_name(n) for n in CACHE_JSON_COLUMNS}
+    cached_json_class_names = {
+        _cached_name(name) for name, spec in CACHE_TABLES.items() if spec.json_columns
+    }
     has_json_columns = any(cls.name in cached_json_class_names for cls in classes)
 
     # Add standard imports from the original file
@@ -1440,7 +1501,7 @@ def generate_module_imports(
     # modules and the base module (shared entity bases feed cache tables via
     # inheritance).
     needs_datetime_import = any(
-        cls.name in (cached_class_names | _CACHE_BASE_CLASSES) for cls in classes
+        cls.name in (cached_class_names | ENTITY_BASE_CLASSES) for cls in classes
     )
     if needs_datetime_import:
         import_lines.append("from datetime import datetime")


### PR DESCRIPTION
Closes part of #389 (Items 2 + 3) and folds in #390 Item 4 (`_CACHE_BASE_CLASSES` ↔ `ENTITY_SUBTYPES` unification). Stacks on top of #406 conceptually but doesn't share files.

## Summary

Merge four parallel cache-table configs in `scripts/generate_pydantic_models.py` into one typed dictionary:

- `CACHE_TABLES: set[str]` (membership)
- `CACHE_TABLE_RENAMES: dict[str, str]` (alternate cache class name)
- `CACHE_EXTRA_FIELDS: dict[str, list[str]]` (raw text strings hoisted onto the cache class body)
- `CACHE_JSON_COLUMNS: dict[str, list[str]]` (fields stored as `Column(JSON)`)

…all become entries on a new `CacheTableSpec` dataclass keyed by API class name. `CACHE_RELATIONSHIPS` (different cardinality — list of parent→child links) stays separate per the issue.

## Why

A reader auditing one class's cache configuration previously had to consult four separate top-level dicts. The stringly-typed extra-fields entries (`"    tracking_location_id: int | None = None"` — raw source line with embedded indent) required future contributors to know the leading-spaces-matter rule, that pydantic infers the column type from the annotation, and that descriptions don't propagate.

The new `CacheExtraField` dataclass exposes `name` / `python_type` / `default` / `description` and a `render()` method. `description` defaults to `None` (preserves byte-identical output for fields without docs) and emits an `Annotated[..., Field(description=...)]` shape when set.

`ENTITY_BASE_CLASSES = ENTITY_SUBTYPES | {"BaseEntity"}` (defined alongside `ENTITY_SUBTYPES`) replaces `_CACHE_BASE_CLASSES`; the two sets differed only in whether `BaseEntity` was included, so the duplicate goes away.

## Generated-file diff

The structural refactor alone produces a **byte-identical** generator output (verified). The only generated diff in this PR is one description added to `tracking_location_id` (the only existing extra-field) explaining why it's cache-only — the value-add of `CacheExtraField` paying off immediately:

```python
# before
tracking_location_id: int | None = None

# after
tracking_location_id: Annotated[
    int | None,
    Field(
        description="(cache-only) Hoisted from OutsourcedPurchaseOrder so the single ``purchase_order`` cache table can filter by tracking location without a UNION across regular/outsourced rows."
    ),
] = None
```

## Test plan

- [x] `uv run poe generate-pydantic` — only `tracking_location_id` description changes; rest byte-identical
- [x] `uv run poe check` — full suite passes (2,439 tests)
- [x] Lint/type-check/format clean

## Issue follow-ups

- #389 fully addressed (Items 1 — sync.py refactor in #406; Items 2+3 — this PR; Item 4 deferred per issue)
- #390 Item 4 absorbed; remaining 3 nits (fixture rename, narration comments, factories TYPE_CHECKING) still open for a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)