### PR TITLE
chore: add pre-push hook blocking direct pushes to main from non-main branches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@
 #
 # See issue #134 for background on why we use local hooks.
 
+# Make `pre-commit install` set up the pre-push hook too. Without this, the
+# pre-push hook would silently not run for contributors who only ran the bare
+# `pre-commit install` from the README. See block-push-to-main below.
+default_install_hook_types: [pre-commit, pre-push]
+
 # Global exclude — Claude Code agent worktrees are parallel git checkouts
 # living under the main repo only for locality. They have their own branches
 # and pre-commit cycles; formatting/linting them from a sibling worktree's
@@ -67,5 +72,19 @@ repos:
         name: pytest
         entry: uv run poe test
         language: system
+        pass_filenames: false
+        always_run: true
+
+      # Refuse pushes that would land non-main commits on the `main` ref.
+      # See CLAUDE.md "Known Pitfalls" — git's tracked-upstream resolution can
+      # silently route `git push -u origin <branch>` to main when the local
+      # branch was created from origin/main. This hook is the only mechanical
+      # guardrail until #429 (GitHub App auth migration) lets us tighten the
+      # ruleset's admin bypass.
+      - id: block-push-to-main
+        name: block direct push to main from a non-main branch
+        entry: scripts/pre-push-guard.sh
+        language: system
+        stages: [pre-push]
         pass_filenames: false
         always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,10 @@ Common mistakes to avoid:
 
 - **Editing generated files** - `api/**/*.py`, `models/**/*.py`, and `client.py` are
   generated. Run `uv run poe regenerate-client` instead of editing them directly.
+
 - **Forgetting pydantic regeneration** - After `uv run poe regenerate-client`, always
   run `uv run poe generate-pydantic` too. They must stay in sync.
+
 - **Generator/schema edits without committing the regen** - Whenever you edit a
   generator script (`scripts/generate_pydantic_models.py`,
   `scripts/regenerate_client.py`) **or** the OpenAPI spec (`docs/katana-openapi.yaml`),
@@ -91,6 +93,7 @@ Common mistakes to avoid:
   [`docs/upstream-specs/README.md`](docs/upstream-specs/README.md)
   (`poe refresh-upstream-spec` → `poe audit-spec` → `poe validate-response-examples` →
   `poe validate-examples`).
+
 - **OpenAPI spec is 3.1 — use 3.1 conventions** - `docs/katana-openapi.yaml` declares
   `openapi: 3.1.0`. Use 3.1 features rather than 3.0 work-arounds. Specifically:
   **`$ref` siblings are legal in 3.1**, so attach property metadata (especially
@@ -98,6 +101,7 @@ Common mistakes to avoid:
   `allOf: [{$ref: ...}]` (the 3.0 idiom — usually unnecessary for new edits here, though
   the spec still has a few legacy cases). Use `allOf` only for real composition
   (combining a `$ref` with additional properties), not as a description-attacher.
+
 - **Property descriptions live at the use-site, not the schema-definition site** - When
   a property references a shared schema via `$ref`, put the property's `description` as
   a sibling of the `$ref` so the description describes the *role of this field on this
@@ -111,22 +115,29 @@ Common mistakes to avoid:
   use-site descriptions are also what surfaces in the generated client's IDE hovertext /
   generated docs. Bare `$ref` drops the description from generated pydantic — avoid
   except when the schema's own description is enough context for every caller (rare).
+
 - **UNSET vs None confusion** - attrs model fields that are unset use a sentinel value,
   not `None`. Use `unwrap_unset(field, default)` from
   `katana_public_api_client.domain.converters`, not `isinstance` or `hasattr` checks.
+
 - **Manual status code checks** - Don't write `if response.status_code == 200`. Use
   `unwrap_as()`, `unwrap_data()`, or `is_success()` from
   `katana_public_api_client.utils`.
+
 - **Wrapping API methods for retries** - Resilience (retries, rate limiting) is at the
   transport layer. All 100+ endpoints get it automatically via `KatanaClient`.
+
 - **Raw list responses in tests** - Katana wraps ALL list responses in
   `{"data": [...]}`. Never define raw arrays in mocks.
+
 - **Help resource drift** - `katana_mcp_server/.../resources/help.py` contains hardcoded
   tool documentation. When adding or modifying tool parameters, also update the help
   resource content to stay in sync.
+
 - **None-to-UNSET conversion** - When building attrs API request models from optional
   fields, use `to_unset(value)` from `katana_public_api_client.domain.converters`
   instead of `value if value is not None else UNSET`.
+
 - **Polluting the API spec/models with cache-only fields** - The OpenAPI spec at
   `docs/katana-openapi.yaml` and the generated pydantic models in
   `katana_public_api_client/models_pydantic/_generated/*.py` reflect Katana's actual
@@ -140,6 +151,7 @@ Common mistakes to avoid:
   the conversion pattern: attrs → API pydantic (via the registry) → cache pydantic (via
   `model_dump`/`model_validate`), with relationship fields set after construction since
   SQLModel `Relationship` descriptors don't accept input via `__init__`.
+
 - **Fix bugs at the client/generator layer when the root cause lives there** - The
   Katana client (`katana_public_api_client`) is a published, standalone package.
   Third-party Python users hit the same bugs we hit in MCP. When a bug surfaces in
@@ -151,6 +163,7 @@ Common mistakes to avoid:
   `_attrs_*_to_cached`. `Column(JSON)` failing to serialize a pydantic instance → fix
   `inject_json_columns` in `scripts/generate_pydantic_models.py`, not `sync.py`. Missing
   enum value → patch spec + regenerate, not enum-tolerant deserialization downstream.
+
 - **List responses must use a `ListResponse` schema with `data` array property** -
   Katana wraps every GET list endpoint in `{"data": [...]}`. If the OpenAPI spec defines
   a 200 response as `type: array`, the generated parser iterates `response.json()`
@@ -161,21 +174,47 @@ Common mistakes to avoid:
   `properties.data: {type: array, items: {$ref: ...}}`) and reference it from the
   operation. The only documented exception is `/user_info`, which returns a flat object,
   not wrapped.
+
 - **Real names and emails from live API responses must never enter the repo** - When
   testing against the live Katana API and incorporating response data into the spec,
   examples, or test fixtures, replace real names/emails with generic placeholders
   (`Jane Doe`, `jane.doe@example.com`, etc.). Privacy concern — real user data from
   production accounts should not be committed.
+
 - **Always call functions with named/keyword arguments** - Use `func(param=value)`, not
   `func(value)`, for all calls — including third-party constructors (especially
   `prefab_ui` components, which only accept keyword args), API methods, and cache
   helpers. Caught by review when positional args caused runtime errors with
   `prefab_ui.Metric`. Explicitness > brevity.
+
 - **Never delete `.claude/worktrees/` directories or their contents** - Other agents may
   be actively working inside them; deleting destroys their in-progress context. If a
   worktree causes downstream issues (e.g., `ty` type checker scanning into it),
   **exclude the path in tool config** — never `rm -rf` the directory. Treat
   `.claude/worktrees/` as off-limits for destructive operations.
+
+- **First push of a feature branch — use `HEAD:refs/heads/<name>`, not bare branch
+  name** - When a local branch was created via `git checkout -b <name> origin/main`, its
+  upstream is set to `origin/main`. A subsequent `git push -u origin <name>` then
+  resolves to its tracked upstream and pushes the local tip **straight to `main`** —
+  bypassing PR review and triggering semantic-release. This actually happened: commit
+  `30f3fd86` reached main + tagged `mcp-v0.44.1` + published to PyPI before we could
+  cancel the pipeline. **Always use the explicit destination ref** for first-time
+  pushes:
+
+  ```bash
+  # Wrong — pushes to whatever the local branch tracks (may be main)
+  git push -u origin chore/foo
+
+  # Right — explicit destination, creates the remote branch
+  git push -u origin HEAD:refs/heads/chore/foo
+  ```
+
+  A `pre-push` hook at `.pre-commit-config.yaml`'s `pre-push` stage enforces this for
+  contributors who run pre-commit; do not bypass with `--no-verify`. The `Protect Main`
+  ruleset has `bypass_mode: always` for the Admin role (required by semantic-release's
+  PAT-based pushes); tightening that bypass is tracked in #429 (GitHub App migration).
+  Until #429 lands, the local hook is the only mechanical guardrail.
 
 ## Using the LSP tool
 

--- a/scripts/pre-push-guard.sh
+++ b/scripts/pre-push-guard.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Pre-push guard: refuse pushes that land non-main commits on the `main` ref.
+#
+# Why this exists: when a feature branch is created via
+#   git checkout -b <name> origin/main
+# git sets the new local branch's upstream to origin/main. A subsequent
+#   git push -u origin <name>
+# resolves <name> to the tracked upstream and pushes straight to main. This
+# actually happened — commit 30f3fd86 reached main and triggered an unintended
+# semantic-release publish before we could cancel the pipeline.
+#
+# pre-commit invokes this with the remote name as $1, the URL as $2, and
+# `<local-ref> <local-sha> <remote-ref> <remote-sha>` lines on stdin.
+#
+# Bypass via --no-verify is forbidden by project policy (see CLAUDE.md). The
+# right form for first-time feature-branch pushes is:
+#   git push -u origin HEAD:refs/heads/<branch-name>
+
+set -euo pipefail
+
+EXIT_CODE=0
+
+while read -r local_ref _local_sha remote_ref _remote_sha; do
+    # Skip deletions (local_ref is empty when a remote ref is being deleted).
+    [ -z "$local_ref" ] && continue
+
+    # Only guard pushes that target main.
+    case "$remote_ref" in
+        refs/heads/main) ;;
+        *) continue ;;
+    esac
+
+    # The local ref-name pushed to main must itself be `main`. Refuse anything else.
+    case "$local_ref" in
+        refs/heads/main) ;;  # ok — main → main is the legitimate path for admins
+        *)
+            local_short="${local_ref#refs/heads/}"
+            cat >&2 <<EOF
+ERROR: refusing to push '$local_short' to remote 'main'.
+
+This is almost always git's tracked-upstream resolution biting you — the
+local branch was probably created via 'git checkout -b $local_short origin/main',
+so its upstream is origin/main and a bare 'git push -u origin $local_short' targets main.
+
+The fix: use an explicit destination ref so the remote branch name matches:
+
+    git push -u origin HEAD:refs/heads/$local_short
+
+If you genuinely need to push to main from a non-main branch (rare), do it
+through a PR. Bypassing this hook with --no-verify is forbidden by project policy
+— see CLAUDE.md 'Known Pitfalls'.
+EOF
+            EXIT_CODE=1
+            ;;
+    esac
+done
+
+exit "$EXIT_CODE"

--- a/scripts/pre-push-guard.sh
+++ b/scripts/pre-push-guard.sh
@@ -32,8 +32,12 @@ while read -r local_ref _local_sha remote_ref _remote_sha; do
 
     # The local ref-name pushed to main must itself be `main`. Refuse anything else.
     case "$local_ref" in
-        refs/heads/main) ;;  # ok — main → main is the legitimate path for admins
-        *)
+        refs/heads/main)
+            # ok — main → main is the legitimate path for admins/release automation
+            ;;
+        refs/heads/*)
+            # Branch other than main → main: the common upstream-tracking mistake.
+            # Suggest the canonical safe form with the actual branch name.
             local_short="${local_ref#refs/heads/}"
             cat >&2 <<EOF
 ERROR: refusing to push '$local_short' to remote 'main'.
@@ -49,6 +53,25 @@ The fix: use an explicit destination ref so the remote branch name matches:
 If you genuinely need to push to main from a non-main branch (rare), do it
 through a PR. Bypassing this hook with --no-verify is forbidden by project policy
 — see CLAUDE.md 'Known Pitfalls'.
+EOF
+            EXIT_CODE=1
+            ;;
+        *)
+            # Detached HEAD push, tag-to-main push, or some other unusual ref shape.
+            # Don't try to construct a branch name from a ref we don't understand —
+            # print a generic safe form instead.
+            cat >&2 <<EOF
+ERROR: refusing to push '$local_ref' to remote 'main'.
+
+The local ref isn't a normal branch (got: $local_ref). Pushes to main from
+anything other than the local 'main' branch are blocked.
+
+If you intended to push your current work to a new feature branch:
+
+    git push -u origin HEAD:refs/heads/<branch-name>
+
+Then open a PR. Bypassing this hook with --no-verify is forbidden by project
+policy — see CLAUDE.md 'Known Pitfalls'.
 EOF
             EXIT_CODE=1
             ;;


### PR DESCRIPTION
## Summary

Adds a mechanical guardrail against the class of mistake that put commit `30f3fd86` on main without a PR earlier this week, immediately triggering semantic-release and publishing `katana-mcp-server==0.44.1` to PyPI before we could cancel the pipeline.

## What happens

- **Hook** `scripts/pre-push-guard.sh` reads the `<local-ref> <local-sha> <remote-ref> <remote-sha>` lines git passes pre-push hooks on stdin, and refuses any push where `remote_ref == refs/heads/main` but `local_ref != refs/heads/main`. Outputs the canonical safe-push form so the contributor isn't left guessing.
- **Registered** in `.pre-commit-config.yaml` at the `pre-push` stage, with `default_install_hook_types: [pre-commit, pre-push]` so existing `uv run pre-commit install` invocations pick it up automatically. No README change needed for new contributors.
- **Documented** in `CLAUDE.md` "Known Pitfalls" with the canonical safe form (`git push -u origin HEAD:refs/heads/<branch-name>`) and a pointer to #429 (the GitHub App migration that lets us tighten ruleset admin bypass).

## Why a hook and not just docs

Docs failed me — the rule was in my session memory and I still mis-typed `git push -u origin <branch>`. Memory and docs work for knowledge gaps; they don't work for muscle-memory mistakes under fatigue. The hook is mechanical: it can't be circumvented without `--no-verify`, which CLAUDE.md already forbids.

## Why we still need this when #429 exists

#429 (migrate publishing workflows to GitHub App auth) is the proper fix — it lets us tighten the `Protect Main` ruleset's admin bypass to `pull_request` mode, which would have rejected `30f3fd86` server-side. Until that lands, the local hook is the only mechanical line of defense.

## Test plan

- [x] Hook tested directly with the four input shapes git passes pre-push hooks:
  - `refs/heads/chore/foo → refs/heads/main` → **rejected** with helpful message ✅
  - `refs/heads/main → refs/heads/main` → allowed (legitimate admin/release path) ✅
  - `refs/heads/chore/foo → refs/heads/chore/foo` → allowed ✅
  - empty local-ref (deletion) → allowed ✅
- [x] `uv run poe check` — all 2,509 tests pass
- [x] This PR's own first push used the safe form (`HEAD:refs/heads/<name>`), so the hook didn't trigger — confirms the canonical form works fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)