### PR TITLE
perf(mcp): batch catalog-cache SKU lookups via get_many_by_ids

### DIFF
--- a/katana_mcp_server/src/katana_mcp/cache.py
+++ b/katana_mcp_server/src/katana_mcp/cache.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -456,6 +457,32 @@ class CatalogCache:
         ) as cursor:
             row = await cursor.fetchone()
             return json.loads(row[0]) if row else None
+
+    async def get_many_by_ids(
+        self, entity_type: str, entity_ids: Iterable[int]
+    ) -> dict[int, dict[str, Any]]:
+        """Look up many entities by type and IDs in one query.
+
+        Returns ``{id: data}`` for IDs that hit the cache; missing IDs are
+        absent from the result. Empty input → empty dict (no DB read). Use
+        instead of ``asyncio.gather(get_by_id(...) ...)`` when enriching a
+        batch of rows with cached lookups — one query replaces N reads.
+
+        IDs are passed as a JSON array parameter and expanded via
+        ``json_each``, so the SQL text is constant (no string interpolation)
+        and the IDs go through SQLite's regular parameter binding.
+        """
+        ids = list({int(i) for i in entity_ids})
+        if not ids:
+            return {}
+        db = self._conn()
+        async with db.execute(
+            "SELECT id, data FROM entities "
+            "WHERE entity_type = ? "
+            "AND id IN (SELECT value FROM json_each(?))",
+            (entity_type, json.dumps(ids)),
+        ) as cursor:
+            return {int(row[0]): json.loads(row[1]) for row in await cursor.fetchall()}
 
     async def get_by_sku(self, sku: str) -> dict[str, Any] | None:
         """Look up a variant by SKU (case-insensitive)."""

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -866,18 +866,22 @@ async def _fetch_mo_recipe_rows(
     )
     raw_rows = unwrap_data(response, default=[])
 
-    variant_ids = [unwrap_unset(row.variant_id, None) for row in raw_rows]
-    variants = await asyncio.gather(
-        *(
-            services.cache.get_by_id(EntityType.VARIANT, v_id)
-            if v_id is not None
-            else none_coro()
-            for v_id in variant_ids
-        )
-    )
+    # One batched IN-clause SQLite read instead of one read per recipe row —
+    # a full-bike Mayhem MO has ~30 rows, all looked up by variant_id.
+    variant_ids = {
+        v_id
+        for v_id in (unwrap_unset(row.variant_id, None) for row in raw_rows)
+        if v_id is not None
+    }
+    variants = await services.cache.get_many_by_ids(EntityType.VARIANT, variant_ids)
     return [
-        _recipe_row_info_from_attrs(row, variant.get("sku") if variant else None)
-        for row, variant in zip(raw_rows, variants, strict=True)
+        _recipe_row_info_from_attrs(
+            row,
+            (variants.get(v_id) or {}).get("sku")
+            if (v_id := unwrap_unset(row.variant_id, None)) is not None
+            else None,
+        )
+        for row in raw_rows
     ]
 
 
@@ -2890,20 +2894,14 @@ async def _resolve_variant_skus(
     """Resolve SKUs for the given variant IDs via the legacy catalog cache.
 
     Returns ``{variant_id: sku_or_None}``. Empty input → empty dict (no
-    catalog reads). Hitting the cache is cheap per-call but proportional to
-    ``len(variant_ids)``; callers should aggregate/sort/slice first so this
-    only fires for the variants surfaced in the response.
+    catalog reads). Issues one batched SQL ``IN``-clause read; missing
+    variants map to ``None``. Callers should aggregate/sort/slice first
+    so this only fires for the variants surfaced in the response.
     """
     if not variant_ids:
         return {}
-    ids = sorted(variant_ids)
-    lookups = await asyncio.gather(
-        *(services.cache.get_by_id(EntityType.VARIANT, vid) for vid in ids)
-    )
-    return {
-        vid: (variant.get("sku") if variant else None)
-        for vid, variant in zip(ids, lookups, strict=True)
-    }
+    variants = await services.cache.get_many_by_ids(EntityType.VARIANT, variant_ids)
+    return {vid: (variants.get(vid) or {}).get("sku") for vid in variant_ids}
 
 
 @observe_tool

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -29,7 +29,6 @@ from katana_mcp.tools.tool_result_utils import (
     format_md_table,
     iso_or_none,
     make_tool_result,
-    none_coro,
     parse_request_dates,
     resolve_entity_name,
 )
@@ -1020,27 +1019,26 @@ async def _get_sales_order_impl(
 
     raw_rows = unwrap_unset(so.sales_order_rows, [])
 
-    # Parallelize variant lookups across all rows (N+1 fix) AND the address
-    # fetch — both depend only on the SO we just loaded.
-    variant_ids = [unwrap_unset(r.variant_id, None) for r in raw_rows]
+    # One batched IN-clause SQLite read for all row variants, in parallel
+    # with the address fetch — both depend only on the SO we just loaded.
+    variant_ids = {
+        v_id
+        for v_id in (unwrap_unset(r.variant_id, None) for r in raw_rows)
+        if v_id is not None
+    }
     variants, addresses = await asyncio.gather(
-        asyncio.gather(
-            *(
-                services.cache.get_by_id(EntityType.VARIANT, v_id)
-                if v_id is not None
-                else none_coro()
-                for v_id in variant_ids
-            )
-        ),
+        services.cache.get_many_by_ids(EntityType.VARIANT, variant_ids),
         _fetch_sales_order_addresses(services, so.id),
     )
 
     row_details: list[SalesOrderRowDetail] = []
-    for r, variant in zip(raw_rows, variants, strict=True):
+    for r in raw_rows:
+        v_id = unwrap_unset(r.variant_id, None)
+        variant = variants.get(v_id) if v_id is not None else None
         row_details.append(
             SalesOrderRowDetail(
                 id=r.id,
-                variant_id=unwrap_unset(r.variant_id, None),
+                variant_id=v_id,
                 sku=variant.get("sku") if variant else None,
                 quantity=unwrap_unset(r.quantity, None),
                 sales_order_id=unwrap_unset(r.sales_order_id, None),

--- a/katana_mcp_server/tests/conftest.py
+++ b/katana_mcp_server/tests/conftest.py
@@ -85,6 +85,7 @@ def create_mock_context():
     mock_cache.smart_search = AsyncMock(return_value=[])
     mock_cache.get_by_sku = AsyncMock(return_value=None)
     mock_cache.get_by_id = AsyncMock(return_value=None)
+    mock_cache.get_many_by_ids = AsyncMock(return_value={})
     mock_cache.mark_dirty = AsyncMock()
     mock_lifespan_context.cache = mock_cache
 

--- a/katana_mcp_server/tests/test_cache.py
+++ b/katana_mcp_server/tests/test_cache.py
@@ -264,6 +264,42 @@ class TestDirectLookups:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_get_many_by_ids_returns_dict_keyed_by_id(self, cache):
+        await cache.sync(
+            "variant",
+            [
+                _variant(2, "SKU-002", "Item 2"),
+                _variant(3, "SKU-003", "Item 3"),
+            ],
+            VARIANT_INDEX,
+        )
+        result = await cache.get_many_by_ids("variant", [1, 2, 3])
+        assert set(result.keys()) == {1, 2, 3}
+        assert result[1]["sku"] == "FOX-FORK-160"
+        assert result[2]["sku"] == "SKU-002"
+        assert result[3]["sku"] == "SKU-003"
+
+    @pytest.mark.asyncio
+    async def test_get_many_by_ids_omits_missing(self, cache):
+        # Cache has only id=1 from the autouse fixture; 999 is absent.
+        result = await cache.get_many_by_ids("variant", [1, 999])
+        assert set(result.keys()) == {1}
+
+    @pytest.mark.asyncio
+    async def test_get_many_by_ids_empty_input_no_query(self, cache):
+        # Empty input must short-circuit — calling with [] would otherwise
+        # build an `IN ()` clause that's a SQLite syntax error.
+        result = await cache.get_many_by_ids("variant", [])
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_get_many_by_ids_dedups_input(self, cache):
+        # Caller may pass duplicates (e.g., when one variant blocks several
+        # MOs); dedup-then-query keeps the IN-clause minimal.
+        result = await cache.get_many_by_ids("variant", [1, 1, 1])
+        assert set(result.keys()) == {1}
+
+    @pytest.mark.asyncio
     async def test_get_by_sku(self, cache):
         result = await cache.get_by_sku("FOX-FORK-160")
         assert result is not None

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -615,11 +615,11 @@ _UNWRAP_DATA = "katana_public_api_client.utils.unwrap_data"
 async def test_get_manufacturing_order_recipe():
     """Test listing recipe rows for an MO."""
     context, lifespan_ctx = create_mock_context()
-    lifespan_ctx.cache.get_by_id = AsyncMock(
-        side_effect=[
-            {"id": 101, "sku": "FORK-001"},
-            {"id": 102, "sku": "BOLT-004"},
-        ]
+    lifespan_ctx.cache.get_many_by_ids = AsyncMock(
+        return_value={
+            101: {"id": 101, "sku": "FORK-001"},
+            102: {"id": 102, "sku": "BOLT-004"},
+        }
     )
 
     def _mk_row(row_id: int, variant_id: int, qpu: float, cost: float) -> MagicMock:
@@ -2109,13 +2109,12 @@ def no_sync_recipe_rows():
 
 
 def _stub_variant_cache(context, sku_by_id: dict[int, str]) -> None:
-    """Stub services.cache.get_by_id(VARIANT, ...) to return SKUs for tests."""
+    """Stub services.cache.get_many_by_ids(VARIANT, ...) to return SKUs for tests."""
 
-    async def _lookup(_entity_type, vid):
-        sku = sku_by_id.get(vid)
-        return {"sku": sku} if sku else None
+    async def _lookup(_entity_type, vids):
+        return {vid: {"sku": sku_by_id[vid]} for vid in vids if vid in sku_by_id}
 
-    context.request_context.lifespan_context.cache.get_by_id = AsyncMock(
+    context.request_context.lifespan_context.cache.get_many_by_ids = AsyncMock(
         side_effect=_lookup
     )
 
@@ -2537,9 +2536,10 @@ async def test_list_blocking_ingredients_resolves_skus_only_for_kept_variants(
     assert result.by_variant is not None and len(result.by_variant) == 1
     assert result.by_variant[0].variant_id == 500
     assert result.by_variant[0].sku == "WHEEL"
-    # Legacy cache hit only once — for the kept variant. The dropped
-    # variant 600 never makes it to the catalog cache.
-    cache_mock = context.request_context.lifespan_context.cache.get_by_id
+    # Legacy cache batch helper called exactly once with only the kept
+    # variant ID — the dropped variant 600 never makes it to the catalog
+    # cache, validating slice-then-resolve over fetch-then-trim.
+    cache_mock = context.request_context.lifespan_context.cache.get_many_by_ids
     assert cache_mock.await_count == 1
-    awaited_vid = cache_mock.await_args.args[1]
-    assert awaited_vid == 500
+    awaited_vids = cache_mock.await_args.args[1]
+    assert set(awaited_vids) == {500}

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -1177,13 +1177,14 @@ async def test_get_sales_order_enriches_row_sku_from_cache():
     """Row-level variant cache hits populate SalesOrderRowDetail.sku."""
     context, lifespan_ctx = create_mock_context()
 
-    # Cache returns a variant dict for variant_id 500
-    async def fake_get_by_id(_entity_type, variant_id):
-        if variant_id == 500:
-            return {"id": 500, "sku": "BIKE-A", "display_name": "Bike A"}
-        return None
+    # Cache returns a variant dict for variant_id 500; missing IDs are
+    # absent from the result (per get_many_by_ids contract).
+    catalog = {500: {"id": 500, "sku": "BIKE-A", "display_name": "Bike A"}}
 
-    lifespan_ctx.cache.get_by_id = AsyncMock(side_effect=fake_get_by_id)
+    async def fake_get_many_by_ids(_entity_type, variant_ids):
+        return {vid: catalog[vid] for vid in variant_ids if vid in catalog}
+
+    lifespan_ctx.cache.get_many_by_ids = AsyncMock(side_effect=fake_get_many_by_ids)
 
     mock_so = _make_mock_so(
         id=9,


### PR DESCRIPTION
## Summary

Every site that enriched a batch of rows with cached variant SKUs did N independent SQLite reads via \`asyncio.gather(get_by_id(...) ...)\`. For a full-bike Mayhem MO (~30 recipe rows) or a multi-line sales order, that fan-out adds up. This PR adds a batch helper and switches three call sites to it.

## What changed

- **\`CatalogCache.get_many_by_ids(entity_type, ids) -> {id: data}\`** — single parametrized \`IN\`-clause query. Empty input short-circuits (avoids the \`IN ()\` syntax error). Caller input is deduped before the query.
- **Three call sites switched** (one read per call instead of N):
  - \`_fetch_mo_recipe_rows\` — powers \`get_manufacturing_order\` / \`get_manufacturing_order_recipe\`.
  - \`_get_sales_order_impl\` — variant SKU lookups for every SO row, still in parallel with the address fetch.
  - \`_resolve_variant_skus\` — the helper #449 added for \`list_blocking_ingredients\`.
- **Test infrastructure**:
  - New unit tests for the helper (returns-keyed-by-id, omits-missing, empty-input-short-circuit, dedups-input).
  - \`conftest.create_mock_context\` adds \`get_many_by_ids\` to the default cache mock so AsyncMock auto-vivification doesn't cascade into runtime errors.
  - Existing tests updated where they explicitly mocked \`get_by_id\` for SKU resolution.

## Test plan

- [x] \`uv run poe check\` — 2528 passed, 2 skipped.
- [x] New direct tests for \`get_many_by_ids\` cover the empty/missing/dedup paths.

Closes #452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)