### PR TITLE
feat(mcp): embed katana_url deep-links in tool responses

### DIFF
--- a/katana_mcp_server/.env.example
+++ b/katana_mcp_server/.env.example
@@ -7,6 +7,10 @@ KATANA_API_KEY=your-api-key-here
 # Optional: Override the Katana API base URL
 # KATANA_BASE_URL=https://api.katanamrp.com/v1
 
+# Optional: Override the Katana web-app base URL used when building the
+# `katana_url` deep-links returned by tool responses.
+# KATANA_WEB_BASE_URL=https://factory.katanamrp.com
+
 # Optional: Override the MCP server port (default: 8765)
 # MCP_PORT=8765
 

--- a/katana_mcp_server/src/katana_mcp/__init__.py
+++ b/katana_mcp_server/src/katana_mcp/__init__.py
@@ -21,7 +21,8 @@ Example:
           "args": ["katana-mcp-server"],
           "env": {
             "KATANA_API_KEY": "your-api-key",
-            "KATANA_BASE_URL": "https://api.katanamrp.com/v1"
+            "KATANA_BASE_URL": "https://api.katanamrp.com/v1",
+            "KATANA_WEB_BASE_URL": "https://factory.katanamrp.com"
           }
         }
       }

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -998,7 +998,7 @@ Create a stock transfer moving inventory between two locations.
 - `expected_arrival_date` (required): Expected arrival datetime (ISO-8601)
 - `rows` (required): Line items `[{variant_id, quantity, batch_transactions?}]` —
   `batch_transactions` is `[{batch_id, quantity}]` for batch-tracked variants
-- `order_no` (optional): Stock transfer number (auto-assigned when omitted)
+- `order_no` (optional): Stock transfer number. When omitted, the tool generates a `ST-<unix-ts>` default before sending — Katana's API requires the field.
 - `additional_info` (optional): Notes
 - `confirm` (optional, default false): false=preview, true=create
 

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -87,6 +87,30 @@ Every list/get/search and reporting tool accepts a shared `format` parameter:
 Default behavior is unchanged. Pass `format="json"` when chaining tool calls
 or feeding output into downstream aggregation / filtering.
 
+## Linking to Katana
+
+`get_*` and `create_*` tools (and the rows on their `list_*` siblings)
+return a `katana_url` field for the entity. Prefer that over composing
+URLs by hand — Katana's path conventions are inconsistent
+(`/salesorder/{id}` is singular, `/products/{id}` is plural) and easy to
+get wrong silently.
+
+Patterns (base: `factory.katanamrp.com`, override via `KATANA_WEB_BASE_URL`):
+
+| Entity | Path |
+|--------|------|
+| Sales orders | `/salesorder/{id}` |
+| Manufacturing orders | `/manufacturingorder/{id}` |
+| Purchase orders | `/purchaseorder/{id}` |
+| Products / materials | `/products/{id}` (variants link to parent item) |
+| Customers | `/contacts/customers/{id}` |
+| Stock transfers | `/stocktransfer/{id}` |
+| Stock adjustments | `/stockadjustment/{id}` |
+
+`katana_url` is `None` when the entity id isn't available — typically
+create-tool previews (no id assigned until confirm=true). Update-tool
+previews already know the id and return a populated `katana_url`.
+
 ## Common Workflows
 
 1. **Reorder low stock**: check_inventory → create_purchase_order

--- a/katana_mcp_server/src/katana_mcp/server.py
+++ b/katana_mcp_server/src/katana_mcp/server.py
@@ -249,6 +249,23 @@ Destructive tools advertise this via the standard MCP ``destructiveHint``
 tool annotation, which the host uses to confirm with the user before
 invocation. The server itself does not gate further.
 
+## Resource URLs
+
+Tool responses include a `katana_url` field where applicable — prefer it
+over composing URLs yourself. Patterns (base: factory.katanamrp.com,
+overridable via `KATANA_WEB_BASE_URL`):
+
+  /salesorder/{id}              — sales orders
+  /manufacturingorder/{id}      — manufacturing orders
+  /purchaseorder/{id}           — purchase orders
+  /products/{id}                — products and materials (variants link
+                                  to the parent item)
+  /contacts/customers/{id}      — customers
+  /stocktransfer/{id}           — stock transfers
+  /stockadjustment/{id}         — stock adjustments
+
+Top-level pages: /inventory, /sales, /purchases, /manufacturingorders.
+
 ## Resources
 
 Browse cached reference data:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
@@ -17,6 +17,7 @@ from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.tool_result_utils import UI_META, make_tool_result
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.domain.converters import to_unset
 from katana_public_api_client.models import (
     CreateMaterialRequest as ApiCreateMaterialRequest,
@@ -59,6 +60,7 @@ class CreateProductResponse(BaseModel):
     type: str = "product"
     success: bool = True
     message: str = "Product created successfully"
+    katana_url: str | None = None
 
 
 async def _create_product_impl(
@@ -123,6 +125,7 @@ async def _create_product_impl(
             name=product.name or "",
             sku=request.sku,
             message=f"Product '{product.name}' created successfully with SKU {request.sku}",
+            katana_url=katana_web_url("product", product.id),
         )
 
     except Exception as e:
@@ -188,6 +191,7 @@ class CreateMaterialResponse(BaseModel):
     type: str = "material"
     success: bool = True
     message: str = "Material created successfully"
+    katana_url: str | None = None
 
 
 async def _create_material_impl(
@@ -250,6 +254,7 @@ async def _create_material_impl(
             name=material.name or "",
             sku=request.sku,
             message=f"Material '{material.name}' created successfully with SKU {request.sku}",
+            katana_url=katana_web_url("material", material.id),
         )
 
     except Exception as e:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
@@ -19,6 +19,7 @@ from katana_mcp.services import get_services
 from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.tool_result_utils import make_simple_result
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_mcp.web_urls import katana_web_url
 
 # ============================================================================
 # Tool 1: search_customers
@@ -48,6 +49,7 @@ class CustomerInfo(BaseModel):
     phone: str | None = None
     currency: str | None = None
     company: str | None = None
+    katana_url: str | None = None
 
 
 class SearchCustomersResponse(BaseModel):
@@ -58,13 +60,15 @@ class SearchCustomersResponse(BaseModel):
 
 
 def _customer_from_dict(d: dict) -> CustomerInfo:
+    customer_id = d.get("id", 0)
     return CustomerInfo(
-        id=d.get("id", 0),
+        id=customer_id,
         name=d.get("name") or "",
         email=d.get("email"),
         phone=d.get("phone"),
         currency=d.get("currency"),
         company=d.get("company"),
+        katana_url=katana_web_url("customer", customer_id) if customer_id else None,
     )
 
 
@@ -180,6 +184,7 @@ class GetCustomerResponse(BaseModel):
     """
 
     id: int
+    katana_url: str | None = None
     name: str
     first_name: str | None = None
     last_name: str | None = None
@@ -279,8 +284,10 @@ async def _get_customer_impl(
     # (tracked in #342). Fetch-on-demand — one extra HTTP call per get_customer.
     addresses = await _fetch_customer_addresses(services, request.customer_id)
 
+    customer_id = d.get("id", request.customer_id)
     return GetCustomerResponse(
-        id=d.get("id", request.customer_id),
+        id=customer_id,
+        katana_url=katana_web_url("customer", customer_id),
         name=d.get("name") or "",
         first_name=d.get("first_name"),
         last_name=d.get("last_name"),

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
@@ -60,15 +60,15 @@ class SearchCustomersResponse(BaseModel):
 
 
 def _customer_from_dict(d: dict) -> CustomerInfo:
-    customer_id = d.get("id", 0)
+    customer_id = d.get("id")
     return CustomerInfo(
-        id=customer_id,
+        id=customer_id or 0,
         name=d.get("name") or "",
         email=d.get("email"),
         phone=d.get("phone"),
         currency=d.get("currency"),
         company=d.get("company"),
-        katana_url=katana_web_url("customer", customer_id) if customer_id else None,
+        katana_url=katana_web_url("customer", customer_id),
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -30,6 +30,7 @@ from katana_mcp.tools.tool_result_utils import (
     parse_request_dates,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 
 logger = get_logger(__name__)
@@ -695,6 +696,7 @@ class StockAdjustmentResponse(BaseModel):
     is_preview: bool
     message: str
     rows_summary: str
+    katana_url: str | None = None
 
 
 async def _create_stock_adjustment_impl(
@@ -782,6 +784,7 @@ async def _create_stock_adjustment_impl(
         is_preview=False,
         message="Stock adjustment created successfully",
         rows_summary=rows_summary,
+        katana_url=katana_web_url("stock_adjustment", adj_id),
     )
 
 
@@ -809,6 +812,8 @@ async def create_stock_adjustment(
     )
     if response.id:
         md += f"\n**Adjustment ID**: {response.id}\n"
+    if response.katana_url:
+        md += f"**Katana URL**: {response.katana_url}\n"
 
     return make_simple_result(
         md,
@@ -919,6 +924,7 @@ class StockAdjustmentSummary(BaseModel):
     additional_info: str | None
     row_count: int
     rows: list[StockAdjustmentRowInfo] | None = None
+    katana_url: str | None = None
 
 
 class ListStockAdjustmentsResponse(BaseModel):
@@ -1114,6 +1120,7 @@ async def _list_stock_adjustments_impl(
                 additional_info=adj.additional_info,
                 row_count=row_count,
                 rows=row_infos,
+                katana_url=katana_web_url("stock_adjustment", adj.id),
             )
         )
 
@@ -1226,6 +1233,7 @@ class UpdateStockAdjustmentResponse(BaseModel):
     additional_info: str | None = None
     changes_summary: str
     message: str
+    katana_url: str | None = None
 
 
 def _format_changes_summary(request: UpdateStockAdjustmentParams) -> str:
@@ -1301,6 +1309,7 @@ async def _update_stock_adjustment_impl(
                 f"Preview — call again with confirm=true to update stock "
                 f"adjustment {request.id}"
             ),
+            katana_url=katana_web_url("stock_adjustment", request.id),
         )
 
     services = get_services(context)
@@ -1346,6 +1355,7 @@ async def _update_stock_adjustment_impl(
         additional_info=unwrap_unset(updated.additional_info, None),
         changes_summary=changes_summary,
         message=f"Stock adjustment {updated.id} updated successfully",
+        katana_url=katana_web_url("stock_adjustment", updated.id),
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -26,6 +26,7 @@ from katana_mcp.tools.tool_result_utils import (
     make_tool_result,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_mcp.web_urls import EntityKind, katana_web_url
 from katana_public_api_client.domain.converters import to_unset
 from katana_public_api_client.models import (
     CreateMaterialRequest,
@@ -210,6 +211,14 @@ class CreateItemRequest(BaseModel):
     additional_info: str | None = Field(None, description="Additional notes")
 
 
+def _item_katana_url(item_type: ItemType, id: int | None) -> str | None:
+    """Web URL for a product or material. Services have no URL pattern."""
+    if id is None or item_type == ItemType.SERVICE:
+        return None
+    kind: EntityKind = "product" if item_type == ItemType.PRODUCT else "material"
+    return katana_web_url(kind, id)
+
+
 class CreateItemResponse(BaseModel):
     """Response from creating an item."""
 
@@ -220,6 +229,7 @@ class CreateItemResponse(BaseModel):
     sku: str | None = None
     success: bool = True
     message: str = "Item created successfully"
+    katana_url: str | None = None
 
 
 async def _create_item_impl(
@@ -288,6 +298,7 @@ async def _create_item_impl(
         type=request.type,
         sku=request.sku,
         message=f"{request.type.value.title()} '{result.name}' created successfully with SKU {request.sku}",
+        katana_url=_item_katana_url(request.type, result.id),
     )
 
 
@@ -381,6 +392,7 @@ class ItemDetailsResponse(BaseModel):
     id: int
     name: str
     type: ItemType
+    katana_url: str | None = None
     uom: str | None = None
     category_name: str | None = None
     is_sellable: bool | None = None
@@ -534,10 +546,12 @@ async def _get_item_impl(
     configs = [c for c in (_config_to_info(raw) for raw in d.get("configs") or []) if c]
     supplier = _supplier_to_info(d.get("supplier"))
 
+    item_id = d.get("id", request.id)
     return ItemDetailsResponse(
-        id=d.get("id", request.id),
+        id=item_id,
         name=d.get("name") or "",
         type=request.type,
+        katana_url=_item_katana_url(request.type, item_id),
         uom=d.get("uom"),
         category_name=d.get("category_name"),
         is_sellable=d.get("is_sellable"),
@@ -672,6 +686,7 @@ class UpdateItemResponse(BaseModel):
     type: ItemType
     success: bool = True
     message: str = "Item updated successfully"
+    katana_url: str | None = None
 
 
 async def _update_item_impl(
@@ -779,6 +794,7 @@ async def _update_item_impl(
         name=item_name or "Unknown",
         type=request.type,
         message=f"{request.type.value.title()} (ID {request.id}) updated successfully",
+        katana_url=_item_katana_url(request.type, request.id),
     )
 
 
@@ -944,6 +960,11 @@ class VariantDetailsResponse(BaseModel):
     material_id: int | None = None
     product_or_material_name: str | None = None
 
+    # Deep-link to the parent product or material — variants don't have
+    # their own page in Katana's web app, so callers click through to the
+    # parent record.
+    katana_url: str | None = None
+
     # Barcode & Inventory
     internal_barcode: str | None = None
     registered_barcode: str | None = None
@@ -994,6 +1015,7 @@ def _dict_to_variant_details(v: dict[str, Any]) -> VariantDetailsResponse:
     Surfaces every field the generated ``Variant`` attrs model exposes, so
     callers get the full shape in a single call.
     """
+    parent_id = v.get("product_id") or v.get("material_id")
     return VariantDetailsResponse(
         id=v["id"],
         sku=v.get("sku") or "",
@@ -1004,6 +1026,7 @@ def _dict_to_variant_details(v: dict[str, Any]) -> VariantDetailsResponse:
         product_id=v.get("product_id"),
         material_id=v.get("material_id"),
         product_or_material_name=v.get("parent_name"),
+        katana_url=katana_web_url("product", parent_id),
         internal_barcode=v.get("internal_barcode"),
         registered_barcode=v.get("registered_barcode"),
         supplier_item_codes=v.get("supplier_item_codes") or [],

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -1015,7 +1015,15 @@ def _dict_to_variant_details(v: dict[str, Any]) -> VariantDetailsResponse:
     Surfaces every field the generated ``Variant`` attrs model exposes, so
     callers get the full shape in a single call.
     """
-    parent_id = v.get("product_id") or v.get("material_id")
+    product_id = v.get("product_id")
+    material_id = v.get("material_id")
+    # Variants don't have their own page in Katana; link to whichever
+    # parent (product or material) actually owns this variant. Picking
+    # by which field is non-null (vs `or`) keeps the kind correct if
+    # the URL paths ever diverge.
+    parent_url = katana_web_url("product", product_id) or katana_web_url(
+        "material", material_id
+    )
     return VariantDetailsResponse(
         id=v["id"],
         sku=v.get("sku") or "",
@@ -1023,10 +1031,10 @@ def _dict_to_variant_details(v: dict[str, Any]) -> VariantDetailsResponse:
         sales_price=v.get("sales_price"),
         purchase_price=v.get("purchase_price"),
         type=v.get("type") or v.get("type_"),
-        product_id=v.get("product_id"),
-        material_id=v.get("material_id"),
+        product_id=product_id,
+        material_id=material_id,
         product_or_material_name=v.get("parent_name"),
-        katana_url=katana_web_url("product", parent_id),
+        katana_url=parent_url,
         internal_barcode=v.get("internal_barcode"),
         registered_barcode=v.get("registered_barcode"),
         supplier_item_codes=v.get("supplier_item_codes") or [],

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -41,6 +41,7 @@ from katana_mcp.tools.tool_result_utils import (
     parse_request_dates,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     CreateManufacturingOrderRequest as APICreateManufacturingOrderRequest,
@@ -134,6 +135,7 @@ class ManufacturingOrderResponse(BaseModel):
     warnings: list[str] = Field(default_factory=list)
     next_actions: list[str] = Field(default_factory=list)
     message: str
+    katana_url: str | None = None
 
 
 async def _create_manufacturing_order_impl(
@@ -361,6 +363,7 @@ async def _create_manufacturing_order_impl(
             production_deadline_date=production_deadline_date,
             additional_info=additional_info,
             is_preview=False,
+            katana_url=katana_web_url("manufacturing_order", mo.id),
             next_actions=next_actions,
             message=f"Successfully created manufacturing order {order_no or mo.id} (ID: {mo.id})",
         )
@@ -660,6 +663,7 @@ class GetManufacturingOrderResponse(BaseModel):
     """
 
     id: int
+    katana_url: str | None = None
     order_no: str | None = None
     status: str | None = None
     variant_id: int | None = None
@@ -935,6 +939,7 @@ def _build_mo_response(
     ]
     return GetManufacturingOrderResponse(
         id=mo.id,
+        katana_url=katana_web_url("manufacturing_order", mo.id),
         order_no=unwrap_unset(mo.order_no, None),
         status=enum_to_str(unwrap_unset(mo.status, None)),
         variant_id=unwrap_unset(mo.variant_id, None),
@@ -2307,6 +2312,7 @@ class ManufacturingOrderSummary(BaseModel):
     is_linked_to_sales_order: bool | None
     sales_order_id: int | None
     total_cost: float | None
+    katana_url: str | None = None
 
 
 class ListManufacturingOrdersResponse(BaseModel):
@@ -2454,6 +2460,7 @@ async def _list_manufacturing_orders_impl(
                 is_linked_to_sales_order=mo.is_linked_to_sales_order,
                 sales_order_id=mo.sales_order_id,
                 total_cost=mo.total_cost,
+                katana_url=katana_web_url("manufacturing_order", mo.id),
             )
         )
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -37,6 +37,7 @@ from katana_mcp.tools.tool_result_utils import (
     resolve_entity_name,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
@@ -109,6 +110,7 @@ class PurchaseOrderResponse(BaseModel):
     warnings: list[str] = Field(default_factory=list)
     next_actions: list[str] = Field(default_factory=list)
     message: str
+    katana_url: str | None = None
 
 
 def _po_response_to_tool_result(
@@ -275,6 +277,7 @@ async def _create_purchase_order_impl(
             total_cost=total_cost,
             currency=currency,
             is_preview=False,
+            katana_url=katana_web_url("purchase_order", po.id),
             next_actions=[
                 f"Purchase order created with ID {po.id}",
                 "Use receive_purchase_order to receive items when they arrive",
@@ -664,6 +667,7 @@ class GetPurchaseOrderResponse(BaseModel):
     """
 
     id: int
+    katana_url: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
     deleted_at: str | None = None
@@ -900,6 +904,7 @@ def _build_get_purchase_order_response(
 
     return GetPurchaseOrderResponse(
         id=po.id,
+        katana_url=katana_web_url("purchase_order", po.id),
         created_at=_iso_optional(unwrap_unset(po.created_at, None)),
         updated_at=_iso_optional(unwrap_unset(po.updated_at, None)),
         deleted_at=_iso_optional(unwrap_unset(po.deleted_at, None)),
@@ -1733,6 +1738,7 @@ class PurchaseOrderSummary(BaseModel):
     total: float | None
     row_count: int
     rows: list[PurchaseOrderRowSummary] | None = None
+    katana_url: str | None = None
 
 
 class ListPurchaseOrdersResponse(BaseModel):
@@ -1931,6 +1937,7 @@ async def _list_purchase_orders_impl(
                 total=po.total,
                 row_count=row_count,
                 rows=rows,
+                katana_url=katana_web_url("purchase_order", po.id),
             )
         )
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -34,6 +34,7 @@ from katana_mcp.tools.tool_result_utils import (
     resolve_entity_name,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.client_types import UNSET, Unset
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
@@ -138,6 +139,7 @@ class SalesOrderResponse(BaseModel):
     warnings: list[str] = Field(default_factory=list)
     next_actions: list[str] = Field(default_factory=list)
     message: str
+    katana_url: str | None = None
 
 
 async def _create_sales_order_impl(
@@ -289,6 +291,7 @@ async def _create_sales_order_impl(
             total=total,
             currency=currency,
             is_preview=False,
+            katana_url=katana_web_url("sales_order", so.id),
             next_actions=[
                 f"Sales order created with ID {so.id}",
                 "Use fulfill_order to ship items when ready",
@@ -475,6 +478,7 @@ class SalesOrderSummary(BaseModel):
     currency: str | None
     row_count: int
     rows: list[SalesOrderRowInfo] | None = None
+    katana_url: str | None = None
 
 
 class ListSalesOrdersResponse(BaseModel):
@@ -676,6 +680,7 @@ async def _list_sales_orders_impl(
                 currency=so.currency,
                 row_count=row_count,
                 rows=row_infos,
+                katana_url=katana_web_url("sales_order", so.id),
             )
         )
 
@@ -848,6 +853,7 @@ class GetSalesOrderResponse(BaseModel):
 
     # Identifiers / header
     id: int
+    katana_url: str | None = None
     order_no: str | None = None
     customer_id: int | None = None
     location_id: int | None = None
@@ -1069,6 +1075,7 @@ async def _get_sales_order_impl(
 
     return GetSalesOrderResponse(
         id=so.id,
+        katana_url=katana_web_url("sales_order", so.id),
         order_no=unwrap_unset(so.order_no, None),
         customer_id=unwrap_unset(so.customer_id, None),
         location_id=unwrap_unset(so.location_id, None),

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -38,6 +38,7 @@ from katana_mcp.tools.tool_result_utils import (
     resolve_entity_name,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     CreateStockTransferRequest as APICreateStockTransferRequest,
@@ -104,6 +105,7 @@ class StockTransferSummary(BaseModel):
     created_at: str | None
     row_count: int
     rows: list[StockTransferRowInfo] | None = None
+    katana_url: str | None = None
 
 
 def _build_row_info(row: Any) -> StockTransferRowInfo:
@@ -148,6 +150,7 @@ def _build_summary(transfer: Any, *, include_rows: bool) -> StockTransferSummary
         else None,
         row_count=len(raw_rows),
         rows=row_infos,
+        katana_url=katana_web_url("stock_transfer", transfer.id),
     )
 
 
@@ -222,6 +225,7 @@ class StockTransferResponse(BaseModel):
     warnings: list[str] = Field(default_factory=list)
     next_actions: list[str] = Field(default_factory=list)
     message: str
+    katana_url: str | None = None
 
 
 def _transfer_to_response(
@@ -241,6 +245,7 @@ def _transfer_to_response(
         else None,
         is_preview=is_preview,
         message=message,
+        katana_url=katana_web_url("stock_transfer", transfer.id),
     )
 
 
@@ -444,6 +449,8 @@ async def create_stock_transfer(
         lines.append(f"- **Expected Arrival**: {response.expected_arrival_date}")
     if response.status:
         lines.append(f"- **Status**: {response.status}")
+    if response.katana_url:
+        lines.append(f"- **Katana URL**: {response.katana_url}")
     if response.warnings:
         lines.append("")
         lines.append("### Warnings")

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -196,8 +196,9 @@ class CreateStockTransferRequest(BaseModel):
     order_no: str | None = Field(
         default=None,
         description=(
-            "Optional transfer number (stock_transfer_number). Katana auto-assigns "
-            "one when omitted."
+            "Optional transfer number (stock_transfer_number). When omitted, "
+            "the MCP tool generates a timestamp-based default (``ST-<unix-ts>``) "
+            "before the request is sent — Katana's API requires the field."
         ),
     )
     additional_info: str | None = Field(
@@ -378,12 +379,17 @@ async def _create_stock_transfer_impl(
 
     api_rows = _build_row_requests(request.rows)
 
+    # ``stock_transfer_number`` is required by the live API. Auto-generate a
+    # timestamp-based default if the caller didn't provide one — matches the
+    # pattern in ``_create_manufacturing_order_impl``.
+    transfer_number = request.order_no or f"ST-{int(datetime.now(UTC).timestamp())}"
+
     api_request = APICreateStockTransferRequest(
         source_location_id=request.source_location_id,
         target_location_id=request.destination_location_id,
         expected_arrival_date=request.expected_arrival_date,
         order_created_date=datetime.now(UTC),
-        stock_transfer_number=to_unset(request.order_no),
+        stock_transfer_number=transfer_number,
         additional_info=to_unset(request.additional_info),
         stock_transfer_rows=api_rows,
     )

--- a/katana_mcp_server/src/katana_mcp/web_urls.py
+++ b/katana_mcp_server/src/katana_mcp/web_urls.py
@@ -1,0 +1,58 @@
+"""Build Katana web-app URLs for deep-linking from tool responses.
+
+Tool responses include a ``katana_url`` field where applicable so agents
+never compose URLs themselves and can't get path conventions wrong
+(e.g., ``manufacturingorder`` vs ``manufacturingorders``).
+
+The base URL comes from ``KATANA_WEB_BASE_URL`` (default
+``https://factory.katanamrp.com``), parallel to ``KATANA_BASE_URL`` which
+points at the API.
+
+See issue #442 for the motivation and full URL pattern list.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+EntityKind = Literal[
+    "sales_order",
+    "manufacturing_order",
+    "purchase_order",
+    "product",
+    "material",
+    "customer",
+    "stock_transfer",
+    "stock_adjustment",
+]
+
+DEFAULT_WEB_BASE_URL = "https://factory.katanamrp.com"
+
+# Path templates per entity. Variants link to their parent product/material —
+# Katana's web app does not have per-variant pages.
+_PATHS: dict[EntityKind, str] = {
+    "sales_order": "/salesorder/{id}",
+    "manufacturing_order": "/manufacturingorder/{id}",
+    "purchase_order": "/purchaseorder/{id}",
+    "product": "/products/{id}",
+    "material": "/products/{id}",
+    "customer": "/contacts/customers/{id}",
+    "stock_transfer": "/stocktransfer/{id}",
+    "stock_adjustment": "/stockadjustment/{id}",
+}
+
+
+def _base_url() -> str:
+    return os.getenv("KATANA_WEB_BASE_URL", DEFAULT_WEB_BASE_URL).rstrip("/")
+
+
+def katana_web_url(kind: EntityKind, id: int | None) -> str | None:
+    """Return the web-app URL for an entity, or ``None`` if id is missing.
+
+    ``id is None`` short-circuits to ``None`` so preview-mode responses
+    (no id assigned yet) can call this unconditionally.
+    """
+    if id is None:
+        return None
+    return f"{_base_url()}{_PATHS[kind].format(id=id)}"

--- a/katana_mcp_server/tests/test_web_urls.py
+++ b/katana_mcp_server/tests/test_web_urls.py
@@ -1,0 +1,49 @@
+"""Tests for the Katana web-app URL helper."""
+
+from __future__ import annotations
+
+import pytest
+from katana_mcp.web_urls import DEFAULT_WEB_BASE_URL, EntityKind, katana_web_url
+
+
+@pytest.mark.parametrize(
+    ("kind", "id", "expected_path"),
+    [
+        ("sales_order", 12345, "/salesorder/12345"),
+        ("manufacturing_order", 67890, "/manufacturingorder/67890"),
+        ("purchase_order", 1, "/purchaseorder/1"),
+        ("product", 42, "/products/42"),
+        ("material", 99, "/products/99"),
+        ("customer", 7, "/contacts/customers/7"),
+        ("stock_transfer", 555, "/stocktransfer/555"),
+        ("stock_adjustment", 222, "/stockadjustment/222"),
+    ],
+)
+def test_known_entity_kinds_build_expected_url(
+    kind: EntityKind, id: int, expected_path: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KATANA_WEB_BASE_URL", raising=False)
+    assert katana_web_url(kind, id) == f"{DEFAULT_WEB_BASE_URL}{expected_path}"
+
+
+def test_none_id_returns_none() -> None:
+    """Preview-mode responses (no id yet) get None — callers can pass through."""
+    assert katana_web_url("sales_order", None) is None
+
+
+def test_env_override_is_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KATANA_WEB_BASE_URL", "https://eu.katanamrp.com")
+    assert katana_web_url("sales_order", 1) == "https://eu.katanamrp.com/salesorder/1"
+
+
+def test_trailing_slash_on_base_is_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A trailing slash on the configured base must not double up."""
+    monkeypatch.setenv("KATANA_WEB_BASE_URL", "https://factory.katanamrp.com/")
+    url = katana_web_url("manufacturing_order", 9)
+    assert url == "https://factory.katanamrp.com/manufacturingorder/9"
+    assert "//manufacturingorder" not in url
+
+
+def test_default_constant_matches_documented_value() -> None:
+    """The default must match the value documented in CLAUDE.md and #442."""
+    assert DEFAULT_WEB_BASE_URL == "https://factory.katanamrp.com"

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -484,3 +484,69 @@ def test_variant_to_summary_falls_back_to_default_cost_when_purchase_price_absen
 
     assert summary is not None
     assert summary.purchase_price == 50.0
+
+
+# ============================================================================
+# katana_url deep-link wiring (#442)
+# ============================================================================
+
+
+@pytest.fixture
+def _no_web_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin tests to the default `factory.katanamrp.com` base, regardless of
+    whatever the developer/CI happened to export in ``KATANA_WEB_BASE_URL``.
+    Without this, the URL-equality assertions below fail in environments that
+    point at a non-default Katana domain.
+    """
+    monkeypatch.delenv("KATANA_WEB_BASE_URL", raising=False)
+
+
+def test_dict_to_variant_details_uses_product_id_for_product_variants(
+    _no_web_base_url: None,
+):
+    from katana_mcp.tools.foundation.items import _dict_to_variant_details
+
+    response = _dict_to_variant_details(
+        {"id": 1, "sku": "P-1", "product_id": 42, "material_id": None}
+    )
+    assert response.katana_url == "https://factory.katanamrp.com/products/42"
+
+
+def test_dict_to_variant_details_falls_back_to_material_id_for_material_variants(
+    _no_web_base_url: None,
+):
+    """Material-owned variants must link to the parent material — the previous
+    `katana_web_url("product", parent_id)` form produced the right URL only
+    because both kinds happen to map to /products/{id}. If those paths ever
+    diverge, this test pins the correct kind selection.
+    """
+    from katana_mcp.tools.foundation.items import _dict_to_variant_details
+
+    response = _dict_to_variant_details(
+        {"id": 2, "sku": "M-1", "product_id": None, "material_id": 99}
+    )
+    assert response.katana_url == "https://factory.katanamrp.com/products/99"
+
+
+def test_dict_to_variant_details_no_parent_returns_none_url():
+    from katana_mcp.tools.foundation.items import _dict_to_variant_details
+
+    response = _dict_to_variant_details(
+        {"id": 3, "sku": "ORPHAN", "product_id": None, "material_id": None}
+    )
+    assert response.katana_url is None
+
+
+def test_item_katana_url_returns_none_for_service_type(_no_web_base_url: None):
+    """Services have no /products/{id}-style page in Katana's web app."""
+    from katana_mcp.tools.foundation.items import _item_katana_url
+
+    assert _item_katana_url(ItemType.SERVICE, 123) is None
+    assert (
+        _item_katana_url(ItemType.PRODUCT, 123)
+        == "https://factory.katanamrp.com/products/123"
+    )
+    assert (
+        _item_katana_url(ItemType.MATERIAL, 456)
+        == "https://factory.katanamrp.com/products/456"
+    )


### PR DESCRIPTION
## Summary

Closes #442. Adds a `katana_url` field to MCP tool responses so agents can deep-link directly to Katana web-app pages instead of composing URLs by guessing path conventions (which Katana spells inconsistently — e.g. `/salesorder/{id}` singular but `/products/{id}` plural).

**Coverage** (7 entity types, 14 response classes):

- Sales orders — create, get, list rows
- Manufacturing orders — create, get, list rows
- Purchase orders — create, get, list rows
- Products / materials — create, get, update, search rows (variants link to parent)
- Customers — get, search rows
- Stock transfers — create/get, list rows
- Stock adjustments — create, update, list rows

**Helper**: `katana_mcp/web_urls.py` centralizes URL construction with `KATANA_WEB_BASE_URL` env override (default `https://factory.katanamrp.com`), parallel to the existing `KATANA_BASE_URL`. The MCP `instructions` block and `katana://help` resource document the URL patterns as a safety net.

**Bonus bug fix** (separate commit): `stock_transfers.py:_create_stock_transfer_impl` was passing `to_unset(request.order_no)` for `stock_transfer_number`, but the OpenAPI spec marks that field required (`str`, not `str | Unset`). Now auto-generates `ST-{timestamp}` when caller omits it, matching the manufacturing-orders pattern.

## Out of scope (deferred)

- **Suppliers / locations / operators** — read-only resources only, no `get_*` tool today.
- **Reporting tools** (`top_selling_variants`, `sales_summary`, `inventory_velocity`) — aggregations, no single entity.
- **`fulfill_order` / `verify_order_document`** — action tools, no entity ID returned.
- **Sibling MCP server** (`statuspro-mcp-server`) — same DX gap, parallel ticket to file later.

## Test plan

- [x] `uv run poe check` — 2507 tests pass, format/lint clean
- [x] `uv run pytest katana_mcp_server/tests/test_web_urls.py` — 12 helper tests (entity coverage, `id=None`, env override, trailing-slash)
- [ ] Manual MCP-inspector smoke: spin up server, call `get_sales_order` against live API, confirm `katana_url` resolves in browser
- [ ] Verify the unconfirmed paths against live UI before merge: `/stocktransfer/{id}`, `/stockadjustment/{id}`, materials use `/products/{id}` (not `/materials/{id}`)

## Notes for reviewers

- Pyright LSP flags ~40 SQLAlchemy descriptor false positives across the foundation tools. These are pre-existing on main and tracked in #445 (with a 5th option I added: regen `Cached*` with `Mapped[T]`). `ty` (the actual CI checker) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)