### PR TITLE
chore: tech-debt sweep — narrow bare excepts, drop dead clear_registry

### DIFF
--- a/katana_mcp_server/src/katana_mcp/_fastmcp_patches.py
+++ b/katana_mcp_server/src/katana_mcp/_fastmcp_patches.py
@@ -19,12 +19,15 @@ so only the get_cached_typeadapter patch is needed now.
 from __future__ import annotations
 
 import inspect
+import logging
 import types
 from collections.abc import Callable
 from functools import lru_cache
 from typing import Annotated, Any, get_args, get_origin, get_type_hints
 
 from pydantic import Field, TypeAdapter
+
+logger = logging.getLogger(__name__)
 
 # Track whether patches have been applied (mutable container avoids global statement)
 _state: dict[str, bool] = {"patched": False}
@@ -86,9 +89,18 @@ def _patched_get_cached_typeadapter[T](cls: T) -> TypeAdapter[T]:
         and hasattr(cls, "__annotations__")
         and cls.__annotations__
     ):
+        # ``get_type_hints`` raises NameError on unresolvable forward
+        # refs and TypeError on malformed annotations; both are recoverable
+        # by falling back to the raw annotation dict, but we log so the
+        # silent-fallback behavior is observable.
         try:
             resolved_hints = get_type_hints(cls, include_extras=True)
-        except Exception:
+        except (NameError, TypeError) as exc:
+            logger.debug(
+                "get_type_hints failed for %r — falling back to __annotations__: %s",
+                cls,
+                exc,
+            )
             resolved_hints = cls.__annotations__
 
         # Process annotations to convert string descriptions to Fields

--- a/katana_mcp_server/src/katana_mcp/unpack.py
+++ b/katana_mcp_server/src/katana_mcp/unpack.py
@@ -30,11 +30,14 @@ from __future__ import annotations
 
 import functools
 import inspect
+import logging
 from collections.abc import Callable
 from typing import Annotated, Any, get_args, get_origin, get_type_hints
 
 from pydantic import BaseModel, ValidationError
 from pydantic_core import PydanticUndefined
+
+logger = logging.getLogger(__name__)
 
 
 class Unpack:
@@ -85,11 +88,19 @@ def unpack_pydantic_params(func: Callable) -> Callable:
     new_params = []
     unpack_mapping: dict[str, tuple[type[BaseModel], list[str]]] = {}
 
-    # Get type hints to resolve string annotations (from __future__ import annotations)
+    # Get type hints to resolve string annotations (from __future__ import
+    # annotations). NameError is the typical failure when a forward ref can't
+    # be resolved at decoration time; TypeError surfaces from malformed
+    # annotations. Both fall back to raw annotations cleanly, but log so the
+    # silent-fallback behavior is observable.
     try:
         type_hints = get_type_hints(func, include_extras=True)
-    except Exception:
-        # If get_type_hints() fails, fall back to raw annotations
+    except (NameError, TypeError) as exc:
+        logger.debug(
+            "get_type_hints failed for %r — falling back to empty hint dict: %s",
+            func,
+            exc,
+        )
         type_hints = {}
 
     # Track if we've added any KEYWORD_ONLY params

--- a/katana_public_api_client/models_pydantic/_registry.py
+++ b/katana_public_api_client/models_pydantic/_registry.py
@@ -150,14 +150,6 @@ def is_registered(model_class: type) -> bool:
     return model_class in _attrs_to_pydantic or model_class in _pydantic_to_attrs
 
 
-def clear_registry() -> None:
-    """Clear all registrations. Mainly for testing purposes."""
-    _attrs_to_pydantic.clear()
-    _pydantic_to_attrs.clear()
-    _attrs_name_to_class.clear()
-    _pydantic_name_to_class.clear()
-
-
 def get_registration_stats() -> dict[str, Any]:
     """Get statistics about the current registry state.
 


### PR DESCRIPTION
## Summary

Closes #371 items 1 and 2. Items 3 (inventory TODOs) and 4 (pyright union narrowing) are deferred — out of scope for this sweep, will be filed separately if worth tracking.

## What changed

**Item 1 — narrow bare \`except Exception\`:**

Two sites wrapped \`get_type_hints()\` calls with bare \`except Exception:\` and silently fell back. The recoverable failure modes are \`NameError\` (unresolved forward ref at decoration time) and \`TypeError\` (malformed annotation). Other exceptions should propagate.

- \`_fastmcp_patches.py:91\` — narrowed to \`(NameError, TypeError)\`, added \`logger.debug\` for observable fallback.
- \`unpack.py:91\` — same.

Both files now have a module-level \`logger = logging.getLogger(__name__)\`.

**Item 2 — delete dead \`clear_registry()\`:**

\`katana_public_api_client/models_pydantic/_registry.py:153\`. Verified unreferenced anywhere in the repo. Module path is underscore-prefixed (\`models_pydantic._registry\`), so this is internal API and removal doesn't need a breaking-change marker.

## Test plan

- [x] \`uv run poe check\` — 2544 passed.

Closes #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)