### PR TITLE
docs(harness): require breaking-change marker for schema/generator changes that drop or narrow public surface

### DIFF
--- a/.github/agents/guides/shared/COMMIT_STANDARDS.md
+++ b/.github/agents/guides/shared/COMMIT_STANDARDS.md
@@ -212,6 +212,69 @@ Before version 1.0.0, breaking changes still bump MINOR (not MAJOR):
 1. **Don't break conventions** - Follow the format strictly
 1. **Don't commit broken code** - Run validation before committing
 
+## Schema and Generator Changes
+
+Edits to the OpenAPI spec (`docs/katana-openapi.yaml`) or to the generator scripts
+(`scripts/generate_pydantic_models.py`, `scripts/regenerate_client.py`) can ripple
+into the **public client surface** in ways that break consumers — even when each
+individual change reads as a "fix" or "chore". Those ripples must be captured in
+the commit message so the auto-generated changelog flags them.
+
+### What counts as a breaking schema change
+
+Use `feat(client)!:` (or `fix(client)!:`) **with a `BREAKING CHANGE:` footer**
+whenever a spec or generator edit causes any of the following in the regenerated
+client output:
+
+- A previously-exported class **disappears** (e.g., a `StrEnum` was deduped into
+  a structurally identical sibling — see #414 / `OutsourcedRecipeIngredientAvailability`
+  collapsed into `OutsourcedPurchaseOrderIngredientAvailability`)
+- A field **type narrows** in a way that makes previously-valid values raise
+  (e.g., `type: string` → `$ref` to a `StrEnum` — see #410)
+- A field is **renamed** or **removed** on a response or request schema
+- An endpoint path is **removed**
+- A required field becomes **optional** (changes parse semantics) or vice versa
+
+The footer must list the affected name(s) so a consumer searching the
+changelog for the broken import or attribute can find the change:
+
+```
+fix(client)!: dedupe collapses OutsourcedRecipeIngredientAvailability
+
+The pydantic generator's structural-dedupe pass (``reuse-model = true`` in
+datamodel-codegen) now collapses ``OutsourcedRecipeIngredientAvailability``
+into ``OutsourcedPurchaseOrderIngredientAvailability`` because their value
+sets matched after #409 added ``NO_RECIPE``.
+
+BREAKING CHANGE: ``katana_public_api_client.models_pydantic.OutsourcedRecipeIngredientAvailability``
+no longer exists; import ``OutsourcedPurchaseOrderIngredientAvailability``
+instead. Both enums had identical values; the rewrite is mechanical.
+Refs #409
+```
+
+### What does NOT need the breaking-change marker
+
+- Adding a new endpoint or field (purely additive)
+- Adding a value to an existing enum (parse stays tolerant; old values still work)
+- Generated-file diff is byte-identical (e.g., a docstring tweak in the generator
+  that doesn't change emitted code)
+- Internal-only refactors that don't change the surface (e.g., consolidating
+  generator config dicts — see #407)
+
+### Why this matters pre-1.0
+
+The package is pre-1.0, so breaking changes bump MINOR (per the
+"Pre-1.0 Special Rules" section above) — *not* MAJOR. That's a smaller
+version-number signal than a 1.x → 2.x bump, so the **changelog entry** carries
+the discoverability for affected consumers. Without the breaking-change footer,
+the change shows up in the changelog as a normal `fix:` line and consumers hit
+an `ImportError` (or `ValueError`, etc.) without a breadcrumb to follow.
+
+When in doubt, run `uv run poe regenerate-client && uv run poe generate-pydantic`
+and inspect `git diff katana_public_api_client/`. If the diff removes any
+top-level class, removes any `__all__` entry, or changes a field's type
+annotation in a non-additive way, use `!` and `BREAKING CHANGE:`.
+
 ## Multi-Package Changes
 
 If a change affects both packages, create separate commits:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,13 @@ Common mistakes to avoid:
   without its regen leaves CI green-but-stale until the next time someone runs
   the generator; pushing regen output without the input change drifts in the
   other direction. Note the generated-file impact in the PR description (e.g.,
-  "byte-identical except X" or list affected files).
+  "byte-identical except X" or list affected files). When the regen drops a
+  previously-public class (e.g., a `StrEnum` deduped into a sibling) or
+  narrows a field's type, the commit must use the breaking-change marker
+  (`feat(client)!:` / `fix(client)!:`) with a `BREAKING CHANGE:` footer
+  naming the affected symbol — see
+  [`.github/agents/guides/shared/COMMIT_STANDARDS.md`](.github/agents/guides/shared/COMMIT_STANDARDS.md)
+  "Schema and Generator Changes" for the full rule.
 - **OpenAPI spec is 3.1 — use 3.1 conventions** - `docs/katana-openapi.yaml`
   declares `openapi: 3.1.0`. Use 3.1 features rather than 3.0 work-arounds.
   Specifically: **`$ref` siblings are legal in 3.1**, so attach property


### PR DESCRIPTION
Closes #414 (documentation-only fix; no alias-emission).

## Summary

#414 was filed after Copilot flagged that PR #409's dedupe-collapse silently dropped `OutsourcedRecipeIngredientAvailability` from `katana_public_api_client.models_pydantic._generated`. The original proposal was to add backwards-compat alias machinery in the generator. **Rejected**: the package is pre-1.0; aliases would carry permanent runtime surface for a compatibility guarantee we haven't committed to. Instead, surface the drop in the auto-generated changelog so consumers searching for the broken import find it.

## Rule

When a spec or generator edit causes the regenerated client to:

- Remove a previously-exported class (e.g., dedupe-collapse)
- Narrow a field type in a non-additive way (e.g., `type: string` → `$ref` to a `StrEnum`)
- Rename or remove a field/endpoint
- Flip required ↔ optional on a request/response field

…the commit must use `feat(client)!:` / `fix(client)!:` with a `BREAKING CHANGE:` footer that names the affected symbol(s). Pre-1.0, the bump is still MINOR, but the changelog entry carries the discoverability for consumers.

## Files

- `.github/agents/guides/shared/COMMIT_STANDARDS.md` — new "Schema and Generator Changes" section
- `CLAUDE.md` — cross-link from the existing regen-with-input pitfall

## Test plan

- [x] `uv run poe quick-check` — format/lint clean (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)