### PR TITLE
chore(mcp): post-#342 review nits — fixture renames + factories TYPE_CHECKING cleanup

### DIFF
--- a/katana_mcp_server/tests/factories.py
+++ b/katana_mcp_server/tests/factories.py
@@ -14,28 +14,28 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from katana_mcp.typed_cache import TypedCacheEngine
+from katana_mcp.tools.tool_result_utils import naive_utc
+from katana_mcp.typed_cache import TypedCacheEngine
 
-    from katana_public_api_client.models_pydantic._generated import (
-        CachedManufacturingOrder,
-        CachedManufacturingOrderRecipeRow,
-        CachedPurchaseOrder,
-        CachedPurchaseOrderRow,
-        CachedSalesOrder,
-        CachedSalesOrderRow,
-        CachedStockAdjustment,
-        CachedStockAdjustmentRow,
-        CachedStockTransfer,
-        CachedStockTransferRow,
-        ManufacturingOrderStatus,
-        PurchaseOrderEntityType,
-        PurchaseOrderStatus,
-        SalesOrderProductionStatus,
-        SalesOrderStatus,
-    )
+from katana_public_api_client.models_pydantic._generated import (
+    CachedManufacturingOrder,
+    CachedManufacturingOrderRecipeRow,
+    CachedPurchaseOrder,
+    CachedPurchaseOrderRow,
+    CachedSalesOrder,
+    CachedSalesOrderRow,
+    CachedStockAdjustment,
+    CachedStockAdjustmentRow,
+    CachedStockTransfer,
+    CachedStockTransferRow,
+    ManufacturingOrderStatus,
+    PurchaseOrderEntityType,
+    PurchaseOrderStatus,
+    SalesOrderProductionStatus,
+    SalesOrderStatus,
+)
 
 
 async def seed_cache(typed_cache: TypedCacheEngine, entities: Iterable[Any]) -> None:
@@ -83,26 +83,19 @@ def make_sales_order(
     flavor without breaking later comparisons. ``created_at`` defaults
     to 2026-04-01 so date-window filter tests have a stable reference.
     """
-    from katana_mcp.tools.tool_result_utils import naive_utc
-
-    from katana_public_api_client.models_pydantic._generated import (
-        CachedSalesOrder as _CachedSalesOrder,
-        SalesOrderProductionStatus as _ProductionStatus,
-        SalesOrderStatus as _SalesOrderStatus,
-    )
 
     resolved_status = (
-        _SalesOrderStatus(status)
+        SalesOrderStatus(status)
         if isinstance(status, str)
-        else (status if status is not None else _SalesOrderStatus.not_shipped)
+        else (status if status is not None else SalesOrderStatus.not_shipped)
     )
     resolved_prod_status = (
-        _ProductionStatus(production_status)
+        SalesOrderProductionStatus(production_status)
         if isinstance(production_status, str)
         else production_status
     )
 
-    cached = _CachedSalesOrder(
+    cached = CachedSalesOrder(
         id=id,
         order_no=order_no,
         customer_id=customer_id,
@@ -133,11 +126,7 @@ def make_sales_order_row(
     linked_manufacturing_order_id: int | None = None,
 ) -> CachedSalesOrderRow:
     """Build a ``CachedSalesOrderRow`` for direct cache insertion."""
-    from katana_public_api_client.models_pydantic._generated import (
-        CachedSalesOrderRow as _CachedSalesOrderRow,
-    )
-
-    return _CachedSalesOrderRow(
+    return CachedSalesOrderRow(
         id=id,
         sales_order_id=sales_order_id,
         variant_id=variant_id,
@@ -173,13 +162,8 @@ def make_stock_adjustment(
     ``created_at`` defaults to 2026-04-01 to match the sales-order builder
     so cross-entity date-window tests share a baseline.
     """
-    from katana_mcp.tools.tool_result_utils import naive_utc
 
-    from katana_public_api_client.models_pydantic._generated import (
-        CachedStockAdjustment as _CachedStockAdjustment,
-    )
-
-    cached = _CachedStockAdjustment(
+    cached = CachedStockAdjustment(
         id=id,
         stock_adjustment_number=stock_adjustment_number,
         location_id=location_id,
@@ -203,11 +187,7 @@ def make_stock_adjustment_row(
     cost_per_unit: float | None = None,
 ) -> CachedStockAdjustmentRow:
     """Build a ``CachedStockAdjustmentRow`` for direct cache insertion."""
-    from katana_public_api_client.models_pydantic._generated import (
-        CachedStockAdjustmentRow as _CachedStockAdjustmentRow,
-    )
-
-    return _CachedStockAdjustmentRow(
+    return CachedStockAdjustmentRow(
         id=id,
         stock_adjustment_id=stock_adjustment_id,
         variant_id=variant_id,
@@ -248,20 +228,14 @@ def make_manufacturing_order(
     ``created_at`` both default to 2026-04-01 to match the other
     factories' baseline.
     """
-    from katana_mcp.tools.tool_result_utils import naive_utc
-
-    from katana_public_api_client.models_pydantic._generated import (
-        CachedManufacturingOrder as _CachedManufacturingOrder,
-        ManufacturingOrderStatus as _ManufacturingOrderStatus,
-    )
 
     resolved_status = (
-        _ManufacturingOrderStatus(status)
+        ManufacturingOrderStatus(status)
         if isinstance(status, str)
-        else (status if status is not None else _ManufacturingOrderStatus.not_started)
+        else (status if status is not None else ManufacturingOrderStatus.not_started)
     )
 
-    return _CachedManufacturingOrder(
+    return CachedManufacturingOrder(
         id=id,
         order_no=order_no,
         status=resolved_status,
@@ -300,11 +274,7 @@ def make_manufacturing_order_recipe_row(
     to build parent-child fixtures for tools that join MOs to recipe rows
     (e.g., ``inventory_velocity``'s MO-consumption path).
     """
-    from katana_public_api_client.models_pydantic._generated import (
-        CachedManufacturingOrderRecipeRow as _CachedManufacturingOrderRecipeRow,
-    )
-
-    return _CachedManufacturingOrderRecipeRow(
+    return CachedManufacturingOrderRecipeRow(
         id=id,
         manufacturing_order_id=manufacturing_order_id,
         variant_id=variant_id,
@@ -348,24 +318,19 @@ def make_purchase_order(
     pass ``"outsourced"`` plus a ``tracking_location_id`` for outsourced
     fixtures.
     """
-    from katana_mcp.tools.tool_result_utils import naive_utc
-
-    from katana_public_api_client.models_pydantic._generated import (
-        CachedPurchaseOrder as _CachedPurchaseOrder,
-        PurchaseOrderEntityType as _EntityType,
-        PurchaseOrderStatus as _Status,
-    )
 
     resolved_entity_type = (
-        _EntityType(entity_type) if isinstance(entity_type, str) else entity_type
+        PurchaseOrderEntityType(entity_type)
+        if isinstance(entity_type, str)
+        else entity_type
     )
     resolved_status = (
-        _Status(status)
+        PurchaseOrderStatus(status)
         if isinstance(status, str)
-        else (status if status is not None else _Status.not_received)
+        else (status if status is not None else PurchaseOrderStatus.not_received)
     )
 
-    cached = _CachedPurchaseOrder(
+    cached = CachedPurchaseOrder(
         id=id,
         order_no=order_no,
         entity_type=resolved_entity_type,
@@ -398,13 +363,8 @@ def make_purchase_order_row(
     total: float | None = None,
 ) -> CachedPurchaseOrderRow:
     """Build a ``CachedPurchaseOrderRow`` for direct cache insertion."""
-    from katana_mcp.tools.tool_result_utils import naive_utc
 
-    from katana_public_api_client.models_pydantic._generated import (
-        CachedPurchaseOrderRow as _CachedPurchaseOrderRow,
-    )
-
-    return _CachedPurchaseOrderRow(
+    return CachedPurchaseOrderRow(
         id=id,
         purchase_order_id=purchase_order_id,
         variant_id=variant_id,
@@ -443,13 +403,8 @@ def make_stock_transfer(
     spec types it that way; Katana returns lowercase enum values). Pass
     raw lowercase strings here — that matches what real API rows carry.
     """
-    from katana_mcp.tools.tool_result_utils import naive_utc
 
-    from katana_public_api_client.models_pydantic._generated import (
-        CachedStockTransfer as _CachedStockTransfer,
-    )
-
-    cached = _CachedStockTransfer(
+    cached = CachedStockTransfer(
         id=id,
         stock_transfer_number=stock_transfer_number,
         source_location_id=source_location_id,
@@ -476,11 +431,7 @@ def make_stock_transfer_row(
     cost_per_unit: float | None = None,
 ) -> CachedStockTransferRow:
     """Build a ``CachedStockTransferRow`` for direct cache insertion."""
-    from katana_public_api_client.models_pydantic._generated import (
-        CachedStockTransferRow as _CachedStockTransferRow,
-    )
-
-    return _CachedStockTransferRow(
+    return CachedStockTransferRow(
         id=id,
         stock_transfer_id=stock_transfer_id,
         variant_id=variant_id,

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -916,7 +916,7 @@ async def test_create_manufacturing_order_make_to_order_with_subassemblies():
 
 
 @pytest.fixture
-def no_mo_sync():
+def no_sync():
     """Patch ``ensure_manufacturing_orders_synced`` to a no-op."""
     with patch_typed_cache_sync("manufacturing_orders"):
         yield
@@ -936,7 +936,7 @@ async def test_list_manufacturing_orders_limit_le_250_validation():
 
 @pytest.mark.asyncio
 async def test_list_manufacturing_orders_filters_by_ids(
-    context_with_typed_cache, no_mo_sync
+    context_with_typed_cache, no_sync
 ):
     """`ids` restricts the returned set to the specified MO IDs."""
     from katana_mcp.tools.foundation.manufacturing_orders import (
@@ -963,7 +963,7 @@ async def test_list_manufacturing_orders_filters_by_ids(
 
 @pytest.mark.asyncio
 async def test_list_manufacturing_orders_filters_by_status(
-    context_with_typed_cache, no_mo_sync
+    context_with_typed_cache, no_sync
 ):
     """`status` matches the cache's enum column exactly."""
     from katana_mcp.tools.foundation.manufacturing_orders import (
@@ -995,7 +995,7 @@ async def test_list_manufacturing_orders_filters_by_status(
 
 @pytest.mark.asyncio
 async def test_list_manufacturing_orders_filters_by_location_and_so_link(
-    context_with_typed_cache, no_mo_sync
+    context_with_typed_cache, no_sync
 ):
     """`location_id` and `is_linked_to_sales_order` apply as direct column filters."""
     from katana_mcp.tools.foundation.manufacturing_orders import (
@@ -1032,7 +1032,7 @@ async def test_list_manufacturing_orders_filters_by_location_and_so_link(
 
 @pytest.mark.asyncio
 async def test_list_manufacturing_orders_excludes_deleted_by_default(
-    context_with_typed_cache, no_mo_sync
+    context_with_typed_cache, no_sync
 ):
     """Soft-deleted MOs are filtered unless include_deleted=True."""
     from katana_mcp.tools.foundation.manufacturing_orders import (
@@ -1062,7 +1062,7 @@ async def test_list_manufacturing_orders_excludes_deleted_by_default(
 
 @pytest.mark.asyncio
 async def test_list_manufacturing_orders_date_filters(
-    context_with_typed_cache, no_mo_sync
+    context_with_typed_cache, no_sync
 ):
     """All four date columns (created_at, updated_at, production_deadline_date) apply as ranges."""
     from katana_mcp.tools.foundation.manufacturing_orders import (
@@ -1111,7 +1111,7 @@ async def test_list_manufacturing_orders_date_filters(
 
 @pytest.mark.asyncio
 async def test_list_manufacturing_orders_invalid_date_raises(
-    context_with_typed_cache, no_mo_sync
+    context_with_typed_cache, no_sync
 ):
     """Malformed ISO-8601 for a date filter surfaces as ValueError."""
     from katana_mcp.tools.foundation.manufacturing_orders import (
@@ -1129,7 +1129,7 @@ async def test_list_manufacturing_orders_invalid_date_raises(
 
 @pytest.mark.asyncio
 async def test_list_manufacturing_orders_caps_to_limit(
-    context_with_typed_cache, no_mo_sync
+    context_with_typed_cache, no_sync
 ):
     """`limit` caps the result size even when more rows match."""
     from katana_mcp.tools.foundation.manufacturing_orders import (
@@ -1153,7 +1153,7 @@ async def test_list_manufacturing_orders_caps_to_limit(
 
 @pytest.mark.asyncio
 async def test_list_manufacturing_orders_pagination_meta_populated_on_explicit_page(
-    context_with_typed_cache, no_mo_sync
+    context_with_typed_cache, no_sync
 ):
     """An explicit `page` populates `pagination` from a SQL COUNT against the same filter set."""
     from katana_mcp.tools.foundation.manufacturing_orders import (
@@ -1182,7 +1182,7 @@ async def test_list_manufacturing_orders_pagination_meta_populated_on_explicit_p
 
 @pytest.mark.asyncio
 async def test_list_manufacturing_orders_pagination_meta_none_without_page(
-    context_with_typed_cache, no_mo_sync
+    context_with_typed_cache, no_sync
 ):
     """Without an explicit `page`, `pagination` is `None`."""
     from katana_mcp.tools.foundation.manufacturing_orders import (

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -2057,7 +2057,7 @@ async def test_verify_order_document_embeds_po_without_nested_heading():
 
 
 @pytest.fixture
-def no_po_sync():
+def no_sync():
     """Patch ``ensure_purchase_orders_synced`` to a no-op."""
     with patch_typed_cache_sync("purchase_orders"):
         yield
@@ -2076,9 +2076,7 @@ async def test_list_purchase_orders_limit_le_250_validation():
 
 
 @pytest.mark.asyncio
-async def test_list_purchase_orders_filters_by_ids(
-    context_with_typed_cache, no_po_sync
-):
+async def test_list_purchase_orders_filters_by_ids(context_with_typed_cache, no_sync):
     """`ids` restricts the returned set to specific PO IDs."""
     from katana_mcp.tools.foundation.purchase_orders import (
         ListPurchaseOrdersRequest,
@@ -2104,7 +2102,7 @@ async def test_list_purchase_orders_filters_by_ids(
 
 @pytest.mark.asyncio
 async def test_list_purchase_orders_filters_by_status_and_billing(
-    context_with_typed_cache, no_po_sync
+    context_with_typed_cache, no_sync
 ):
     """`status` and `billing_status` apply as enum-typed column filters."""
     from katana_mcp.tools.foundation.purchase_orders import (
@@ -2142,7 +2140,7 @@ async def test_list_purchase_orders_filters_by_status_and_billing(
 
 @pytest.mark.asyncio
 async def test_list_purchase_orders_filters_by_entity_type_and_tracking_location(
-    context_with_typed_cache, no_po_sync
+    context_with_typed_cache, no_sync
 ):
     """`entity_type` filters regular vs outsourced; `tracking_location_id` is hoisted from the outsourced subclass."""
     from katana_mcp.tools.foundation.purchase_orders import (
@@ -2180,7 +2178,7 @@ async def test_list_purchase_orders_filters_by_entity_type_and_tracking_location
 
 @pytest.mark.asyncio
 async def test_list_purchase_orders_filters_by_supplier_currency_and_location(
-    context_with_typed_cache, no_po_sync
+    context_with_typed_cache, no_sync
 ):
     """Direct column filters: supplier_id, currency, location_id."""
     from katana_mcp.tools.foundation.purchase_orders import (
@@ -2216,7 +2214,7 @@ async def test_list_purchase_orders_filters_by_supplier_currency_and_location(
 
 @pytest.mark.asyncio
 async def test_list_purchase_orders_excludes_deleted_by_default(
-    context_with_typed_cache, no_po_sync
+    context_with_typed_cache, no_sync
 ):
     """Soft-deleted POs are filtered unless include_deleted=True."""
     from katana_mcp.tools.foundation.purchase_orders import (
@@ -2243,7 +2241,7 @@ async def test_list_purchase_orders_excludes_deleted_by_default(
 
 
 @pytest.mark.asyncio
-async def test_list_purchase_orders_date_filters(context_with_typed_cache, no_po_sync):
+async def test_list_purchase_orders_date_filters(context_with_typed_cache, no_sync):
     """`created_*` and `expected_arrival_*` apply as indexed range filters."""
     from katana_mcp.tools.foundation.purchase_orders import (
         ListPurchaseOrdersRequest,
@@ -2288,7 +2286,7 @@ async def test_list_purchase_orders_date_filters(context_with_typed_cache, no_po
 
 @pytest.mark.asyncio
 async def test_list_purchase_orders_invalid_date_raises(
-    context_with_typed_cache, no_po_sync
+    context_with_typed_cache, no_sync
 ):
     """Malformed ISO-8601 surfaces as ValueError."""
     from katana_mcp.tools.foundation.purchase_orders import (
@@ -2305,7 +2303,7 @@ async def test_list_purchase_orders_invalid_date_raises(
 
 
 @pytest.mark.asyncio
-async def test_list_purchase_orders_caps_to_limit(context_with_typed_cache, no_po_sync):
+async def test_list_purchase_orders_caps_to_limit(context_with_typed_cache, no_sync):
     """`limit` caps the result size even when more rows match."""
     from katana_mcp.tools.foundation.purchase_orders import (
         ListPurchaseOrdersRequest,
@@ -2327,7 +2325,7 @@ async def test_list_purchase_orders_caps_to_limit(context_with_typed_cache, no_p
 
 @pytest.mark.asyncio
 async def test_list_purchase_orders_pagination_meta_populated_on_explicit_page(
-    context_with_typed_cache, no_po_sync
+    context_with_typed_cache, no_sync
 ):
     """An explicit `page` populates `pagination` from a SQL COUNT against the same filter set."""
     from katana_mcp.tools.foundation.purchase_orders import (
@@ -2353,7 +2351,7 @@ async def test_list_purchase_orders_pagination_meta_populated_on_explicit_page(
 
 
 @pytest.mark.asyncio
-async def test_list_purchase_orders_include_rows(context_with_typed_cache, no_po_sync):
+async def test_list_purchase_orders_include_rows(context_with_typed_cache, no_sync):
     """include_rows=True exposes per-PO line item detail."""
     from katana_mcp.tools.foundation.purchase_orders import (
         ListPurchaseOrdersRequest,

--- a/katana_mcp_server/tests/tools/test_stock_transfers.py
+++ b/katana_mcp_server/tests/tools/test_stock_transfers.py
@@ -228,7 +228,7 @@ async def test_create_stock_transfer_rejects_empty_rows():
 
 
 @pytest.fixture
-def no_st_sync():
+def no_sync():
     """Patch ``ensure_stock_transfers_synced`` to a no-op."""
     with patch_typed_cache_sync("stock_transfers"):
         yield
@@ -236,7 +236,7 @@ def no_st_sync():
 
 @pytest.mark.asyncio
 async def test_list_stock_transfers_invalid_date_raises(
-    context_with_typed_cache, no_st_sync
+    context_with_typed_cache, no_sync
 ):
     """Malformed ISO-8601 date is surfaced as ValueError."""
     context, _, _typed_cache = context_with_typed_cache
@@ -249,7 +249,7 @@ async def test_list_stock_transfers_invalid_date_raises(
 
 @pytest.mark.asyncio
 async def test_list_stock_transfers_filters_by_status(
-    context_with_typed_cache, no_st_sync
+    context_with_typed_cache, no_sync
 ):
     """Status filter (uppercase Literal) folds to lowercase against the cache column."""
     context, _, typed_cache = context_with_typed_cache
@@ -270,9 +270,7 @@ async def test_list_stock_transfers_filters_by_status(
 
 
 @pytest.mark.asyncio
-async def test_list_stock_transfers_location_filters(
-    context_with_typed_cache, no_st_sync
-):
+async def test_list_stock_transfers_location_filters(context_with_typed_cache, no_sync):
     """source_location_id / destination_location_id apply as direct column filters."""
     context, _, typed_cache = context_with_typed_cache
     await seed_cache(
@@ -297,7 +295,7 @@ async def test_list_stock_transfers_location_filters(
 
 @pytest.mark.asyncio
 async def test_list_stock_transfers_filters_by_number(
-    context_with_typed_cache, no_st_sync
+    context_with_typed_cache, no_sync
 ):
     """`stock_transfer_number` is an exact-match column filter."""
     context, _, typed_cache = context_with_typed_cache
@@ -317,7 +315,7 @@ async def test_list_stock_transfers_filters_by_number(
 
 
 @pytest.mark.asyncio
-async def test_list_stock_transfers_date_filters(context_with_typed_cache, no_st_sync):
+async def test_list_stock_transfers_date_filters(context_with_typed_cache, no_sync):
     """`created_after` / `created_before` apply as indexed range filters."""
     context, _, typed_cache = context_with_typed_cache
     await seed_cache(
@@ -341,7 +339,7 @@ async def test_list_stock_transfers_date_filters(context_with_typed_cache, no_st
 
 
 @pytest.mark.asyncio
-async def test_list_stock_transfers_caps_to_limit(context_with_typed_cache, no_st_sync):
+async def test_list_stock_transfers_caps_to_limit(context_with_typed_cache, no_sync):
     """`limit` caps the result size even when more rows match."""
     context, _, typed_cache = context_with_typed_cache
     await seed_cache(
@@ -357,7 +355,7 @@ async def test_list_stock_transfers_caps_to_limit(context_with_typed_cache, no_s
 
 
 @pytest.mark.asyncio
-async def test_list_stock_transfers_include_rows(context_with_typed_cache, no_st_sync):
+async def test_list_stock_transfers_include_rows(context_with_typed_cache, no_sync):
     """include_rows=True exposes per-transfer row details."""
     context, _, typed_cache = context_with_typed_cache
     await seed_cache(
@@ -393,7 +391,7 @@ async def test_list_stock_transfers_include_rows(context_with_typed_cache, no_st
 
 @pytest.mark.asyncio
 async def test_list_stock_transfers_pagination_meta_when_page_set(
-    context_with_typed_cache, no_st_sync
+    context_with_typed_cache, no_sync
 ):
     """An explicit `page` populates `pagination` from a SQL COUNT against the same filter set."""
     context, _, typed_cache = context_with_typed_cache
@@ -415,7 +413,7 @@ async def test_list_stock_transfers_pagination_meta_when_page_set(
 
 @pytest.mark.asyncio
 async def test_list_stock_transfers_no_pagination_when_page_not_set(
-    context_with_typed_cache, no_st_sync
+    context_with_typed_cache, no_sync
 ):
     """When page is not set, pagination meta stays None."""
     context, _, typed_cache = context_with_typed_cache


### PR DESCRIPTION
Closes #390.

## Summary

Cleanup pass on three of the four review nits surfaced post-#342. Items 2 and 4 were already addressed elsewhere; this PR handles Items 1 and 3.

### Item 1 — Standardize cache-sync fixture names

Rename `no_<X>_sync` → `no_sync` in three test files. `test_inventory.py` and `test_sales_orders.py` already use `no_sync`; the prefixed variants existed without justification.

| File | Before | After |
|---|---|---|
| `tests/tools/test_manufacturing_orders.py` | `no_mo_sync` | `no_sync` |
| `tests/tools/test_purchase_orders.py` | `no_po_sync` | `no_sync` |
| `tests/tools/test_stock_transfers.py` | `no_st_sync` | `no_sync` |

### Item 3 — Drop `factories.py` `TYPE_CHECKING` block + deferred imports

- Move all `Cached<Entity>` / status-enum / `TypedCacheEngine` / `naive_utc` imports to module top.
- Drop the `as _Cached<Name>` aliasing inside each `make_*` function (only existed to avoid shadowing the `TYPE_CHECKING`-imported name, which is gone).

`factories.py`: 489 → 432 lines (-57).

### Items 2 + 4 — already shipped

- **Item 2** (numbered narration comments in `_list_*_impl`): removed in earlier slam-dunk work (#391). Verified via grep.
- **Item 4** (`_CACHE_BASE_CLASSES` ↔ `ENTITY_SUBTYPES` unification): absorbed into #407 (CacheTableSpec consolidation).

## Test plan

- [x] `uv run poe check` — 2,452 tests pass; lint / format / type clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)