### PR TITLE
refactor(mcp): collapse coerce-list field annotations behind type aliases

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -14,11 +14,11 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, Field
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
-from katana_mcp.tools.list_coercion import coerce_str_list_input
+from katana_mcp.tools.list_coercion import CoercedIntListOpt, CoercedStrIntList
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
@@ -43,9 +43,7 @@ logger = get_logger(__name__)
 class CheckInventoryRequest(BaseModel):
     """Request model for checking inventory."""
 
-    skus_or_variant_ids: Annotated[
-        list[str | int], BeforeValidator(coerce_str_list_input)
-    ] = Field(
+    skus_or_variant_ids: CoercedStrIntList = Field(
         ...,
         min_length=1,
         description=(
@@ -861,7 +859,7 @@ class ListStockAdjustmentsRequest(BaseModel):
         ),
     )
     location_id: int | None = Field(default=None, description="Filter by location ID")
-    ids: Annotated[list[int] | None, BeforeValidator(coerce_str_list_input)] = Field(
+    ids: CoercedIntListOpt = Field(
         default=None,
         description=(
             "Restrict to a specific set of stock adjustment IDs. "

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -12,13 +12,13 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, Field
 
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.decorators import cache_read
-from katana_mcp.tools.list_coercion import coerce_str_list_input
+from katana_mcp.tools.list_coercion import CoercedIntListOpt, CoercedStrListOpt
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
     format_md_table,
@@ -748,9 +748,7 @@ class UpdateItemRequest(BaseModel):
         None,
         description="SKU to identify which variant to update (uses first variant if omitted)",
     )
-    supplier_item_codes: Annotated[
-        list[str] | None, BeforeValidator(coerce_str_list_input)
-    ] = Field(
+    supplier_item_codes: CoercedStrListOpt = Field(
         default=None,
         description=(
             'JSON array of supplier item codes, e.g. ["10654627", "10654628"]. '
@@ -1043,20 +1041,16 @@ class GetVariantDetailsRequest(BaseModel):
         default=None,
         description="Single variant ID to look up directly",
     )
-    skus: Annotated[list[str] | None, BeforeValidator(coerce_str_list_input)] = Field(
+    skus: CoercedStrListOpt = Field(
         default=None,
         description=(
             'Batch lookup: JSON array of SKUs, e.g. ["WS74001", "WS74002"]. '
             "Each SKU is matched case-insensitively."
         ),
     )
-    variant_ids: Annotated[list[int] | None, BeforeValidator(coerce_str_list_input)] = (
-        Field(
-            default=None,
-            description=(
-                "Batch lookup: JSON array of variant IDs, e.g. [12345, 67890]."
-            ),
-        )
+    variant_ids: CoercedIntListOpt = Field(
+        default=None,
+        description="Batch lookup: JSON array of variant IDs, e.g. [12345, 67890].",
     )
     format: Literal["markdown", "json"] = Field(
         default="markdown",

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -15,12 +15,12 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, Field
 
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
-from katana_mcp.tools.list_coercion import coerce_str_list_input
+from katana_mcp.tools.list_coercion import CoercedIntList, CoercedIntListOpt
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
@@ -1568,9 +1568,7 @@ class VariantSpec(BaseModel):
 class VariantReplacement(BaseModel):
     """Replace a variant across multiple MOs with one or more new components."""
 
-    manufacturing_order_ids: Annotated[
-        list[int], BeforeValidator(coerce_str_list_input)
-    ] = Field(
+    manufacturing_order_ids: CoercedIntList = Field(
         ...,
         min_length=1,
         description=(
@@ -1599,11 +1597,9 @@ class ExplicitChange(BaseModel):
     """Explicit per-MO list of row deletions and additions."""
 
     manufacturing_order_id: int
-    remove_row_ids: Annotated[list[int], BeforeValidator(coerce_str_list_input)] = (
-        Field(
-            default_factory=list,
-            description="JSON array of recipe row IDs to delete, e.g. [42, 87].",
-        )
+    remove_row_ids: CoercedIntList = Field(
+        default_factory=list,
+        description="JSON array of recipe row IDs to delete, e.g. [42, 87].",
     )
     add_variants: list[VariantSpec] = Field(default_factory=list)
 
@@ -2119,7 +2115,7 @@ class ListManufacturingOrdersRequest(BaseModel):
     )
 
     # Domain filters
-    ids: Annotated[list[int] | None, BeforeValidator(coerce_str_list_input)] = Field(
+    ids: CoercedIntListOpt = Field(
         default=None,
         description=(
             "Filter by explicit list of manufacturing order IDs. "

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -17,11 +17,11 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, Field
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
-from katana_mcp.tools.list_coercion import coerce_str_list_input
+from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
@@ -1600,7 +1600,7 @@ class ListPurchaseOrdersRequest(BaseModel):
     )
 
     # Domain filters
-    ids: Annotated[list[int] | None, BeforeValidator(coerce_str_list_input)] = Field(
+    ids: CoercedIntListOpt = Field(
         default=None,
         description=(
             "Filter by explicit list of purchase order IDs. "

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -44,13 +44,13 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, Field
 
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.decorators import cache_read
-from katana_mcp.tools.list_coercion import coerce_str_list_input
+from katana_mcp.tools.list_coercion import CoercedStrIntListOpt
 from katana_mcp.tools.tool_result_utils import (
     apply_date_window_filters,
     format_md_table,
@@ -645,9 +645,7 @@ class InventoryVelocityRequest(BaseModel):
         default=None,
         description=("SKU (string) or variant_id (int) to analyze. Single-item shape."),
     )
-    sku_or_variant_ids: Annotated[
-        list[str | int] | None, BeforeValidator(coerce_str_list_input)
-    ] = Field(
+    sku_or_variant_ids: CoercedStrIntListOpt = Field(
         default=None,
         description=(
             "Batch shape: JSON array of SKUs (strings) and/or variant IDs (integers), "

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -14,12 +14,12 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, Field
 
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
-from katana_mcp.tools.list_coercion import coerce_str_list_input
+from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.schemas import ConfirmationResult, require_confirmation
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
@@ -378,7 +378,7 @@ class ListSalesOrdersRequest(BaseModel):
 
     # Domain filters
     order_no: str | None = Field(default=None, description="Filter by exact order_no")
-    ids: Annotated[list[int] | None, BeforeValidator(coerce_str_list_input)] = Field(
+    ids: CoercedIntListOpt = Field(
         default=None,
         description=(
             "Filter by explicit list of sales order IDs. "

--- a/katana_mcp_server/src/katana_mcp/tools/list_coercion.py
+++ b/katana_mcp_server/src/katana_mcp/tools/list_coercion.py
@@ -11,15 +11,18 @@ When this happens, pydantic raises ``Input should be a valid list
 to retry. The recovery is mechanical and lossless — split on commas (or
 parse as JSON), strip whitespace, hand pydantic a real list. So we do it.
 
-Usage on a request-model field::
+Usage on a request-model field — prefer the prebuilt aliases::
 
-    from typing import Annotated
-    from pydantic import BeforeValidator, Field
-    from katana_mcp.tools.list_coercion import coerce_str_list_input
+    from pydantic import Field
+    from katana_mcp.tools.list_coercion import CoercedStrListOpt
 
-    skus: Annotated[
-        list[str] | None, BeforeValidator(coerce_str_list_input)
-    ] = Field(default=None, description="Batch: list of SKUs to look up")
+    skus: CoercedStrListOpt = Field(
+        default=None, description="Batch: list of SKUs to look up"
+    )
+
+Required (non-Optional) variants and the heterogeneous ``str | int`` shape
+have aliases too — see below. Use the raw ``coerce_str_list_input``
+validator directly only for one-off types that don't fit the aliases.
 
 Apply only to **LLM-facing** request-model fields. Internal/response-side
 list fields don't need it — pydantic-on-pydantic round-trips already use
@@ -29,7 +32,9 @@ real lists.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Annotated, Any
+
+from pydantic import BeforeValidator
 
 
 def coerce_str_list_input(value: Any) -> Any:
@@ -60,3 +65,18 @@ def coerce_str_list_input(value: Any) -> Any:
 
     # Fall back to CSV: split, strip, drop empty fragments.
     return [item.strip() for item in s.split(",") if item.strip()]
+
+
+# Type aliases — collapse the per-field
+# ``Annotated[list[X] | None, BeforeValidator(coerce_str_list_input)]`` boilerplate
+# into a single readable token at the call site. ``Opt`` suffix marks the
+# Optional/None-default variant; bare names are required (non-Optional).
+
+CoercedStrList = Annotated[list[str], BeforeValidator(coerce_str_list_input)]
+CoercedStrListOpt = Annotated[list[str] | None, BeforeValidator(coerce_str_list_input)]
+CoercedIntList = Annotated[list[int], BeforeValidator(coerce_str_list_input)]
+CoercedIntListOpt = Annotated[list[int] | None, BeforeValidator(coerce_str_list_input)]
+CoercedStrIntList = Annotated[list[str | int], BeforeValidator(coerce_str_list_input)]
+CoercedStrIntListOpt = Annotated[
+    list[str | int] | None, BeforeValidator(coerce_str_list_input)
+]

--- a/katana_mcp_server/tests/tools/test_list_coercion.py
+++ b/katana_mcp_server/tests/tools/test_list_coercion.py
@@ -14,22 +14,26 @@ Both should now recover transparently without losing data.
 
 from __future__ import annotations
 
-from typing import Annotated
-
 import pytest
-from katana_mcp.tools.list_coercion import coerce_str_list_input
-from pydantic import BaseModel, BeforeValidator, Field, ValidationError
+from katana_mcp.tools.list_coercion import (
+    CoercedIntListOpt,
+    CoercedStrIntList,
+    CoercedStrListOpt,
+)
+from pydantic import BaseModel, Field, ValidationError
 
 
 class _RequestStub(BaseModel):
     """Mimics the shape of an LLM-facing request-model field."""
 
-    skus: Annotated[list[str] | None, BeforeValidator(coerce_str_list_input)] = Field(
-        default=None
-    )
-    ids: Annotated[list[int] | None, BeforeValidator(coerce_str_list_input)] = Field(
-        default=None
-    )
+    skus: CoercedStrListOpt = Field(default=None)
+    ids: CoercedIntListOpt = Field(default=None)
+    # Stub of a ``CoercedStrIntList`` (mixed str|int list, required-typed)
+    # so the mixed-type tests below can exercise the alias. Uses
+    # ``default_factory`` so ``_build()`` can omit it. The empty-string +
+    # ``min_length`` interaction is covered separately via an inline model
+    # in ``test_empty_string_plus_min_length_one_raises_min_length_error``.
+    required_mixed: CoercedStrIntList = Field(default_factory=list)
 
 
 def _build(**kwargs: object) -> _RequestStub:
@@ -110,3 +114,44 @@ def test_int_input_for_int_list_raises_normal_pydantic_error():
 def test_single_value_string_no_comma_yields_one_item_list():
     # ``skus="WS74001"`` is the LLM's most innocent form of the bug.
     assert _build(skus="WS74001").skus == ["WS74001"]
+
+
+def test_mixed_type_list_passthrough():
+    # The CoercedStrIntList alias accepts mixed input types — pydantic
+    # validates each element against ``str | int``.
+    req = _build(required_mixed=["WS74001", 12345, "WS74002"])
+    assert req.required_mixed == ["WS74001", 12345, "WS74002"]
+
+
+def test_csv_with_numeric_items_for_str_int_list_keeps_strings():
+    # CSV path returns strings; pydantic's ``str | int`` union accepts both.
+    # Numeric-looking pieces stay as the type pydantic picks (str on the
+    # left wins for ``str | int``).
+    req = _build(required_mixed="WS74001,12345")
+    assert req.required_mixed == ["WS74001", "12345"]
+
+
+def test_empty_string_plus_min_length_one_raises_min_length_error():
+    """Empty string coerces to ``[]``, so a field with ``min_length=1``
+    raises a ``too_short`` error rather than the original ``list_type``
+    error. Documents the resulting UX so a future contributor doesn't
+    accidentally regress to the old shape.
+    """
+
+    class _Req(BaseModel):
+        skus: CoercedStrListOpt = Field(default=None, min_length=1)
+
+    with pytest.raises(ValidationError) as exc_info:
+        _Req.model_validate({"skus": ""})
+
+    errors = exc_info.value.errors()
+    assert errors[0]["type"] == "too_short"
+
+
+def test_non_numeric_string_for_int_list_raises_pydantic_error():
+    # CSV split yields ``["WS74001"]``; pydantic can't coerce that to int.
+    # The error is per-item, not on the list shape — useful diagnostic.
+    with pytest.raises(ValidationError) as exc_info:
+        _build(ids="WS74001")
+    errors = exc_info.value.errors()
+    assert errors[0]["type"] == "int_parsing"

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.44.0"
+version = "0.44.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Polish PR for the list-coercion feature shipped in `mcp-v0.44.1` (commit `30f3fd86`). The original work landed straight on main without review due to a `git push` mishap; we ran three review agents on the commit ourselves to claw back the review value, and this PR addresses their findings.

## Findings addressed

**Reuse — collapse repeated boilerplate.** The phrase `Annotated[list[int] | None, BeforeValidator(coerce_str_list_input)]` repeated verbatim 11 times across 6 tool files. Adds six prebuilt aliases in `list_coercion.py`:

- `CoercedStrList` / `CoercedStrListOpt`
- `CoercedIntList` / `CoercedIntListOpt`
- `CoercedStrIntList` / `CoercedStrIntListOpt`

Refactors the 11 sites to use the appropriate alias. Each per-field declaration goes from three lines of type-noise to a single token:

```diff
- ids: Annotated[list[int] | None, BeforeValidator(coerce_str_list_input)] = Field(
-     default=None,
-     description="Filter by explicit list of purchase order IDs. ..."
- )
+ ids: CoercedIntListOpt = Field(
+     default=None,
+     description="Filter by explicit list of purchase order IDs. ..."
+ )
```

**Quality — uncovered edge cases.** Adds four tests:

- Mixed-type list passthrough (`["WS74001", 12345]` for `list[str | int]`)
- CSV with numeric items for `list[str | int]` (left-side `str` of the union wins)
- Empty string + `min_length=1` interaction → raises `too_short`, not `list_type` (documents the UX so a future contributor can't accidentally regress)
- Non-numeric string for `list[int]` → per-item `int_parsing` error (useful diagnostic)

**Efficiency — clean.** No changes warranted; the validator already short-circuits non-strings, gates JSON parsing on a leading `[`, and pydantic builds the schema once at import time.

## Files changed

- `katana_mcp_server/src/katana_mcp/tools/list_coercion.py` — adds six type aliases (~10 LoC)
- 6 tool files (`items.py`, `inventory.py`, `manufacturing_orders.py`, `purchase_orders.py`, `sales_orders.py`, `reporting.py`) — replace verbose `Annotated[...]` declarations with the new aliases
- `katana_mcp_server/tests/tools/test_list_coercion.py` — adds 4 tests; updates the test stub to use the aliases (still 19 tests total, all passing)
- `uv.lock` — reflects 0.44.0 → 0.44.1 from the prior release commit

## Test plan

- [x] `uv run poe check` — all 2,509 tests pass (4 new vs. 2,505 in v0.44.1)
- [ ] Verify behavior unchanged: any existing call site that worked at v0.44.1 still works after this refactor (pure rename + alias)

## Branch-protection note

The reason this PR exists is that `30f3fd86` was force-pushed straight to main when `git push -u origin <branch>` resolved its tracked upstream as `main`. We've added a memory note about always using `git push -u origin HEAD:refs/heads/<name>` for first-time pushes — but the cleaner fix is **branch protection on main** that requires PRs + status checks. Worth adding as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)