### PR TITLE
feat(mcp)!: compact MO triage + cross-MO blocking-ingredient rollup

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -535,32 +535,84 @@ run as indexed SQL against the typed cache.
 
 - `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
-**Returns:** Summary rows with id, order_no, status, variant_id, planned/
-actual qty, location_id, order_created_date, production_deadline_date,
-done_date, is_linked_to_sales_order, sales_order_id, total_cost. When `page`
-is set, also returns `pagination` with total_records/total_pages/etc. To
-inspect recipe ingredients, call `get_manufacturing_order_recipe` for a
-specific MO — the list endpoint doesn't bundle them.
+**Returns:** Summary rows with id, order_no, status, ingredient_availability,
+variant_id, planned/actual qty, location_id, order_created_date,
+production_deadline_date, done_date, is_linked_to_sales_order, sales_order_id,
+total_cost. The `ingredient_availability` column is the rolled-up MO-level
+state (IN_STOCK / NOT_AVAILABLE / EXPECTED / …) — use it to pick which MOs
+to drill into without fanning out to `get_manufacturing_order` for each. When
+`page` is set, also returns `pagination` with total_records/total_pages/etc.
+For per-row recipe detail on a specific MO, call `get_manufacturing_order_recipe`
+or `get_manufacturing_order` (which now bundles blocking rows by default).
 
 ---
 
 ### get_manufacturing_order
-Look up a manufacturing order by order number or ID with exhaustive detail.
-For multiple manufacturing orders at once, use
-`list_manufacturing_orders(ids=[...])` — it returns a summary table and
-supports all the same filters in a single call.
+Look up a manufacturing order by order number or ID. **Compact-by-default**
+for procurement triage: returns the MO header + only blocking recipe rows,
+metadata stripped, operation rows and production records omitted.
 
 **Parameters:**
 - `order_no` (optional): Order number (e.g., '#WEB20082 / 1')
 - `order_id` (optional): Manufacturing order ID
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
+- `format` (optional, default "markdown"): "markdown" | "json"
+- `include_rows` (optional, default `"blocking"`): Recipe-row projection.
+  - `"blocking"` — only rows with `ingredient_availability` in {NOT_AVAILABLE, EXPECTED}.
+  - `"all"` — every recipe row.
+  - `"none"` — omit `recipe_rows` entirely; skips the upstream API call.
+- `include_operation_rows` (optional, default `false`): When `true`, fetch
+  and include the operation-row collection.
+- `include_productions` (optional, default `false`): When `true`, fetch and
+  include the production-record collection.
+- `verbose` (optional, default `false`): When `true`, restore stripped metadata
+  (`created_at`/`updated_at`/`deleted_at` on every nested row) and empty
+  `batch_transactions: []` placeholders. Use with `include_rows="all"`,
+  `include_operation_rows=true`, `include_productions=true` to reproduce the
+  legacy exhaustive payload.
 
-**Returns:** Single-object response with every field Katana exposes on the MO
-(status, quantities, costs, timings, timestamps, linked sales order fields,
-batch and serial transactions) plus the full `recipe_rows`, `operation_rows`,
-and `productions` lists fetched from their respective endpoints. Markdown
-labels use canonical Pydantic field names (e.g. `**production_deadline_date**:`)
-so downstream consumers can't confuse section headers with field names.
+**Returns:** Single-object response with every scalar MO field (status,
+quantities, costs, timings, linked sales order fields). Recipe rows / operation
+rows / production records are populated according to the include flags above.
+Markdown labels use canonical Pydantic field names (e.g.
+`**production_deadline_date**:`) so downstream consumers can't confuse section
+headers with field names.
+
+---
+
+### list_blocking_ingredients
+Roll up blocking-ingredient recipe rows across manufacturing orders.
+Cache-backed: a single typed-cache join, no per-MO fan-out. Answers
+"which SKUs is procurement blocked on, across the active queue?"
+
+**Default scope:** NOT_STARTED + IN_PROGRESS MOs.
+**Blocking definition:** recipe rows with `ingredient_availability` in
+{NOT_AVAILABLE, EXPECTED}. IN_STOCK / PROCESSED / NOT_APPLICABLE / NO_RECIPE
+are excluded by design — they don't represent actionable procurement work.
+
+**Parameters:**
+- `mo_status` (optional): MO statuses to scope to (defaults to active).
+- `mo_ids` (optional): Restrict to specific MO IDs.
+- `mo_order_nos` (optional): Restrict to specific order_no values.
+- `location_id` (optional): Restrict to MOs at one production location.
+- `production_deadline_after` / `production_deadline_before` (optional):
+  ISO-8601 bounds on `production_deadline_date`.
+- `group_by` (optional, default `"variant"`):
+  - `"variant"` — one row per blocking SKU, sorted by affected_mo_count
+    desc, then total_remaining_quantity desc. The procurement-priority view.
+  - `"mo"` — one block per MO, sorted by deadline. Preserves per-row detail.
+- `limit` (optional, default 100, max 500): Max aggregate rows.
+- `format` (optional, default "markdown").
+
+**Returns:** When `group_by="variant"`: rows with variant_id, sku,
+affected_mo_count, affected_mo_order_nos (truncated to 5 in markdown),
+total_planned_quantity (per-unit times MO planned_quantity, summed),
+total_remaining_quantity, earliest_expected_date. When `group_by="mo"`: per-MO
+sections with id, order_no, status, deadline, and the blocking recipe rows
+nested. Top-level `total_blocking_rows` and `total_affected_mos` are always
+populated.
+
+**Cache freshness:** typed-cache sync is debounced to 5 minutes — the rollup
+may lag the live API by up to that window.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -9,6 +9,7 @@ These tools provide:
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Annotated, Any, Literal
@@ -20,7 +21,11 @@ from pydantic import BaseModel, Field
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
-from katana_mcp.tools.list_coercion import CoercedIntList, CoercedIntListOpt
+from katana_mcp.tools.list_coercion import (
+    CoercedIntList,
+    CoercedIntListOpt,
+    CoercedStrListOpt,
+)
 from katana_mcp.tools.tool_result_utils import (
     BLOCK_WARNING_PREFIX,
     UI_META,
@@ -41,6 +46,9 @@ from katana_public_api_client.models import (
     CreateManufacturingOrderRequest as APICreateManufacturingOrderRequest,
     GetAllManufacturingOrdersStatus,
     ManufacturingOrder,
+)
+from katana_public_api_client.models_pydantic._generated import (
+    OutsourcedPurchaseOrderIngredientAvailability,
 )
 from katana_public_api_client.utils import unwrap_as
 
@@ -413,6 +421,28 @@ async def create_manufacturing_order(
 # Tool 2: get_manufacturing_order
 # ============================================================================
 
+# Recipe-row metadata fields stripped from the compact response. These have
+# no value for triage workflows (they're fetched per-MO so reading them adds
+# no provenance information that wasn't already on the parent MO).
+_ROW_METADATA_FIELDS = frozenset({"created_at", "updated_at", "deleted_at"})
+
+# Recipe rows in these availability states are considered "blocking" for the
+# procurement triage view. IN_STOCK / PROCESSED / NOT_APPLICABLE / NO_RECIPE
+# are deliberately excluded:
+#   - IN_STOCK: material on hand, not blocking.
+#   - PROCESSED: already consumed by a production run.
+#   - NOT_APPLICABLE: not an inventory-tracked item (e.g., a service line).
+#   - NO_RECIPE: BOM metadata problem, not a procurement problem.
+# Stored as the enum's string values so it works for both Python comparison
+# (against ``RecipeRowInfo.ingredient_availability: str``) and the SQL ``IN``
+# clause against the cached ``ingredient_availability`` column.
+_BLOCKING_AVAILABILITY: frozenset[str] = frozenset(
+    {
+        OutsourcedPurchaseOrderIngredientAvailability.not_available.value,
+        OutsourcedPurchaseOrderIngredientAvailability.expected.value,
+    }
+)
+
 
 class GetManufacturingOrderRequest(BaseModel):
     """Request to look up a manufacturing order."""
@@ -426,6 +456,39 @@ class GetManufacturingOrderRequest(BaseModel):
         description=(
             "Output format: 'markdown' (default) for human-readable tables; "
             "'json' for structured data consumable by downstream tools/aggregations."
+        ),
+    )
+    include_rows: Literal["all", "blocking", "none"] = Field(
+        default="blocking",
+        description=(
+            "Recipe-row projection. 'blocking' (default) returns only rows whose "
+            "ingredient_availability is NOT_AVAILABLE or EXPECTED — the procurement "
+            "triage view. 'all' returns every recipe row. 'none' omits the array "
+            "and skips the recipe-row API call entirely."
+        ),
+    )
+    include_operation_rows: bool = Field(
+        default=False,
+        description=(
+            "When true, fetch and include operation_rows. Off by default to keep "
+            "the response under inline tool-result limits — operation rows are bulky "
+            "and irrelevant to procurement triage."
+        ),
+    )
+    include_productions: bool = Field(
+        default=False,
+        description=(
+            "When true, fetch and include production records. Off by default — "
+            "production history is the largest contributor to MO payload size."
+        ),
+    )
+    verbose: bool = Field(
+        default=False,
+        description=(
+            "When true, restore metadata fields stripped from the compact view: "
+            "created_at, updated_at, deleted_at, and empty batch_transactions on "
+            "every nested row. Use with include_rows='all', include_operation_rows=True, "
+            "and include_productions=True to reproduce the legacy exhaustive payload."
         ),
     )
 
@@ -918,10 +981,14 @@ def _build_mo_response(
 async def _get_manufacturing_order_impl(
     request: GetManufacturingOrderRequest, context: Context
 ) -> GetManufacturingOrderResponse:
-    """Look up a manufacturing order by order number or ID with exhaustive detail.
+    """Look up a manufacturing order by order number or ID.
 
-    Fetches the MO record plus its recipe rows, operation rows, and production
-    records — each via its own API call (cache-first migration tracked in #342).
+    Compact-by-default: ``include_rows='blocking'`` filters recipe rows to
+    procurement-actionable rows; operation rows and production records are
+    omitted unless explicitly requested. Each related-resource fetch is a
+    separate HTTP call (cache-first migration tracked in #342) — gating on
+    the ``include_*`` flags also skips the upstream call when the data
+    isn't needed.
     """
     from katana_public_api_client.api.manufacturing_order import (
         get_all_manufacturing_orders,
@@ -949,24 +1016,43 @@ async def _get_manufacturing_order_impl(
             raise ValueError(f"Manufacturing order '{request.order_no}' not found")
         mo = orders[0]
 
-    # Related resources — fetched in parallel. Each is a separate HTTP call
-    # today; the cache epic (#342) will move these to cache-first.
-    recipe_rows, operation_rows, productions = await asyncio.gather(
-        _fetch_mo_recipe_rows(services, mo.id),
-        _fetch_mo_operation_rows(services, mo.id),
-        _fetch_mo_productions(services, mo.id),
-    )
+    # Gate each related-resource fetch on its include flag. asyncio.gather
+    # over the requested subset keeps the parallel-fetch advantage while
+    # avoiding wasted HTTP calls when the caller doesn't want the data.
+    fetch_recipe = request.include_rows != "none"
+    fetchers: list[Any] = [
+        _fetch_mo_recipe_rows(services, mo.id) if fetch_recipe else none_coro(),
+        _fetch_mo_operation_rows(services, mo.id)
+        if request.include_operation_rows
+        else none_coro(),
+        _fetch_mo_productions(services, mo.id)
+        if request.include_productions
+        else none_coro(),
+    ]
+    recipe_rows, operation_rows, productions = await asyncio.gather(*fetchers)
+    recipe_rows = recipe_rows or []
+    operation_rows = operation_rows or []
+    productions = productions or []
+
+    if request.include_rows == "blocking":
+        recipe_rows = [
+            r
+            for r in recipe_rows
+            if r.ingredient_availability in _BLOCKING_AVAILABILITY
+        ]
 
     return _build_mo_response(mo, recipe_rows, operation_rows, productions)
 
 
-def _render_mo_scalar_lines(response: GetManufacturingOrderResponse) -> list[str]:
+def _render_mo_scalar_lines(
+    response: GetManufacturingOrderResponse, *, verbose: bool = True
+) -> list[str]:
     """Render every scalar MO field as ``**field_name**: value`` lines.
 
     Uses canonical Pydantic field names so LLM consumers can't confuse a
     prettified label with a different field name (see #346 follow-on).
     """
-    scalar_fields = (
+    scalar_fields: tuple[str, ...] = (
         "id",
         "order_no",
         "status",
@@ -992,10 +1078,9 @@ def _render_mo_scalar_lines(response: GetManufacturingOrderResponse) -> list[str
         "material_cost",
         "subassemblies_cost",
         "operations_cost",
-        "created_at",
-        "updated_at",
-        "deleted_at",
     )
+    if verbose:
+        scalar_fields += ("created_at", "updated_at", "deleted_at")
     lines: list[str] = []
     for fname in scalar_fields:
         val = getattr(response, fname)
@@ -1019,10 +1104,10 @@ def _render_list_field(label: str, items: list[Any], renderer: Any) -> list[str]
     return lines
 
 
-def _render_recipe_row_md(row: RecipeRowInfo) -> str:
+def _render_recipe_row_md(row: RecipeRowInfo, *, verbose: bool = True) -> str:
     """Render a single recipe row as a compact multi-line block."""
     lines = [f"  - **id**: {row.id}"]
-    scalar_fields = (
+    scalar_fields: tuple[str, ...] = (
         "manufacturing_order_id",
         "variant_id",
         "sku",
@@ -1034,10 +1119,9 @@ def _render_recipe_row_md(row: RecipeRowInfo) -> str:
         "ingredient_availability",
         "ingredient_expected_date",
         "cost",
-        "created_at",
-        "updated_at",
-        "deleted_at",
     )
+    if verbose:
+        scalar_fields += ("created_at", "updated_at", "deleted_at")
     for fname in scalar_fields:
         val = getattr(row, fname)
         if val is None or val == "":
@@ -1047,15 +1131,15 @@ def _render_recipe_row_md(row: RecipeRowInfo) -> str:
         lines.append(f"    **batch_transactions** ({len(row.batch_transactions)}):")
         for bt in row.batch_transactions:
             lines.append(f"      - batch_id={bt.batch_id}, quantity={bt.quantity}")
-    else:
+    elif verbose:
         lines.append("    **batch_transactions**: []")
     return "\n".join(lines)
 
 
-def _render_operation_row_md(row: OperationRowInfo) -> str:
+def _render_operation_row_md(row: OperationRowInfo, *, verbose: bool = True) -> str:
     """Render a single operation row as a compact multi-line block."""
     lines = [f"  - **id**: {row.id}"]
-    scalar_fields = (
+    scalar_fields: tuple[str, ...] = (
         "manufacturing_order_id",
         "status",
         "type_",
@@ -1077,10 +1161,9 @@ def _render_operation_row_md(row: OperationRowInfo) -> str:
         "group_boundary",
         "is_status_actionable",
         "completed_at",
-        "created_at",
-        "updated_at",
-        "deleted_at",
     )
+    if verbose:
+        scalar_fields += ("created_at", "updated_at", "deleted_at")
     for fname in scalar_fields:
         val = getattr(row, fname)
         if val is None or val == "":
@@ -1089,7 +1172,8 @@ def _render_operation_row_md(row: OperationRowInfo) -> str:
     for list_name in ("assigned_operators", "completed_by_operators"):
         items = getattr(row, list_name)
         if not items:
-            lines.append(f"    **{list_name}**: []")
+            if verbose:
+                lines.append(f"    **{list_name}**: []")
             continue
         lines.append(f"    **{list_name}** ({len(items)}):")
         for op in items:
@@ -1097,18 +1181,17 @@ def _render_operation_row_md(row: OperationRowInfo) -> str:
     return "\n".join(lines)
 
 
-def _render_production_md(prod: ProductionInfo) -> str:
+def _render_production_md(prod: ProductionInfo, *, verbose: bool = True) -> str:
     """Render a single production record as a compact multi-line block."""
     lines = [f"  - **id**: {prod.id}"]
-    scalar_fields = (
+    scalar_fields: tuple[str, ...] = (
         "manufacturing_order_id",
         "factory_id",
         "quantity",
         "production_date",
-        "created_at",
-        "updated_at",
-        "deleted_at",
     )
+    if verbose:
+        scalar_fields += ("created_at", "updated_at", "deleted_at")
     for fname in scalar_fields:
         val = getattr(prod, fname)
         if val is None or val == "":
@@ -1146,11 +1229,19 @@ def _render_production_md(prod: ProductionInfo) -> str:
 
 def _render_mo_list_fields_md(
     response: GetManufacturingOrderResponse,
+    *,
+    verbose: bool = True,
+    include_rows: Literal["all", "blocking", "none"] = "all",
+    include_operation_rows: bool = True,
+    include_productions: bool = True,
 ) -> list[str]:
     """Render every list-shaped field with canonical names + explicit list syntax.
 
     Empty lists render as ``**field**: []`` (motivation: #346 follow-on —
-    no bare section headers that could be misread as scalar values).
+    no bare section headers that could be misread as scalar values) when
+    ``verbose=True``. In compact mode, empty/omitted collections are
+    suppressed entirely so the response stays under inline tool-result
+    limits.
     """
     lines: list[str] = []
     # MO-level batch_transactions
@@ -1159,7 +1250,7 @@ def _render_mo_list_fields_md(
         lines.append(f"**batch_transactions** ({len(response.batch_transactions)}):")
         for bt in response.batch_transactions:
             lines.append(f"  - batch_id={bt.batch_id}, quantity={bt.quantity}")
-    else:
+    elif verbose:
         lines.append("**batch_transactions**: []")
     # MO-level serial_numbers
     if response.serial_numbers:
@@ -1170,19 +1261,42 @@ def _render_mo_list_fields_md(
                 f"  - id={sn.id}, serial_number={sn.serial_number}, "
                 f"transaction_date={sn.transaction_date}"
             )
-    else:
+    elif verbose:
         lines.append("**serial_numbers**: []")
-    lines.extend(
-        _render_list_field("recipe_rows", response.recipe_rows, _render_recipe_row_md)
-    )
-    lines.extend(
-        _render_list_field(
-            "operation_rows", response.operation_rows, _render_operation_row_md
+
+    # Render each collection with the canonical field-name label. In
+    # compact mode, an empty/omitted collection is suppressed entirely
+    # (no ``**field**: []`` placeholder) so the response stays small. The
+    # blocking-filter is surfaced as a sibling annotation rather than
+    # decorating the field name, so consumers parsing the markdown still
+    # see the canonical ``recipe_rows`` header.
+    if include_rows != "none" and (verbose or response.recipe_rows):
+        if include_rows == "blocking":
+            lines.append("")
+            lines.append("_recipe_rows filtered to blocking rows only_")
+        lines.extend(
+            _render_list_field(
+                "recipe_rows",
+                response.recipe_rows,
+                lambda r: _render_recipe_row_md(r, verbose=verbose),
+            )
         )
-    )
-    lines.extend(
-        _render_list_field("productions", response.productions, _render_production_md)
-    )
+    if include_operation_rows and (verbose or response.operation_rows):
+        lines.extend(
+            _render_list_field(
+                "operation_rows",
+                response.operation_rows,
+                lambda r: _render_operation_row_md(r, verbose=verbose),
+            )
+        )
+    if include_productions and (verbose or response.productions):
+        lines.extend(
+            _render_list_field(
+                "productions",
+                response.productions,
+                lambda p: _render_production_md(p, verbose=verbose),
+            )
+        )
     return lines
 
 
@@ -1191,38 +1305,86 @@ def _render_mo_list_fields_md(
 async def get_manufacturing_order(
     request: Annotated[GetManufacturingOrderRequest, Unpack()], context: Context
 ) -> ToolResult:
-    """Look up a manufacturing order by number or ID with exhaustive detail.
+    """Look up a manufacturing order by number or ID, compact-by-default.
 
-    For multiple manufacturing orders at once, use ``list_manufacturing_orders(ids=[...])`` —
-    it returns a summary table and supports all the same filters.
+    The default response shape is built for procurement triage: every scalar
+    MO field, plus only the *blocking* recipe rows (those with
+    ``ingredient_availability`` of NOT_AVAILABLE / EXPECTED), with per-row
+    metadata stripped. Operation rows and production records are omitted
+    unless ``include_operation_rows`` / ``include_productions`` are set.
 
-    Returns every field Katana exposes on the manufacturing order (status,
-    quantities, costs, timings, timestamps, linked sales order, batch and
-    serial transactions) plus the full recipe rows, operation rows, and
-    production records. Use with ``list_manufacturing_orders`` for discovery
-    workflows; this tool is the single-call path to the rest.
+    Toggle the projection with the request flags:
+      * ``include_rows`` — ``"blocking"`` (default), ``"all"``, or ``"none"``.
+      * ``include_operation_rows`` / ``include_productions`` — bring the
+        respective collections back; each triggers its own upstream fetch.
+      * ``verbose`` — restore stripped metadata (created_at/updated_at/deleted_at)
+        and explicit empty-list placeholders. Combined with all three
+        ``include_*`` flags this reproduces the legacy exhaustive payload
+        byte-for-byte.
 
-    Provide either order_no (e.g., '#WEB20082 / 1') or order_id.
+    For multiple manufacturing orders at once, use
+    ``list_manufacturing_orders(ids=[...])`` — it returns a summary table
+    that already exposes ``ingredient_availability`` so you can pick which
+    MOs to drill into. To roll up blocking SKUs across many MOs, use
+    ``list_blocking_ingredients``.
+
+    Provide either ``order_no`` (e.g., '#WEB20082 / 1') or ``order_id``.
     """
     response = await _get_manufacturing_order_impl(request, context)
 
+    # In compact mode, prune null fields and per-row metadata from the JSON
+    # output so the response fits under inline tool-result limits. The
+    # production-record shape mixes scalar metadata to drop with nested
+    # collections to descend into; pydantic accepts that as a dict that
+    # mixes ``True`` (exclude leaf) with nested ``{"__all__": ...}`` dicts.
+    # Collections the caller explicitly opted out of are dropped entirely
+    # (rather than serialized as ``[]``) so the documented "omit" contract
+    # actually holds in the JSON payload.
+    dump_kwargs: dict[str, Any] = {}
+    exclude: dict[str, Any] = {}
+    if request.include_rows == "none":
+        exclude["recipe_rows"] = True
+    elif not request.verbose:
+        exclude["recipe_rows"] = {"__all__": set(_ROW_METADATA_FIELDS)}
+    if not request.include_operation_rows:
+        exclude["operation_rows"] = True
+    elif not request.verbose:
+        exclude["operation_rows"] = {"__all__": set(_ROW_METADATA_FIELDS)}
+    if not request.include_productions:
+        exclude["productions"] = True
+    elif not request.verbose:
+        production_exclude: dict[str, Any] = dict.fromkeys(_ROW_METADATA_FIELDS, True)
+        production_exclude["ingredients"] = {"__all__": set(_ROW_METADATA_FIELDS)}
+        production_exclude["operations"] = {"__all__": set(_ROW_METADATA_FIELDS)}
+        exclude["productions"] = {"__all__": production_exclude}
+    if not request.verbose:
+        dump_kwargs["exclude_none"] = True
+    if exclude:
+        dump_kwargs["exclude"] = exclude
+
     if request.format == "json":
         return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
+            content=response.model_dump_json(indent=2, **dump_kwargs),
+            structured_content=response.model_dump(**dump_kwargs),
         )
 
     # Labels use the canonical Pydantic field names so LLM consumers can't
     # confuse a section header with the field name (see #346 follow-on).
     md_lines = [f"## MO {response.order_no or response.id}"]
-    md_lines.extend(_render_mo_scalar_lines(response))
-    md_lines.extend(_render_mo_list_fields_md(response))
-
-    from katana_mcp.tools.tool_result_utils import make_simple_result
+    md_lines.extend(_render_mo_scalar_lines(response, verbose=request.verbose))
+    md_lines.extend(
+        _render_mo_list_fields_md(
+            response,
+            verbose=request.verbose,
+            include_rows=request.include_rows,
+            include_operation_rows=request.include_operation_rows,
+            include_productions=request.include_productions,
+        )
+    )
 
     return make_simple_result(
         "\n".join(md_lines),
-        structured_data=response.model_dump(),
+        structured_data=response.model_dump(**dump_kwargs),
     )
 
 
@@ -2134,6 +2296,7 @@ class ManufacturingOrderSummary(BaseModel):
     id: int
     order_no: str | None
     status: str | None
+    ingredient_availability: str | None
     variant_id: int | None
     planned_quantity: float | None
     actual_quantity: float | None
@@ -2280,6 +2443,7 @@ async def _list_manufacturing_orders_impl(
                 id=mo.id,
                 order_no=mo.order_no,
                 status=enum_to_str(mo.status),
+                ingredient_availability=enum_to_str(mo.ingredient_availability),
                 variant_id=mo.variant_id,
                 planned_quantity=mo.planned_quantity,
                 actual_quantity=mo.actual_quantity,
@@ -2345,6 +2509,7 @@ async def list_manufacturing_orders(
             headers=[
                 "Order #",
                 "Status",
+                "Ingredients",
                 "Variant",
                 "Planned",
                 "Actual",
@@ -2355,6 +2520,7 @@ async def list_manufacturing_orders(
                 [
                     o.order_no or o.id,
                     o.status or "—",
+                    o.ingredient_availability or "—",
                     o.variant_id if o.variant_id is not None else "—",
                     o.planned_quantity if o.planned_quantity is not None else "—",
                     o.actual_quantity if o.actual_quantity is not None else "—",
@@ -2375,6 +2541,482 @@ async def list_manufacturing_orders(
             md += summary
 
     return make_simple_result(md, structured_data=response.model_dump())
+
+
+# ============================================================================
+# Tool: list_blocking_ingredients
+# ============================================================================
+
+
+class ListBlockingIngredientsRequest(BaseModel):
+    """Request to roll up blocking-ingredient rows across manufacturing orders."""
+
+    mo_status: CoercedStrListOpt = Field(
+        default=None,
+        description=(
+            "MO statuses to scope the rollup. JSON array (or CSV string) of "
+            'GetAllManufacturingOrdersStatus values, e.g. ["NOT_STARTED", "IN_PROGRESS"]. '
+            "Defaults to NOT_STARTED + IN_PROGRESS — the active queue procurement "
+            "actually cares about."
+        ),
+    )
+    mo_ids: CoercedIntListOpt = Field(
+        default=None,
+        description=(
+            "Restrict the rollup to a specific list of MO IDs. JSON array of "
+            "integers, e.g. [101, 202, 303]."
+        ),
+    )
+    mo_order_nos: CoercedStrListOpt = Field(
+        default=None,
+        description=(
+            "Restrict the rollup to MOs with these order_no values. JSON array "
+            'of strings, e.g. ["#WEB20402 / 1", "#WEB20462 / 2"].'
+        ),
+    )
+    location_id: int | None = Field(
+        default=None,
+        description="Restrict the rollup to MOs at this production location.",
+    )
+    production_deadline_after: str | None = Field(
+        default=None,
+        description="ISO-8601 datetime lower bound on production_deadline_date.",
+    )
+    production_deadline_before: str | None = Field(
+        default=None,
+        description="ISO-8601 datetime upper bound on production_deadline_date.",
+    )
+    group_by: Literal["variant", "mo"] = Field(
+        default="variant",
+        description=(
+            "Aggregation axis. 'variant' (default) returns one row per blocking "
+            "SKU with the count of affected MOs and total quantity needed — the "
+            "procurement-priority view. 'mo' returns one block per MO with its "
+            "blocking rows, preserving per-row detail."
+        ),
+    )
+    limit: int = Field(
+        default=100,
+        ge=1,
+        le=500,
+        description="Max aggregate rows to return (default 100, max 500).",
+    )
+    format: Literal["markdown", "json"] = Field(
+        default="markdown",
+        description=(
+            "Output format: 'markdown' (default) for human-readable tables; "
+            "'json' for structured data."
+        ),
+    )
+
+
+class BlockingRow(BaseModel):
+    """One blocking recipe-row entry within a per-MO grouping."""
+
+    recipe_row_id: int
+    variant_id: int | None
+    sku: str | None
+    planned_quantity_per_unit: float | None
+    total_remaining_quantity: float | None
+    ingredient_availability: str | None
+    ingredient_expected_date: str | None
+
+
+class BlockingIngredientByMO(BaseModel):
+    """A manufacturing order with at least one blocking recipe row."""
+
+    manufacturing_order_id: int
+    order_no: str | None
+    status: str | None
+    production_deadline_date: str | None
+    blocking_rows: list[BlockingRow]
+
+
+class BlockingIngredientByVariant(BaseModel):
+    """A SKU rolled up across the MOs it's blocking."""
+
+    variant_id: int
+    sku: str | None
+    affected_mo_count: int
+    affected_mo_order_nos: list[str]
+    total_planned_quantity: float
+    total_remaining_quantity: float
+    earliest_expected_date: str | None
+
+
+class ListBlockingIngredientsResponse(BaseModel):
+    """Aggregate response for ``list_blocking_ingredients``.
+
+    Exactly one of ``by_variant`` / ``by_mo`` is populated based on the
+    request's ``group_by`` setting.
+    """
+
+    by_variant: list[BlockingIngredientByVariant] | None = None
+    by_mo: list[BlockingIngredientByMO] | None = None
+    total_blocking_rows: int
+    total_affected_mos: int
+
+
+@dataclass
+class _VariantAggregate:
+    """In-loop accumulator for the variant-rollup branch of ``list_blocking_ingredients``.
+
+    ``mo_ids`` and ``order_nos`` are tracked separately because the
+    affected-MO count must reflect every blocked MO regardless of whether
+    Katana populated its ``order_no`` (rare but possible — e.g., MOs created
+    via API before an order_no was assigned). Display lists only show the
+    populated order numbers.
+    """
+
+    mo_ids: set[int] = field(default_factory=set)
+    order_nos: set[str] = field(default_factory=set)
+    planned: float = 0.0
+    remaining: float = 0.0
+    earliest: datetime | None = None
+
+
+def _coerce_status_filter(
+    statuses: list[str] | None,
+) -> list[Any]:
+    """Translate request-side status strings to the cached enum used in queries.
+
+    Default to the active-procurement scope (NOT_STARTED + IN_PROGRESS) when
+    the caller doesn't pin one. ``coerce_enum`` raises ``ValueError`` if a
+    string isn't a valid ``ManufacturingOrderStatus`` member, so an LLM that
+    sends, say, ``["IN-PROGRESS"]`` (hyphen) gets a clear schema-boundary error.
+    """
+    from katana_public_api_client.models_pydantic._generated import (
+        ManufacturingOrderStatus,
+    )
+
+    if statuses is None:
+        return [
+            ManufacturingOrderStatus.not_started,
+            ManufacturingOrderStatus.in_progress,
+        ]
+    return [coerce_enum(s, ManufacturingOrderStatus, "mo_status") for s in statuses]
+
+
+async def _list_blocking_ingredients_impl(
+    request: ListBlockingIngredientsRequest, context: Context
+) -> ListBlockingIngredientsResponse:
+    """Aggregate blocking recipe rows across MOs from the typed cache.
+
+    The cache holds both ``CachedManufacturingOrder`` and
+    ``CachedManufacturingOrderRecipeRow`` already (synced by the velocity
+    report and by sibling tools); the rollup is a single SQL join + filter.
+    Variant SKUs come from the legacy in-memory ``CatalogCache`` since
+    variants don't have a typed-cache table yet.
+    """
+    from sqlmodel import select
+
+    from katana_mcp.typed_cache import (
+        ensure_manufacturing_order_recipe_rows_synced,
+        ensure_manufacturing_orders_synced,
+    )
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedManufacturingOrder,
+        CachedManufacturingOrderRecipeRow,
+    )
+
+    services = get_services(context)
+
+    # The two sync helpers acquire disjoint per-entity locks, so gather is
+    # safe here (same pattern as `_fetch_completed_mo_recipe_rows_in_window`).
+    await asyncio.gather(
+        ensure_manufacturing_orders_synced(services.client, services.typed_cache),
+        ensure_manufacturing_order_recipe_rows_synced(
+            services.client, services.typed_cache
+        ),
+    )
+
+    parsed_dates = parse_request_dates(
+        request, ("production_deadline_after", "production_deadline_before")
+    )
+
+    statuses = _coerce_status_filter(request.mo_status)
+
+    # Fetch (recipe_row, mo) pairs for any MO/row in scope. Filtering happens
+    # at the SQL layer to keep the wire-payload off the Python heap.
+    stmt = (
+        select(CachedManufacturingOrderRecipeRow, CachedManufacturingOrder)
+        .join(
+            CachedManufacturingOrder,
+            CachedManufacturingOrder.id
+            == CachedManufacturingOrderRecipeRow.manufacturing_order_id,
+        )
+        .where(CachedManufacturingOrder.deleted_at.is_(None))
+        .where(CachedManufacturingOrderRecipeRow.deleted_at.is_(None))
+        .where(CachedManufacturingOrder.status.in_(statuses))
+        .where(
+            CachedManufacturingOrderRecipeRow.ingredient_availability.in_(
+                list(_BLOCKING_AVAILABILITY)
+            )
+        )
+    )
+    if request.mo_ids is not None:
+        stmt = stmt.where(CachedManufacturingOrder.id.in_(request.mo_ids))
+    if request.mo_order_nos is not None:
+        stmt = stmt.where(CachedManufacturingOrder.order_no.in_(request.mo_order_nos))
+    if request.location_id is not None:
+        stmt = stmt.where(CachedManufacturingOrder.location_id == request.location_id)
+    stmt = apply_date_window_filters(
+        stmt,
+        parsed_dates,
+        ge_pairs={
+            "production_deadline_after": CachedManufacturingOrder.production_deadline_date,
+        },
+        le_pairs={
+            "production_deadline_before": CachedManufacturingOrder.production_deadline_date,
+        },
+    )
+
+    async with services.typed_cache.session() as session:
+        result = await session.exec(stmt)
+        pairs: list[tuple[Any, Any]] = list(result.all())
+
+    total_blocking_rows = len(pairs)
+    total_affected_mos = len({mo.id for _row, mo in pairs})
+
+    # Aggregate first, slice to ``limit`` second, resolve SKUs third — only
+    # the variants that survived the limit hit the legacy catalog cache.
+    # Avoids an N-row SQLite read when the caller wants the top-N rollup
+    # but the join produced thousands of recipe rows.
+    if request.group_by == "mo":
+        by_mo_map: dict[int, BlockingIngredientByMO] = {}
+        for row, mo in pairs:
+            entry = by_mo_map.get(mo.id)
+            if entry is None:
+                entry = BlockingIngredientByMO(
+                    manufacturing_order_id=mo.id,
+                    order_no=mo.order_no,
+                    status=enum_to_str(mo.status),
+                    production_deadline_date=iso_or_none(mo.production_deadline_date),
+                    blocking_rows=[],
+                )
+                by_mo_map[mo.id] = entry
+            entry.blocking_rows.append(
+                BlockingRow(
+                    recipe_row_id=row.id,
+                    variant_id=row.variant_id,
+                    sku=None,  # filled in below after slicing
+                    planned_quantity_per_unit=row.planned_quantity_per_unit,
+                    total_remaining_quantity=row.total_remaining_quantity,
+                    # WHERE clause guarantees ingredient_availability is set
+                    # to one of the blocking enum values; enum_to_str returns
+                    # the canonical string for those.
+                    ingredient_availability=enum_to_str(row.ingredient_availability),
+                    ingredient_expected_date=iso_or_none(row.ingredient_expected_date),
+                )
+            )
+        # Earliest deadline first — that's the procurement priority order.
+        by_mo = sorted(
+            by_mo_map.values(),
+            key=lambda e: e.production_deadline_date or "9999-12-31",
+        )[: request.limit]
+        kept_variant_ids = {
+            br.variant_id
+            for entry in by_mo
+            for br in entry.blocking_rows
+            if br.variant_id is not None
+        }
+        sku_by_variant = await _resolve_variant_skus(services, kept_variant_ids)
+        for entry in by_mo:
+            for br in entry.blocking_rows:
+                if br.variant_id is not None:
+                    br.sku = sku_by_variant.get(br.variant_id)
+        return ListBlockingIngredientsResponse(
+            by_mo=by_mo,
+            total_blocking_rows=total_blocking_rows,
+            total_affected_mos=total_affected_mos,
+        )
+
+    # group_by == "variant"
+    agg: dict[int, _VariantAggregate] = {}
+    for row, mo in pairs:
+        if row.variant_id is None:
+            continue
+        bucket = agg.setdefault(row.variant_id, _VariantAggregate())
+        bucket.mo_ids.add(mo.id)
+        if mo.order_no:
+            bucket.order_nos.add(mo.order_no)
+        per_unit = row.planned_quantity_per_unit or 0.0
+        mo_qty = mo.planned_quantity or 0.0
+        bucket.planned += float(per_unit) * float(mo_qty)
+        bucket.remaining += float(row.total_remaining_quantity or 0.0)
+        if row.ingredient_expected_date is not None and (
+            bucket.earliest is None or row.ingredient_expected_date < bucket.earliest
+        ):
+            bucket.earliest = row.ingredient_expected_date
+
+    by_variant: list[BlockingIngredientByVariant] = [
+        BlockingIngredientByVariant(
+            variant_id=vid,
+            sku=None,  # filled in below after slicing
+            affected_mo_count=len(bucket.mo_ids),
+            affected_mo_order_nos=sorted(bucket.order_nos),
+            total_planned_quantity=bucket.planned,
+            total_remaining_quantity=bucket.remaining,
+            earliest_expected_date=iso_or_none(bucket.earliest),
+        )
+        for vid, bucket in agg.items()
+    ]
+    # Most-affected SKUs first; ties broken by total remaining quantity.
+    by_variant.sort(key=lambda v: (-v.affected_mo_count, -v.total_remaining_quantity))
+    by_variant = by_variant[: request.limit]
+    sku_by_variant = await _resolve_variant_skus(
+        services, {v.variant_id for v in by_variant}
+    )
+    for v in by_variant:
+        v.sku = sku_by_variant.get(v.variant_id)
+
+    return ListBlockingIngredientsResponse(
+        by_variant=by_variant,
+        total_blocking_rows=total_blocking_rows,
+        total_affected_mos=total_affected_mos,
+    )
+
+
+async def _resolve_variant_skus(
+    services: Any, variant_ids: set[int] | frozenset[int]
+) -> dict[int, str | None]:
+    """Resolve SKUs for the given variant IDs via the legacy catalog cache.
+
+    Returns ``{variant_id: sku_or_None}``. Empty input → empty dict (no
+    catalog reads). Hitting the cache is cheap per-call but proportional to
+    ``len(variant_ids)``; callers should aggregate/sort/slice first so this
+    only fires for the variants surfaced in the response.
+    """
+    if not variant_ids:
+        return {}
+    ids = sorted(variant_ids)
+    lookups = await asyncio.gather(
+        *(services.cache.get_by_id(EntityType.VARIANT, vid) for vid in ids)
+    )
+    return {
+        vid: (variant.get("sku") if variant else None)
+        for vid, variant in zip(ids, lookups, strict=True)
+    }
+
+
+@observe_tool
+@unpack_pydantic_params
+async def list_blocking_ingredients(
+    request: Annotated[ListBlockingIngredientsRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Roll up blocking-ingredient recipe rows across manufacturing orders.
+
+    Answers "what should procurement order first?" by aggregating recipe
+    rows whose ``ingredient_availability`` is NOT_AVAILABLE or EXPECTED
+    across active MOs. Cache-backed: a single typed-cache join, no per-MO
+    fan-out.
+
+    **Default scope:** NOT_STARTED + IN_PROGRESS MOs. Override via ``mo_status``.
+
+    **group_by="variant"** (default) — one row per SKU, sorted by impact:
+
+    | SKU | Variant ID | Affected MOs | Total Planned | Total Remaining | Earliest Expected |
+
+    **group_by="mo"** — one block per MO, sorted by deadline. Useful when
+    you need per-row detail (notes, exact remaining qty per row).
+    """
+    response = await _list_blocking_ingredients_impl(request, context)
+
+    if request.format == "json":
+        return ToolResult(
+            content=response.model_dump_json(indent=2, exclude_none=True),
+            structured_content=response.model_dump(exclude_none=True),
+        )
+
+    if request.group_by == "variant":
+        rows = response.by_variant or []
+        if not rows:
+            md = (
+                f"## Blocking Ingredients\n\nNo blocking recipe rows in scope "
+                f"(scanned {response.total_blocking_rows} blocking row(s) across "
+                f"{response.total_affected_mos} MO(s))."
+            )
+        else:
+            table = format_md_table(
+                headers=[
+                    "SKU",
+                    "Variant ID",
+                    "Affected MOs",
+                    "Total Planned",
+                    "Total Remaining",
+                    "Earliest Expected",
+                    "Order #s",
+                ],
+                rows=[
+                    [
+                        v.sku or "—",
+                        v.variant_id,
+                        v.affected_mo_count,
+                        f"{v.total_planned_quantity:g}",
+                        f"{v.total_remaining_quantity:g}",
+                        v.earliest_expected_date or "—",
+                        ", ".join(v.affected_mo_order_nos[:5])
+                        + (
+                            f" (+{len(v.affected_mo_order_nos) - 5} more)"
+                            if len(v.affected_mo_order_nos) > 5
+                            else ""
+                        ),
+                    ]
+                    for v in rows
+                ],
+            )
+            md = (
+                f"## Blocking Ingredients by Variant ({len(rows)} variant(s) "
+                f"across {response.total_affected_mos} affected MO(s), "
+                f"{response.total_blocking_rows} blocking row(s))\n\n{table}"
+            )
+    else:
+        mos = response.by_mo or []
+        if not mos:
+            md = "## Blocking Ingredients\n\nNo blocking recipe rows in scope."
+        else:
+            sections: list[str] = [
+                f"## Blocking Ingredients by MO ({len(mos)} MO(s), "
+                f"{response.total_blocking_rows} blocking row(s))"
+            ]
+            for entry in mos:
+                deadline = entry.production_deadline_date or "—"
+                sections.append(
+                    f"\n### {entry.order_no or entry.manufacturing_order_id} "
+                    f"(status: {entry.status or '—'}, deadline: {deadline})"
+                )
+                sections.append(
+                    format_md_table(
+                        headers=[
+                            "SKU",
+                            "Variant ID",
+                            "Per-Unit",
+                            "Remaining",
+                            "Availability",
+                            "Expected",
+                        ],
+                        rows=[
+                            [
+                                r.sku or "—",
+                                r.variant_id if r.variant_id is not None else "—",
+                                r.planned_quantity_per_unit
+                                if r.planned_quantity_per_unit is not None
+                                else "—",
+                                r.total_remaining_quantity
+                                if r.total_remaining_quantity is not None
+                                else "—",
+                                r.ingredient_availability or "—",
+                                r.ingredient_expected_date or "—",
+                            ]
+                            for r in entry.blocking_rows
+                        ],
+                    )
+                )
+            md = "\n".join(sections)
+
+    return make_simple_result(
+        md, structured_data=response.model_dump(exclude_none=True)
+    )
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -2411,6 +3053,10 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "manufacturing", "read"},
         annotations=_read,
     )(get_manufacturing_order)
+    mcp.tool(
+        tags={"orders", "manufacturing", "read", "procurement"},
+        annotations=_read,
+    )(list_blocking_ingredients)
     mcp.tool(
         tags={"orders", "manufacturing", "read"},
         annotations=_read,

--- a/katana_mcp_server/tests/factories.py
+++ b/katana_mcp_server/tests/factories.py
@@ -204,8 +204,9 @@ def make_stock_adjustment_row(
 def make_manufacturing_order(
     *,
     id: int = 1,
-    order_no: str = "MO-TEST",
+    order_no: str | None = "MO-TEST",
     status: ManufacturingOrderStatus | str | None = None,
+    ingredient_availability: str | None = None,
     variant_id: int | None = 100,
     location_id: int | None = 1,
     planned_quantity: float | None = 10.0,
@@ -235,10 +236,21 @@ def make_manufacturing_order(
         else (status if status is not None else ManufacturingOrderStatus.not_started)
     )
 
+    from katana_public_api_client.models_pydantic._generated import (
+        OutsourcedPurchaseOrderIngredientAvailability,
+    )
+
+    resolved_ingredient_availability = (
+        OutsourcedPurchaseOrderIngredientAvailability(ingredient_availability)
+        if ingredient_availability is not None
+        else None
+    )
+
     return CachedManufacturingOrder(
         id=id,
         order_no=order_no,
         status=resolved_status,
+        ingredient_availability=resolved_ingredient_availability,
         variant_id=variant_id,
         location_id=location_id,
         planned_quantity=planned_quantity,
@@ -265,6 +277,9 @@ def make_manufacturing_order_recipe_row(
     total_consumed_quantity: float | None = None,
     total_remaining_quantity: float | None = None,
     cost: float | None = None,
+    ingredient_availability: str | None = None,
+    ingredient_expected_date: datetime | None = None,
+    deleted_at: datetime | None = None,
 ) -> CachedManufacturingOrderRecipeRow:
     """Build a ``CachedManufacturingOrderRecipeRow`` for direct cache insertion.
 
@@ -272,8 +287,19 @@ def make_manufacturing_order_recipe_row(
     FK back to its parent ``CachedManufacturingOrder.id`` via
     ``manufacturing_order_id``. Use alongside :func:`make_manufacturing_order`
     to build parent-child fixtures for tools that join MOs to recipe rows
-    (e.g., ``inventory_velocity``'s MO-consumption path).
+    (e.g., ``inventory_velocity``'s MO-consumption path,
+    ``list_blocking_ingredients``'s availability rollup).
     """
+    from katana_public_api_client.models_pydantic._generated import (
+        OutsourcedPurchaseOrderIngredientAvailability,
+    )
+
+    resolved_availability = (
+        OutsourcedPurchaseOrderIngredientAvailability(ingredient_availability)
+        if ingredient_availability is not None
+        else None
+    )
+
     return CachedManufacturingOrderRecipeRow(
         id=id,
         manufacturing_order_id=manufacturing_order_id,
@@ -283,6 +309,9 @@ def make_manufacturing_order_recipe_row(
         total_consumed_quantity=total_consumed_quantity,
         total_remaining_quantity=total_remaining_quantity,
         cost=cost,
+        ingredient_availability=resolved_availability,
+        ingredient_expected_date=naive_utc(ingredient_expected_date),
+        deleted_at=naive_utc(deleted_at),
     )
 
 

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -1426,10 +1426,12 @@ async def test_get_manufacturing_order_format_json_returns_json():
     assert data["id"] == 3001
     assert data["order_no"] == "MO-2024-001"
     assert data["status"] == "IN_PROGRESS"
-    # Exhaustive response always has list-shaped fields present (may be empty)
+    # Default include_rows="blocking" returns an empty list (zero blocking
+    # rows on this stub); operation_rows + productions are off by default,
+    # so they're omitted entirely from the JSON.
     assert data["recipe_rows"] == []
-    assert data["operation_rows"] == []
-    assert data["productions"] == []
+    assert "operation_rows" not in data
+    assert "productions" not in data
 
 
 @pytest.mark.asyncio
@@ -1547,7 +1549,15 @@ async def test_get_manufacturing_order_full_field_coverage():
         patch(_FETCH_OPS, new_callable=AsyncMock, return_value=[]),
         patch(_FETCH_PRODS, new_callable=AsyncMock, return_value=[]),
     ):
-        request = GetManufacturingOrderRequest(order_id=3001)
+        # Legacy shape: opt back into every collection to preserve the
+        # exhaustive-field contract this test pins.
+        request = GetManufacturingOrderRequest(
+            order_id=3001,
+            include_rows="all",
+            include_operation_rows=True,
+            include_productions=True,
+            verbose=True,
+        )
         result = await _get_manufacturing_order_impl(request, context)
 
     # Every scalar field on ManufacturingOrder must reach the response:
@@ -1647,7 +1657,15 @@ async def test_get_manufacturing_order_fetches_related_resources():
             _FETCH_PRODS, new_callable=AsyncMock, return_value=[production]
         ) as mock_fetch_prods,
     ):
-        request = GetManufacturingOrderRequest(order_id=3001)
+        # Legacy shape: opt back into every collection so all three fetch
+        # helpers are awaited and the recipe row (IN_STOCK) survives the
+        # default "blocking" filter.
+        request = GetManufacturingOrderRequest(
+            order_id=3001,
+            include_rows="all",
+            include_operation_rows=True,
+            include_productions=True,
+        )
         result = await _get_manufacturing_order_impl(request, context)
 
     # Each helper called exactly once with the MO id:
@@ -1694,7 +1712,18 @@ async def test_get_manufacturing_order_markdown_uses_canonical_field_names():
             subassemblies_cost=2250.0,
             sales_order_row_id=2501,
         )
-        result = await get_manufacturing_order(order_id=3001, context=context)
+        # Verbose-mode rendering pins the explicit-empty-list contract.
+        # Compact mode (the default) suppresses ``**field**: []`` placeholders
+        # to keep the response small — that surface is exercised by separate
+        # compact-mode tests below.
+        result = await get_manufacturing_order(
+            order_id=3001,
+            include_rows="all",
+            include_operation_rows=True,
+            include_productions=True,
+            verbose=True,
+            context=context,
+        )
 
     text = result.content[0].text
     # Canonical scalar labels — the prettified versions the old impl used
@@ -1776,3 +1805,741 @@ async def test_get_manufacturing_order_recipe_full_field_coverage():
     assert info.total_actual_quantity == 125.0
     assert info.ingredient_availability == "IN_STOCK"
     assert info.cost == 437.5
+
+
+# ============================================================================
+# Compact-by-default get_manufacturing_order
+# ============================================================================
+
+
+def _mk_recipe_row(
+    *,
+    id: int,
+    availability: str,
+    variant_id: int = 200,
+    sku: str | None = None,
+):
+    """Build a minimal RecipeRowInfo for compact-mode tests."""
+    from katana_mcp.tools.foundation.manufacturing_orders import RecipeRowInfo
+
+    return RecipeRowInfo(
+        id=id,
+        manufacturing_order_id=3001,
+        variant_id=variant_id,
+        sku=sku,
+        ingredient_availability=availability,
+        created_at="2024-01-15T08:00:00+00:00",
+        updated_at="2024-01-20T14:30:00+00:00",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_manufacturing_order_default_filters_to_blocking_rows():
+    """Default include_rows='blocking' drops IN_STOCK and other non-blocking rows.
+
+    Procurement triage view: a Mayhem-140 build has dozens of IN_STOCK rows,
+    a few NOT_AVAILABLE/EXPECTED rows. Only the blocking ones survive.
+    """
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        GetManufacturingOrderRequest,
+        _get_manufacturing_order_impl,
+    )
+
+    context, _ = create_mock_context()
+    mo = _full_mo_attrs()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = mo
+
+    rows = [
+        _mk_recipe_row(id=1, availability="IN_STOCK"),
+        _mk_recipe_row(id=2, availability="NOT_AVAILABLE"),
+        _mk_recipe_row(id=3, availability="EXPECTED"),
+        _mk_recipe_row(id=4, availability="PROCESSED"),
+        _mk_recipe_row(id=5, availability="NOT_APPLICABLE"),
+    ]
+
+    with (
+        patch(
+            f"{_MO_API}.get_manufacturing_order.asyncio_detailed",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ),
+        patch(_FETCH_RECIPE, new_callable=AsyncMock, return_value=rows),
+        patch(_FETCH_OPS, new_callable=AsyncMock, return_value=[]) as mock_ops,
+        patch(_FETCH_PRODS, new_callable=AsyncMock, return_value=[]) as mock_prods,
+    ):
+        result = await _get_manufacturing_order_impl(
+            GetManufacturingOrderRequest(order_id=3001), context
+        )
+
+    assert {r.id for r in result.recipe_rows} == {2, 3}
+    # Operation rows / productions are off by default → no upstream calls.
+    mock_ops.assert_not_awaited()
+    mock_prods.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_manufacturing_order_include_rows_none_skips_recipe_fetch():
+    """include_rows='none' skips the recipe fetch entirely."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        GetManufacturingOrderRequest,
+        _get_manufacturing_order_impl,
+    )
+
+    context, _ = create_mock_context()
+    mo = _full_mo_attrs()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = mo
+
+    with (
+        patch(
+            f"{_MO_API}.get_manufacturing_order.asyncio_detailed",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ),
+        patch(_FETCH_RECIPE, new_callable=AsyncMock) as mock_recipe,
+        patch(_FETCH_OPS, new_callable=AsyncMock) as mock_ops,
+        patch(_FETCH_PRODS, new_callable=AsyncMock) as mock_prods,
+    ):
+        result = await _get_manufacturing_order_impl(
+            GetManufacturingOrderRequest(order_id=3001, include_rows="none"), context
+        )
+
+    mock_recipe.assert_not_awaited()
+    mock_ops.assert_not_awaited()
+    mock_prods.assert_not_awaited()
+    assert result.recipe_rows == []
+    assert result.operation_rows == []
+    assert result.productions == []
+
+
+@pytest.mark.asyncio
+async def test_get_manufacturing_order_include_rows_all_keeps_in_stock():
+    """include_rows='all' returns every recipe row regardless of availability."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        GetManufacturingOrderRequest,
+        _get_manufacturing_order_impl,
+    )
+
+    context, _ = create_mock_context()
+    mo = _full_mo_attrs()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = mo
+
+    rows = [
+        _mk_recipe_row(id=1, availability="IN_STOCK"),
+        _mk_recipe_row(id=2, availability="NOT_AVAILABLE"),
+    ]
+
+    with (
+        patch(
+            f"{_MO_API}.get_manufacturing_order.asyncio_detailed",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ),
+        patch(_FETCH_RECIPE, new_callable=AsyncMock, return_value=rows),
+        patch(_FETCH_OPS, new_callable=AsyncMock, return_value=[]),
+        patch(_FETCH_PRODS, new_callable=AsyncMock, return_value=[]),
+    ):
+        result = await _get_manufacturing_order_impl(
+            GetManufacturingOrderRequest(order_id=3001, include_rows="all"),
+            context,
+        )
+
+    assert {r.id for r in result.recipe_rows} == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_get_manufacturing_order_compact_json_strips_row_metadata():
+    """Compact mode JSON drops created_at/updated_at/deleted_at on recipe rows."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        GetManufacturingOrderResponse,
+    )
+
+    context, _ = create_mock_context()
+
+    with patch(
+        "katana_mcp.tools.foundation.manufacturing_orders._get_manufacturing_order_impl",
+        new_callable=AsyncMock,
+    ) as mock_impl:
+        mock_impl.return_value = GetManufacturingOrderResponse(
+            id=3001,
+            order_no="MO-X",
+            recipe_rows=[
+                _mk_recipe_row(id=1, availability="NOT_AVAILABLE"),
+            ],
+        )
+        result = await get_manufacturing_order(
+            order_id=3001, format="json", context=context
+        )
+
+    data = json.loads(_content_text(result))
+    row = data["recipe_rows"][0]
+    assert "created_at" not in row
+    assert "updated_at" not in row
+    assert "deleted_at" not in row
+    # Substantive fields survive:
+    assert row["id"] == 1
+    assert row["ingredient_availability"] == "NOT_AVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_get_manufacturing_order_verbose_json_keeps_row_metadata():
+    """verbose=True restores the metadata fields on every row."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        GetManufacturingOrderResponse,
+    )
+
+    context, _ = create_mock_context()
+
+    with patch(
+        "katana_mcp.tools.foundation.manufacturing_orders._get_manufacturing_order_impl",
+        new_callable=AsyncMock,
+    ) as mock_impl:
+        mock_impl.return_value = GetManufacturingOrderResponse(
+            id=3001,
+            order_no="MO-X",
+            recipe_rows=[
+                _mk_recipe_row(id=1, availability="NOT_AVAILABLE"),
+            ],
+        )
+        result = await get_manufacturing_order(
+            order_id=3001, format="json", verbose=True, context=context
+        )
+
+    data = json.loads(_content_text(result))
+    row = data["recipe_rows"][0]
+    assert row["created_at"] == "2024-01-15T08:00:00+00:00"
+    assert row["updated_at"] == "2024-01-20T14:30:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_get_manufacturing_order_compact_markdown_omits_empty_lists():
+    """Compact markdown does not emit ``**field**: []`` placeholders for
+    suppressed/empty collections."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        GetManufacturingOrderResponse,
+    )
+
+    context, _ = create_mock_context()
+
+    with patch(
+        "katana_mcp.tools.foundation.manufacturing_orders._get_manufacturing_order_impl",
+        new_callable=AsyncMock,
+    ) as mock_impl:
+        mock_impl.return_value = GetManufacturingOrderResponse(
+            id=3001,
+            order_no="MO-X",
+            status="IN_PROGRESS",
+        )
+        result = await get_manufacturing_order(order_id=3001, context=context)
+
+    text = result.content[0].text
+    # No bracketed-empty placeholders in compact mode.
+    assert "**recipe_rows**: []" not in text
+    assert "**operation_rows**: []" not in text
+    assert "**productions**: []" not in text
+    assert "**batch_transactions**: []" not in text
+    assert "**serial_numbers**: []" not in text
+    # Suppressed collections do not appear at all (no canonical-name header,
+    # no decorated label, no annotation note).
+    assert "**recipe_rows**" not in text
+    assert "**operation_rows**" not in text
+    assert "**productions**" not in text
+    assert "filtered to blocking rows only" not in text
+    # Scalar header is still rendered.
+    assert "**status**: IN_PROGRESS" in text
+
+
+# ============================================================================
+# list_manufacturing_orders ingredient_availability column
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_manufacturing_orders_includes_ingredient_availability(
+    context_with_typed_cache, no_sync
+):
+    """The list summary surfaces the rolled-up MO-level availability."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListManufacturingOrdersRequest,
+        _list_manufacturing_orders_impl,
+    )
+
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_manufacturing_order(
+                id=1, order_no="MO-1", ingredient_availability="IN_STOCK"
+            ),
+            make_manufacturing_order(
+                id=2, order_no="MO-2", ingredient_availability="NOT_AVAILABLE"
+            ),
+            make_manufacturing_order(
+                id=3, order_no="MO-3", ingredient_availability=None
+            ),
+        ],
+    )
+
+    result = await _list_manufacturing_orders_impl(
+        ListManufacturingOrdersRequest(), context
+    )
+
+    by_id = {o.id: o.ingredient_availability for o in result.orders}
+    assert by_id == {1: "IN_STOCK", 2: "NOT_AVAILABLE", 3: None}
+
+
+# ============================================================================
+# list_blocking_ingredients
+# ============================================================================
+
+
+@pytest.fixture
+def no_sync_recipe_rows():
+    """Patch typed-cache sync for both MOs and recipe rows (used by the rollup)."""
+    with (
+        patch_typed_cache_sync("manufacturing_orders"),
+        patch_typed_cache_sync("manufacturing_order_recipe_rows"),
+    ):
+        yield
+
+
+def _stub_variant_cache(context, sku_by_id: dict[int, str]) -> None:
+    """Stub services.cache.get_by_id(VARIANT, ...) to return SKUs for tests."""
+
+    async def _lookup(_entity_type, vid):
+        sku = sku_by_id.get(vid)
+        return {"sku": sku} if sku else None
+
+    context.request_context.lifespan_context.cache.get_by_id = AsyncMock(
+        side_effect=_lookup
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_blocking_ingredients_aggregates_by_variant(
+    context_with_typed_cache, no_sync_recipe_rows
+):
+    """Three MOs blocked on the same variant → one rollup row, count=3."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListBlockingIngredientsRequest,
+        _list_blocking_ingredients_impl,
+    )
+
+    from tests.factories import make_manufacturing_order_recipe_row
+
+    context, _, typed_cache = context_with_typed_cache
+    _stub_variant_cache(context, {500: "WHEEL-29"})
+
+    await seed_cache(
+        typed_cache,
+        [
+            make_manufacturing_order(id=1, order_no="MO-1", status="IN_PROGRESS"),
+            make_manufacturing_order(id=2, order_no="MO-2", status="NOT_STARTED"),
+            make_manufacturing_order(id=3, order_no="MO-3", status="IN_PROGRESS"),
+            make_manufacturing_order_recipe_row(
+                id=11,
+                manufacturing_order_id=1,
+                variant_id=500,
+                planned_quantity_per_unit=2.0,
+                total_remaining_quantity=4.0,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+            make_manufacturing_order_recipe_row(
+                id=12,
+                manufacturing_order_id=2,
+                variant_id=500,
+                planned_quantity_per_unit=2.0,
+                total_remaining_quantity=4.0,
+                ingredient_availability="EXPECTED",
+            ),
+            make_manufacturing_order_recipe_row(
+                id=13,
+                manufacturing_order_id=3,
+                variant_id=500,
+                planned_quantity_per_unit=2.0,
+                total_remaining_quantity=4.0,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+        ],
+    )
+
+    result = await _list_blocking_ingredients_impl(
+        ListBlockingIngredientsRequest(), context
+    )
+
+    assert result.total_blocking_rows == 3
+    assert result.total_affected_mos == 3
+    assert result.by_mo is None
+    assert result.by_variant is not None and len(result.by_variant) == 1
+    rollup = result.by_variant[0]
+    assert rollup.variant_id == 500
+    assert rollup.sku == "WHEEL-29"
+    assert rollup.affected_mo_count == 3
+    assert sorted(rollup.affected_mo_order_nos) == ["MO-1", "MO-2", "MO-3"]
+    assert rollup.total_remaining_quantity == 12.0
+
+
+@pytest.mark.asyncio
+async def test_list_blocking_ingredients_excludes_in_stock_rows(
+    context_with_typed_cache, no_sync_recipe_rows
+):
+    """IN_STOCK and other non-blocking rows must not enter the rollup."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListBlockingIngredientsRequest,
+        _list_blocking_ingredients_impl,
+    )
+
+    from tests.factories import make_manufacturing_order_recipe_row
+
+    context, _, typed_cache = context_with_typed_cache
+    _stub_variant_cache(context, {500: "WHEEL", 600: "FORK"})
+
+    await seed_cache(
+        typed_cache,
+        [
+            make_manufacturing_order(id=1, order_no="MO-1", status="IN_PROGRESS"),
+            make_manufacturing_order_recipe_row(
+                id=11,
+                manufacturing_order_id=1,
+                variant_id=500,
+                ingredient_availability="IN_STOCK",
+            ),
+            make_manufacturing_order_recipe_row(
+                id=12,
+                manufacturing_order_id=1,
+                variant_id=600,
+                ingredient_availability="NOT_AVAILABLE",
+                total_remaining_quantity=2.0,
+            ),
+        ],
+    )
+
+    result = await _list_blocking_ingredients_impl(
+        ListBlockingIngredientsRequest(), context
+    )
+
+    assert result.total_blocking_rows == 1
+    assert result.by_variant is not None and len(result.by_variant) == 1
+    assert result.by_variant[0].variant_id == 600
+
+
+@pytest.mark.asyncio
+async def test_list_blocking_ingredients_filters_by_status(
+    context_with_typed_cache, no_sync_recipe_rows
+):
+    """Default scope is NOT_STARTED + IN_PROGRESS — DONE MOs are excluded."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListBlockingIngredientsRequest,
+        _list_blocking_ingredients_impl,
+    )
+
+    from tests.factories import make_manufacturing_order_recipe_row
+
+    context, _, typed_cache = context_with_typed_cache
+    _stub_variant_cache(context, {500: "WHEEL"})
+
+    await seed_cache(
+        typed_cache,
+        [
+            make_manufacturing_order(id=1, order_no="MO-1", status="DONE"),
+            make_manufacturing_order(id=2, order_no="MO-2", status="IN_PROGRESS"),
+            make_manufacturing_order_recipe_row(
+                id=11,
+                manufacturing_order_id=1,
+                variant_id=500,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+            make_manufacturing_order_recipe_row(
+                id=12,
+                manufacturing_order_id=2,
+                variant_id=500,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+        ],
+    )
+
+    result = await _list_blocking_ingredients_impl(
+        ListBlockingIngredientsRequest(), context
+    )
+
+    assert result.total_blocking_rows == 1
+    assert result.total_affected_mos == 1
+
+
+@pytest.mark.asyncio
+async def test_list_blocking_ingredients_excludes_deleted(
+    context_with_typed_cache, no_sync_recipe_rows
+):
+    """Soft-deleted MOs and soft-deleted recipe rows are filtered out."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListBlockingIngredientsRequest,
+        _list_blocking_ingredients_impl,
+    )
+
+    from tests.factories import make_manufacturing_order_recipe_row
+
+    context, _, typed_cache = context_with_typed_cache
+    _stub_variant_cache(context, {500: "WHEEL"})
+
+    await seed_cache(
+        typed_cache,
+        [
+            make_manufacturing_order(
+                id=1,
+                order_no="MO-DEL",
+                status="IN_PROGRESS",
+                deleted_at=datetime(2025, 1, 1, tzinfo=UTC),
+            ),
+            make_manufacturing_order(id=2, order_no="MO-LIVE", status="IN_PROGRESS"),
+            make_manufacturing_order_recipe_row(
+                id=11,
+                manufacturing_order_id=1,
+                variant_id=500,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+            make_manufacturing_order_recipe_row(
+                id=12,
+                manufacturing_order_id=2,
+                variant_id=500,
+                ingredient_availability="NOT_AVAILABLE",
+                deleted_at=datetime(2025, 1, 1, tzinfo=UTC),
+            ),
+        ],
+    )
+
+    result = await _list_blocking_ingredients_impl(
+        ListBlockingIngredientsRequest(), context
+    )
+
+    assert result.total_blocking_rows == 0
+
+
+@pytest.mark.asyncio
+async def test_list_blocking_ingredients_groups_by_mo(
+    context_with_typed_cache, no_sync_recipe_rows
+):
+    """group_by='mo' returns one block per affected MO with per-row detail."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListBlockingIngredientsRequest,
+        _list_blocking_ingredients_impl,
+    )
+
+    from tests.factories import make_manufacturing_order_recipe_row
+
+    context, _, typed_cache = context_with_typed_cache
+    _stub_variant_cache(context, {500: "WHEEL", 600: "FORK"})
+
+    await seed_cache(
+        typed_cache,
+        [
+            make_manufacturing_order(id=1, order_no="MO-A", status="IN_PROGRESS"),
+            make_manufacturing_order(id=2, order_no="MO-B", status="IN_PROGRESS"),
+            make_manufacturing_order_recipe_row(
+                id=11,
+                manufacturing_order_id=1,
+                variant_id=500,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+            make_manufacturing_order_recipe_row(
+                id=12,
+                manufacturing_order_id=1,
+                variant_id=600,
+                ingredient_availability="EXPECTED",
+            ),
+            make_manufacturing_order_recipe_row(
+                id=13,
+                manufacturing_order_id=2,
+                variant_id=500,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+        ],
+    )
+
+    result = await _list_blocking_ingredients_impl(
+        ListBlockingIngredientsRequest(group_by="mo"), context
+    )
+
+    assert result.by_variant is None
+    assert result.by_mo is not None and len(result.by_mo) == 2
+    by_id = {entry.manufacturing_order_id: entry for entry in result.by_mo}
+    assert sorted(by_id.keys()) == [1, 2]
+    assert len(by_id[1].blocking_rows) == 2
+    assert len(by_id[2].blocking_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_blocking_ingredients_counts_mos_without_order_no(
+    context_with_typed_cache, no_sync_recipe_rows
+):
+    """``affected_mo_count`` reflects every blocked MO even when ``order_no``
+    is None — display lists only show populated order numbers, but the count
+    must not be undercounted by missing display labels.
+    """
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListBlockingIngredientsRequest,
+        _list_blocking_ingredients_impl,
+    )
+
+    from tests.factories import make_manufacturing_order_recipe_row
+
+    context, _, typed_cache = context_with_typed_cache
+    _stub_variant_cache(context, {500: "WHEEL"})
+
+    mo_with_order_no = make_manufacturing_order(
+        id=1, order_no="MO-NUMBERED", status="IN_PROGRESS"
+    )
+    mo_no_order_no = make_manufacturing_order(id=2, order_no=None, status="IN_PROGRESS")
+    await seed_cache(
+        typed_cache,
+        [
+            mo_with_order_no,
+            mo_no_order_no,
+            make_manufacturing_order_recipe_row(
+                id=11,
+                manufacturing_order_id=1,
+                variant_id=500,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+            make_manufacturing_order_recipe_row(
+                id=12,
+                manufacturing_order_id=2,
+                variant_id=500,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+        ],
+    )
+
+    result = await _list_blocking_ingredients_impl(
+        ListBlockingIngredientsRequest(), context
+    )
+
+    assert result.total_affected_mos == 2
+    assert result.by_variant is not None and len(result.by_variant) == 1
+    rollup = result.by_variant[0]
+    assert rollup.affected_mo_count == 2
+    assert rollup.affected_mo_order_nos == ["MO-NUMBERED"]
+
+
+@pytest.mark.asyncio
+async def test_list_blocking_ingredients_omits_recipe_rows_in_compact_json():
+    """``include_rows='none'`` must drop the recipe_rows key from JSON."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        GetManufacturingOrderResponse,
+    )
+
+    context, _ = create_mock_context()
+
+    with patch(
+        "katana_mcp.tools.foundation.manufacturing_orders._get_manufacturing_order_impl",
+        new_callable=AsyncMock,
+    ) as mock_impl:
+        mock_impl.return_value = GetManufacturingOrderResponse(
+            id=3001, order_no="MO-X", status="IN_PROGRESS"
+        )
+        result = await get_manufacturing_order(
+            order_id=3001, format="json", include_rows="none", context=context
+        )
+
+    data = json.loads(_content_text(result))
+    assert "recipe_rows" not in data
+    assert "operation_rows" not in data
+    assert "productions" not in data
+
+
+@pytest.mark.asyncio
+async def test_list_blocking_ingredients_accepts_csv_order_nos():
+    """``mo_order_nos`` accepts a CSV string via CoercedStrListOpt for LLM ergonomics."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListBlockingIngredientsRequest,
+    )
+
+    # CoercedStrListOpt's BeforeValidator accepts CSV/JSON strings as well as
+    # bare lists; ``model_validate`` is the schema-boundary entry point that
+    # exercises that coercion (the constructor is statically typed to list[str]).
+    request = ListBlockingIngredientsRequest.model_validate(
+        {"mo_order_nos": "MO-1,MO-2"}
+    )
+    assert request.mo_order_nos == ["MO-1", "MO-2"]
+
+
+@pytest.mark.asyncio
+async def test_list_blocking_ingredients_accepts_csv_status():
+    """``mo_status`` accepts a CSV string the same way ``mo_order_nos`` does."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListBlockingIngredientsRequest,
+    )
+
+    request = ListBlockingIngredientsRequest.model_validate(
+        {"mo_status": "NOT_STARTED,IN_PROGRESS"}
+    )
+    assert request.mo_status == ["NOT_STARTED", "IN_PROGRESS"]
+
+
+@pytest.mark.asyncio
+async def test_list_blocking_ingredients_resolves_skus_only_for_kept_variants(
+    context_with_typed_cache, no_sync_recipe_rows
+):
+    """SKU lookups must happen *after* aggregation+slice so the legacy
+    catalog cache only handles variants that actually appear in the response.
+
+    Seeds two blocking variants (impact 1 and 2 MOs respectively); with
+    ``limit=1`` only the higher-impact variant survives. Asserts that
+    ``services.cache.get_by_id`` was awaited exactly once — for that variant.
+    """
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        ListBlockingIngredientsRequest,
+        _list_blocking_ingredients_impl,
+    )
+
+    from tests.factories import make_manufacturing_order_recipe_row
+
+    context, _, typed_cache = context_with_typed_cache
+    _stub_variant_cache(context, {500: "WHEEL", 600: "FORK"})
+
+    await seed_cache(
+        typed_cache,
+        [
+            make_manufacturing_order(id=1, order_no="MO-1", status="IN_PROGRESS"),
+            make_manufacturing_order(id=2, order_no="MO-2", status="IN_PROGRESS"),
+            # variant 500: blocked across both MOs (higher impact, kept)
+            make_manufacturing_order_recipe_row(
+                id=11,
+                manufacturing_order_id=1,
+                variant_id=500,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+            make_manufacturing_order_recipe_row(
+                id=12,
+                manufacturing_order_id=2,
+                variant_id=500,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+            # variant 600: blocked on MO-1 only (lower impact, dropped by limit=1)
+            make_manufacturing_order_recipe_row(
+                id=13,
+                manufacturing_order_id=1,
+                variant_id=600,
+                ingredient_availability="NOT_AVAILABLE",
+            ),
+        ],
+    )
+
+    result = await _list_blocking_ingredients_impl(
+        ListBlockingIngredientsRequest(limit=1), context
+    )
+
+    # Only the higher-impact variant survives.
+    assert result.by_variant is not None and len(result.by_variant) == 1
+    assert result.by_variant[0].variant_id == 500
+    assert result.by_variant[0].sku == "WHEEL"
+    # Legacy cache hit only once — for the kept variant. The dropped
+    # variant 600 never makes it to the catalog cache.
+    cache_mock = context.request_context.lifespan_context.cache.get_by_id
+    assert cache_mock.await_count == 1
+    awaited_vid = cache_mock.await_args.args[1]
+    assert awaited_vid == 500

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.45.0"
+version = "0.45.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Procurement triage workflow was forced to fan out 32+ individual `get_manufacturing_order` calls (each ~58–60K chars on a full-bike MO, overflowing the inline tool result limit) just to find which MOs were blocked. This change makes that workflow a one-call answer.

- **`get_manufacturing_order`: compact-by-default.** New params `include_rows` (`"blocking"` default), `include_operation_rows` / `include_productions` (off by default), and `verbose`. Compact mode strips per-row metadata (`created_at`/`updated_at`/`deleted_at`) and skips upstream fetches for collections the caller didn't ask for. `verbose=True` + the `include_*` flags reproduce the legacy exhaustive payload byte-for-byte.

- **`list_manufacturing_orders`: `ingredient_availability` column.** `ManufacturingOrderSummary` now exposes the rolled-up MO-level state. One list call surfaces every blocked MO; no per-MO fan-out needed.

- **`list_blocking_ingredients` (new tool).** Cache-backed SQL aggregate of blocking recipe rows across MOs. `group_by="variant"` rolls up by SKU sorted by impact (the procurement-priority view); `group_by="mo"` returns per-MO sections for drilldown. Default scope is `NOT_STARTED + IN_PROGRESS`. Reuses the `CachedManufacturingOrderRecipeRow` sync that `inventory_velocity` already populates — no new cache tables.

## Breaking change

`get_manufacturing_order`'s default response shape is now compact: only blocking recipe rows, no operation rows, no production records, no per-row metadata. Pass `include_rows="all"`, `include_operation_rows=True`, `include_productions=True`, `verbose=True` to reproduce the legacy payload byte-for-byte. Justification in the commit message.

## Test plan

- [x] \`uv run poe check\` (2507 passed, 2 skipped)
- [x] Unit coverage for compact-by-default, \`include_rows="none"\` skipping fetches, \`verbose=True\` restoring metadata, JSON metadata stripping, and all four \`list_blocking_ingredients\` paths (variant rollup, in-stock exclusion, status filter, soft-delete exclusion, MO grouping)
- [ ] Manual smoke test against \`katana-erp-dev\`:
  - \`list_manufacturing_orders\` shows the new \`Ingredients\` column
  - \`get_manufacturing_order order_no="#WEB20402 / 1"\` returns < 24K chars (was 60K)
  - \`get_manufacturing_order ... verbose=True include_rows=all include_operation_rows=True include_productions=True\` reproduces the legacy payload
  - \`list_blocking_ingredients\` surfaces real blocking variants from the dev tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)