### PR TITLE
fix(ci): match breaking-change marker in release pre-check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,12 @@ jobs:
         id: check
         run: |
           # Check if there are any commits with (client) scope or no scope since last
-          # client release
+          # client release. The optional ``!`` between ``(scope)`` and ``:`` matches
+          # the Conventional Commits breaking-change form (e.g. ``feat(client)!:``)
+          # so a major-version bump isn't silently skipped — see #451.
           if git log $(git describe --tags --abbrev=0 --match="client-v*" 2>/dev/null || \
             echo "HEAD~10")..HEAD --pretty=format:"%s" | \
-            grep -qE '^(feat|fix|perf)(\(client\))?:'; then
+            grep -qE '^(feat|fix|perf)(\(client\))?!?:'; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -144,10 +146,13 @@ jobs:
       - name: Check for MCP changes
         id: check
         run: |
-          # Check if there are any commits with (mcp) scope since last mcp release
+          # Check if there are any commits with (mcp) scope since last mcp release.
+          # The optional ``!`` between ``(mcp)`` and ``:`` matches the Conventional
+          # Commits breaking-change form (e.g. ``feat(mcp)!:``) so a major-version
+          # bump isn't silently skipped — see #451.
           if git log $(git describe --tags --abbrev=0 --match="mcp-v*" 2>/dev/null || \
             echo "HEAD~10")..HEAD --pretty=format:"%s" | \
-            grep -qE '^(feat|fix|perf)\(mcp\):'; then
+            grep -qE '^(feat|fix|perf)\(mcp\)!?:'; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

The release pre-check regex in \`release.yml\` was missing the Conventional Commits breaking-change form (\`feat(scope)!:\`), which silently skipped semantic-release for breaking changes — including the \`feat(mcp)!:\` merge of #449 that should have cut \`mcp-v1.0.0\` but didn't.

## Fix

Insert \`!?\` between the closing scope paren and the literal \`:\` in both the client and mcp pre-check regexes. Verified against the full Conventional-Commits matrix (12 commit shapes) — all valid forms with/without \`!\` and with/without scope match correctly; \`chore\`/\`docs\`/non-matching scopes are still rejected.

## Test plan

- [x] Local regex behavior verified across 12 commit-subject permutations.
- [x] yamllint passes on the workflow file.
- [ ] After merge: trigger \`release.yml\` via \`workflow_dispatch\` against \`main\` to cut the queued \`mcp-v1.0.0\` (the 8b936d58 \`feat(mcp)!:\` commit since \`mcp-v0.45.1\` will satisfy the new pre-check).

Closes #451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)