### PR TITLE
feat(mcp): add full PO modification tools + canonical pattern

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -50,6 +50,10 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **receive_purchase_order** - Receive items and update inventory
 - **verify_order_document** - Verify supplier documents against POs (returns the full PO alongside match/discrepancy details)
 - **get_purchase_order** - Look up a PO by number or ID — exhaustive detail (every PO/row field, additional cost rows, accounting metadata)
+- **update_purchase_order** - Update header fields (incl. status, expected_arrival_date)
+- **delete_purchase_order** - Delete a PO (preview/confirm)
+- **add_purchase_order_row / update_purchase_order_row / delete_purchase_order_row** - Full row-level CRUD with per-field diff previews
+- **add_purchase_order_additional_cost / update_purchase_order_additional_cost / delete_purchase_order_additional_cost** - Manage freight/duty/handling cost rows
 
 ### Manufacturing & Sales
 - **create_manufacturing_order** - Create production work orders
@@ -785,6 +789,115 @@ Pydantic field names as labels (`**status**`, `**purchase_order_rows** (N):`,
 `**additional_cost_rows**: []`) so LLM consumers can't misread a section
 header as a different field (#346 follow-on). Use this whenever full
 detail is needed; use `list_purchase_orders` for discovery.
+
+---
+
+### update_purchase_order
+Update header fields on an existing PO. Status transitions are folded in
+here as a regular field — there's no separate `update_purchase_order_status`
+tool because Katana's API treats it as a normal PATCH field.
+
+**Parameters:**
+- `id` (required): Purchase order ID
+- `order_no`, `supplier_id`, `currency`, `location_id`,
+  `tracking_location_id`, `expected_arrival_date`, `order_created_date`,
+  `additional_info` (optional): Header fields to overwrite
+- `status` (optional): DRAFT / NOT_RECEIVED / PARTIALLY_RECEIVED / RECEIVED.
+  To flip to RECEIVED with inventory updates use `receive_purchase_order`
+  instead.
+- `confirm` (optional, default false): false=preview with per-field diff,
+  true=apply
+
+**Returns:** A `ModificationResponse` with `is_preview`, the per-field
+`changes` list (old/new for every supplied field), `katana_url`, and
+`next_actions`.
+
+---
+
+### delete_purchase_order
+Delete a purchase order. Destructive — the order record is removed.
+
+**Parameters:**
+- `id` (required): Purchase order ID
+- `confirm` (optional, default false): false=preview, true=delete
+
+---
+
+### add_purchase_order_row
+Add a new line item to an existing PO.
+
+**Parameters:**
+- `purchase_order_id` (required): Parent PO ID
+- `variant_id`, `quantity`, `price_per_unit` (required): Core line item
+- `tax_rate_id`, `tax_name`, `tax_rate`, `currency`, `purchase_uom`,
+  `purchase_uom_conversion_rate`, `arrival_date` (optional)
+- `confirm` (optional, default false)
+
+---
+
+### update_purchase_order_row
+Update fields on an existing PO row. Accepts any subset of `quantity`,
+`variant_id`, taxes, `price_per_unit`, UOM fields, `received_date`, and the
+row-level `arrival_date` (separate from the PO header's arrival date — Katana
+tracks per-row dates so different lines on the same PO can arrive on
+different days).
+
+**Parameters:**
+- `id` (required): Row ID
+- Any subset of: `quantity`, `variant_id`, `tax_rate_id`, `tax_name`,
+  `tax_rate`, `price_per_unit`, `purchase_uom`,
+  `purchase_uom_conversion_rate`, `received_date`, `arrival_date`
+- `confirm` (optional, default false): false=preview with per-field diff,
+  true=apply
+
+---
+
+### delete_purchase_order_row
+Delete a PO row. Destructive.
+
+**Parameters:**
+- `id` (required): Row ID
+- `confirm` (optional, default false)
+
+---
+
+### add_purchase_order_additional_cost
+Add an additional-cost row (freight, duties, handling fees) to a PO. Katana
+models additional-cost rows as members of a *cost group*; the PO carries a
+`default_group_id` that the rows attach to. The tool accepts the parent PO
+id (familiar) and resolves the group id internally — pass `group_id`
+directly only if the PO has multiple groups and you need a non-default one.
+
+**Parameters:**
+- `purchase_order_id` *or* `group_id` (one is required): Parent linkage.
+  Tool resolves `default_group_id` from the PO when only `purchase_order_id`
+  is given.
+- `additional_cost_id` (required): Catalog entry ID for the cost type
+- `tax_rate_id` (required): Tax rate ID
+- `price` (required): Cost amount
+- `distribution_method` (optional): BY_VALUE distributes proportionally
+  to row value; NON_DISTRIBUTED leaves it unallocated
+- `confirm` (optional, default false)
+
+---
+
+### update_purchase_order_additional_cost
+Update a PO additional-cost row. Per-field diff against the existing row.
+
+**Parameters:**
+- `id` (required): Cost row ID
+- Any subset of: `additional_cost_id`, `tax_rate_id`, `price`,
+  `distribution_method`
+- `confirm` (optional, default false)
+
+---
+
+### delete_purchase_order_additional_cost
+Delete a PO additional-cost row. Destructive.
+
+**Parameters:**
+- `id` (required): Cost row ID
+- `confirm` (optional, default false)
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -1,0 +1,222 @@
+"""Shared infrastructure for entity-modification MCP tools.
+
+Provides a uniform Pydantic response model + helpers for consistent
+preview/confirm UX across modification tools (PO, SO, MO, ...).
+
+A modification tool follows this shape:
+
+1. Build a request Pydantic model with ``confirm: bool = False`` and the
+   fields to modify (all ``Optional`` for PATCH-style operations).
+2. In the impl, optionally fetch the existing entity for diff context, then
+   compute a list of :class:`FieldChange` via :func:`compute_field_diff`.
+3. If ``confirm=False`` return :class:`ModificationResponse` with
+   ``is_preview=True``.
+4. If ``confirm=True`` call the API, then return
+   :class:`ModificationResponse` with ``is_preview=False``.
+
+Use :func:`render_modification_md` (or :func:`to_tool_result`) to produce the
+markdown for the :class:`ToolResult` content. Markdown rendering is the only
+output channel today; Prefab UI for diff visualization can layer on later by
+operating on the same response model.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+from enum import Enum
+from typing import Any, ClassVar
+
+from fastmcp.tools import ToolResult
+from pydantic import BaseModel, Field
+
+from katana_mcp.tools.tool_result_utils import BLOCK_WARNING_PREFIX, make_simple_result
+from katana_public_api_client.client_types import UNSET
+from katana_public_api_client.domain.converters import unwrap_unset
+
+
+class FieldChange(BaseModel):
+    """A single field-level change in a modification preview/result.
+
+    Exactly one of ``is_added`` / ``is_unchanged`` / ``is_unknown_prior``
+    is true, or all three are false (in which case the field's value is
+    being replaced with a different non-null value).
+
+    ``is_unknown_prior`` is distinct from ``is_added``: ``is_added`` means
+    "the entity didn't have this field set before" (genuine create), while
+    ``is_unknown_prior`` means "we couldn't determine the prior state"
+    (best-effort fetch failed). Renderers should make the distinction
+    visible — implying a field was empty when we just don't know is
+    misleading.
+
+    There is no "cleared" / ``is_removed`` flag: the diff source iterates
+    ``request.model_dump(exclude_none=True)``, so fields explicitly set to
+    ``None`` are skipped. Update tools translate request-side ``None`` to
+    UNSET via ``to_unset`` before serializing the PATCH, which omits the
+    field from the body — so "set to null to clear" isn't a behavior we
+    expose today. If a Katana endpoint ever needs explicit clears, add an
+    ``unset_fields: list[str]`` companion alongside the patch body and a
+    matching ``is_cleared`` here.
+    """
+
+    field: str
+    old: Any | None = None
+    new: Any | None = None
+    is_added: bool = False
+    is_unchanged: bool = False
+    is_unknown_prior: bool = False
+
+
+class ModificationResponse(BaseModel):
+    """Uniform response for every modification tool.
+
+    The same shape covers update / delete / row-create / row-update /
+    row-delete operations. Tool-specific impls populate the fields that
+    apply; callers can rely on the common envelope.
+    """
+
+    entity_type: str
+    entity_id: int | None = None
+    parent_entity_id: int | None = None
+    operation: str
+    is_preview: bool
+    changes: list[FieldChange] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    next_actions: list[str] = Field(default_factory=list)
+    katana_url: str | None = None
+    message: str
+
+    DEFAULT_EXCLUDED: ClassVar[tuple[str, ...]] = ("id", "confirm")
+
+
+def _normalize(value: Any) -> Any:
+    """Normalize a value for diff comparison.
+
+    UNSET sentinels collapse to ``None``; datetimes flatten to ISO strings;
+    enums to their wire value. Lists and dicts are returned as-is — the
+    caller is responsible for upstream comparability.
+    """
+    if value is UNSET:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def compute_field_diff(
+    existing: Any,
+    request: BaseModel,
+    *,
+    field_map: dict[str, str] | None = None,
+    exclude: Iterable[str] = ModificationResponse.DEFAULT_EXCLUDED,
+    unknown_prior: bool = False,
+) -> list[FieldChange]:
+    """Compute :class:`FieldChange` entries for fields the request will set.
+
+    Iterates ``request.model_dump(exclude_none=True)`` so only fields the
+    caller provided contribute to the diff. For each, the matching attr on
+    ``existing`` is fetched (via ``unwrap_unset`` so attrs UNSET sentinels
+    behave as ``None``) and compared after :func:`_normalize`.
+
+    Args:
+        existing: Existing entity (attrs or pydantic). When ``None`` and
+            ``unknown_prior`` is False, every field is reported as
+            ``is_added`` (preview before fetch — genuine create).
+        request: Pydantic request model. None-valued fields are skipped so
+            partial updates only diff the fields the user touched.
+        field_map: Optional ``request_field -> entity_attr`` rename map for
+            fields that don't share names across the layers.
+        exclude: Field names on the request to skip (defaults to ``id`` and
+            ``confirm``).
+        unknown_prior: When True, ``existing`` being ``None`` represents a
+            failed best-effort fetch (the entity exists, we just couldn't
+            read it). Each change is then marked ``is_unknown_prior`` so
+            the rendering layer can show "(prior unknown) → new" instead
+            of implying the prior value was empty. Mutually exclusive with
+            a non-None ``existing`` — if the fetch succeeded, this flag is
+            ignored.
+    """
+    field_map = field_map or {}
+    exclude_set = set(exclude)
+    changes: list[FieldChange] = []
+    treat_as_unknown = existing is None and unknown_prior
+    # ``exclude_none=True`` skips fields the caller didn't supply, which is
+    # what we want for partial updates — the diff only covers fields the user
+    # actually intends to set. The trade-off is we can't represent "explicit
+    # clear" here; see FieldChange's docstring.
+    for name, value in request.model_dump(exclude_none=True).items():
+        if name in exclude_set:
+            continue
+        attr_name = field_map.get(name, name)
+        old: Any = None
+        if existing is not None:
+            raw = getattr(existing, attr_name, UNSET)
+            old = _normalize(unwrap_unset(raw, None))
+        new = _normalize(value)
+        if treat_as_unknown:
+            changes.append(
+                FieldChange(field=name, old=None, new=new, is_unknown_prior=True)
+            )
+        elif old == new:
+            changes.append(FieldChange(field=name, old=old, new=new, is_unchanged=True))
+        elif old is None:
+            changes.append(FieldChange(field=name, old=None, new=new, is_added=True))
+        else:
+            changes.append(FieldChange(field=name, old=old, new=new))
+    return changes
+
+
+def render_modification_md(response: ModificationResponse) -> str:
+    """Render a :class:`ModificationResponse` as the markdown content body."""
+    op_title = response.operation.replace("_", " ").title()
+    entity_title = response.entity_type.replace("_", " ").title()
+    state_label = "PREVIEW" if response.is_preview else op_title.upper()
+
+    lines = [f"## {entity_title} {op_title} ({state_label})"]
+
+    if response.entity_id is not None:
+        lines.append(f"- **ID**: {response.entity_id}")
+    if response.parent_entity_id is not None:
+        lines.append(f"- **Parent ID**: {response.parent_entity_id}")
+    lines.append(f"- **Message**: {response.message}")
+    if response.katana_url:
+        lines.append(f"- **Katana URL**: {response.katana_url}")
+
+    if response.changes:
+        lines.append("")
+        lines.append("### Changes")
+        for change in response.changes:
+            if change.is_unchanged:
+                lines.append(f"- `{change.field}`: (unchanged) {change.new}")
+            elif change.is_unknown_prior:
+                lines.append(f"- `{change.field}`: (prior unknown) → {change.new}")
+            elif change.is_added:
+                lines.append(f"- `{change.field}`: (set) → {change.new}")
+            else:
+                lines.append(f"- `{change.field}`: {change.old} → {change.new}")
+
+    if response.warnings:
+        lines.append("")
+        lines.append("### Warnings")
+        for w in response.warnings:
+            is_block = w.startswith(BLOCK_WARNING_PREFIX)
+            display = w.removeprefix(BLOCK_WARNING_PREFIX).lstrip() if is_block else w
+            prefix = "**[BLOCKED]** " if is_block else ""
+            lines.append(f"- {prefix}{display}")
+
+    if response.next_actions:
+        lines.append("")
+        lines.append("### Next Actions")
+        lines.extend(f"- {a}" for a in response.next_actions)
+
+    return "\n".join(lines)
+
+
+def to_tool_result(response: ModificationResponse) -> ToolResult:
+    """Build a :class:`ToolResult` from a :class:`ModificationResponse`."""
+    return make_simple_result(
+        render_modification_md(response),
+        structured_data=response.model_dump(),
+    )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -21,6 +21,11 @@ from pydantic import BaseModel, Field
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
+from katana_mcp.tools._modification import (
+    ModificationResponse,
+    compute_field_diff,
+    to_tool_result,
+)
 from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.tool_result_utils import (
     BLOCK_WARNING_PREFIX,
@@ -41,13 +46,22 @@ from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
+    CostDistributionMethod,
+    CreatePurchaseOrderAdditionalCostRowRequest as APICreatePOAdditionalCostRowRequest,
     CreatePurchaseOrderInitialStatus,
     CreatePurchaseOrderRequest as APICreatePurchaseOrderRequest,
+    CreatePurchaseOrderRowRequest as APICreatePurchaseOrderRowRequest,
     FindPurchaseOrdersBillingStatus,
     FindPurchaseOrdersStatus,
+    PurchaseOrderAdditionalCostRow,
     PurchaseOrderEntityType,
+    PurchaseOrderRow,
     PurchaseOrderRowRequest,
+    PurchaseOrderStatus,
     RegularPurchaseOrder,
+    UpdatePurchaseOrderAdditionalCostRowRequest as APIUpdatePOAdditionalCostRowRequest,
+    UpdatePurchaseOrderRequest as APIUpdatePurchaseOrderRequest,
+    UpdatePurchaseOrderRowRequest as APIUpdatePurchaseOrderRowRequest,
 )
 from katana_public_api_client.utils import is_success, unwrap, unwrap_as
 
@@ -2027,6 +2041,1049 @@ async def list_purchase_orders(
     return make_simple_result(md, structured_data=response.model_dump())
 
 
+# ============================================================================
+# Tool: update_purchase_order (header fields, including status)
+# ============================================================================
+
+
+# Tool-facing uppercase status literal — accepts every value Katana defines.
+# Folded into ``update_purchase_order`` rather than a separate status tool to
+# keep the surface uniform with the canonical entity-modification pattern in
+# ``katana_mcp.tools._modification``.
+PurchaseOrderStatusLiteral = Literal[
+    "DRAFT", "NOT_RECEIVED", "PARTIALLY_RECEIVED", "RECEIVED"
+]
+
+
+_PO_STATUS_API_VALUE: dict[PurchaseOrderStatusLiteral, PurchaseOrderStatus] = {
+    "DRAFT": PurchaseOrderStatus.DRAFT,
+    "NOT_RECEIVED": PurchaseOrderStatus.NOT_RECEIVED,
+    "PARTIALLY_RECEIVED": PurchaseOrderStatus.PARTIALLY_RECEIVED,
+    "RECEIVED": PurchaseOrderStatus.RECEIVED,
+}
+
+
+class UpdatePurchaseOrderRequest(BaseModel):
+    """Request to update header fields on an existing purchase order.
+
+    Status transitions are folded in here as a regular field — Katana's API
+    accepts ``status`` as part of the same PATCH body, so a separate
+    ``update_purchase_order_status`` tool would only duplicate surface area.
+    """
+
+    id: int = Field(..., description="Purchase order ID")
+    order_no: str | None = Field(default=None, description="New PO number")
+    supplier_id: int | None = Field(default=None, description="New supplier ID")
+    currency: str | None = Field(
+        default=None, description="New currency code (e.g., USD)"
+    )
+    location_id: int | None = Field(
+        default=None, description="New receiving location ID"
+    )
+    tracking_location_id: int | None = Field(
+        default=None, description="New tracking location ID"
+    )
+    status: PurchaseOrderStatusLiteral | None = Field(
+        default=None,
+        description=(
+            "New status — DRAFT / NOT_RECEIVED / PARTIALLY_RECEIVED / RECEIVED. "
+            "Use receive_purchase_order to flip to RECEIVED with inventory updates."
+        ),
+    )
+    expected_arrival_date: datetime | None = Field(
+        default=None, description="New expected arrival date"
+    )
+    order_created_date: datetime | None = Field(
+        default=None, description="New order created date"
+    )
+    additional_info: str | None = Field(
+        default=None, description="New notes / additional info"
+    )
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, applies the update.",
+    )
+
+
+async def _fetch_purchase_order_attrs(
+    services: Any, po_id: int
+) -> RegularPurchaseOrder | None:
+    """Fetch the existing PO attrs object for diff context.
+
+    Returns ``None`` on failure rather than raising — the diff is best-effort
+    UX and the caller still surfaces the change set the user requested.
+    """
+    from katana_public_api_client.api.purchase_order import get_purchase_order as _get
+
+    try:
+        response = await _get.asyncio_detailed(id=po_id, client=services.client)
+        existing = unwrap_as(response, RegularPurchaseOrder)
+        return existing
+    except Exception as exc:
+        logger.info(
+            f"Could not fetch PO {po_id} for diff context: {exc} — "
+            "preview will report changes without prior values."
+        )
+        return None
+
+
+async def _update_purchase_order_impl(
+    request: UpdatePurchaseOrderRequest, context: Context
+) -> ModificationResponse:
+    """Implementation of update_purchase_order tool."""
+    services = get_services(context)
+
+    has_any_field = any(
+        v is not None
+        for v in (
+            request.order_no,
+            request.supplier_id,
+            request.currency,
+            request.location_id,
+            request.tracking_location_id,
+            request.status,
+            request.expected_arrival_date,
+            request.order_created_date,
+            request.additional_info,
+        )
+    )
+    if not has_any_field:
+        raise ValueError(
+            "At least one field must be provided to update — supply order_no, "
+            "supplier_id, currency, location_id, tracking_location_id, status, "
+            "expected_arrival_date, order_created_date, or additional_info."
+        )
+
+    existing = await _fetch_purchase_order_attrs(services, request.id)
+    fetch_failed = existing is None
+    # An update target is assumed to exist — when the best-effort fetch fails,
+    # the diff renders "(prior unknown) → new" rather than implying the field
+    # was empty. The warning surfaces the same context to the LLM/UI.
+    changes = compute_field_diff(existing, request, unknown_prior=fetch_failed)
+    warnings = (
+        [
+            f"Could not fetch purchase order {request.id} for diff context — "
+            "preview shows requested values without prior state."
+        ]
+        if fetch_failed
+        else []
+    )
+    katana_url = katana_web_url("purchase_order", request.id)
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="purchase_order",
+            entity_id=request.id,
+            operation="update",
+            is_preview=True,
+            changes=changes,
+            warnings=warnings,
+            next_actions=[
+                "Review the proposed changes",
+                "Set confirm=true to apply the update",
+            ],
+            katana_url=katana_url,
+            message=(
+                f"Preview: update purchase order {request.id} ({len(changes)} field(s))"
+            ),
+        )
+
+    api_status = (
+        _PO_STATUS_API_VALUE[request.status] if request.status is not None else None
+    )
+    api_request = APIUpdatePurchaseOrderRequest(
+        order_no=to_unset(request.order_no),
+        supplier_id=to_unset(request.supplier_id),
+        currency=to_unset(request.currency),
+        location_id=to_unset(request.location_id),
+        tracking_location_id=to_unset(request.tracking_location_id),
+        status=to_unset(api_status),
+        expected_arrival_date=to_unset(request.expected_arrival_date),
+        order_created_date=to_unset(request.order_created_date),
+        additional_info=to_unset(request.additional_info),
+    )
+
+    from katana_public_api_client.api.purchase_order import update_purchase_order
+
+    api_response = await update_purchase_order.asyncio_detailed(
+        id=request.id, client=services.client, body=api_request
+    )
+    updated = unwrap_as(api_response, RegularPurchaseOrder)
+    logger.info(f"Updated purchase order {updated.id}")
+
+    return ModificationResponse(
+        entity_type="purchase_order",
+        entity_id=updated.id,
+        operation="update",
+        is_preview=False,
+        changes=changes,
+        next_actions=[f"Purchase order {updated.id} updated"],
+        katana_url=katana_url,
+        message=f"Successfully updated purchase order {updated.id}",
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def update_purchase_order(
+    request: Annotated[UpdatePurchaseOrderRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Update header fields on an existing purchase order.
+
+    Two-step flow: ``confirm=false`` returns a preview with a per-field diff
+    against the current PO; ``confirm=true`` applies the PATCH. Accepts any
+    subset of ``order_no``, ``supplier_id``, ``currency``, ``location_id``,
+    ``tracking_location_id``, ``status``, ``expected_arrival_date``,
+    ``order_created_date``, and ``additional_info``. Status transitions are
+    handled via this same tool — there's no separate status endpoint.
+    """
+    response = await _update_purchase_order_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
+# Tool: delete_purchase_order
+# ============================================================================
+
+
+class DeletePurchaseOrderRequest(BaseModel):
+    """Request to delete a purchase order."""
+
+    id: int = Field(..., description="Purchase order ID to delete")
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, deletes the PO.",
+    )
+
+
+async def _delete_purchase_order_impl(
+    request: DeletePurchaseOrderRequest, context: Context
+) -> ModificationResponse:
+    """Implementation of delete_purchase_order tool."""
+    katana_url = katana_web_url("purchase_order", request.id)
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="purchase_order",
+            entity_id=request.id,
+            operation="delete",
+            is_preview=True,
+            next_actions=[
+                "Review the deletion",
+                "Set confirm=true to delete the purchase order",
+            ],
+            katana_url=katana_url,
+            message=f"Preview: delete purchase order {request.id}",
+        )
+
+    services = get_services(context)
+    from katana_public_api_client.api.purchase_order import delete_purchase_order
+
+    response = await delete_purchase_order.asyncio_detailed(
+        id=request.id, client=services.client
+    )
+    if not is_success(response):
+        unwrap(response)
+
+    logger.info(f"Deleted purchase order {request.id}")
+    return ModificationResponse(
+        entity_type="purchase_order",
+        entity_id=request.id,
+        operation="delete",
+        is_preview=False,
+        next_actions=[f"Purchase order {request.id} has been deleted"],
+        katana_url=None,
+        message=f"Successfully deleted purchase order {request.id}",
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def delete_purchase_order(
+    request: Annotated[DeletePurchaseOrderRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Delete a purchase order.
+
+    Two-step flow: ``confirm=false`` returns a preview, ``confirm=true``
+    deletes the PO. Destructive — the order record is removed.
+    """
+    response = await _delete_purchase_order_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
+# Tool: add_purchase_order_row
+# ============================================================================
+
+
+class AddPurchaseOrderRowRequest(BaseModel):
+    """Request to add a new line item to an existing purchase order."""
+
+    purchase_order_id: int = Field(..., description="Parent purchase order ID")
+    variant_id: int = Field(..., description="Variant ID to order")
+    quantity: float = Field(..., description="Quantity to order", gt=0)
+    price_per_unit: float = Field(..., description="Unit price")
+    tax_rate_id: int | None = Field(default=None, description="Tax rate ID")
+    tax_name: str | None = Field(default=None, description="Tax name")
+    tax_rate: str | None = Field(default=None, description="Tax rate value")
+    currency: str | None = Field(default=None, description="Currency code")
+    purchase_uom: str | None = Field(
+        default=None, description="Purchase unit of measure"
+    )
+    purchase_uom_conversion_rate: float | None = Field(
+        default=None, description="UOM conversion rate"
+    )
+    arrival_date: datetime | None = Field(
+        default=None, description="Expected arrival date for this row"
+    )
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, adds the row.",
+    )
+
+
+async def _add_purchase_order_row_impl(
+    request: AddPurchaseOrderRowRequest, context: Context
+) -> ModificationResponse:
+    """Implementation of add_purchase_order_row tool."""
+    parent_url = katana_web_url("purchase_order", request.purchase_order_id)
+    # New row — every supplied field is reported as added (no existing entity).
+    changes = compute_field_diff(
+        None, request, exclude=("confirm", "purchase_order_id")
+    )
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="purchase_order_row",
+            entity_id=None,
+            parent_entity_id=request.purchase_order_id,
+            operation="create_row",
+            is_preview=True,
+            changes=changes,
+            next_actions=[
+                "Review the new row",
+                "Set confirm=true to add the row",
+            ],
+            katana_url=parent_url,
+            message=(
+                f"Preview: add row to purchase order {request.purchase_order_id} "
+                f"(variant {request.variant_id}, qty {request.quantity})"
+            ),
+        )
+
+    services = get_services(context)
+    api_request = APICreatePurchaseOrderRowRequest(
+        purchase_order_id=request.purchase_order_id,
+        quantity=request.quantity,
+        variant_id=request.variant_id,
+        price_per_unit=request.price_per_unit,
+        tax_rate_id=to_unset(request.tax_rate_id),
+        tax_name=to_unset(request.tax_name),
+        tax_rate=to_unset(request.tax_rate),
+        currency=to_unset(request.currency),
+        purchase_uom_conversion_rate=to_unset(request.purchase_uom_conversion_rate),
+        purchase_uom=to_unset(request.purchase_uom),
+        arrival_date=to_unset(request.arrival_date),
+    )
+
+    from katana_public_api_client.api.purchase_order_row import (
+        create_purchase_order_row,
+    )
+
+    api_response = await create_purchase_order_row.asyncio_detailed(
+        client=services.client, body=api_request
+    )
+    new_row = unwrap_as(api_response, PurchaseOrderRow)
+    logger.info(f"Added row {new_row.id} to purchase order {request.purchase_order_id}")
+
+    return ModificationResponse(
+        entity_type="purchase_order_row",
+        entity_id=new_row.id,
+        parent_entity_id=request.purchase_order_id,
+        operation="create_row",
+        is_preview=False,
+        changes=changes,
+        next_actions=[
+            f"Row {new_row.id} added to purchase order {request.purchase_order_id}"
+        ],
+        katana_url=parent_url,
+        message=(
+            f"Successfully added row {new_row.id} to purchase order "
+            f"{request.purchase_order_id}"
+        ),
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def add_purchase_order_row(
+    request: Annotated[AddPurchaseOrderRowRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Add a new line item to an existing purchase order.
+
+    Two-step flow: ``confirm=false`` returns a preview, ``confirm=true``
+    POSTs the new row. Required: ``purchase_order_id``, ``variant_id``,
+    ``quantity``, ``price_per_unit``. Optional fields cover taxes, UOM,
+    and per-row arrival date.
+    """
+    response = await _add_purchase_order_row_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
+# Tool: update_purchase_order_row
+# ============================================================================
+
+
+class UpdatePurchaseOrderRowRequest(BaseModel):
+    """Request to update fields on an existing purchase order row."""
+
+    id: int = Field(..., description="Purchase order row ID")
+    quantity: float | None = Field(default=None, description="New quantity", gt=0)
+    variant_id: int | None = Field(default=None, description="New variant ID")
+    tax_rate_id: int | None = Field(default=None, description="New tax rate ID")
+    tax_name: str | None = Field(default=None, description="New tax name")
+    tax_rate: str | None = Field(default=None, description="New tax rate value")
+    price_per_unit: float | None = Field(default=None, description="New unit price")
+    purchase_uom_conversion_rate: float | None = Field(
+        default=None, description="New UOM conversion rate"
+    )
+    purchase_uom: str | None = Field(
+        default=None, description="New purchase unit of measure"
+    )
+    received_date: datetime | None = Field(
+        default=None, description="New received date"
+    )
+    arrival_date: datetime | None = Field(
+        default=None, description="New expected arrival date for this row"
+    )
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, applies the update.",
+    )
+
+
+async def _fetch_purchase_order_row(
+    services: Any, row_id: int
+) -> PurchaseOrderRow | None:
+    """Fetch the existing PO row for diff context. Returns ``None`` on failure."""
+    from katana_public_api_client.api.purchase_order_row import (
+        get_purchase_order_row as _get,
+    )
+
+    try:
+        response = await _get.asyncio_detailed(id=row_id, client=services.client)
+        return unwrap_as(response, PurchaseOrderRow)
+    except Exception as exc:
+        logger.info(
+            f"Could not fetch PO row {row_id} for diff context: {exc} — "
+            "preview will report changes without prior values."
+        )
+        return None
+
+
+async def _update_purchase_order_row_impl(
+    request: UpdatePurchaseOrderRowRequest, context: Context
+) -> ModificationResponse:
+    """Implementation of update_purchase_order_row tool."""
+    services = get_services(context)
+
+    has_any_field = any(
+        v is not None
+        for v in (
+            request.quantity,
+            request.variant_id,
+            request.tax_rate_id,
+            request.tax_name,
+            request.tax_rate,
+            request.price_per_unit,
+            request.purchase_uom_conversion_rate,
+            request.purchase_uom,
+            request.received_date,
+            request.arrival_date,
+        )
+    )
+    if not has_any_field:
+        raise ValueError(
+            "At least one field must be provided to update — supply quantity, "
+            "variant_id, tax_rate_id, tax_name, tax_rate, price_per_unit, "
+            "purchase_uom_conversion_rate, purchase_uom, received_date, or "
+            "arrival_date."
+        )
+
+    existing = await _fetch_purchase_order_row(services, request.id)
+    fetch_failed = existing is None
+    changes = compute_field_diff(existing, request, unknown_prior=fetch_failed)
+    parent_id = (
+        unwrap_unset(existing.purchase_order_id, None) if existing is not None else None
+    )
+    parent_url = (
+        katana_web_url("purchase_order", parent_id) if parent_id is not None else None
+    )
+    warnings = (
+        [
+            f"Could not fetch purchase order row {request.id} for diff context — "
+            "preview shows requested values without prior state."
+        ]
+        if fetch_failed
+        else []
+    )
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="purchase_order_row",
+            entity_id=request.id,
+            parent_entity_id=parent_id,
+            operation="update_row",
+            is_preview=True,
+            changes=changes,
+            warnings=warnings,
+            next_actions=[
+                "Review the proposed changes",
+                "Set confirm=true to apply the update",
+            ],
+            katana_url=parent_url,
+            message=(
+                f"Preview: update purchase order row {request.id} "
+                f"({len(changes)} field(s))"
+            ),
+        )
+
+    api_request = APIUpdatePurchaseOrderRowRequest(
+        quantity=to_unset(request.quantity),
+        variant_id=to_unset(request.variant_id),
+        tax_rate_id=to_unset(request.tax_rate_id),
+        tax_name=to_unset(request.tax_name),
+        tax_rate=to_unset(request.tax_rate),
+        price_per_unit=to_unset(request.price_per_unit),
+        purchase_uom_conversion_rate=to_unset(request.purchase_uom_conversion_rate),
+        purchase_uom=to_unset(request.purchase_uom),
+        received_date=to_unset(request.received_date),
+        arrival_date=to_unset(request.arrival_date),
+    )
+
+    from katana_public_api_client.api.purchase_order_row import (
+        update_purchase_order_row,
+    )
+
+    api_response = await update_purchase_order_row.asyncio_detailed(
+        id=request.id, client=services.client, body=api_request
+    )
+    updated = unwrap_as(api_response, PurchaseOrderRow)
+    logger.info(f"Updated purchase order row {updated.id}")
+
+    # When the pre-update fetch failed, parent_id/url are still None — but the
+    # PATCH response echoes purchase_order_id, so we can recover the parent
+    # context from it. This keeps the confirm-path response well-formed even
+    # when the preview-context fetch was best-effort and lossy.
+    final_parent_id = parent_id or unwrap_unset(updated.purchase_order_id, None)
+    final_parent_url = parent_url or (
+        katana_web_url("purchase_order", final_parent_id)
+        if final_parent_id is not None
+        else None
+    )
+
+    return ModificationResponse(
+        entity_type="purchase_order_row",
+        entity_id=updated.id,
+        parent_entity_id=final_parent_id,
+        operation="update_row",
+        is_preview=False,
+        changes=changes,
+        next_actions=[f"Row {updated.id} updated"],
+        katana_url=final_parent_url,
+        message=f"Successfully updated purchase order row {updated.id}",
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def update_purchase_order_row(
+    request: Annotated[UpdatePurchaseOrderRowRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Update fields on an existing purchase order row.
+
+    Two-step flow: ``confirm=false`` returns a preview with per-field diff,
+    ``confirm=true`` applies the PATCH. Accepts any subset of quantity,
+    variant_id, taxes, price_per_unit, UOM fields, received_date, and the
+    row-level arrival_date (separate from the PO header's arrival date).
+    """
+    response = await _update_purchase_order_row_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
+# Tool: delete_purchase_order_row
+# ============================================================================
+
+
+class DeletePurchaseOrderRowRequest(BaseModel):
+    """Request to delete a purchase order row."""
+
+    id: int = Field(..., description="Purchase order row ID to delete")
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, deletes the row.",
+    )
+
+
+async def _delete_purchase_order_row_impl(
+    request: DeletePurchaseOrderRowRequest, context: Context
+) -> ModificationResponse:
+    """Implementation of delete_purchase_order_row tool."""
+    services = get_services(context)
+    existing = await _fetch_purchase_order_row(services, request.id)
+    parent_id = (
+        unwrap_unset(existing.purchase_order_id, None) if existing is not None else None
+    )
+    parent_url = (
+        katana_web_url("purchase_order", parent_id) if parent_id is not None else None
+    )
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="purchase_order_row",
+            entity_id=request.id,
+            parent_entity_id=parent_id,
+            operation="delete_row",
+            is_preview=True,
+            next_actions=[
+                "Review the deletion",
+                "Set confirm=true to delete the row",
+            ],
+            katana_url=parent_url,
+            message=f"Preview: delete purchase order row {request.id}",
+        )
+
+    from katana_public_api_client.api.purchase_order_row import (
+        delete_purchase_order_row,
+    )
+
+    response = await delete_purchase_order_row.asyncio_detailed(
+        id=request.id, client=services.client
+    )
+    if not is_success(response):
+        unwrap(response)
+
+    logger.info(f"Deleted purchase order row {request.id}")
+    return ModificationResponse(
+        entity_type="purchase_order_row",
+        entity_id=request.id,
+        parent_entity_id=parent_id,
+        operation="delete_row",
+        is_preview=False,
+        next_actions=[f"Row {request.id} has been deleted"],
+        katana_url=parent_url,
+        message=f"Successfully deleted purchase order row {request.id}",
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def delete_purchase_order_row(
+    request: Annotated[DeletePurchaseOrderRowRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Delete a purchase order row.
+
+    Two-step flow: ``confirm=false`` returns a preview, ``confirm=true``
+    deletes the row. Destructive.
+    """
+    response = await _delete_purchase_order_row_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
+# Tool: add_purchase_order_additional_cost
+# ============================================================================
+
+
+CostDistributionMethodLiteral = Literal["BY_VALUE", "NON_DISTRIBUTED"]
+
+_DISTRIBUTION_METHOD_API_VALUE: dict[
+    CostDistributionMethodLiteral, CostDistributionMethod
+] = {
+    "BY_VALUE": CostDistributionMethod.BY_VALUE,
+    "NON_DISTRIBUTED": CostDistributionMethod.NON_DISTRIBUTED,
+}
+
+
+class AddPurchaseOrderAdditionalCostRequest(BaseModel):
+    """Request to add a new additional-cost row (freight, duties, etc.) to a PO.
+
+    Katana models additional-cost rows as members of a *cost group* — the PO
+    carries a ``default_group_id`` that the rows attach to. We accept the
+    parent PO id (familiar to users) and resolve the group id internally.
+    Use ``group_id`` instead if the PO has multiple groups and you need to
+    target a specific one.
+    """
+
+    purchase_order_id: int | None = Field(
+        default=None,
+        description=(
+            "Parent purchase order ID. The tool resolves the PO's "
+            "``default_group_id`` automatically. Either this or ``group_id`` "
+            "must be provided."
+        ),
+    )
+    group_id: int | None = Field(
+        default=None,
+        description=(
+            "Cost group ID to attach the row to. Pass directly when the PO "
+            "has multiple groups and you need to target a non-default one. "
+            "Either this or ``purchase_order_id`` must be provided."
+        ),
+    )
+    additional_cost_id: int = Field(..., description="Additional-cost catalog entry ID")
+    tax_rate_id: int = Field(..., description="Tax rate ID")
+    price: float = Field(..., description="Cost amount")
+    distribution_method: CostDistributionMethodLiteral | None = Field(
+        default=None,
+        description=(
+            "How the cost is allocated across rows: BY_VALUE distributes "
+            "proportionally to row value, NON_DISTRIBUTED leaves it unallocated. "
+            "Defaults to Katana's server-side default when omitted."
+        ),
+    )
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, adds the cost row.",
+    )
+
+
+async def _resolve_default_group_id(
+    services: Any, purchase_order_id: int
+) -> int | None:
+    """Look up a PO's ``default_group_id`` to attach additional-cost rows to."""
+    existing = await _fetch_purchase_order_attrs(services, purchase_order_id)
+    if existing is None:
+        return None
+    return unwrap_unset(existing.default_group_id, None)
+
+
+async def _add_purchase_order_additional_cost_impl(
+    request: AddPurchaseOrderAdditionalCostRequest, context: Context
+) -> ModificationResponse:
+    """Implementation of add_purchase_order_additional_cost tool."""
+    if request.purchase_order_id is None and request.group_id is None:
+        raise ValueError("Either purchase_order_id or group_id must be provided.")
+
+    services = get_services(context)
+    group_id: int | None = request.group_id
+    if group_id is None and request.purchase_order_id is not None:
+        group_id = await _resolve_default_group_id(services, request.purchase_order_id)
+        if group_id is None:
+            raise ValueError(
+                f"Could not resolve default_group_id for purchase order "
+                f"{request.purchase_order_id} — supply ``group_id`` directly."
+            )
+    # The earlier guard guarantees at least one of (purchase_order_id, group_id)
+    # is set, and the resolve branch raises if it can't fill in group_id — so by
+    # this point group_id is non-None. The narrow keeps the type checker honest.
+    assert group_id is not None
+
+    parent_url = (
+        katana_web_url("purchase_order", request.purchase_order_id)
+        if request.purchase_order_id is not None
+        else None
+    )
+    changes = compute_field_diff(
+        None,
+        request,
+        exclude=("confirm", "purchase_order_id"),
+    )
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="purchase_order_additional_cost",
+            entity_id=None,
+            parent_entity_id=request.purchase_order_id,
+            operation="create_additional_cost",
+            is_preview=True,
+            changes=changes,
+            next_actions=[
+                "Review the cost row",
+                "Set confirm=true to add the row",
+            ],
+            katana_url=parent_url,
+            message=(
+                f"Preview: add additional cost (group {group_id}, "
+                f"price {request.price})"
+            ),
+        )
+
+    api_distribution = (
+        _DISTRIBUTION_METHOD_API_VALUE[request.distribution_method]
+        if request.distribution_method is not None
+        else None
+    )
+    api_request = APICreatePOAdditionalCostRowRequest(
+        additional_cost_id=request.additional_cost_id,
+        group_id=group_id,
+        tax_rate_id=request.tax_rate_id,
+        price=request.price,
+        distribution_method=to_unset(api_distribution),
+    )
+
+    from katana_public_api_client.api.purchase_order_additional_cost_row import (
+        create_po_additional_cost_row,
+    )
+
+    api_response = await create_po_additional_cost_row.asyncio_detailed(
+        client=services.client, body=api_request
+    )
+    new_row = unwrap_as(api_response, PurchaseOrderAdditionalCostRow)
+    logger.info(f"Added additional-cost row {new_row.id} to group {group_id}")
+
+    return ModificationResponse(
+        entity_type="purchase_order_additional_cost",
+        entity_id=new_row.id,
+        parent_entity_id=request.purchase_order_id,
+        operation="create_additional_cost",
+        is_preview=False,
+        changes=changes,
+        next_actions=[f"Additional-cost row {new_row.id} added to group {group_id}"],
+        katana_url=parent_url,
+        message=f"Successfully added additional-cost row {new_row.id}",
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def add_purchase_order_additional_cost(
+    request: Annotated[AddPurchaseOrderAdditionalCostRequest, Unpack()],
+    context: Context,
+) -> ToolResult:
+    """Add an additional-cost row (freight, duties, handling fees) to a PO.
+
+    Two-step flow: ``confirm=false`` returns a preview, ``confirm=true``
+    POSTs the new row. Required: ``additional_cost_id``, ``tax_rate_id``,
+    ``price``, and **either** ``purchase_order_id`` **or** ``group_id``.
+    When only ``purchase_order_id`` is provided, the tool resolves the PO's
+    ``default_group_id`` automatically. Optional ``distribution_method``
+    chooses how the cost is allocated across line items.
+    """
+    response = await _add_purchase_order_additional_cost_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
+# Tool: update_purchase_order_additional_cost
+# ============================================================================
+
+
+class UpdatePurchaseOrderAdditionalCostRequest(BaseModel):
+    """Request to update an existing PO additional-cost row."""
+
+    id: int = Field(..., description="Additional-cost row ID")
+    additional_cost_id: int | None = Field(
+        default=None, description="New additional-cost catalog entry ID"
+    )
+    tax_rate_id: int | None = Field(default=None, description="New tax rate ID")
+    price: float | None = Field(default=None, description="New cost amount")
+    distribution_method: CostDistributionMethodLiteral | None = Field(
+        default=None,
+        description="New distribution method (BY_VALUE / NON_DISTRIBUTED)",
+    )
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, applies the update.",
+    )
+
+
+async def _update_purchase_order_additional_cost_impl(
+    request: UpdatePurchaseOrderAdditionalCostRequest, context: Context
+) -> ModificationResponse:
+    """Implementation of update_purchase_order_additional_cost tool."""
+    services = get_services(context)
+
+    has_any_field = any(
+        v is not None
+        for v in (
+            request.additional_cost_id,
+            request.tax_rate_id,
+            request.price,
+            request.distribution_method,
+        )
+    )
+    if not has_any_field:
+        raise ValueError(
+            "At least one field must be provided to update — supply "
+            "additional_cost_id, tax_rate_id, price, or distribution_method."
+        )
+
+    # No diff context — there's no get-by-id endpoint dedicated to a single
+    # additional-cost row in the generated client (the existing
+    # `get_po_additional_cost_row` endpoint takes the row id, but the
+    # response shape is the row itself, so we can fetch it). Try and fall
+    # back gracefully.
+    existing: PurchaseOrderAdditionalCostRow | None = None
+    try:
+        from katana_public_api_client.api.purchase_order_additional_cost_row import (
+            get_po_additional_cost_row,
+        )
+
+        get_response = await get_po_additional_cost_row.asyncio_detailed(
+            id=request.id, client=services.client
+        )
+        existing = unwrap_as(get_response, PurchaseOrderAdditionalCostRow)
+    except Exception as exc:
+        logger.info(
+            f"Could not fetch additional-cost row {request.id} for diff "
+            f"context: {exc} — preview will report changes without prior values."
+        )
+
+    fetch_failed = existing is None
+    changes = compute_field_diff(existing, request, unknown_prior=fetch_failed)
+    warnings = (
+        [
+            f"Could not fetch additional-cost row {request.id} for diff context — "
+            "preview shows requested values without prior state."
+        ]
+        if fetch_failed
+        else []
+    )
+
+    # Additional-cost rows are scoped by ``group_id``, not ``purchase_order_id`` —
+    # the row schema doesn't expose a back-reference to its parent PO and there's
+    # no list filter to derive it cheaply. Leave parent_entity_id unset.
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="purchase_order_additional_cost",
+            entity_id=request.id,
+            operation="update_additional_cost",
+            is_preview=True,
+            changes=changes,
+            warnings=warnings,
+            next_actions=[
+                "Review the proposed changes",
+                "Set confirm=true to apply the update",
+            ],
+            message=(
+                f"Preview: update additional-cost row {request.id} "
+                f"({len(changes)} field(s))"
+            ),
+        )
+
+    api_distribution = (
+        _DISTRIBUTION_METHOD_API_VALUE[request.distribution_method]
+        if request.distribution_method is not None
+        else None
+    )
+    api_request = APIUpdatePOAdditionalCostRowRequest(
+        additional_cost_id=to_unset(request.additional_cost_id),
+        tax_rate_id=to_unset(request.tax_rate_id),
+        price=to_unset(request.price),
+        distribution_method=to_unset(api_distribution),
+    )
+
+    from katana_public_api_client.api.purchase_order_additional_cost_row import (
+        update_additional_cost_row,
+    )
+
+    api_response = await update_additional_cost_row.asyncio_detailed(
+        id=request.id, client=services.client, body=api_request
+    )
+    updated = unwrap_as(api_response, PurchaseOrderAdditionalCostRow)
+    logger.info(f"Updated additional-cost row {updated.id}")
+
+    return ModificationResponse(
+        entity_type="purchase_order_additional_cost",
+        entity_id=updated.id,
+        operation="update_additional_cost",
+        is_preview=False,
+        changes=changes,
+        next_actions=[f"Additional-cost row {updated.id} updated"],
+        message=f"Successfully updated additional-cost row {updated.id}",
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def update_purchase_order_additional_cost(
+    request: Annotated[UpdatePurchaseOrderAdditionalCostRequest, Unpack()],
+    context: Context,
+) -> ToolResult:
+    """Update an additional-cost row on a purchase order.
+
+    Two-step flow: ``confirm=false`` returns a preview with per-field diff,
+    ``confirm=true`` applies the PATCH. Accepts any subset of
+    ``additional_cost_id``, ``tax_rate_id``, ``price``, and
+    ``distribution_method``.
+    """
+    response = await _update_purchase_order_additional_cost_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
+# Tool: delete_purchase_order_additional_cost
+# ============================================================================
+
+
+class DeletePurchaseOrderAdditionalCostRequest(BaseModel):
+    """Request to delete a PO additional-cost row."""
+
+    id: int = Field(..., description="Additional-cost row ID to delete")
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, deletes the row.",
+    )
+
+
+async def _delete_purchase_order_additional_cost_impl(
+    request: DeletePurchaseOrderAdditionalCostRequest, context: Context
+) -> ModificationResponse:
+    """Implementation of delete_purchase_order_additional_cost tool."""
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="purchase_order_additional_cost",
+            entity_id=request.id,
+            operation="delete_additional_cost",
+            is_preview=True,
+            next_actions=[
+                "Review the deletion",
+                "Set confirm=true to delete the row",
+            ],
+            message=f"Preview: delete additional-cost row {request.id}",
+        )
+
+    services = get_services(context)
+    from katana_public_api_client.api.purchase_order_additional_cost_row import (
+        delete_po_additional_cost,
+    )
+
+    response = await delete_po_additional_cost.asyncio_detailed(
+        id=request.id, client=services.client
+    )
+    if not is_success(response):
+        unwrap(response)
+
+    logger.info(f"Deleted additional-cost row {request.id}")
+    return ModificationResponse(
+        entity_type="purchase_order_additional_cost",
+        entity_id=request.id,
+        operation="delete_additional_cost",
+        is_preview=False,
+        next_actions=[f"Additional-cost row {request.id} has been deleted"],
+        message=f"Successfully deleted additional-cost row {request.id}",
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def delete_purchase_order_additional_cost(
+    request: Annotated[DeletePurchaseOrderAdditionalCostRequest, Unpack()],
+    context: Context,
+) -> ToolResult:
+    """Delete an additional-cost row from a purchase order.
+
+    Two-step flow: ``confirm=false`` returns a preview, ``confirm=true``
+    deletes the row. Destructive.
+    """
+    response = await _delete_purchase_order_additional_cost_impl(request, context)
+    return to_tool_result(response)
+
+
 def register_tools(mcp: FastMCP) -> None:
     """Register all purchase order tools with the FastMCP instance.
 
@@ -2041,6 +3098,18 @@ def register_tools(mcp: FastMCP) -> None:
     _read = ToolAnnotations(
         readOnlyHint=True,
         destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+    _update = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+    _destructive = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
         idempotentHint=True,
         openWorldHint=True,
     )
@@ -2066,3 +3135,30 @@ def register_tools(mcp: FastMCP) -> None:
     mcp.tool(tags={"orders", "purchasing", "read"}, annotations=_read)(
         get_purchase_order
     )
+    mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_update)(
+        update_purchase_order
+    )
+    mcp.tool(
+        tags={"orders", "purchasing", "write", "destructive"},
+        annotations=_destructive,
+    )(delete_purchase_order)
+    mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_write)(
+        add_purchase_order_row
+    )
+    mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_update)(
+        update_purchase_order_row
+    )
+    mcp.tool(
+        tags={"orders", "purchasing", "write", "destructive"},
+        annotations=_destructive,
+    )(delete_purchase_order_row)
+    mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_write)(
+        add_purchase_order_additional_cost
+    )
+    mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_update)(
+        update_purchase_order_additional_cost
+    )
+    mcp.tool(
+        tags={"orders", "purchasing", "write", "destructive"},
+        annotations=_destructive,
+    )(delete_purchase_order_additional_cost)

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -1,0 +1,200 @@
+"""Unit tests for the shared entity-modification helpers.
+
+These cover the pure-Python diff/render layer in
+``katana_mcp.tools._modification``. The modifier-tool integration tests live
+alongside their entity (e.g. ``test_purchase_orders.py``) and exercise the
+helper through the actual tool flow.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from unittest.mock import MagicMock
+
+from katana_mcp.tools._modification import (
+    FieldChange,
+    ModificationResponse,
+    compute_field_diff,
+    render_modification_md,
+    to_tool_result,
+)
+from pydantic import BaseModel
+
+from katana_public_api_client.client_types import UNSET
+
+
+class _SampleEnum(StrEnum):
+    DRAFT = "DRAFT"
+    DONE = "DONE"
+
+
+class _SampleRequest(BaseModel):
+    id: int
+    name: str | None = None
+    qty: int | None = None
+    when: datetime | None = None
+    state: _SampleEnum | None = None
+    confirm: bool = False
+
+
+def test_compute_field_diff_skips_id_and_confirm_by_default():
+    request = _SampleRequest(id=1, name="x", confirm=True)
+    diff = compute_field_diff(None, request)
+    assert {c.field for c in diff} == {"name"}
+
+
+def test_compute_field_diff_marks_added_when_existing_field_is_none():
+    existing = MagicMock()
+    existing.name = UNSET  # treated as None via unwrap_unset
+    request = _SampleRequest(id=1, name="new")
+    diff = compute_field_diff(existing, request)
+    assert len(diff) == 1
+    assert diff[0].is_added is True
+    assert diff[0].old is None
+    assert diff[0].new == "new"
+
+
+def test_compute_field_diff_marks_replacement_when_both_set_and_different():
+    existing = MagicMock()
+    existing.name = "old"
+    request = _SampleRequest(id=1, name="new")
+    diff = compute_field_diff(existing, request)
+    assert diff[0].is_added is False
+    assert diff[0].is_unchanged is False
+    assert diff[0].old == "old"
+    assert diff[0].new == "new"
+
+
+def test_compute_field_diff_marks_unchanged_when_values_match():
+    existing = MagicMock()
+    existing.qty = 5
+    request = _SampleRequest(id=1, qty=5)
+    diff = compute_field_diff(existing, request)
+    assert diff[0].is_unchanged is True
+
+
+def test_compute_field_diff_normalizes_datetime_to_iso():
+    when = datetime(2026, 5, 1, tzinfo=UTC)
+    existing = MagicMock()
+    existing.when = when
+    request = _SampleRequest(id=1, when=when)
+    diff = compute_field_diff(existing, request)
+    assert diff[0].is_unchanged is True
+    assert diff[0].old == when.isoformat()
+
+
+def test_compute_field_diff_normalizes_enum_to_value():
+    existing = MagicMock()
+    existing.state = _SampleEnum.DRAFT
+    request = _SampleRequest(id=1, state=_SampleEnum.DONE)
+    diff = compute_field_diff(existing, request)
+    assert diff[0].old == "DRAFT"
+    assert diff[0].new == "DONE"
+
+
+def test_compute_field_diff_field_map_renames_attr_lookup():
+    existing = MagicMock()
+    existing.real_name = "old"  # entity uses `real_name`, request uses `name`
+    request = _SampleRequest(id=1, name="new")
+    diff = compute_field_diff(existing, request, field_map={"name": "real_name"})
+    assert diff[0].old == "old"
+    assert diff[0].new == "new"
+
+
+def test_compute_field_diff_unknown_prior_marks_changes_distinctly():
+    """``unknown_prior=True`` distinguishes "fetch failed" from "create"."""
+    request = _SampleRequest(id=1, name="new", qty=5)
+    diff = compute_field_diff(None, request, unknown_prior=True)
+    assert len(diff) == 2
+    for change in diff:
+        assert change.is_unknown_prior is True
+        assert change.is_added is False
+        assert change.old is None
+
+
+def test_compute_field_diff_unknown_prior_ignored_when_existing_present():
+    """If we DID get the entity, ``unknown_prior`` doesn't override actual diff."""
+    existing = MagicMock()
+    existing.name = "old"
+    existing.qty = 5
+    request = _SampleRequest(id=1, name="new", qty=5)
+    diff = compute_field_diff(existing, request, unknown_prior=True)
+    by_field = {c.field: c for c in diff}
+    assert by_field["name"].old == "old"  # real diff, not unknown
+    assert by_field["name"].is_unknown_prior is False
+    assert by_field["qty"].is_unchanged is True
+
+
+def test_render_modification_md_unknown_prior_label():
+    response = ModificationResponse(
+        entity_type="purchase_order",
+        entity_id=42,
+        operation="update",
+        is_preview=True,
+        message="Preview: update (prior unknown)",
+        changes=[
+            FieldChange(field="qty", old=None, new=5, is_unknown_prior=True),
+        ],
+    )
+    md = render_modification_md(response)
+    # Distinct from `(set) → ...` which would imply prior=empty.
+    assert "`qty`: (prior unknown) → 5" in md
+
+
+def test_render_modification_md_preview_label():
+    response = ModificationResponse(
+        entity_type="purchase_order",
+        entity_id=42,
+        operation="update",
+        is_preview=True,
+        message="Preview: update",
+        changes=[FieldChange(field="qty", old=1, new=2)],
+        next_actions=["Set confirm=true"],
+    )
+    md = render_modification_md(response)
+    assert "## Purchase Order Update (PREVIEW)" in md
+    assert "**ID**: 42" in md
+    assert "`qty`: 1 → 2" in md
+    assert "Set confirm=true" in md
+
+
+def test_render_modification_md_confirmed_label_uses_operation():
+    response = ModificationResponse(
+        entity_type="purchase_order",
+        entity_id=42,
+        operation="delete",
+        is_preview=False,
+        message="Successfully deleted",
+    )
+    md = render_modification_md(response)
+    assert "## Purchase Order Delete (DELETE)" in md
+
+
+def test_render_modification_md_includes_parent_id_when_set():
+    response = ModificationResponse(
+        entity_type="purchase_order_row",
+        entity_id=555,
+        parent_entity_id=42,
+        operation="update_row",
+        is_preview=False,
+        message="ok",
+    )
+    md = render_modification_md(response)
+    assert "**Parent ID**: 42" in md
+
+
+def test_to_tool_result_serializes_response_as_structured_data():
+    response = ModificationResponse(
+        entity_type="purchase_order",
+        entity_id=1,
+        operation="update",
+        is_preview=False,
+        message="ok",
+    )
+    result = to_tool_result(response)
+    # The structured payload mirrors the response model — downstream callers
+    # rely on the shape via ``structured_content``.
+    assert result.structured_content is not None
+    assert result.structured_content["entity_type"] == "purchase_order"
+    assert result.structured_content["operation"] == "update"

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -7,15 +7,31 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from katana_mcp.tools.foundation.purchase_orders import (
+    AddPurchaseOrderAdditionalCostRequest,
+    AddPurchaseOrderRowRequest,
+    DeletePurchaseOrderAdditionalCostRequest,
+    DeletePurchaseOrderRequest,
+    DeletePurchaseOrderRowRequest,
     DiscrepancyType,
     DocumentItem,
     GetPurchaseOrderRequest,
     ReceiveItemRequest,
     ReceivePurchaseOrderRequest,
     ReceivePurchaseOrderResponse,
+    UpdatePurchaseOrderAdditionalCostRequest,
+    UpdatePurchaseOrderRequest,
+    UpdatePurchaseOrderRowRequest,
     VerifyOrderDocumentRequest,
+    _add_purchase_order_additional_cost_impl,
+    _add_purchase_order_row_impl,
+    _delete_purchase_order_additional_cost_impl,
+    _delete_purchase_order_impl,
+    _delete_purchase_order_row_impl,
     _get_purchase_order_impl,
     _receive_purchase_order_impl,
+    _update_purchase_order_additional_cost_impl,
+    _update_purchase_order_impl,
+    _update_purchase_order_row_impl,
     _verify_order_document_impl,
     get_purchase_order,
     list_purchase_orders,
@@ -2522,3 +2538,535 @@ async def test_verify_order_document_format_json_returns_json():
     data = json.loads(_content_text(result))
     assert data["order_id"] == 5
     assert data["overall_status"] == "match"
+
+
+# ============================================================================
+# Modification tools — header (update / delete)
+# ============================================================================
+
+
+# Patch path constants for the new modification tools — keep them near the
+# tests so a future move catches the rename in one place.
+_PO_GET = "katana_public_api_client.api.purchase_order.get_purchase_order"
+_PO_UPDATE = "katana_public_api_client.api.purchase_order.update_purchase_order"
+_PO_DELETE = "katana_public_api_client.api.purchase_order.delete_purchase_order"
+_PO_ROW_GET = "katana_public_api_client.api.purchase_order_row.get_purchase_order_row"
+_PO_ROW_CREATE = (
+    "katana_public_api_client.api.purchase_order_row.create_purchase_order_row"
+)
+_PO_ROW_UPDATE = (
+    "katana_public_api_client.api.purchase_order_row.update_purchase_order_row"
+)
+_PO_ROW_DELETE = (
+    "katana_public_api_client.api.purchase_order_row.delete_purchase_order_row"
+)
+_PO_COST_CREATE = (
+    "katana_public_api_client.api.purchase_order_additional_cost_row."
+    "create_po_additional_cost_row"
+)
+_PO_COST_UPDATE = (
+    "katana_public_api_client.api.purchase_order_additional_cost_row."
+    "update_additional_cost_row"
+)
+_PO_COST_DELETE = (
+    "katana_public_api_client.api.purchase_order_additional_cost_row."
+    "delete_po_additional_cost"
+)
+_PO_UNWRAP_AS = "katana_mcp.tools.foundation.purchase_orders.unwrap_as"
+
+
+@pytest.mark.asyncio
+async def test_update_purchase_order_preview_diffs_against_existing():
+    """Preview fetches the existing PO so the diff shows old → new values."""
+    context, _ = create_mock_context()
+
+    existing = create_mock_po(order_id=42, order_no="PO-OLD", rows=[])
+    existing.expected_arrival_date = datetime(2026, 1, 1, tzinfo=UTC)
+
+    request = UpdatePurchaseOrderRequest(
+        id=42,
+        order_no="PO-NEW",
+        expected_arrival_date=datetime(2026, 2, 15, tzinfo=UTC),
+        confirm=False,
+    )
+
+    with (
+        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_PO_UNWRAP_AS, return_value=existing),
+    ):
+        response = await _update_purchase_order_impl(request, context)
+
+    assert response.is_preview is True
+    assert response.entity_id == 42
+    assert response.entity_type == "purchase_order"
+    assert response.operation == "update"
+    # Both fields show as a real before→after diff
+    by_field = {c.field: c for c in response.changes}
+    assert by_field["order_no"].old == "PO-OLD"
+    assert by_field["order_no"].new == "PO-NEW"
+    assert by_field["expected_arrival_date"].old == "2026-01-01T00:00:00+00:00"
+    assert by_field["expected_arrival_date"].new == "2026-02-15T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_update_purchase_order_requires_at_least_one_field():
+    context, _ = create_mock_context()
+    with pytest.raises(ValueError, match="At least one field"):
+        await _update_purchase_order_impl(
+            UpdatePurchaseOrderRequest(id=42, confirm=False), context
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_purchase_order_preview_when_fetch_fails():
+    """When the diff fetch fails, preview marks fields ``is_unknown_prior``.
+
+    Regression test for the original ambiguity where fetch failure was
+    indistinguishable from a missing field — the preview would imply
+    "field was empty before" rather than "we couldn't read prior state".
+    """
+    context, _ = create_mock_context()
+
+    with patch(
+        "katana_mcp.tools.foundation.purchase_orders._fetch_purchase_order_attrs",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        request = UpdatePurchaseOrderRequest(id=42, order_no="PO-NEW", confirm=False)
+        response = await _update_purchase_order_impl(request, context)
+
+    assert response.is_preview is True
+    by_field = {c.field: c for c in response.changes}
+    assert by_field["order_no"].is_unknown_prior is True
+    assert by_field["order_no"].is_added is False
+    assert any("diff context" in w for w in response.warnings)
+
+
+@pytest.mark.asyncio
+async def test_update_purchase_order_confirm_applies_status_via_same_tool():
+    """Status is folded into update_purchase_order — no separate status tool."""
+    context, _ = create_mock_context()
+
+    updated = create_mock_po(order_id=42, order_no="PO-NEW", rows=[])
+
+    with (
+        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(f"{_PO_UPDATE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_PO_UNWRAP_AS, return_value=updated),
+    ):
+        request = UpdatePurchaseOrderRequest(
+            id=42, status="PARTIALLY_RECEIVED", confirm=True
+        )
+        response = await _update_purchase_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert response.entity_id == 42
+    # The PATCH carries the API enum value, not the user-facing literal.
+    body = mock_api.await_args.kwargs["body"]
+    assert body.status.value == "PARTIALLY_RECEIVED"
+
+
+@pytest.mark.asyncio
+async def test_delete_purchase_order_preview():
+    context, _ = create_mock_context()
+    response = await _delete_purchase_order_impl(
+        DeletePurchaseOrderRequest(id=42, confirm=False), context
+    )
+
+    assert response.is_preview is True
+    assert response.entity_id == 42
+    assert response.operation == "delete"
+    assert "Preview" in response.message
+
+
+@pytest.mark.asyncio
+async def test_delete_purchase_order_confirm_calls_api():
+    context, _ = create_mock_context()
+
+    api_response = MagicMock()
+    api_response.status_code = 204
+    api_response.parsed = None
+
+    with (
+        patch(f"{_PO_DELETE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(
+            "katana_mcp.tools.foundation.purchase_orders.is_success",
+            return_value=True,
+        ),
+    ):
+        mock_api.return_value = api_response
+        response = await _delete_purchase_order_impl(
+            DeletePurchaseOrderRequest(id=42, confirm=True), context
+        )
+
+    assert response.is_preview is False
+    mock_api.assert_awaited_once()
+    assert mock_api.await_args.kwargs["id"] == 42
+
+
+# ============================================================================
+# Modification tools — purchase_order_row (add / update / delete)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_add_purchase_order_row_preview():
+    context, _ = create_mock_context()
+
+    request = AddPurchaseOrderRowRequest(
+        purchase_order_id=42,
+        variant_id=100,
+        quantity=10,
+        price_per_unit=5.0,
+        confirm=False,
+    )
+    response = await _add_purchase_order_row_impl(request, context)
+
+    assert response.is_preview is True
+    assert response.parent_entity_id == 42
+    assert response.entity_id is None
+    assert response.operation == "create_row"
+    # Every supplied field reports as added (no existing row to diff against)
+    by_field = {c.field: c for c in response.changes}
+    assert by_field["variant_id"].is_added is True
+    assert by_field["variant_id"].new == 100
+
+
+@pytest.mark.asyncio
+async def test_add_purchase_order_row_confirm_calls_api():
+    context, _ = create_mock_context()
+
+    new_row = MagicMock()
+    new_row.id = 555
+
+    with (
+        patch(f"{_PO_ROW_CREATE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_PO_UNWRAP_AS, return_value=new_row),
+    ):
+        request = AddPurchaseOrderRowRequest(
+            purchase_order_id=42,
+            variant_id=100,
+            quantity=10,
+            price_per_unit=5.0,
+            confirm=True,
+        )
+        response = await _add_purchase_order_row_impl(request, context)
+
+    assert response.is_preview is False
+    assert response.entity_id == 555
+    body = mock_api.await_args.kwargs["body"]
+    assert body.purchase_order_id == 42
+    assert body.variant_id == 100
+
+
+@pytest.mark.asyncio
+async def test_update_purchase_order_row_preview_uses_existing_for_diff():
+    context, _ = create_mock_context()
+
+    existing = MagicMock()
+    existing.purchase_order_id = 42
+    existing.quantity = 10
+    existing.price_per_unit = 5.0
+    existing.arrival_date = UNSET
+
+    with (
+        patch(f"{_PO_ROW_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_PO_UNWRAP_AS, return_value=existing),
+    ):
+        request = UpdatePurchaseOrderRowRequest(
+            id=555,
+            quantity=15,
+            arrival_date=datetime(2026, 3, 1, tzinfo=UTC),
+            confirm=False,
+        )
+        response = await _update_purchase_order_row_impl(request, context)
+
+    assert response.is_preview is True
+    assert response.entity_id == 555
+    assert response.parent_entity_id == 42
+    by_field = {c.field: c for c in response.changes}
+    assert by_field["quantity"].old == 10
+    assert by_field["quantity"].new == 15
+    assert by_field["arrival_date"].is_added is True
+
+
+@pytest.mark.asyncio
+async def test_update_purchase_order_row_requires_at_least_one_field():
+    context, _ = create_mock_context()
+    with pytest.raises(ValueError, match="At least one field"):
+        await _update_purchase_order_row_impl(
+            UpdatePurchaseOrderRowRequest(id=555, confirm=False), context
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_purchase_order_row_confirm_calls_api():
+    context, _ = create_mock_context()
+
+    existing = MagicMock()
+    existing.purchase_order_id = 42
+    existing.quantity = 10
+    updated = MagicMock()
+    updated.id = 555
+
+    # First call (in _fetch_purchase_order_row) returns the existing row;
+    # second call (the actual update) returns the updated row. We patch
+    # unwrap_as to feed both deterministically.
+    with (
+        patch(f"{_PO_ROW_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(f"{_PO_ROW_UPDATE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_PO_UNWRAP_AS, side_effect=[existing, updated]),
+    ):
+        request = UpdatePurchaseOrderRowRequest(id=555, quantity=20, confirm=True)
+        response = await _update_purchase_order_row_impl(request, context)
+
+    assert response.is_preview is False
+    assert response.entity_id == 555
+    assert response.parent_entity_id == 42
+    body = mock_api.await_args.kwargs["body"]
+    assert body.quantity == 20
+
+
+@pytest.mark.asyncio
+async def test_update_purchase_order_row_recovers_parent_id_when_prefetch_fails():
+    """When the pre-update fetch fails, the confirm response still carries
+    parent_id by reading purchase_order_id off the PATCH response.
+
+    Without this fallback, a successful row update following a fetch failure
+    would return a well-formed entity_id but ``parent_entity_id=None`` and
+    ``katana_url=None`` — missing context that the API just gave us.
+    """
+    context, _ = create_mock_context()
+
+    updated = MagicMock()
+    updated.id = 555
+    updated.purchase_order_id = 42
+
+    with (
+        # Pre-update fetch returns None to simulate failure
+        patch(
+            "katana_mcp.tools.foundation.purchase_orders._fetch_purchase_order_row",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(f"{_PO_ROW_UPDATE}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_PO_UNWRAP_AS, return_value=updated),
+    ):
+        request = UpdatePurchaseOrderRowRequest(id=555, quantity=20, confirm=True)
+        response = await _update_purchase_order_row_impl(request, context)
+
+    assert response.is_preview is False
+    assert response.entity_id == 555
+    # Recovered from updated.purchase_order_id rather than the failed prefetch
+    assert response.parent_entity_id == 42
+    assert response.katana_url is not None
+    assert "42" in response.katana_url
+
+
+@pytest.mark.asyncio
+async def test_delete_purchase_order_row_preview():
+    context, _ = create_mock_context()
+
+    existing = MagicMock()
+    existing.purchase_order_id = 42
+
+    with (
+        patch(f"{_PO_ROW_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_PO_UNWRAP_AS, return_value=existing),
+    ):
+        response = await _delete_purchase_order_row_impl(
+            DeletePurchaseOrderRowRequest(id=555, confirm=False), context
+        )
+
+    assert response.is_preview is True
+    assert response.entity_id == 555
+    assert response.parent_entity_id == 42
+
+
+@pytest.mark.asyncio
+async def test_delete_purchase_order_row_confirm_calls_api():
+    context, _ = create_mock_context()
+
+    existing = MagicMock()
+    existing.purchase_order_id = 42
+
+    api_response = MagicMock()
+    api_response.status_code = 204
+    api_response.parsed = None
+
+    with (
+        patch(f"{_PO_ROW_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(f"{_PO_ROW_DELETE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_PO_UNWRAP_AS, return_value=existing),
+        patch(
+            "katana_mcp.tools.foundation.purchase_orders.is_success",
+            return_value=True,
+        ),
+    ):
+        mock_api.return_value = api_response
+        response = await _delete_purchase_order_row_impl(
+            DeletePurchaseOrderRowRequest(id=555, confirm=True), context
+        )
+
+    assert response.is_preview is False
+    mock_api.assert_awaited_once()
+    assert mock_api.await_args.kwargs["id"] == 555
+
+
+# ============================================================================
+# Modification tools — purchase_order_additional_cost (add / update / delete)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_add_additional_cost_resolves_default_group_id():
+    """When given a PO id, the tool looks up its default_group_id."""
+    context, _ = create_mock_context()
+
+    existing_po = create_mock_po(order_id=42, order_no="PO-1", rows=[])
+    existing_po.default_group_id = 21
+    new_row = MagicMock()
+    new_row.id = 999
+
+    with (
+        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(
+            f"{_PO_COST_CREATE}.asyncio_detailed", new_callable=AsyncMock
+        ) as mock_api,
+        patch(_PO_UNWRAP_AS, side_effect=[existing_po, new_row]),
+    ):
+        request = AddPurchaseOrderAdditionalCostRequest(
+            purchase_order_id=42,
+            additional_cost_id=11,
+            tax_rate_id=31,
+            price=125.0,
+            distribution_method="BY_VALUE",
+            confirm=True,
+        )
+        response = await _add_purchase_order_additional_cost_impl(request, context)
+
+    assert response.is_preview is False
+    assert response.entity_id == 999
+    body = mock_api.await_args.kwargs["body"]
+    assert body.group_id == 21  # from default_group_id
+    assert body.distribution_method.value == "BY_VALUE"
+
+
+@pytest.mark.asyncio
+async def test_add_additional_cost_requires_po_or_group_id():
+    context, _ = create_mock_context()
+    with pytest.raises(ValueError, match="purchase_order_id or group_id"):
+        await _add_purchase_order_additional_cost_impl(
+            AddPurchaseOrderAdditionalCostRequest(
+                additional_cost_id=11,
+                tax_rate_id=31,
+                price=125.0,
+                confirm=False,
+            ),
+            context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_additional_cost_preview():
+    context, _ = create_mock_context()
+
+    existing = MagicMock()
+    existing.additional_cost_id = 11
+    existing.tax_rate_id = 31
+    existing.price = 100.0
+    existing.distribution_method = "BY_VALUE"
+
+    with (
+        patch(
+            "katana_public_api_client.api.purchase_order_additional_cost_row."
+            "get_po_additional_cost_row.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        patch(_PO_UNWRAP_AS, return_value=existing),
+    ):
+        request = UpdatePurchaseOrderAdditionalCostRequest(
+            id=99, price=150.0, confirm=False
+        )
+        response = await _update_purchase_order_additional_cost_impl(request, context)
+
+    assert response.is_preview is True
+    assert response.entity_id == 99
+    by_field = {c.field: c for c in response.changes}
+    assert by_field["price"].old == 100.0
+    assert by_field["price"].new == 150.0
+
+
+@pytest.mark.asyncio
+async def test_update_additional_cost_confirm_calls_api():
+    context, _ = create_mock_context()
+    updated = MagicMock()
+    updated.id = 99
+
+    with (
+        patch(
+            "katana_public_api_client.api.purchase_order_additional_cost_row."
+            "get_po_additional_cost_row.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            f"{_PO_COST_UPDATE}.asyncio_detailed", new_callable=AsyncMock
+        ) as mock_api,
+        # The first unwrap_as call (fetch existing) raises — we exercise the
+        # best-effort fallback path. The second returns the updated row.
+        patch(_PO_UNWRAP_AS, side_effect=[Exception("boom"), updated]),
+    ):
+        request = UpdatePurchaseOrderAdditionalCostRequest(
+            id=99, price=150.0, confirm=True
+        )
+        response = await _update_purchase_order_additional_cost_impl(request, context)
+
+    assert response.is_preview is False
+    body = mock_api.await_args.kwargs["body"]
+    assert body.price == 150.0
+
+
+@pytest.mark.asyncio
+async def test_update_additional_cost_requires_at_least_one_field():
+    context, _ = create_mock_context()
+    with pytest.raises(ValueError, match="At least one field"):
+        await _update_purchase_order_additional_cost_impl(
+            UpdatePurchaseOrderAdditionalCostRequest(id=99, confirm=False),
+            context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_additional_cost_preview():
+    context, _ = create_mock_context()
+    response = await _delete_purchase_order_additional_cost_impl(
+        DeletePurchaseOrderAdditionalCostRequest(id=99, confirm=False), context
+    )
+    assert response.is_preview is True
+    assert response.entity_id == 99
+
+
+@pytest.mark.asyncio
+async def test_delete_additional_cost_confirm_calls_api():
+    context, _ = create_mock_context()
+
+    api_response = MagicMock()
+    api_response.status_code = 204
+
+    with (
+        patch(
+            f"{_PO_COST_DELETE}.asyncio_detailed", new_callable=AsyncMock
+        ) as mock_api,
+        patch(
+            "katana_mcp.tools.foundation.purchase_orders.is_success",
+            return_value=True,
+        ),
+    ):
+        mock_api.return_value = api_response
+        response = await _delete_purchase_order_additional_cost_impl(
+            DeletePurchaseOrderAdditionalCostRequest(id=99, confirm=True), context
+        )
+
+    assert response.is_preview is False
+    mock_api.assert_awaited_once()
+    assert mock_api.await_args.kwargs["id"] == 99


### PR DESCRIPTION
## Summary
- Establishes a canonical entity-modification pattern (`_modification.py`) — uniform `ModificationResponse` envelope, per-field diff preview, common markdown rendering — for use across all entity-mutation tools.
- Closes the PO mutation gap by adding **8 new tools**: header `update`/`delete`, row CRUD (`add`/`update`/`delete`), and additional-cost CRUD. All follow the canonical pattern with `confirm=false` previews showing before→after diffs.
- Status transitions are folded into `update_purchase_order` rather than split into a separate tool (Katana's PATCH already accepts `status` — the split would only duplicate surface).

This is **PR 1 of 2**. PR 2 will piggyback off `_modification.py` to extend SO/MO with the same coverage and retire `update_stock_transfer_status` in favor of the folded pattern.

## What's in
- `katana_mcp/tools/_modification.py` — shared `FieldChange`, `ModificationResponse`, `compute_field_diff`, `render_modification_md`, `to_tool_result`
- 8 new PO tools wired into `register_tools` with appropriate `destructive` annotations
- Help resource updated (CLAUDE.md flags this as drift-prone)
- 27 new tests (11 unit tests for the helper, 16 integration tests across the 8 tools)
- All 2576 tests pass; pre-existing pyright errors on `list_purchase_orders` SQL code are untouched

## Pattern in 30 seconds
```python
class UpdatePurchaseOrderRequest(BaseModel):
    id: int
    # ... optional fields ...
    confirm: bool = False

async def _update_purchase_order_impl(req, ctx) -> ModificationResponse:
    existing = await _fetch_purchase_order_attrs(...)  # for diff
    changes = compute_field_diff(existing, req)
    if not req.confirm:
        return ModificationResponse(is_preview=True, changes=changes, ...)
    # ... call API, return ModificationResponse(is_preview=False, ...)
```

## Test plan
- [x] `uv run poe check` — passes
- [x] All 27 new tests pass
- [x] No regressions: 74/76 pre-existing PO tests pass (2 pre-existing skips)
- [ ] Manual: try `update_purchase_order` against a live PO and confirm the diff preview shows the actual current values
- [ ] Manual: roll a supplier ETA across multiple rows via `update_purchase_order_row` to validate the original use case

🤖 Generated with [Claude Code](https://claude.com/claude-code)