### PR TITLE
docs(harness): capture /open-pr push-refspec safety in CLAUDE.md + skill

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -32,6 +32,8 @@ Take a feature branch from "implementation done" to "PR open, CI green, review a
 - **Self-review the full diff** — review every change before opening, not just the latest commit.
 - **Stage specific files** — never `git add -A` or `git add .`.
 - **HEREDOC for messages** — commit messages and PR bodies always use HEREDOC for proper formatting.
+- **Push with the safe refspec, never the bare branch name** — use `git push -u origin HEAD:refs/heads/<branch-name>`, **not** `git push -u origin <branch-name>`. The bare form resolves the destination via the local branch's *upstream*. When a feature branch is created with `git checkout -b <name> origin/main`, its upstream is `origin/main` — and `git push -u origin <name>` then pushes straight to **`main`**, not to a new remote `<name>` ref. This actually happened twice in this repo (commit 30f3fd86 and again during #436 development); the pre-push guard at `scripts/pre-push-guard.sh` exists for this reason but does not fire from worktrees that haven't installed the repo hooks via `uv run pre-commit install`. Always use the explicit-destination form. Same rule applies to subsequent pushes (`git push --force-with-lease` after a rebase).
+- **Prefer `/open-pr` over manual `git push` + `gh pr create`** — never hand-roll the PR-opening flow even when the changes are small. The skill encodes the validate → self-review → push → CI-watch → review-address sequence; manual sequences skip self-review and reopen the push-refspec trap above. If the work isn't yet at a clean tip, run `/pre-commit` or `/verify` first, then `/open-pr`.
 - **File issues for deferred work** — if the self-review identifies out-of-scope problems, create a tracking issue with `gh issue create` before opening the PR.
 - **Delegate review-comment handling** — never duplicate `/review-pr`; invoke it.
 - **Run `/review-pr` before auto-merge can land** — CI-green is not the only gate. Reviewer feedback (Copilot, human, bot) is the other half. Auto-merge fires the moment CI passes, which can race ahead of unresolved comments and silently land a PR with unaddressed findings. After opening the PR, **always** invoke `/review-pr <#>` to surface and address every unresolved comment before allowing the merge to land. Applies to small cleanup PRs too — the failure mode compounds across multi-PR epics.
@@ -42,7 +44,7 @@ Take a feature branch from "implementation done" to "PR open, CI green, review a
 1. **Pre-flight** — confirm not on `main`, run `uv run poe check`, check for existing PR (Phase 1).
 2. **Self-review** — read the full diff vs base; fix issues found (Phase 2).
 3. **Organize commits** — group into logical commits with conventional format (Phase 3).
-4. **Push and create** — `git push -u`, `gh pr create` with HEREDOC body (Phase 4).
+4. **Push and create** — `git push -u origin HEAD:refs/heads/<branch>`, `gh pr create` with HEREDOC body (Phase 4).
 5. **Wait for CI** — `gh pr checks --watch`; fix failures in-place (Phase 5).
 6. **Wait for review** — poll for ≤15 min; if comments arrive, delegate to `/review-pr` (Phases 6–7).
 7. **Summary** — print PR URL, commit count, CI status, review state (Phase 8).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,14 @@ Guidance for Claude Code working with this repository.
 
 ```bash
 uv sync --all-extras         # Install dependencies
-uv run pre-commit install    # Setup hooks
+uv run pre-commit install    # Setup hooks (installs both pre-commit AND pre-push)
 cp .env.example .env         # Add KATANA_API_KEY
 ```
+
+**Worktrees: re-run `uv run pre-commit install` after `git worktree add`** — pre-commit
+hooks aren't shared across worktrees. The `pre-push-guard.sh` that blocks unintended
+pushes to `main` (see `Known Pitfalls`) only fires when the hook is installed in the
+worktree's `.git/hooks/`.
 
 ## Essential Commands
 


### PR DESCRIPTION
## Summary

Output of \`/harness retro\` after the #436/#440 work. Two related findings, both project-local:

1. **\`/open-pr\` skill prescribed the unsafe push form.** \`git push -u origin <branch>\` resolves the destination via the local branch's *upstream* — not by branch name. Branches created with \`git checkout -b <name> origin/main\` inherit \`origin/main\` as upstream, and the bare push then fast-forwards \`main\`. This bit the repo twice (commit \`30f3fd86\` originally and again during #436 development before I caught it). The pre-push-guard script's own docstring already prescribes the explicit-destination form (\`git push -u origin HEAD:refs/heads/<branch>\`); just propagating that guidance into \`SKILL.md\`.

2. **Pre-push hook doesn't auto-install in worktrees.** \`scripts/pre-push-guard.sh\` is configured in \`.pre-commit-config.yaml\` with \`default_install_hook_types: [pre-commit, pre-push]\`, but pre-commit hooks aren't shared across worktrees. The protection silently doesn't fire from a fresh \`git worktree add\` until \`pre-commit install\` runs locally there. CLAUDE.md Quick Start now calls this out.

## Changes

- \`.claude/skills/open-pr/SKILL.md\` — CRITICAL section gains the push-refspec rule (with the trap mechanics explained inline so the reason survives) and a \"prefer /open-pr over manual git push + gh pr create\" rule. Phase 4 example uses the safe form.
- \`CLAUDE.md\` — Quick Start mentions the pre-push hook reinstall step for worktrees.
- (Out of band) \`~/.claude/projects/.../feedback_use_open_pr_skill.md\` removed — content migrated into the harness; memory is for ephemeral state, not project rules.

Net diff: +9 / -2 across 2 files.

## Test plan

- [x] \`uv run poe check\` passes (no Python changes; doc-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)