### PR TITLE
docs(mcp): rewrite architecture.md for post-typed-cache / EntitySpec architecture

### DIFF
--- a/katana_mcp_server/docs/architecture.md
+++ b/katana_mcp_server/docs/architecture.md
@@ -1,868 +1,244 @@
-# Katana MCP Server - Comprehensive Architecture Design
+# Katana MCP Server — Architecture
 
-**Date**: 2025-10-29 **Version**: 1.0 **Status**: Reference Document
+This document describes how the `katana-mcp-server` package is structured today. Design
+rationale for individual decisions lives in [ADRs](adr/README.md) — this doc is the map,
+not the encyclopedia.
 
-> **⚠️ CURRENT IMPLEMENTATION**: This document provides comprehensive background on MCP
-> best practices and architectural patterns. For the **current implementation plan**,
-> see [MCP_V0.1.0_IMPLEMENTATION_PLAN.md](MCP_V0.1.0_IMPLEMENTATION_PLAN.md).
+## Overview
 
-______________________________________________________________________
+The MCP server exposes Katana Manufacturing ERP to AI assistants via the
+[Model Context Protocol](https://modelcontextprotocol.io). It is built on
+[FastMCP](https://github.com/jlowin/fastmcp) and consumes the Python
+[`katana-openapi-client`](../../katana_public_api_client/docs/README.md) package for
+HTTP. Resilience (retries, rate-limiting, smart pagination) lives in the client's
+transport layer — the MCP server inherits all of it for free, and **must not** wrap API
+calls with its own retry / rate-limit logic.
 
-## Table of Contents
-
-1. [Executive Summary](#executive-summary)
-1. [MCP Primitives & Best Practices](#mcp-primitives--best-practices)
-1. [Katana API Capabilities](#katana-api-capabilities)
-1. [Proposed MCP Architecture](#proposed-mcp-architecture)
-1. [Tools Design](#tools-design)
-1. [Resources Design](#resources-design)
-1. [Prompts Design](#prompts-design)
-1. [Security & Production Readiness](#security--production-readiness)
-1. [Implementation Phases](#implementation-phases)
-1. [Success Metrics](#success-metrics)
-
-______________________________________________________________________
-
-## Executive Summary
-
-This document outlines a comprehensive redesign of the Katana MCP server based on:
-
-- **2025 MCP best practices** from the official specification
-- **Modern architectural patterns** for production MCP servers
-- **Deep understanding** of Katana Manufacturing ERP capabilities
-- **Real-world manufacturing workflows** and use cases
-
-### Key Design Principles
-
-1. **Single Responsibility**: One MCP server focused on Katana ERP
-1. **Defense in Depth**: Layered security with validation and sanitization
-1. **Fail-Safe Design**: Graceful degradation under failure
-1. **Production Excellence**: Observability, monitoring, health checks
-1. **User-Centric**: Design around actual manufacturing workflows
-
-______________________________________________________________________
-
-## MCP Primitives & Best Practices
-
-### Available MCP Features
-
-| Primitive       | Purpose                       | When to Use                                         |
-| --------------- | ----------------------------- | --------------------------------------------------- |
-| **Tools**       | Functions AI can execute      | Actions, computations, external system interactions |
-| **Resources**   | Context/data for AI           | Expose existing information, documents, datasets    |
-| **Prompts**     | Templated workflows           | Guide user interactions, common patterns            |
-| **Sampling**    | Server-initiated LLM requests | Autonomous workflows, multi-step reasoning          |
-| **Roots**       | URI/filesystem boundaries     | Data source/location discovery                      |
-| **Elicitation** | Request user input            | Clarification, confirmation, additional data        |
-
-### 2025 Best Practices (from modelcontextprotocol.info)
-
-#### Architecture
-
-- ✅ **Single Responsibility** - One clear purpose per server
-- ✅ **Defense in Depth** - Network isolation, auth, authorization, validation
-- ✅ **Fail-Safe Design** - Circuit breakers, caching, rate limiting, safe defaults
-
-#### Implementation
-
-- ✅ **Configuration Management** - Environment variables, validation, secrets
-- ✅ **Comprehensive Error Handling** - 4xx client, 5xx server, external errors
-- ✅ **Performance Optimization** - Connection pooling, multi-level caching, async
-
-#### Production Operations
-
-- ✅ **Monitoring & Observability** - Structured logging, metrics, tracing
-- ✅ **Health Checks** - Database, cache, APIs, disk, memory
-- ✅ **Deployment Strategies** - Rolling updates, resource limits, autoscaling
-
-### Performance Targets (from best practices)
-
-| Metric       | Target                     |
-| ------------ | -------------------------- |
-| Throughput   | >1000 req/sec per instance |
-| P95 Latency  | \<100ms (simple ops)       |
-| P99 Latency  | \<500ms (complex ops)      |
-| Error Rate   | \<0.1%                     |
-| Availability | >99.9%                     |
-
-______________________________________________________________________
-
-## Katana API Capabilities
-
-### Core Domains (52 API endpoints organized)
-
-#### 1. **Catalog Management** (Products, Materials, Services)
-
-- Products (finished goods): 8 endpoints
-- Materials (raw materials): 8 endpoints
-- Services (external): 8 endpoints
-- Variants (SKU-level): 8 endpoints
-- BOMs (recipes): 7 endpoints
-
-#### 2. **Inventory Operations**
-
-- Inventory levels: 7 endpoints
-- Stock adjustments: 6 endpoints
-- Stock transfers: 7 endpoints
-- Stocktakes (counts): 6 endpoints
-- Batches & serial numbers: 10 endpoints
-- Storage bins & locations: 9 endpoints
-
-#### 3. **Order Management**
-
-- Sales orders: 9 endpoints
-- Purchase orders: 8 endpoints
-- Manufacturing orders: 10 endpoints
-- Sales returns: 8 endpoints
-- Order fulfillments: 7 endpoints
-
-#### 4. **Business Relations**
-
-- Customers: 6 endpoints
-- Suppliers: 6 endpoints
-- Addresses: 12 endpoints
-
-#### 5. **Configuration & Admin**
-
-- Price lists: 22 endpoints
-- Tax rates: 4 endpoints
-- Custom fields: 3 endpoints
-- Webhooks: 8 endpoints
-- Users: 3 endpoints
-- Factories & locations: 8 endpoints
-
-### Manufacturing Workflow Patterns
+## Layered structure
 
 ```
-┌────────────────────────────────────────────────────────────────┐
-│                    MANUFACTURING WORKFLOW                       │
-└────────────────────────────────────────────────────────────────┘
-
-1. CATALOG SETUP
-   ├─ Create products with variants
-   ├─ Define materials and BOMs
-   └─ Set up suppliers and pricing
-
-2. SALES PROCESS
-   ├─ Receive sales order
-   ├─ Check inventory availability
-   ├─ Create manufacturing orders if needed
-   └─ Fulfill and ship
-
-3. PROCUREMENT
-   ├─ Monitor low stock
-   ├─ Create purchase orders
-   ├─ Receive and inspect goods
-   └─ Update inventory
-
-4. PRODUCTION
-   ├─ Schedule manufacturing orders
-   ├─ Allocate materials
-   ├─ Track production progress
-   ├─ Perform quality checks
-   └─ Complete and stock finished goods
-
-5. INVENTORY MANAGEMENT
-   ├─ Track stock levels
-   ├─ Perform stock counts
-   ├─ Transfer between locations
-   └─ Adjust for discrepancies
+┌────────────────────────────────────────────────────────────┐
+│  FastMCP entry (server.py)                                 │
+│   - registers tools / resources / prompts                  │
+│   - hot-reload + HTTP/STDIO transports                     │
+├────────────────────────────────────────────────────────────┤
+│  Tools           Resources         Prompts                 │
+│  tools/          resources/        prompts/                │
+│   foundation/     help.py           workflows.py           │
+│   workflows/      inventory.py                             │
+│                   reference.py                             │
+├────────────────────────────────────────────────────────────┤
+│  Services / dependencies (services/dependencies.py)        │
+│   get_services(context) → KatanaClient + caches            │
+├────────────────────────────────────────────────────────────┤
+│  Caches (two, by design — see ADR-0018)                    │
+│   CatalogCache (cache.py)       — reference entities       │
+│   TypedCacheEngine (typed_cache/) — transactional entities │
+├────────────────────────────────────────────────────────────┤
+│  KatanaClient (katana_public_api_client)                   │
+│   - transport-layer resilience                             │
+│   - generated attrs request/response models                │
+│   - generated pydantic models + Cached<Entity> siblings    │
+└────────────────────────────────────────────────────────────┘
 ```
 
-______________________________________________________________________
+## Tools
 
-## Proposed MCP Architecture
+Tools live under `katana_mcp/tools/` and split into two sublayers:
 
-### High-Level Structure
+- **Foundation tools** (`tools/foundation/`) — thin, single-purpose tools organized by
+  Katana domain: `catalog.py`, `customers.py`, `inventory.py`, `items.py`,
+  `manufacturing_orders.py`, `orders.py`, `purchase_orders.py`, `reporting.py`,
+  `sales_orders.py`, `stock_transfers.py`. Each module exposes the `get_*` / `list_*` /
+  `create_*` / `update_*` operations for its domain and follows the conventions in
+  [ADR-0016](adr/0016-tool-interface-pattern.md) and
+  [ADR-0019](adr/0019-tool-description-batch-conventions.md).
+- **Workflows** (`tools/workflows/`) — a planned extension layer for future multi-step
+  compositions built on top of foundation tools. This directory is currently a stub:
+  `register_all_workflow_tools` is a no-op and there are no concrete workflow tool
+  modules yet. Add fulfilment / production-planning examples here only once real
+  workflow tools exist.
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    KATANA MCP SERVER                         │
-├─────────────────────────────────────────────────────────────┤
-│                                                              │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
-│  │    TOOLS     │  │  RESOURCES   │  │   PROMPTS    │      │
-│  │              │  │              │  │              │      │
-│  │ • Inventory  │  │ • Dashboard  │  │ • Workflows  │      │
-│  │ • Orders     │  │ • Reports    │  │ • Templates  │      │
-│  │ • Production │  │ • Analytics  │  │ • Guides     │      │
-│  │ • Catalog    │  │ • Insights   │  │              │      │
-│  └──────────────┘  └──────────────┘  └──────────────┘      │
-│                                                              │
-├─────────────────────────────────────────────────────────────┤
-│                   DOMAIN MODELS LAYER                        │
-│  KatanaVariant • KatanaProduct • KatanaMaterial             │
-│  KatanaSalesOrder • KatanaPurchaseOrder • KatanaMO          │
-├─────────────────────────────────────────────────────────────┤
-│                   RESILIENT CLIENT                           │
-│  • Automatic retries  • Rate limiting  • Pagination         │
-│  • Circuit breakers   • Caching        • Error handling     │
-├─────────────────────────────────────────────────────────────┤
-│                   KATANA API (76+ endpoints)                 │
-└─────────────────────────────────────────────────────────────┘
-```
+### Tool interface pattern (ADR-0016)
 
-### Tool Categories (20-25 tools total)
+Each tool is built around a pydantic `Request` model + `Response` model and an async
+`_impl` function. The `@unpack_pydantic_params` decorator from `katana_mcp/unpack.py`,
+combined with the `Unpack` marker on `Annotated[Request, Unpack()]`, unpacks Request
+fields into named MCP parameters so the JSON schema exposed to the AI matches the model
+— without giving up the structured validation pydantic provides.
 
-#### A. Inventory & Catalog (7-8 tools)
+State-changing tools (`create_*`, `update_*`, `delete_*`, `fulfill_*`, …) use
+elicitation: the first call returns a preview, and the AI must confirm explicitly before
+mutation. See [ADR-0016 §4](adr/0016-tool-interface-pattern.md).
 
-1. `search_products` - Find products/materials/services
-1. `get_variant_details` - Get full variant info with stock
-1. `check_stock_levels` - Check availability across locations
-1. `list_low_stock` - Find items needing reorder
-1. `adjust_stock` - Manual stock adjustments
-1. `transfer_stock` - Move between locations
-1. `search_batches` - Find by batch/serial numbers
-1. `get_bom` - Get recipe/bill of materials
+### Batch-field & docstring conventions (ADR-0019)
 
-#### B. Sales Orders (5-6 tools)
+`list_*` tools that accept multiple filter values use the `<entity>_<field>s` naming
+(`product_ids`, not `ids`). `get_*` tools use the singular form. Every tool's docstring
+opens with a one-line "Returns ..." summary so the AI can route from a partial query
+(see [ADR-0019](adr/0019-tool-description-batch-conventions.md)). The
+`resources/help.py` reference resource mirrors these conventions; it must be kept in
+sync when tool surface changes.
 
-1. `create_sales_order` - New customer order
-1. `get_sales_order` - Retrieve order details
-1. `list_sales_orders` - Find orders (filtered)
-1. `update_sales_order_status` - Change status
-1. `fulfill_sales_order` - Mark as shipped
-1. `create_sales_return` - Handle returns
+### Cache-aware decorators
 
-#### C. Purchase Orders (4-5 tools)
+`tools/decorators.py` provides `@cache_read("entity")` and
+`@cache_write("entity_a", "entity_b")` decorators. `cache_read` triggers an incremental
+sync of the named entity before invoking the tool; `cache_write` invalidates the listed
+entities after a mutating call so the next list/get returns fresh data. Tool
+implementations stay focused on business logic; sync orchestration lives in the
+decorator.
 
-1. `create_purchase_order` - Order from supplier
-1. `get_purchase_order` - Retrieve PO details
-1. `list_purchase_orders` - Find POs (filtered)
-1. `receive_purchase_order` - Goods receipt
-1. `update_purchase_order` - Modify existing PO
+## Resources
 
-#### D. Manufacturing Orders (4-5 tools)
+Resources expose read-only context to the AI:
 
-1. `create_manufacturing_order` - Schedule production
-1. `get_manufacturing_order` - Retrieve MO details
-1. `list_manufacturing_orders` - Find MOs (filtered)
-1. `start_manufacturing_order` - Begin production
-1. `complete_manufacturing_order` - Finish and stock
+- `resources/help.py` — tool reference and conventions
+  ([ADR-0019](adr/0019-tool-description-batch-conventions.md))
+- `resources/inventory.py` — current inventory snapshots
+- `resources/reference.py` — Katana taxonomy and lookup tables
 
-#### E. Business Relations (2-3 tools)
+## Prompts
 
-1. `search_customers` - Find customer records
-1. `search_suppliers` - Find supplier records
-1. `get_customer_orders` - Order history
+`prompts/workflows.py` provides templated multi-step prompts for common manufacturing
+workflows (order fulfilment, cycle counting, etc).
 
-### Resource Categories (5-7 resources)
+## Services & dependencies
 
-Resources expose **read-only data** for context.
-
-#### A. Dashboard Resources
-
-1. `katana://dashboard/inventory` - Current inventory summary
-1. `katana://dashboard/orders` - Active orders overview
-1. `katana://dashboard/production` - Manufacturing status
-
-#### B. Report Resources
-
-1. `katana://reports/low-stock` - Items below threshold
-1. `katana://reports/overdue-orders` - Late orders
-1. `katana://reports/production-schedule` - Upcoming MOs
-
-#### C. Analytics Resources
-
-1. `katana://analytics/turnover` - Inventory turnover rates
-1. `katana://analytics/lead-times` - Supplier performance
-
-### Prompt Categories (8-12 prompts)
-
-Prompts provide **templated workflows** for common tasks.
-
-#### A. Inventory Management
-
-1. `inventory_check` - "Check stock and suggest reorders"
-1. `receive_shipment` - "Process incoming goods"
-1. `cycle_count` - "Perform stock count"
-
-#### B. Order Processing
-
-1. `new_sales_order` - "Create and validate new order"
-1. `fulfill_order` - "Pick, pack, ship workflow"
-1. `rush_order` - "Expedite production for urgent order"
-
-#### C. Production Planning
-
-1. `plan_production` - "Schedule MOs based on demand"
-1. `material_requirements` - "Calculate material needs"
-1. `production_start` - "Begin manufacturing process"
-
-#### D. Troubleshooting
-
-1. `investigate_shortage` - "Find cause of stock discrepancy"
-1. `late_order_analysis` - "Diagnose delays"
-1. `quality_issue` - "Handle production defect"
-
-______________________________________________________________________
-
-## Tools Design
-
-### Design Principles for Tools
-
-1. **Clear Single Purpose** - Each tool does one thing well
-1. **Strict Input Validation** - JSON schema with field validation
-1. **Comprehensive Error Handling** - Client/server/external errors
-1. **Idempotency** - Safe to retry (where possible)
-1. **Explicit Confirmation** - For state-changing operations
-1. **Informative Responses** - Include context for next steps
-
-### Tool Template Structure
+`services/dependencies.py` builds the per-request service container. Tools access it
+via:
 
 ```python
-class ToolRequest(BaseModel):
-    """Strictly validated input schema."""
-    field: str = Field(..., description="Clear description", min_length=1)
+from katana_mcp.services import get_services
 
-class ToolResponse(BaseModel):
-    """Structured, informative output."""
-    result: ResultType
-    metadata: dict[str, Any] = Field(default_factory=dict)  # Context
-    next_actions: list[str] = Field(default_factory=list)   # Suggestions
-
-async def tool_impl(request: ToolRequest, context: Context) -> ToolResponse:
-    """Implementation with error handling and logging."""
-    logger.info("tool_started", **request.dict())
-
-    try:
-        # Input validation
-        if not request.field:
-            raise ValueError("Field required")
-
-        # Business logic
-        client = context.request_context.lifespan_context.client
-        result = await client.domain.operation(request.field)
-
-        # Success logging
-        logger.info("tool_completed", result_count=len(result))
-
-        return ToolResponse(
-            result=result,
-            metadata={"source": "katana_api"},
-            next_actions=["Check result", "Take next step"]
-        )
-
-    except ValueError as e:
-        # Client error (4xx)
-        logger.warning("tool_validation_failed", error=str(e))
-        raise
-    except Exception as e:
-        # Server error (5xx)
-        logger.error("tool_failed", error=str(e), exc_info=True)
-        raise
+services = get_services(context)
+client = services.client            # KatanaClient
+catalog_cache = services.cache      # CatalogCache
+typed_cache = services.typed_cache  # TypedCacheEngine
 ```
 
-### Example: Create Sales Order Tool (Enhanced)
-
-```python
-class CreateSalesOrderRequest(BaseModel):
-    """Request to create a new sales order."""
-    customer_id: int = Field(..., description="Customer ID", gt=0)
-    items: list[OrderItem] = Field(..., description="Order line items", min_items=1)
-    notes: str | None = Field(None, description="Optional order notes")
-    priority: Literal["normal", "high", "urgent"] = Field("normal")
-    requested_delivery_date: date | None = None
-
-    # Elicitation: Ask for confirmation before creating
-    confirm: bool = Field(
-        False,
-        description="Set to true to confirm order creation"
-    )
-
-class OrderItem(BaseModel):
-    """Line item in sales order."""
-    variant_id: int = Field(..., gt=0)
-    quantity: float = Field(..., gt=0)
-    unit_price: float | None = None  # Auto-fill from price list
-
-class CreateSalesOrderResponse(BaseModel):
-    """Response with created order details."""
-    order_id: int
-    order_number: str
-    total_amount: float
-    estimated_delivery: date | None
-    manufacturing_required: bool
-    warnings: list[str] = Field(default_factory=list)
-    next_actions: list[str] = Field(default_factory=list)
-
-async def create_sales_order(
-    request: CreateSalesOrderRequest,
-    context: Context
-) -> CreateSalesOrderResponse:
-    """Create a new sales order with validation and confirmation.
-
-    This tool implements best practices:
-    - Input validation (customer exists, items valid)
-    - Stock availability check
-    - Automatic pricing from price lists
-    - Manufacturing requirement detection
-    - Explicit confirmation for creation
-    - Informative warnings and next actions
-    """
-    logger.info("create_sales_order_started", customer_id=request.customer_id)
-
-    client = context.request_context.lifespan_context.client
-
-    # 1. Validate customer exists
-    customer = await client.customers.get(request.customer_id)
-    if not customer:
-        raise ValueError(f"Customer {request.customer_id} not found")
-
-    # 2. Validate items and check stock
-    warnings = []
-    for item in request.items:
-        variant = await client.variants.get(item.variant_id)
-        if not variant:
-            raise ValueError(f"Variant {item.variant_id} not found")
-
-        # Check stock availability
-        stock = await client.inventory.check_stock(variant.sku)
-        if stock.available < item.quantity:
-            warnings.append(
-                f"Insufficient stock for {variant.sku}: "
-                f"need {item.quantity}, have {stock.available}"
-            )
-
-    # 3. Elicitation: Require confirmation if not provided
-    if not request.confirm:
-        # Return preview without creating
-        return CreateSalesOrderResponse(
-            order_id=0,  # Not created yet
-            order_number="PREVIEW",
-            total_amount=0.0,  # Calculate preview
-            estimated_delivery=request.requested_delivery_date,
-            manufacturing_required=len(warnings) > 0,
-            warnings=warnings + [
-                "⚠️ Order not created. Set confirm=true to create."
-            ],
-            next_actions=[
-                "Review warnings",
-                "Set confirm=true to proceed",
-                "Or adjust quantities"
-            ]
-        )
-
-    # 4. Create order
-    order = await client.sales_orders.create(
-        customer_id=request.customer_id,
-        items=[{
-            "variant_id": item.variant_id,
-            "quantity": item.quantity,
-        } for item in request.items],
-        notes=request.notes,
-    )
-
-    logger.info("sales_order_created", order_id=order.id)
-
-    return CreateSalesOrderResponse(
-        order_id=order.id,
-        order_number=order.order_number,
-        total_amount=order.total_amount,
-        estimated_delivery=order.estimated_delivery,
-        manufacturing_required=len(warnings) > 0,
-        warnings=warnings,
-        next_actions=[
-            f"View order: get_sales_order(order_id={order.id})",
-            "Create manufacturing orders if needed",
-            "Process payment",
-        ]
-    )
-```
-
-______________________________________________________________________
-
-## Resources Design
-
-Resources expose **read-only contextual data** that LLMs can reference.
-
-### Design Principles
-
-1. **URI-based addressing** - `katana://domain/resource`
-1. **Cached & efficient** - Don't hit API on every access
-1. **Structured data** - JSON/YAML for easy parsing
-1. **Time-bounded** - Include timestamps, refresh info
-1. **Actionable** - Link to relevant tools
-
-### Example: Inventory Dashboard Resource
-
-```python
-@mcp.resource("katana://dashboard/inventory")
-async def inventory_dashboard(context: Context) -> Resource:
-    """Current inventory status dashboard.
-
-    Provides:
-    - Total SKU count
-    - Low stock items (< threshold)
-    - Out of stock items
-    - Top movers (by turnover)
-    - Slow movers
-    - Stock value
-
-    Refreshes: Every 5 minutes
-    """
-    client = context.request_context.lifespan_context.client
-
-    # Get cached dashboard data
-    dashboard = await client.inventory.get_dashboard(cache_ttl=300)
-
-    return Resource(
-        uri="katana://dashboard/inventory",
-        mimeType="application/json",
-        text=json.dumps({
-            "generated_at": datetime.now().isoformat(),
-            "next_refresh": (datetime.now() + timedelta(minutes=5)).isoformat(),
-            "summary": {
-                "total_skus": dashboard.total_skus,
-                "total_value": dashboard.total_value,
-                "low_stock_count": len(dashboard.low_stock),
-                "out_of_stock_count": len(dashboard.out_of_stock),
-            },
-            "low_stock_items": [
-                {
-                    "sku": item.sku,
-                    "name": item.name,
-                    "current": item.current_stock,
-                    "threshold": item.reorder_point,
-                    "suggested_order_qty": item.economic_order_quantity,
-                }
-                for item in dashboard.low_stock[:10]
-            ],
-            "out_of_stock": [
-                {"sku": item.sku, "name": item.name}
-                for item in dashboard.out_of_stock[:10]
-            ],
-            "next_actions": [
-                "Review low stock items",
-                "Use list_low_stock tool for full list",
-                "Create purchase orders for critical items",
-            ]
-        }, indent=2)
-    )
-```
-
-______________________________________________________________________
-
-## Prompts Design
-
-Prompts guide users through **common workflows** with structured templates.
-
-### Design Principles
-
-1. **Workflow-oriented** - Match real business processes
-1. **Step-by-step** - Clear progression
-1. **Context-aware** - Reference current state
-1. **Interactive** - Elicit clarifications
-1. **Tool-integrated** - Call appropriate tools
-
-### Example: Fulfill Sales Order Workflow
-
-```python
-@mcp.prompt("fulfill_order")
-async def fulfill_order_prompt(context: Context, order_id: int) -> Prompt:
-    """Guide user through order fulfillment process.
-
-    Workflow:
-    1. Retrieve order details
-    2. Check inventory availability
-    3. Allocate stock
-    4. Generate pick list
-    5. Confirm picking
-    6. Generate packing slip
-    7. Confirm shipping
-    8. Update order status
-    """
-    return Prompt(
-        name="fulfill_order",
-        description=f"Fulfill sales order #{order_id}",
-        messages=[
-            PromptMessage(
-                role="user",
-                content=f"""I need to fulfill sales order #{order_id}.
-
-Please help me through the process:
-
-1. First, show me the order details and check if we have sufficient stock
-2. If stock is available, generate a pick list
-3. After I confirm picking, generate a packing slip
-4. Finally, mark the order as shipped
-
-Let's start by retrieving the order."""
-            ),
-            PromptMessage(
-                role="assistant",
-                content=f"""I'll help you fulfill order #{order_id}. Let me start by retrieving the order details and checking stock availability.
-
-{{% call_tool name="get_sales_order" args={{"order_id": {order_id}}} %}}"""
-            )
-        ]
-    )
-```
-
-______________________________________________________________________
-
-## Security & Production Readiness
-
-### Security Layers
-
-#### 1. Network Isolation
-
-```python
-# Bind to localhost only
-server.bind("127.0.0.1", 8080)
-```
-
-#### 2. Authentication
-
-```python
-# API key from environment
-api_key = os.getenv("KATANA_API_KEY")
-if not api_key:
-    raise ValueError("KATANA_API_KEY required")
-```
-
-#### 3. Authorization
-
-```python
-# Tool-level permissions (future)
-@mcp.tool(requires_permission="inventory:write")
-async def adjust_stock(...):
-    pass
-```
-
-#### 4. Input Validation
-
-```python
-# Pydantic strict mode
-class StrictRequest(BaseModel):
-    class Config:
-        extra = "forbid"  # Reject unknown fields
-        str_strip_whitespace = True
-        min_anystr_length = 1
-```
-
-#### 5. Output Sanitization
-
-```python
-# Remove sensitive data
-def sanitize_response(data: dict) -> dict:
-    """Remove API keys, internal IDs, etc."""
-    return {
-        k: v for k, v in data.items()
-        if k not in ["api_key", "internal_id"]
-    }
-```
-
-#### 6. Monitoring
-
-```python
-# Structured logging with security events
-logger.warning(
-    "unauthorized_access_attempt",
-    user=user_id,
-    resource=resource_name,
-    ip=request.ip
-)
-```
-
-### Production Checklist
-
-#### Phase 1: Core Compliance
-
-- [ ] All tools have input validation
-- [ ] All tools have error handling
-- [ ] All tools have structured logging
-- [ ] Health check endpoint implemented
-- [ ] Configuration validated at startup
-
-#### Phase 2: Security
-
-- [ ] Network isolation configured
-- [ ] API key validation
-- [ ] Input sanitization
-- [ ] Output sanitization
-- [ ] Rate limiting per client
-
-#### Phase 3: Performance
-
-- [ ] Connection pooling (5-20 connections)
-- [ ] Multi-level caching (memory, Redis)
-- [ ] Async processing for long operations
-- [ ] Resource limits configured
-
-#### Phase 4: Observability
-
-- [ ] Prometheus metrics exported
-- [ ] Structured JSON logging
-- [ ] Request tracing with trace IDs
-- [ ] Error alerting configured
-- [ ] Performance dashboards
-
-#### Phase 5: Reliability
-
-- [ ] Circuit breakers on external calls
-- [ ] Graceful degradation modes
-- [ ] Health checks for dependencies
-- [ ] Rolling deployment strategy
-- [ ] Horizontal autoscaling
-
-______________________________________________________________________
-
-## Implementation Phases
-
-### Phase 1: Foundation (Week 1-2)
-
-**Goal**: Core tools with production patterns
-
-#### Deliverables
-
-- [ ] Enhanced inventory tools (3 tools)
-  - `search_products` - With caching, ranking
-  - `check_stock_levels` - Multi-location support
-  - `list_low_stock` - With reorder suggestions
-- [ ] Structured logging system
-- [ ] Health check endpoint
-- [ ] Input validation patterns
-- [ ] Error handling framework
-
-#### Success Criteria
-
-- All tools have comprehensive error handling
-- Structured logs capture key events
-- P95 latency < 100ms
-
-### Phase 2: Core Tools (Week 3-4)
-
-**Goal**: Essential order management
-
-#### Deliverables
-
-- [ ] Sales order tools (4 tools)
-  - Create, get, list, fulfill
-- [ ] Purchase order tools (3 tools)
-  - Create, get, receive
-- [ ] Manufacturing order tools (3 tools)
-  - Create, get, list
-- [ ] Elicitation for confirmations
-- [ ] Response metadata & next actions
-
-#### Success Criteria
-
-- End-to-end order workflows functional
-- Confirmation required for state changes
-- All tools return actionable next steps
-
-### Phase 3: Resources & Prompts (Week 5)
-
-**Goal**: Context and guided workflows
-
-#### Deliverables
-
-- [ ] Dashboard resources (3 resources)
-  - Inventory, orders, production
-- [ ] Report resources (2 resources)
-  - Low stock, overdue orders
-- [ ] Workflow prompts (5 prompts)
-  - New order, fulfillment, production
-- [ ] Resource caching layer
-- [ ] Prompt templates
-
-#### Success Criteria
-
-- Resources refresh efficiently (\<1s)
-- Prompts guide complete workflows
-- Users can complete tasks without API knowledge
-
-### Phase 4: Advanced Features (Week 6-7)
-
-**Goal**: Production excellence
-
-#### Deliverables
-
-- [ ] Advanced inventory tools
-  - Stock transfers, adjustments, batch tracking
-- [ ] Analytics resources
-  - Turnover, lead times
-- [ ] Troubleshooting prompts
-  - Shortage investigation, late orders
-- [ ] Performance optimization
-  - Connection pooling, caching
-- [ ] Monitoring & alerting
-
-#### Success Criteria
-
-- > 1000 req/sec throughput
-- \<0.1% error rate
-- Full observability stack
-
-### Phase 5: Polish & Documentation (Week 8)
-
-**Goal**: Production ready
-
-#### Deliverables
-
-- [ ] Comprehensive documentation
-- [ ] Usage examples
-- [ ] Integration tests
-- [ ] Load testing results
-- [ ] Security audit
-- [ ] Deployment guide
-
-#### Success Criteria
-
-- 99.9% availability in staging
-- All use cases documented
-- Security review passed
-
-______________________________________________________________________
-
-## Success Metrics
-
-### User Experience Metrics
-
-| Metric                 | Target   | Rationale                                 |
-| ---------------------- | -------- | ----------------------------------------- |
-| Task Completion Rate   | >90%     | Users successfully complete workflows     |
-| Time to Complete Order | \<2 min  | From order creation to confirmation       |
-| Error Recovery Rate    | >95%     | Users recover from errors without support |
-| Tool Discovery Time    | \<30 sec | Users find the right tool quickly         |
-
-### Technical Metrics
-
-| Metric                | Target  | Rationale            |
-| --------------------- | ------- | -------------------- |
-| API Call Success Rate | >99.5%  | Including retries    |
-| P95 Response Time     | \<100ms | Simple operations    |
-| P99 Response Time     | \<500ms | Complex operations   |
-| Cache Hit Rate        | >80%    | For frequent queries |
-| Availability          | >99.9%  | Production uptime    |
-
-### Business Metrics
-
-| Metric               | Target   | Rationale                   |
-| -------------------- | -------- | --------------------------- |
-| Orders Processed/Day | Baseline | Track adoption              |
-| Automation Rate      | >50%     | LLM completes without human |
-| Support Tickets      | \<5/week | Measure usability           |
-| User Satisfaction    | >4.5/5   | NPS survey                  |
-
-______________________________________________________________________
-
-## Conclusion
-
-This architecture provides:
-
-1. **Comprehensive Coverage** - 20-25 tools covering all major workflows
-1. **Production Ready** - Security, observability, performance
-1. **User Friendly** - Prompts, resources, clear documentation
-1. **Maintainable** - Clean patterns, single responsibility
-1. **Scalable** - Connection pooling, caching, autoscaling
-
-The phased approach allows us to:
-
-- Validate patterns early (Phase 1)
-- Deliver value incrementally (Phase 2-3)
-- Optimize for production (Phase 4)
-- Launch confidently (Phase 5)
-
-**Next Steps**: Review this design, get feedback, and begin Phase 1 implementation.
+Lifespan management (engine open/close, client cleanup) is handled by `server.py`.
+
+## Caches
+
+The MCP server runs **two** complementary caches. They serve different needs and both
+are permanent — neither is a temporary stepping stone toward the other
+([ADR-0018](adr/0018-sqlmodel-typed-cache.md)).
+
+### CatalogCache (`katana_mcp/cache.py`, `cache_sync.py`)
+
+A generic SQLite + FTS5 store for the 10 reference entity types: variants, products,
+materials, services, suppliers, customers, locations, tax rates, operators, factories.
+Every row projects into a three-text-column `entity_index` (name, description, code) for
+cheap full-text search across heterogeneous types. Powers `search_items` and
+`get_variant_details`-style lookup tools.
+
+### TypedCacheEngine (`katana_mcp/typed_cache/`)
+
+SQLModel-backed per-entity tables for transactional types: sales orders, manufacturing
+orders, purchase orders, stock adjustments, stock transfers, manufacturing-order recipe
+rows. Each entity has its own table with proper FK relationships and JSON columns;
+nested rows (sales-order rows, MO recipe rows, …) become child tables with FKs back to
+the parent.
+
+The transactional types' filter shape (status enums, date ranges, customer/ supplier
+IDs, variant-id-via-rows) and 30+-field schemas don't fit `CatalogCache`'s
+three-text-column projection — hence the dedicated typed store.
+
+### EntitySpec — the generic sync driver
+
+A single generic `_ensure_synced(client, cache, spec)` in `typed_cache/sync.py` drives
+every entity's incremental sync. Each entity has a frozen `EntitySpec` dataclass that
+wires together:
+
+- the **entity key** (used for the per-entity sync lock and `SyncState` row)
+- the **API endpoint** module (`get_all_*` / `find_*`) to call
+- the **cache row class** (`Cached<Entity>`) and the **API pydantic class** (the
+  `from_attrs` intermediary)
+- optional **child-rows configuration** (child class, parent-side rows field, FK field)
+  for entities with nested rows
+- an optional **pydantic_resolver** callback for discriminated unions (purchase orders
+  pick `RegularPurchaseOrder` vs `OutsourcedPurchaseOrder` per row)
+
+Public `ensure_<entity>_synced(client, cache)` functions are thin wrappers over
+`_ensure_synced` so callers and tests stay terse.
+
+The generic driver replaced six near-identical hand-rolled sync helpers — the original
+duplication was a source of silent-desync bugs whenever a typo slipped through one
+entity's lock-key string. New transactional entities are now added by writing one
+`EntitySpec` literal.
+
+### Generated `Cached<Entity>` classes
+
+The `Cached<Entity>` and `Cached<Entity>Row` classes consumed by the typed cache are
+**auto-generated** by `scripts/generate_pydantic_models.py` from the same OpenAPI spec
+that produces the API attrs/pydantic classes. They sit alongside the API pydantic
+classes in `katana_public_api_client/models_pydantic/_generated/` and inherit
+`table=True`, FKs, and JSON columns via the generator's
+`duplicate_cache_tables_as_cached_siblings` pass.
+
+The contract is one-directional: API pydantic stays a clean wire-shape mirror; cache
+concerns (FKs, JSON storage, cache-only fields) live exclusively on the `Cached<Entity>`
+siblings. **Never** add a cache-only field to the OpenAPI spec or to an API pydantic
+class — it pollutes the published client package for third-party users (see CLAUDE.md
+"polluting the API spec/models").
+
+## Client integration
+
+The MCP server depends on
+[`katana-openapi-client`](../../katana_public_api_client/docs/README.md) as a published
+package. All HTTP behavior — retries, rate limiting, smart pagination, observability
+hooks — lives in that client's transport layer (see
+[client ADR-0001](../../katana_public_api_client/docs/adr/0001-transport-layer-resilience.md)).
+The MCP server treats the client as a black box and **must not** wrap API methods with
+its own retry / rate-limit / pagination logic; doing so double-applies behavior and can
+introduce subtle desync between layers.
+
+When a bug surfaces in the MCP server but originates in client-generated code (attrs,
+pydantic, `from_attrs`, generator output), fix it at the client/generator layer. The
+client is consumed by third-party users — they hit the same bugs (see CLAUDE.md "Fix
+bugs at the client/generator layer").
+
+## Adding a new tool
+
+1. **Decide foundation vs workflow.** A direct one-shot Katana operation is a foundation
+   tool; a multi-step orchestration is a workflow.
+1. **Pick the existing module by Katana domain** (`catalog.py`,
+   `manufacturing_orders.py`, etc.) — don't create a new module unless the domain
+   genuinely doesn't fit any existing one.
+1. **Follow ADR-0016** for the request/response shape and the `Unpack` decorator
+   integration; use elicitation for any state-changing operation.
+1. **Follow ADR-0019** for naming (`<entity>_<field>s` for batch list filters, singular
+   for `get_*`) and the docstring opening sentence.
+1. **If the tool reads from cache,** add `@cache_read("entity")`. If it writes, add
+   `@cache_write("entity_a", "entity_b")` listing every entity whose cache should be
+   invalidated.
+1. **For new transactional list tools backed by typed cache:** add an `EntitySpec`
+   literal in `typed_cache/sync.py` and a thin `ensure_<entity>_synced` wrapper. The
+   `Cached<Entity>` row class is auto-generated from the spec by the next regen.
+1. **Update `resources/help.py`** to mirror the new tool's surface (per
+   [ADR-0019 §4](adr/0019-tool-description-batch-conventions.md)).
+1. **Add tests:** unit tests for the request/response shape; integration tests if cache
+   sync is involved.
+
+## References
+
+- [ADR-0010](adr/0010-katana-mcp-server.md) — original MCP server scope
+- [ADR-0016](adr/0016-tool-interface-pattern.md) — tool interface pattern
+- [ADR-0017](adr/0017-automated-tool-documentation.md) — automated tool documentation
+- [ADR-0018](adr/0018-sqlmodel-typed-cache.md) — SQLModel typed cache
+- [ADR-0019](adr/0019-tool-description-batch-conventions.md) — tool description and
+  batch-field conventions
+- [Client ADR-0001](../../katana_public_api_client/docs/adr/0001-transport-layer-resilience.md)
+  — transport-layer resilience pattern
+- [CLAUDE.md](../../CLAUDE.md) — repo-level conventions for AI assistants
+- [Development guide](development.md) — local hot-reload workflow
+- [Deployment guide](deployment.md) — production deployment
+
+## What this doc replaced
+
+A previous 868-line "Comprehensive Architecture Design" (Oct 2025) drafted the server
+before any of it was implemented. It mixed real best-practice notes with hypothetical
+pseudo-code tools and a week-by-week implementation schedule, none of which match the
+current shape. That document is preserved in git history; the canonical architecture
+description is this file plus the ADRs.

--- a/katana_mcp_server/src/katana_mcp/services/dependencies.py
+++ b/katana_mcp_server/src/katana_mcp/services/dependencies.py
@@ -22,12 +22,18 @@ class Services:
     the lifespan function in server.py) and returned by get_services().
 
     Attributes:
-        client: The KatanaClient instance for API operations
-        cache: Persistent SQLite catalog cache with FTS5 search (legacy,
-            holds reference entity types; retires per-entity during #342).
-        typed_cache: SQLModel-backed cache for transactional list tools
-            (sales orders first; see #342). Coexists with ``cache`` until
-            the reference-entity migration epic completes.
+        client: The KatanaClient instance for API operations.
+        cache: ``CatalogCache`` — SQLite + FTS5 store for the 10 reference
+            entity types (variants, products, materials, services, suppliers,
+            customers, locations, tax rates, operators, factories). Powers
+            ``search_items`` and ``get_variant_details``-style lookups.
+        typed_cache: ``TypedCacheEngine`` — SQLModel-backed per-entity tables
+            for transactional types (sales orders, manufacturing orders,
+            purchase orders, stock adjustments/transfers, MO recipe rows).
+            Powers cache-backed ``list_*`` tools.
+
+    Both caches are permanent and complementary; see ADR-0018 and the
+    ``katana_mcp.typed_cache`` package docstring for the rationale.
     """
 
     client: KatanaClient


### PR DESCRIPTION
Closes #401 (Phase 2 PR C — final Phase 2 PR).

The previous 868-line *Comprehensive Architecture Design* was an aspirational, pre-implementation draft from October 2025. It mixed real best-practice notes with hypothetical pseudo-code tools and a week-by-week schedule, none of which match the current shape of the server. With the post-#342 typed cache landed, the EntitySpec sync refactor done, and the foundation/workflow tool split established, the doc had drifted far enough that "delete and rewrite" was clearer than "edit in place."

## Replacement (250 lines)

A focused description of the architecture that exists today:

- **Layered diagram** — FastMCP entry → tools (foundation + workflows) → resources / prompts → services / dependencies → dual caches → KatanaClient
- **Tools** — foundation modules organized by Katana domain; ADR-0016 request/response + `Unpack` pattern; ADR-0019 batch-field naming + docstring opener; cache-aware `@cache_read` / `@cache_write` decorators
- **Resources & prompts** — the actual files in tree
- **Services** — `get_services(context)` wiring
- **Caches** — the two-cache split per ADR-0018, with a dedicated section on the `EntitySpec` generic sync driver in `typed_cache/sync.py`
- **Generated `Cached<Entity>` classes** — sourced from `scripts/generate_pydantic_models.py`, plus the cross-link to CLAUDE.md's "don't pollute the API spec for cache-only fields" rule
- **Client integration** — transport-layer resilience boundary; "fix bugs at the client layer when the root cause lives there" rule
- **Adding a new tool** — short checklist that lands on the right ADRs

The doc points at ADRs (-0010, -0016, -0017, -0018, -0019, client -0001) rather than re-explaining the rationale.

## Bonus fix

`services/dependencies.py` Services dataclass docstring still described the catalog cache as *legacy* / *retires per-entity during #342*. That framing was correct mid-#342 but obsolete now — both caches are permanent and complementary (mirrors the same fix already applied to the `typed_cache` package docstring in #417). Updated to point at ADR-0018 as the canonical source.

## Test plan

- [x] \`uv run poe agent-check\` — format / lint / type-check clean
- [x] \`uv run poe test\` — 2,452 passed
- [x] Spot-checked claims against the codebase: \`Unpack\` location, \`services/dependencies.py\` shape, \`EntitySpec\` definition, foundation tool modules, cache file paths
- [x] All ADR cross-references resolve to existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)