### PR TITLE
chore(mcp): use ShowToast for Cancel buttons (drop SendMessage round-trip)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -428,7 +428,10 @@ def build_order_preview_ui(
                 Button(
                     label="Cancel",
                     variant="outline",
-                    on_click=SendMessage(f"Cancel the {order_type.lower()} creation"),
+                    on_click=ShowToast(
+                        message=f"{order_type} creation cancelled",
+                        variant="info",
+                    ),
                 )
     return app
 
@@ -551,7 +554,7 @@ def build_fulfill_preview_ui(
             Button(
                 label="Cancel",
                 variant="outline",
-                on_click=SendMessage("Cancel the fulfillment"),
+                on_click=ShowToast(message="Fulfillment cancelled", variant="info"),
             )
     return app
 
@@ -759,7 +762,7 @@ def build_receipt_ui(
                     Button(
                         label="Cancel",
                         variant="outline",
-                        on_click=SendMessage("Cancel the receipt"),
+                        on_click=ShowToast(message="Receipt cancelled", variant="info"),
                     )
             else:
                 Button(

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.44.1"
+version = "0.45.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Three Cancel buttons in the Prefab preview UIs (`build_order_preview_ui`, `build_fulfill_preview_ui`, `build_receipt_ui`) were sending synthetic user messages through the chat — \`SendMessage(\"Cancel the X creation\")\` — which the LLM would interpret and acknowledge in-chat. Functionally this is a "do nothing" action, but it polluted the conversation with a fake user message and an LLM response.

Swapped to `ShowToast` (client-side only per the `prefab_ui.actions` docs — no server trip, no LLM round-trip, no tool dispatch). User gets visible "Cancelled" feedback in the iframe overlay; the chat stays clean.

Sites:
- `build_order_preview_ui` Cancel → `ShowToast(message=f"{order_type} creation cancelled", variant="info")`
- `build_fulfill_preview_ui` Cancel → `ShowToast(message="Fulfillment cancelled", variant="info")`
- `build_receipt_ui` (preview branch) Cancel → `ShowToast(message="Receipt cancelled", variant="info")`

Follow-up to #436 (the elicitation/CallTool spec-compliance work). Tracked locally as the "Cancel button UX" task; closes that.

## Test plan

- [x] `uv run poe check` passes (2495 tests, 2 environmentally-skipped).
- [ ] Manual smoke in Claude Desktop: open an MO/PO/SO preview, click Cancel — should display a toast and leave chat untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)