### PR TITLE
test: timing-test flake + speed sweep (saves ~9s = 40% off poe test)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,11 +18,13 @@ _SPEC_PATH = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
 def openapi_spec() -> dict[str, Any]:
     """Parsed contents of ``docs/katana-openapi.yaml``.
 
-    Session-scoped so the (large) spec file is read and YAML-parsed exactly
-    once per pytest run, then shared across the ~7 test modules that
-    inspect it. Without this fixture each module loaded the spec
-    independently — ~0.5s per load times 7 modules dominated the slow-test
-    list (~3-4s of repeated work per ``poe test`` run).
+    Session-scoped so the (large) spec file is read and YAML-parsed once
+    per worker process (or once total in single-process mode — pytest-xdist
+    runs session fixtures once per worker, not once per ``pytest`` invocation),
+    then shared across the ~7 test modules that inspect it. Without this
+    fixture each module loaded the spec independently — ~0.5s per load
+    times 7 modules dominated the slow-test list (~3-4s of repeated work
+    per ``poe test`` run).
     """
     with open(_SPEC_PATH, encoding="utf-8") as f:
         return yaml.safe_load(f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,31 @@
 """Test configuration and fixtures for the Katana OpenAPI Client test suite."""
 
 import os
+from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
+import yaml
 
 from katana_public_api_client import KatanaClient
+
+_SPEC_PATH = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
+
+
+@pytest.fixture(scope="session")
+def openapi_spec() -> dict[str, Any]:
+    """Parsed contents of ``docs/katana-openapi.yaml``.
+
+    Session-scoped so the (large) spec file is read and YAML-parsed exactly
+    once per pytest run, then shared across the ~7 test modules that
+    inspect it. Without this fixture each module loaded the spec
+    independently — ~0.5s per load times 7 modules dominated the slow-test
+    list (~3-4s of repeated work per ``poe test`` run).
+    """
+    with open(_SPEC_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f)
 
 
 @pytest.fixture

--- a/tests/test_api_quality_analysis.py
+++ b/tests/test_api_quality_analysis.py
@@ -5,22 +5,18 @@ consistency across endpoints, extractable parameters worth promoting to
 shared definitions, etc. Direct yaml inspection — no external scripts.
 """
 
-from pathlib import Path
 from typing import Any
 
 import pytest
-import yaml
 
 
 class TestAPIQualityAnalysis:
     """Test API quality metrics and design recommendations."""
 
     @pytest.fixture(scope="class")
-    def api_spec(self) -> dict[str, Any]:
-        """Load the OpenAPI specification."""
-        spec_path = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
-        with open(spec_path, encoding="utf-8") as f:
-            return yaml.safe_load(f)
+    def api_spec(self, openapi_spec: dict[str, Any]) -> dict[str, Any]:
+        """Re-export the session-scoped OpenAPI spec under this class's name."""
+        return openapi_spec
 
     def test_no_orphaned_component_parameters(self, api_spec: dict[str, Any]) -> None:
         """

--- a/tests/test_critical_api_gaps.py
+++ b/tests/test_critical_api_gaps.py
@@ -19,22 +19,18 @@ The tests here focus on absolute requirements that would make the API unusable
 if missing (e.g., core customer endpoints, basic documentation, operation IDs).
 """
 
-from pathlib import Path
 from typing import Any
 
 import pytest
-import yaml
 
 
 class TestCriticalAPIGaps:
     """Test critical API gaps that should be addressed immediately."""
 
     @pytest.fixture(scope="class")
-    def current_spec(self) -> dict[str, Any]:
-        """Load current OpenAPI specification."""
-        spec_path = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
-        with open(spec_path, encoding="utf-8") as f:
-            return yaml.safe_load(f)
+    def current_spec(self, openapi_spec: dict[str, Any]) -> dict[str, Any]:
+        """Re-export the session-scoped OpenAPI spec under this class's name."""
+        return openapi_spec
 
     def test_critical_customer_endpoints_present(self, current_spec: dict[str, Any]):
         """Test that critical customer endpoints are present."""
@@ -204,35 +200,21 @@ class TestCriticalAPIGaps:
     # - test_individual_schema_validation.py for granular validation
     # Tests should not depend on generated analysis files.
 
-    def test_api_specification_completeness(self):
+    def test_api_specification_completeness(self, openapi_spec: dict[str, Any]):
         """Test that the API specification itself is structurally complete."""
-        # Test the actual OpenAPI spec instead of looking for validation files
-        spec_file = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
-
-        assert spec_file.exists(), "OpenAPI specification file should exist"
-
-        # Verify it's valid YAML
-        import yaml
-
-        with open(spec_file, encoding="utf-8") as f:
-            spec_data = yaml.safe_load(f)
-
-        # Basic structure validation
-        assert "openapi" in spec_data, "OpenAPI spec must have version"
-        assert "info" in spec_data, "OpenAPI spec must have info section"
-        assert "paths" in spec_data, "OpenAPI spec must have paths section"
-        assert "components" in spec_data, "OpenAPI spec must have components section"
+        assert "openapi" in openapi_spec, "OpenAPI spec must have version"
+        assert "info" in openapi_spec, "OpenAPI spec must have info section"
+        assert "paths" in openapi_spec, "OpenAPI spec must have paths section"
+        assert "components" in openapi_spec, "OpenAPI spec must have components section"
 
 
 class TestDocumentationCompliance:
     """Test compliance with documentation standards."""
 
     @pytest.fixture(scope="class")
-    def current_spec(self) -> dict[str, Any]:
-        """Load current OpenAPI specification."""
-        spec_path = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
-        with open(spec_path, encoding="utf-8") as f:
-            return yaml.safe_load(f)
+    def current_spec(self, openapi_spec: dict[str, Any]) -> dict[str, Any]:
+        """Re-export the session-scoped OpenAPI spec under this class's name."""
+        return openapi_spec
 
     def test_openapi_info_section_complete(self, current_spec: dict[str, Any]):
         """Test that OpenAPI info section is complete and descriptive."""

--- a/tests/test_endpoint_comprehensive.py
+++ b/tests/test_endpoint_comprehensive.py
@@ -116,11 +116,9 @@ class TestEndpointComprehensive:
     """Comprehensive parameterized testing for all endpoints."""
 
     @pytest.fixture(scope="class")
-    def spec(self) -> dict[str, Any]:
-        """Load OpenAPI specification."""
-        spec_path = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
-        with open(spec_path, encoding="utf-8") as f:
-            return yaml.safe_load(f)
+    def spec(self, openapi_spec: dict[str, Any]) -> dict[str, Any]:
+        """Re-export the session-scoped OpenAPI spec under this class's name."""
+        return openapi_spec
 
     def _resolve_response_description(
         self, response_spec: dict[str, Any], spec: dict[str, Any]
@@ -372,11 +370,9 @@ class TestEndpointCoverageMetrics:
     """Test overall endpoint coverage and quality metrics."""
 
     @pytest.fixture(scope="class")
-    def spec(self) -> dict[str, Any]:
-        """Load OpenAPI specification."""
-        spec_path = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
-        with open(spec_path, encoding="utf-8") as f:
-            return yaml.safe_load(f)
+    def spec(self, openapi_spec: dict[str, Any]) -> dict[str, Any]:
+        """Re-export the session-scoped OpenAPI spec under this class's name."""
+        return openapi_spec
 
     def test_endpoint_coverage_metrics(self, spec: dict[str, Any]):
         """Test overall endpoint coverage and quality metrics."""

--- a/tests/test_endpoint_comprehensive.py
+++ b/tests/test_endpoint_comprehensive.py
@@ -14,6 +14,7 @@ Consolidates:
 All endpoint testing is now parameterized for complete equality and automatic scaling.
 """
 
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -21,12 +22,24 @@ import pytest
 import yaml
 
 
-def pytest_generate_tests(metafunc):
-    """Generate parameterized tests for endpoints."""
-    # Load OpenAPI spec
+@lru_cache(maxsize=1)
+def _load_spec_for_collection() -> dict[str, Any]:
+    """Module-level cached spec loader for ``pytest_generate_tests``.
+
+    The hook can fire multiple times during collection (once per
+    parametrizable test function in this module). Without caching, each
+    call re-reads + re-parses the (large) OpenAPI YAML. The session-scoped
+    ``openapi_spec`` fixture in ``conftest.py`` doesn't help here because
+    fixtures aren't accessible from collection-time hooks.
+    """
     spec_path = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
     with open(spec_path, encoding="utf-8") as f:
-        spec = yaml.safe_load(f)
+        return yaml.safe_load(f)
+
+
+def pytest_generate_tests(metafunc):
+    """Generate parameterized tests for endpoints."""
+    spec = _load_spec_for_collection()
 
     if "endpoint_info" in metafunc.fixturenames:
         # Generate endpoint tuples (path, method, operation_spec)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -229,43 +229,51 @@ async def test_inventory_sync_with_mock():
 
 @pytest.mark.asyncio
 async def test_retry_with_backoff():
-    """Test the retry_with_backoff function logic."""
+    """Test the retry_with_backoff function logic.
+
+    The example's retry helper hard-codes ``delay = 1.0`` for the initial
+    backoff. With two retry sleeps in this test (fail-then-succeed +
+    always-fails) that's ~2s of real wait — about 9% of the entire suite's
+    wall time. Mock ``asyncio.sleep`` in the example module's namespace so
+    the test exercises the retry *logic* (loop, exception capture, attempt
+    counting, re-raise) without the actual wait.
+    """
     example_file = EXAMPLES_DIR / "error_handling.py"
     if not example_file.exists():
         pytest.skip("error_handling.py not found")
 
     module = load_module_from_file(example_file)
 
-    # Test successful operation
-    async def successful_op():
-        return "success"
+    with patch.object(module.asyncio, "sleep", new_callable=AsyncMock):
+        # Successful operation: no retries, no sleep.
+        async def successful_op():
+            return "success"
 
-    result = await module.retry_with_backoff(successful_op, max_attempts=3)
-    assert result == "success"
+        result = await module.retry_with_backoff(successful_op, max_attempts=3)
+        assert result == "success"
 
-    # Test operation that fails then succeeds
-    call_count = 0
+        # Operation that fails then succeeds — one retry, would have slept 1s.
+        call_count = 0
 
-    async def fail_then_succeed():
-        nonlocal call_count
-        call_count += 1
-        if call_count < 2:
-            raise ValueError("Temporary failure")
-        return "success"
+        async def fail_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("Temporary failure")
+            return "success"
 
-    call_count = 0
-    result = await module.retry_with_backoff(
-        fail_then_succeed, max_attempts=3, backoff_factor=0.1
-    )
-    assert result == "success"
-    assert call_count == 2
+        result = await module.retry_with_backoff(
+            fail_then_succeed, max_attempts=3, backoff_factor=0.1
+        )
+        assert result == "success"
+        assert call_count == 2
 
-    # Test operation that always fails
-    async def always_fails():
-        raise ValueError("Permanent failure")
+        # Operation that always fails — re-raises the last exception.
+        async def always_fails():
+            raise ValueError("Permanent failure")
 
-    with pytest.raises(ValueError, match="Permanent failure"):
-        await module.retry_with_backoff(always_fails, max_attempts=2)
+        with pytest.raises(ValueError, match="Permanent failure"):
+            await module.retry_with_backoff(always_fails, max_attempts=2)
 
 
 def test_examples_import_from_correct_modules():

--- a/tests/test_external_documentation_comparison.py
+++ b/tests/test_external_documentation_comparison.py
@@ -29,7 +29,6 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from scripts.audit_spec_drift import AuditReport, audit  # noqa: E402
 
-LOCAL_SPEC_PATH = PROJECT_ROOT / "docs" / "katana-openapi.yaml"
 LIVE_SPEC_PATH = PROJECT_ROOT / "docs" / "upstream-specs" / "live-gateway.yaml"
 
 

--- a/tests/test_external_documentation_comparison.py
+++ b/tests/test_external_documentation_comparison.py
@@ -34,8 +34,9 @@ LIVE_SPEC_PATH = PROJECT_ROOT / "docs" / "upstream-specs" / "live-gateway.yaml"
 
 
 @pytest.fixture(scope="module")
-def local_spec() -> dict[str, Any]:
-    return yaml.safe_load(LOCAL_SPEC_PATH.read_text(encoding="utf-8"))
+def local_spec(openapi_spec: dict[str, Any]) -> dict[str, Any]:
+    """Re-export the session-scoped OpenAPI spec under this module's name."""
+    return openapi_spec
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_openapi_specification.py
+++ b/tests/test_openapi_specification.py
@@ -21,11 +21,13 @@ class TestOpenAPISpecification:
     """Test OpenAPI specification document structure and syntax."""
 
     @pytest.fixture(scope="class")
-    def spec(self) -> dict[str, Any]:
-        """Load OpenAPI specification."""
-        spec_path = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
-        with open(spec_path, encoding="utf-8") as f:
-            return yaml.safe_load(f)
+    def spec(self, openapi_spec: dict[str, Any]) -> dict[str, Any]:
+        """Re-export the session-scoped OpenAPI spec under this class's name.
+
+        Delegates to ``conftest.openapi_spec`` so the YAML is parsed once
+        per run, not once per class.
+        """
+        return openapi_spec
 
     def test_openapi_version_compliance(self, spec: dict[str, Any]):
         """Test OpenAPI version is supported."""

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -73,7 +73,7 @@ class TestPerformance:
             )
 
     @pytest.mark.asyncio
-    async def test_concurrent_requests(self, katana_client):
+    async def test_concurrent_requests(self):
         """``asyncio.gather`` runs all three calls concurrently, not sequentially.
 
         Asserts the property *structurally* (track max concurrent in-flight
@@ -88,14 +88,16 @@ class TestPerformance:
             nonlocal in_flight, max_in_flight
             in_flight += 1
             max_in_flight = max(max_in_flight, in_flight)
-            # Yield to the scheduler so peers get a chance to enter before
-            # we exit — without this, the counter would only ever see 1.
-            await asyncio.sleep(0)
-            response = MagicMock()
-            response.status_code = 200
-            response.parsed = {"id": result_id, "name": f"Result {result_id}"}
-            in_flight -= 1
-            return response
+            try:
+                # Yield to the scheduler so peers get a chance to enter before
+                # we exit — without this, the counter would only ever see 1.
+                await asyncio.sleep(0)
+                response = MagicMock()
+                response.status_code = 200
+                response.parsed = {"id": result_id, "name": f"Result {result_id}"}
+                return response
+            finally:
+                in_flight -= 1
 
         results = await asyncio.gather(make_mock(1), make_mock(2), make_mock(3))
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -74,43 +74,35 @@ class TestPerformance:
 
     @pytest.mark.asyncio
     async def test_concurrent_requests(self, katana_client):
-        """Test that multiple concurrent requests work correctly."""
+        """``asyncio.gather`` runs all three calls concurrently, not sequentially.
 
-        # Create different mock methods for concurrent calls
-        async def mock_method_1():
-            await asyncio.sleep(0.01)  # Simulate network delay
+        Asserts the property *structurally* (track max concurrent in-flight
+        count) rather than with a wall-clock bound. Wall-clock comparisons
+        against tight thresholds flake on slow CI runners — see #446 where a
+        sibling timing test failed at 235.7ms < 100ms on Python 3.14.
+        """
+        in_flight = 0
+        max_in_flight = 0
+
+        async def make_mock(result_id: int):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            # Yield to the scheduler so peers get a chance to enter before
+            # we exit — without this, the counter would only ever see 1.
+            await asyncio.sleep(0)
             response = MagicMock()
             response.status_code = 200
-            response.parsed = {"id": 1, "name": "Result 1"}
+            response.parsed = {"id": result_id, "name": f"Result {result_id}"}
+            in_flight -= 1
             return response
 
-        async def mock_method_2():
-            await asyncio.sleep(0.01)  # Simulate network delay
-            response = MagicMock()
-            response.status_code = 200
-            response.parsed = {"id": 2, "name": "Result 2"}
-            return response
+        results = await asyncio.gather(make_mock(1), make_mock(2), make_mock(3))
 
-        async def mock_method_3():
-            await asyncio.sleep(0.01)  # Simulate network delay
-            response = MagicMock()
-            response.status_code = 200
-            response.parsed = {"id": 3, "name": "Result 3"}
-            return response
-
-        # Enhance the methods using the transport layer (no decorators needed)
-        # The transport layer automatically handles retries
-        enhanced_1 = mock_method_1
-        enhanced_2 = mock_method_2
-        enhanced_3 = mock_method_3
-
-        # Run concurrently
-        start_time = time.time()
-        results = await asyncio.gather(enhanced_1(), enhanced_2(), enhanced_3())
-        end_time = time.time()
-
-        # Should complete in roughly the time of one request (concurrent)
-        assert end_time - start_time < 0.1  # Much less than 3 * 0.01
+        assert max_in_flight == 3, (
+            f"All three coroutines should have been in flight simultaneously "
+            f"(saw max={max_in_flight}); gather() ran them sequentially."
+        )
         assert len(results) == 3
         assert all(r.status_code == 200 for r in results)
 

--- a/tests/test_schema_comprehensive.py
+++ b/tests/test_schema_comprehensive.py
@@ -76,11 +76,9 @@ class TestSchemaComprehensive:
     """Comprehensive parameterized testing for all schemas."""
 
     @pytest.fixture(scope="class")
-    def spec(self) -> dict[str, Any]:
-        """Load OpenAPI specification."""
-        spec_path = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
-        with open(spec_path, encoding="utf-8") as f:
-            return yaml.safe_load(f)
+    def spec(self, openapi_spec: dict[str, Any]) -> dict[str, Any]:
+        """Re-export the session-scoped OpenAPI spec under this class's name."""
+        return openapi_spec
 
     def test_schema_has_description(self, schema_name: str, spec: dict[str, Any]):
         """Test that every schema has a description."""
@@ -253,11 +251,9 @@ class TestSchemaCoverageMetrics:
     """Test overall schema coverage and quality metrics."""
 
     @pytest.fixture(scope="class")
-    def spec(self) -> dict[str, Any]:
-        """Load OpenAPI specification."""
-        spec_path = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
-        with open(spec_path, encoding="utf-8") as f:
-            return yaml.safe_load(f)
+    def spec(self, openapi_spec: dict[str, Any]) -> dict[str, Any]:
+        """Re-export the session-scoped OpenAPI spec under this class's name."""
+        return openapi_spec
 
     def test_schema_coverage_metrics(self, spec: dict[str, Any]):
         """Test overall schema coverage and quality metrics."""

--- a/tests/test_schema_comprehensive.py
+++ b/tests/test_schema_comprehensive.py
@@ -17,6 +17,7 @@ because they cause pytest-xdist collection issues (dynamically generated paramet
 Run explicitly with: pytest -m schema_validation
 """
 
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -27,12 +28,25 @@ import yaml
 pytestmark = pytest.mark.schema_validation
 
 
-def pytest_generate_tests(metafunc):
-    """Generate parameterized tests for schemas."""
-    # Load OpenAPI spec
+@lru_cache(maxsize=1)
+def _load_spec_for_collection() -> dict[str, Any]:
+    """Module-level cached spec loader for ``pytest_generate_tests``.
+
+    The hook fires once per parametrizable test function in this module
+    (~5+ tests parametrize on schema_name / referenced_schema_name).
+    Without caching, the (large) OpenAPI YAML is re-parsed on every hook
+    call. The session-scoped ``openapi_spec`` fixture in ``conftest.py``
+    isn't reachable here because fixtures aren't accessible from
+    collection-time hooks.
+    """
     spec_path = Path(__file__).parent.parent / "docs" / "katana-openapi.yaml"
     with open(spec_path, encoding="utf-8") as f:
-        spec = yaml.safe_load(f)
+        return yaml.safe_load(f)
+
+
+def pytest_generate_tests(metafunc):
+    """Generate parameterized tests for schemas."""
+    spec = _load_spec_for_collection()
 
     if "schema_name" in metafunc.fixturenames:
         schemas = spec.get("components", {}).get("schemas", {})

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.45.1"
+version = "0.46.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Sweep follow-up to #446. Three changes addressing both **CI flakiness** (the immediate trigger) and **test execution speed** (a related but separate concern):

1. **\`test_concurrent_requests\`**: replace wall-clock concurrency assertion with a structural in-flight counter. Same flake pattern that broke #446's CI on Python 3.14 (235.7ms < 100ms); deterministic now.
2. **\`test_retry_with_backoff\`**: mock \`asyncio.sleep\` so the test exercises retry *logic* without the 2 seconds of real wait the example's hard-coded \`delay = 1.0\` would otherwise impose. **2.00s → 0.02s** (100× faster).
3. **OpenAPI spec parsing**: hoist to a session-scoped \`openapi_spec\` fixture in \`tests/conftest.py\`. Seven test modules were each loading + YAML-parsing the (large) spec independently; now done once per pytest run. Eliminates ~3-4s of repeated work.

## Wall-time impact

| Stage | \`uv run poe test\` total |
|-------|---------------------------|
| main (before PR #446) | ~22s |
| After commit 1 (\`ff841471\`) | ~22s (no wall-time change; flake-only fix) |
| After commit 2 (\`a46ec6ce\`) | ~16.9s (-25%) |
| After commit 3 (\`4dc5e09e\`) | **~13.6s (-40%)** |

\`--durations=10\` after this PR: only one ~0.5s entry remains (the session fixture's first parse), down from 9 entries dominated by repeated spec parses.

## Why structural > wall-clock for concurrency tests

\`test_concurrent_requests\` previously used \`time.time()\` deltas to verify gather() ran concurrently. Wall clock under CI load is non-deterministic — exactly the failure mode that hit PR #446. The replacement tracks an in-flight counter and asserts max concurrent reached 3, which is what \"ran concurrently\" actually means and is independent of scheduler latency.

## Why the retry test had 2 seconds of real sleep

\`examples/client/error_handling.py::retry_with_backoff\` hard-codes \`delay = 1.0\` for the initial backoff (regardless of \`backoff_factor\`). The test's two retry sleeps × 1s each = 2s of real wait per CI run. Mocking \`asyncio.sleep\` in the example module's namespace is the standard pattern.

## Why a session-scoped spec fixture

The OpenAPI spec is ~50k+ lines. Each of 7 test modules loaded + parsed it independently with its own class-scoped fixture, costing ~0.5s per load. Hoisting to a session fixture in \`conftest.py\` and having each module's local fixture delegate (\`return openapi_spec\`) keeps existing test param names working while collapsing 7 parses → 1.

## Intentional non-changes

- \`test_yaml_syntax_validity\` still re-parses the YAML directly — testing parse-correctness on the raw file is its whole point.
- \`pytest_generate_tests\` hooks (module-level, run at collection) still load the spec themselves — fixtures aren't accessible from those hooks.
- The 2.0s assertion in \`test_large_pagination_performance\` is unchanged — generous bound, never historically flaked, and the test specifically exercises wall-time of a mocked-sleep transport-layer call.

## Test plan

- [x] \`uv run poe check\` — all green.
- [x] \`uv run poe test\` — 2507 passed, 2 skipped, 13.59s.
- [ ] CI green across Python 3.12 / 3.13 / 3.14 (the flake originally surfaced on 3.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)