### PR TITLE
fix(client): add BLOCKED to ManufacturingOperationStatus + spec audit report

### DIFF
--- a/docs/audit-2026-04-28.md
+++ b/docs/audit-2026-04-28.md
@@ -1,0 +1,357 @@
+# Spec Audit Report — 2026-04-28
+
+Audit of `docs/katana-openapi.yaml` against the upstream Katana API spec archived at
+`docs/katana-api-comprehensive/openapi-spec.json` (the live endpoint at
+`https://app.kfrm.io/v1/openapi.json` was unreachable from the audit environment;
+the comprehensive archive, which includes inline request/response examples, was used
+as the upstream source of truth).
+
+Context: this audit was triggered by issues #313 and #394, both of which were caused by
+`OutsourcedPurchaseOrderIngredientAvailability` missing the `NOT_APPLICABLE` value. The
+goal is to find every other location where the same failure pattern can occur.
+
+______________________________________________________________________
+
+## Path Comparison
+
+- Upstream paths: 104 path-method pairs (97 unique paths)
+- Local paths: 107 unique paths
+- **Missing locally:** none — all upstream paths are represented in the local spec
+- **Extra locally (not in upstream):**
+  - `DELETE /recipes/{id}` — deprecated endpoint; upstream spec has removed it but Katana
+    likely still serves it. Keeping it is harmless.
+  - `GET /serial_numbers/serial_numbers_stock` — alternate path alias for
+    `/serial_numbers_stock`; not in upstream spec. Keeping it is harmless.
+  - `GET /user_info` — documented in CLAUDE.md as the one non-wrapped endpoint. Not
+    present in the upstream spec but confirmed to work.
+
+______________________________________________________________________
+
+## HIGH-Confidence Enum Drift
+
+These are values that the live Katana API can return (or accept) but that are absent
+from the local spec's enum constraints. The failure mode is identical to #313/#394:
+`ValueError: '<VALUE>' is not a valid <EnumClass>` raised by the generated `from_dict`
+parser during deserialization.
+
+### H-1 — `ManufacturingOperationStatus` missing `BLOCKED`
+
+| Attribute                    | Detail                                                                                                                                                                                                   |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Local enum                   | `NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`, `PAUSED`                                                                                                                                                      |
+| Upstream enum (filter param) | `NOT_STARTED`, `BLOCKED`, `IN_PROGRESS`, `PAUSED`, `COMPLETED`                                                                                                                                           |
+| Missing locally              | **`BLOCKED`**                                                                                                                                                                                            |
+| Schema name                  | `ManufacturingOperationStatus`                                                                                                                                                                           |
+| Used by                      | `ManufacturingOrderOperationRow.status` (response field)                                                                                                                                                 |
+| Paths affected               | `GET /manufacturing_order_operation_rows`, `GET /manufacturing_order_operation_rows/{id}`, `PATCH /manufacturing_order_operation_rows/{id}`                                                              |
+| Generated class              | `katana_public_api_client/models/manufacturing_operation_status.py` — `ManufacturingOperationStatus`                                                                                                     |
+| Production impact            | **Certain.** If any operation row is in `BLOCKED` state, `ManufacturingOrderOperationRow.from_dict()` raises `ValueError` and the entire list parse fails.                                               |
+| Confidence                   | HIGH — `BLOCKED` appears in the upstream filter enum and is a documented state in the MO operation lifecycle. The webhook event `manufacturing_order_operation_row.blocked` confirms it is a real state. |
+
+Note: the shared `mo_status` query-parameter component is used for both
+`/manufacturing_orders` and `/manufacturing_order_operation_rows` GET filters. Its
+current enum is `[NOT_STARTED, BLOCKED, IN_PROGRESS, PAUSED, COMPLETED]` — a union of
+both order-level and operation-level statuses. This is misleading (manufacturing
+_orders_ don't have `PAUSED` or `COMPLETED`; manufacturing order _operations_ don't have
+`DONE`). The parameter should be split into two separate components. This is a spec
+quality issue, not a correctness bug — the filter values are ignored by the client
+library and only used for documentation.
+
+### H-2 — `OutsourcedRecipeIngredientAvailability` missing `NO_RECIPE`
+
+| Attribute                                                    | Detail                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Local enum                                                   | `PROCESSED`, `IN_STOCK`, `NOT_AVAILABLE`, `EXPECTED`, `NOT_APPLICABLE` (5 values)                                                                                                                                                                                       |
+| Sibling enum `OutsourcedPurchaseOrderIngredientAvailability` | `PROCESSED`, `IN_STOCK`, `NOT_AVAILABLE`, `EXPECTED`, `NO_RECIPE`, `NOT_APPLICABLE` (6 values)                                                                                                                                                                          |
+| Sibling enum `IngredientAvailability`                        | `PROCESSED`, `IN_STOCK`, `NOT_AVAILABLE`, `EXPECTED`, `NO_RECIPE`, `NOT_APPLICABLE` (6 values)                                                                                                                                                                          |
+| Missing locally                                              | **`NO_RECIPE`**                                                                                                                                                                                                                                                         |
+| Schema name                                                  | `OutsourcedRecipeIngredientAvailability`                                                                                                                                                                                                                                |
+| Used by                                                      | `OutsourcedPurchaseOrderRecipeRow.ingredient_availability` (response field)                                                                                                                                                                                             |
+| Paths affected                                               | `GET /outsourced_purchase_order_recipe_rows`, `GET /outsourced_purchase_order_recipe_rows/{id}`, `PATCH /outsourced_purchase_order_recipe_rows/{id}`                                                                                                                    |
+| Generated class                                              | `katana_public_api_client/models/outsourced_recipe_ingredient_availability.py` — `OutsourcedRecipeIngredientAvailability`                                                                                                                                               |
+| Production impact                                            | **Certain.** If an outsourced recipe row ingredient has no recipe, the API returns `NO_RECIPE` and `OutsourcedPurchaseOrderRecipeRow.from_dict()` raises `ValueError`.                                                                                                  |
+| Confidence                                                   | HIGH — `NO_RECIPE` is present in the structurally identical sibling enums (`IngredientAvailability` and `OutsourcedPurchaseOrderIngredientAvailability`) and in the manufacturing recipe row filter parameter. The absence here is an oversight, not a spec-only value. |
+
+**Dedupe collision risk (the #394 pattern):** Adding `NO_RECIPE` to
+`OutsourcedRecipeIngredientAvailability` makes it structurally identical to both
+`IngredientAvailability` and `OutsourcedPurchaseOrderIngredientAvailability` (all three
+would then have the same 6 values). The openapi-python-client generator deduplicates
+structurally identical enums and consolidates them into one class. If consolidation
+happens:
+
+- `OutsourcedRecipeIngredientAvailability` would be deleted or aliased
+- `OutsourcedPurchaseOrderRecipeRow.ingredient_availability` would use
+  `IngredientAvailability` (or whichever survives)
+- All three `Cached*` pydantic models that reference the ingredient availability type
+  would need updating (via `uv run poe generate-pydantic`)
+
+The fix is correct regardless; the consolidation is a side effect to verify after
+regeneration. The `ManufacturingOrderRecipeRow` model's `ingredient_availability` field
+is already typed as plain `str` (no enum reference in the schema) — this is a separate
+MEDIUM finding (H-3 companion, see below).
+
+### H-3 — `ManufacturingOrderRecipeRow.ingredient_availability` untyped (no enum ref)
+
+| Attribute            | Detail                                                                                                                                                                                                                     |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Current spec         | `ManufacturingOrderRecipeRow.ingredient_availability` is `type: string` with no `$ref`                                                                                                                                     |
+| Expected             | Should reference `IngredientAvailability` (same values, confirmed by upstream filter param `['PROCESSED', 'IN_STOCK', 'NOT_AVAILABLE', 'EXPECTED', 'NO_RECIPE', 'NOT_APPLICABLE']` for `/manufacturing_order_recipe_rows`) |
+| Generated field type | `str` — no enum parsing, no `ValueError` on unknown values                                                                                                                                                                 |
+| Production impact    | **No crash**, but no type safety either. Unknown values pass through silently.                                                                                                                                             |
+| Confidence           | HIGH — the upstream filter param for `/manufacturing_order_recipe_rows` uses the full 6-value set, matching `IngredientAvailability` exactly. The missing `$ref` is an oversight.                                          |
+
+______________________________________________________________________
+
+## MEDIUM-Confidence Schema Drift
+
+These are field-level differences on the high-priority cache-backed entity types. No
+`ValueError` crash risk, but incorrect types can cause silent data corruption in the
+cache layer or validation failures in pydantic strict mode.
+
+### M-1 — `StockTransferStatus` enum values are completely wrong for the PATCH action endpoint
+
+| Attribute                                                    | Detail                                                                                                                                                                                                                                                                                               |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Local `StockTransferStatus`                                  | `pending`, `in_transit`, `completed`, `cancelled`                                                                                                                                                                                                                                                    |
+| Upstream `PATCH /stock_transfers/{id}/status` allowed values | `received`, `created`                                                                                                                                                                                                                                                                                |
+| Mismatch                                                     | The local enum has no values in common with what the upstream endpoint actually accepts                                                                                                                                                                                                              |
+| Schema                                                       | `StockTransferStatus` → `UpdateStockTransferStatusRequest.status`                                                                                                                                                                                                                                    |
+| Generated class                                              | `katana_public_api_client/models/stock_transfer_status.py` — `StockTransferStatus`                                                                                                                                                                                                                   |
+| Impact on responses                                          | The `StockTransfer` response model uses \`status: str                                                                                                                                                                                                                                                |
+| Confidence                                                   | MEDIUM-HIGH — the upstream PATCH body and response example both confirm `received` and `created`. The local `pending/in_transit/completed/cancelled` set appears to be an internal invention.                                                                                                        |
+| Recommendation                                               | Replace `StockTransferStatus` with `[received, created]` **for the request schema only**. The `StockTransfer` response status field should remain a plain `string` (or a separate read-only enum if values are discovered). Add a note that this is a transition-action field, not a general status. |
+
+### M-2 — `SalesReturn.refund_status` field missing enum constraint
+
+| Attribute                             | Detail                                                                                                                                                                        |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Local schema                          | `refund_status: type: [string, null]` (no enum)                                                                                                                               |
+| Upstream filter param `refund_status` | enum `[NOT_REFUNDED, REFUNDED_ALL, PARTIALLY_REFUNDED]`                                                                                                                       |
+| Upstream response example             | `"refund_status": "NOT_REFUNDED"`                                                                                                                                             |
+| Generated pydantic field              | \`refund_status: str                                                                                                                                                          |
+| Impact                                | No crash risk (plain string passes through). However, a proper enum schema would allow the generator to produce a typed enum and enable exhaustive handling in consumer code. |
+| Confidence                            | MEDIUM — the filter param enum is authoritative. A separate `SalesReturnRefundStatus` schema should be defined and referenced from `SalesReturn.refund_status`.               |
+
+### M-3 — `operators.working_area` query parameter missing enum constraint
+
+| Attribute             | Detail                                                                                                    |
+| --------------------- | --------------------------------------------------------------------------------------------------------- |
+| Local schema          | `working_area: type: string` (no enum)                                                                    |
+| Upstream filter param | enum `[shopFloor, warehouse]`                                                                             |
+| Impact                | Client code can pass any string; no validation. Low risk since it's a filter param, not a response field. |
+| Confidence            | MEDIUM — upstream filter param is clear.                                                                  |
+
+### M-4 — `InventoryMovementResourceType` has extra local-only value `ProductionIngredient`
+
+| Attribute                                    | Detail                                                                                                                                                                                                                                  |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Local enum                                   | includes `ProductionIngredient`                                                                                                                                                                                                         |
+| Upstream filter param `/inventory_movements` | `[Production, PurchaseOrderRow, PurchaseOrderRecipeRow, SalesOrderRow, ManufacturingOrderRecipeRow, StockAdjustmentRow, StockTransferRow, ManufacturingOrder, SystemGenerated]`                                                         |
+| Missing from upstream                        | `ProductionIngredient`                                                                                                                                                                                                                  |
+| Impact                                       | If the API never returns `ProductionIngredient`, having it in the local spec is harmless for response parsing. If it IS returned, the local spec is correct and the upstream spec is outdated. If the API NEVER returns it, it's noise. |
+| Confidence                                   | MEDIUM (uncertain direction — need live API confirmation).                                                                                                                                                                              |
+
+### M-5 — `SerialNumberListResponse` wrapper vs actual unwrapped array
+
+| Attribute                | Detail                                                                                                                                                                                                                                                                                   |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Local schema             | `GET /serial_numbers` returns `SerialNumberListResponse` with `{"data": [...]}` wrapper                                                                                                                                                                                                  |
+| Upstream example         | `GET /serial_numbers` returns a raw unwrapped array `[...]`                                                                                                                                                                                                                              |
+| CLAUDE.md rule           | "Katana wraps ALL list responses in `{"data": [...]}`... The only documented exception is `/user_info`"                                                                                                                                                                                  |
+| Current integration test | `serial_number.get_all_serial_numbers` is in `LIST_ENDPOINTS` — if the test passes, the wrapper is correct                                                                                                                                                                               |
+| Impact                   | If the actual API wraps in `data`, local spec is correct and upstream doc is stale. If API returns unwrapped array, then `from_dict` on the response would fail with `ValueError: dictionary update sequence element #0 has length 1` (the "keys as items" bug documented in CLAUDE.md). |
+| Confidence               | MEDIUM (conflicting signals — trust CLAUDE.md rule + integration test over upstream spec example, but verify).                                                                                                                                                                           |
+
+### M-6 — `SerialNumberListResponse` example contains fictional fields
+
+| Attribute                                | Detail                                                                                                         |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Local `SerialNumberListResponse` example | Shows `variant_id`, `location_id`, `status: "IN_STOCK"`, `status: "SOLD"`                                      |
+| Actual `SerialNumber` schema fields      | `id`, `transaction_id`, `serial_number`, `resource_type`, `resource_id`, `transaction_date`, `quantity_change` |
+| Impact                                   | Misleading documentation; no production impact.                                                                |
+| Confidence                               | HIGH — example clearly does not match the schema definition.                                                   |
+
+______________________________________________________________________
+
+## LOW-Confidence Drift
+
+### L-1 — `mo_status` shared query parameter is semantically incorrect
+
+The `mo_status` component parameter with enum
+`[NOT_STARTED, BLOCKED, IN_PROGRESS, PAUSED, COMPLETED]` is referenced by both
+`GET /manufacturing_orders` and `GET /manufacturing_order_operation_rows`. Manufacturing
+_orders_ can be `DONE` (not in the enum) but cannot be `PAUSED` or `COMPLETED`. The
+enum is a superset union that doesn't accurately describe either endpoint. Low risk
+(filter params are ignored in parsing), but confusing for API consumers reading the spec.
+
+### L-2 — `CreatePurchaseOrderInitialStatus` includes `DRAFT` unnecessarily
+
+The upstream `POST /purchase_orders` request body `status` field only lists
+`NOT_RECEIVED`. Local `CreatePurchaseOrderInitialStatus` includes both `DRAFT` and
+`NOT_RECEIVED`. `DRAFT` is a valid status a PO can be in after creation (returned in
+responses), but the upstream spec only allows `NOT_RECEIVED` as the initial creation
+status. This may be an intentional extension, but is worth verifying.
+
+### L-3 — `SalesOrder.invoicing_status` and `SalesOrder.source` are untyped strings
+
+Both fields appear in the upstream response example (`"invoicing_status": "invoiced"`,
+`"source": "api"`) but are defined as plain `string | null` in the local spec without
+enum constraints. These appear to be free-form or integration-specific fields;
+lower risk than status/availability enums.
+
+### L-4 — Upstream `product_operation_rows` path has trailing slash
+
+Upstream spec uses `/product_operation_rows/` (trailing slash) for the POST operation
+while local uses `/product_operation_rows`. Functionally equivalent but worth noting.
+
+### L-5 — Upstream `serial_numbers_stock` example uses string `id` type
+
+Upstream example shows `"id": "1"` (string) while local `SerialNumberStock` schema
+likely defines `id` as integer. Should be verified against actual API behavior.
+
+______________________________________________________________________
+
+## Recommended Next Steps
+
+### For H-1 (ManufacturingOperationStatus missing BLOCKED)
+
+**Action:** Add `BLOCKED` to `ManufacturingOperationStatus` in the spec.
+
+In `docs/katana-openapi.yaml`, the `ManufacturingOperationStatus` schema:
+
+```yaml
+ManufacturingOperationStatus:
+  type: string
+  enum:
+    - NOT_STARTED
+    - IN_PROGRESS    # add BLOCKED here
+    - BLOCKED        # <-- add this
+    - COMPLETED
+    - PAUSED
+```
+
+**Generated files that change after `uv run poe regenerate-client`:**
+
+- `katana_public_api_client/models/manufacturing_operation_status.py` — adds `BLOCKED = "BLOCKED"`
+- `katana_public_api_client/models/update_manufacturing_order_operation_row_request.py` —
+  if it references the status enum, its serialization may change
+
+**After `uv run poe generate-pydantic`:**
+
+- `katana_public_api_client/models_pydantic/_generated/manufacturing.py` — any
+  `ManufacturingOperationStatus` references in pydantic classes update automatically
+
+**Dedupe collision risk:** None. `ManufacturingOperationStatus` (4→5 values) will not
+collide with `ManufacturingOrderStatus` (4 values: `NOT_STARTED, BLOCKED, IN_PROGRESS, DONE`) — they share 3 values but differ in `DONE` vs `PAUSED`/`COMPLETED`.
+
+______________________________________________________________________
+
+### For H-2 (OutsourcedRecipeIngredientAvailability missing NO_RECIPE)
+
+**Action:** Add `NO_RECIPE` to `OutsourcedRecipeIngredientAvailability` in the spec.
+
+**WARNING — dedupe collision risk.** After adding `NO_RECIPE`, all three enums
+(`IngredientAvailability`, `OutsourcedPurchaseOrderIngredientAvailability`,
+`OutsourcedRecipeIngredientAvailability`) would have identical value sets. The generator
+may consolidate them. Before applying the fix:
+
+1. Check the generator's deduplication behavior:
+   `uv run poe regenerate-client` in a scratch branch and compare the output.
+1. If consolidation occurs, verify that all references to
+   `OutsourcedRecipeIngredientAvailability` (specifically in
+   `OutsourcedPurchaseOrderRecipeRow` and its cached sibling) are updated to use
+   the surviving class name.
+1. Run `uv run poe generate-pydantic` and verify the pydantic models compile.
+
+**Generated files that change:**
+
+- `katana_public_api_client/models/outsourced_recipe_ingredient_availability.py` —
+  adds `NO_RECIPE = "NO_RECIPE"` (or is deleted if consolidated)
+- `katana_public_api_client/models/outsourced_purchase_order_recipe_row.py` — may
+  change the imported enum class name
+
+______________________________________________________________________
+
+### For H-3 (ManufacturingOrderRecipeRow.ingredient_availability untyped)
+
+**Action:** Add `$ref: '#/components/schemas/IngredientAvailability'` to
+`ManufacturingOrderRecipeRow.ingredient_availability` in the spec, replacing the plain
+`type: string`.
+
+**Generated files that change:**
+
+- `katana_public_api_client/models/manufacturing_order_recipe_row.py` — adds enum
+  import and parses the field through `IngredientAvailability()`
+
+**Note:** This change *adds* crash protection (previously silent pass-through; now
+`ValueError` on unknown values). If the API returns values not in
+`IngredientAvailability`, this would turn a silent issue into a visible crash. Verify
+that all 6 enum values are correct before applying.
+
+______________________________________________________________________
+
+### For M-1 (StockTransferStatus completely wrong values)
+
+**Action:** Replace the `StockTransferStatus` enum with `[received, created]` and scope
+it to the `UpdateStockTransferStatusRequest` only. Rename to
+`UpdateStockTransferStatusValue` to make the scope clear. The `StockTransfer` response
+`status` field should remain plain `string` until actual response values are confirmed
+from the live API.
+
+**Generated files that change:**
+
+- `katana_public_api_client/models/stock_transfer_status.py` — full replacement
+- `katana_public_api_client/models/update_stock_transfer_status_request.py` — enum reference updates
+
+______________________________________________________________________
+
+### For M-2 (SalesReturn.refund_status missing enum)
+
+**Action:** Define a new `SalesReturnRefundStatus` schema with values
+`[NOT_REFUNDED, REFUNDED_ALL, PARTIALLY_REFUNDED]` and reference it from
+`SalesReturn.refund_status` and the `refund_status` query parameter.
+
+**Generated files that change:**
+
+- New file `katana_public_api_client/models/sales_return_refund_status.py`
+- `katana_public_api_client/models/sales_return.py` — changes `refund_status` from
+  `str | None` to `SalesReturnRefundStatus | None`
+
+______________________________________________________________________
+
+## Integration Test Cross-Reference
+
+Endpoints in `TestSchemaValidation.LIST_ENDPOINTS` (i.e., tested against real API):
+
+- `ManufacturingOrderOperationRow` at `/manufacturing_order_operation_rows` — **at risk**
+  from H-1 if any operation row in the test account is in `BLOCKED` state
+- `OutsourcedPurchaseOrderRecipeRow` — not in `LIST_ENDPOINTS` — **not tested**;
+  H-2 would not be caught by existing integration tests
+- `SalesReturn` at `/sales_returns` — tested; M-2 would not cause a crash (plain string
+  passes through `extra="forbid"` since it's a valid JSON string)
+- `StockTransfer` at `/stock_transfers` — tested; M-1 does not affect response parsing
+  (status is plain `str` in the `StockTransfer` model)
+
+Endpoints not yet covered by integration tests:
+
+- `GET /outsourced_purchase_order_recipe_rows` — **not in LIST_ENDPOINTS** — H-2 is
+  undetected
+- `GET /manufacturing_order_operation_rows/{id}` (single-object) — not tested
+- `GET /purchase_orders/{id}` (single-object) — not tested
+
+______________________________________________________________________
+
+## Priority Order for Fix PRs
+
+| Priority | Finding                                                            | Risk                                                | Notes                                      |
+| -------- | ------------------------------------------------------------------ | --------------------------------------------------- | ------------------------------------------ |
+| 1        | H-1: `ManufacturingOperationStatus` + `BLOCKED`                    | Production crash if any operation is blocked        | No dedupe risk, clean fix                  |
+| 2        | H-2: `OutsourcedRecipeIngredientAvailability` + `NO_RECIPE`        | Production crash for outsourced PO recipe rows      | Dedupe collision must be checked first     |
+| 3        | H-3: `ManufacturingOrderRecipeRow.ingredient_availability` untyped | Currently silent, adding enum adds crash protection | Verify enum values first                   |
+| 4        | M-1: `StockTransferStatus` wrong values                            | Incorrect request enum, no response crash           | Confirm actual status values from live API |
+| 5        | M-2: `SalesReturn.refund_status` missing enum                      | Type safety only, no crash                          | Low urgency                                |
+| 6        | M-3: `operators.working_area` missing enum                         | Filter param only                                   | Very low urgency                           |
+
+______________________________________________________________________
+
+*Audit performed: 2026-04-28. Upstream source: `docs/katana-api-comprehensive/openapi-spec.json` (archived). Live endpoint `https://app.kfrm.io/v1/openapi.json` was unreachable from the audit environment. Findings based on spec comparison + generated model inspection.*

--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -1445,9 +1445,10 @@ components:
       type: string
       enum:
         - NOT_STARTED
+        - BLOCKED
         - IN_PROGRESS
-        - COMPLETED
         - PAUSED
+        - COMPLETED
       description: Status of a manufacturing order operation
 
     PurchaseOrderStatus:

--- a/katana_public_api_client/models/manufacturing_operation_status.py
+++ b/katana_public_api_client/models/manufacturing_operation_status.py
@@ -2,6 +2,7 @@ from enum import StrEnum
 
 
 class ManufacturingOperationStatus(StrEnum):
+    BLOCKED = "BLOCKED"
     COMPLETED = "COMPLETED"
     IN_PROGRESS = "IN_PROGRESS"
     NOT_STARTED = "NOT_STARTED"

--- a/katana_public_api_client/models_pydantic/_generated/common.py
+++ b/katana_public_api_client/models_pydantic/_generated/common.py
@@ -68,9 +68,10 @@ class ProductOperationType(StrEnum):
 
 class ManufacturingOperationStatus(StrEnum):
     not_started = "NOT_STARTED"
+    blocked = "BLOCKED"
     in_progress = "IN_PROGRESS"
-    completed = "COMPLETED"
     paused = "PAUSED"
+    completed = "COMPLETED"
 
 
 class DocumentSendStatus(StrEnum):


### PR DESCRIPTION
Closes part of #395 (Phase 1 + first HIGH-confidence finding).

## Summary

- **Audit report** at `docs/audit-2026-04-28.md` — full spec-auditor pass against upstream. 104 path-method pairs audited, 3 HIGH-confidence enum-drift findings, 5 MEDIUM-confidence schema findings. Serves as baseline for Phase 3's recurring guardrail.
- **H-1 fix** — `ManufacturingOperationStatus` was missing `BLOCKED`. Upstream lists it; the `manufacturing_order_operation_row.blocked` webhook event confirms the value is real-world. Without the value, `ManufacturingOrderOperationRow.from_dict()` raises `ValueError: 'BLOCKED' is not a valid ManufacturingOperationStatus` — same failure mode as #313 / #394.

## Generated diff scope

Just two files (verified via `git diff` after `regenerate-client && generate-pydantic`):

- `katana_public_api_client/models/manufacturing_operation_status.py` — adds `BLOCKED = "BLOCKED"`
- `katana_public_api_client/models_pydantic/_generated/common.py` — adds `blocked = "BLOCKED"` to the pydantic equivalent and reorders to match upstream

No dedupe collision risk: the sibling `ManufacturingOrderStatus` enum has different values, so adding `BLOCKED` doesn't trigger the generator's enum-consolidation pass.

## Test plan

- [x] `uv run poe regenerate-client` — clean
- [x] `uv run poe generate-pydantic` — clean
- [x] `uv run poe check` — full suite passes (2,439 tests)

## Out of scope (follow-ups)

- **H-2** `OutsourcedRecipeIngredientAvailability` missing `NO_RECIPE` — HIGH dedupe-collision risk per the audit (would make all three ingredient-availability enums structurally identical). Separate PR with careful dedupe verification.
- **H-3** `ManufacturingOrderRecipeRow.ingredient_availability` missing `$ref` — verify enum completeness first.
- **M-1 through M-5** — cosmetic / non-crashing schema drift; can batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)