### PR TITLE
fix(mcp): typed-cache freshness — soft-delete semantics + parent/child sync coupling

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -639,8 +639,11 @@ sections with id, order_no, status, deadline, and the blocking recipe rows
 nested. Top-level `total_blocking_rows` and `total_affected_mos` are always
 populated.
 
-**Cache freshness:** typed-cache sync is debounced to 5 minutes — the rollup
-may lag the live API by up to that window.
+**Cache freshness:** every list/rollup tool re-syncs from Katana via an
+incremental `updated_at_min` delta on each invocation, so the rollup reflects
+the API state at the moment of the call (including UI-driven edits and
+soft-deletes). The cache is a read-shape optimization for filtering/joining,
+not a freshness barrier.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -2721,10 +2721,7 @@ async def _list_blocking_ingredients_impl(
     """
     from sqlmodel import select
 
-    from katana_mcp.typed_cache import (
-        ensure_manufacturing_order_recipe_rows_synced,
-        ensure_manufacturing_orders_synced,
-    )
+    from katana_mcp.typed_cache import ensure_manufacturing_orders_synced
     from katana_public_api_client.models_pydantic._generated import (
         CachedManufacturingOrder,
         CachedManufacturingOrderRecipeRow,
@@ -2732,14 +2729,8 @@ async def _list_blocking_ingredients_impl(
 
     services = get_services(context)
 
-    # The two sync helpers acquire disjoint per-entity locks, so gather is
-    # safe here (same pattern as `_fetch_completed_mo_recipe_rows_in_window`).
-    await asyncio.gather(
-        ensure_manufacturing_orders_synced(services.client, services.typed_cache),
-        ensure_manufacturing_order_recipe_rows_synced(
-            services.client, services.typed_cache
-        ),
-    )
+    # MO sync fans out to recipe rows via ``EntitySpec.related_specs``.
+    await ensure_manufacturing_orders_synced(services.client, services.typed_cache)
 
     parsed_dates = parse_request_dates(
         request, ("production_deadline_after", "production_deadline_before")

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -791,25 +791,16 @@ async def _fetch_completed_mo_recipe_rows_in_window(
     """
     from sqlmodel import select
 
-    from katana_mcp.typed_cache import (
-        ensure_manufacturing_order_recipe_rows_synced,
-        ensure_manufacturing_orders_synced,
-    )
+    from katana_mcp.typed_cache import ensure_manufacturing_orders_synced
     from katana_public_api_client.models_pydantic._generated import (
         CachedManufacturingOrder,
         CachedManufacturingOrderRecipeRow,
         ManufacturingOrderStatus,
     )
 
-    # Parallel-safe: the two sync helpers acquire disjoint per-entity locks
-    # (``manufacturing_order`` vs ``manufacturing_order_recipe_row``), so
-    # ``asyncio.gather`` won't deadlock or interleave writes within a table.
-    await asyncio.gather(
-        ensure_manufacturing_orders_synced(services.client, services.typed_cache),
-        ensure_manufacturing_order_recipe_rows_synced(
-            services.client, services.typed_cache
-        ),
-    )
+    # MO sync fans out to recipe rows via ``EntitySpec.related_specs`` —
+    # both watermarks advance in parallel under disjoint per-entity locks.
+    await ensure_manufacturing_orders_synced(services.client, services.typed_cache)
 
     async with services.typed_cache.session() as session:
         # Filter both sides of the join for soft-delete: a recipe row could

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -21,8 +21,9 @@ need to change.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -82,6 +83,15 @@ class EntitySpec:
     ``pydantic_resolver`` overrides ``pydantic_cls`` per-row by dispatching
     on the attrs subclass — used by purchase orders, where the
     discriminated-union root would otherwise lose subclass-only fields.
+
+    ``related_specs`` is for entities whose rows live at a *separate* API
+    endpoint with their own watermark (manufacturing orders + recipe
+    rows: rows aren't nested in the MO response, so the nested-rows
+    triple above doesn't apply). Listing them here means
+    ``_ensure_synced`` fans out to sync them in parallel, so consumers
+    that join parent ↔ child in cache can call a single
+    ``ensure_<parent>_synced`` and trust that both sides are fresh —
+    no caller-side ``asyncio.gather`` to forget.
     """
 
     entity_key: str
@@ -92,6 +102,7 @@ class EntitySpec:
     rows_field: str | None = None
     fk_field: str | None = None
     pydantic_resolver: Callable[[Any], type] | None = None
+    related_specs: tuple[EntitySpec, ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
         # Children are configured by a ``(child_cls, rows_field, fk_field)``
@@ -201,6 +212,30 @@ async def _ensure_synced(
     no ghost rows leak to callers and the historical record survives in
     the cache for any future audit/reporting need. We mirror Katana's own
     soft-delete model rather than hard-deleting locally.
+
+    ``spec.related_specs`` triggers parallel sync of sibling entities
+    (e.g. manufacturing-order recipe rows when MOs are synced) so a
+    consumer joining parent ↔ child in cache only needs to call one
+    ``ensure_<parent>_synced``.
+    """
+    if spec.related_specs:
+        await asyncio.gather(
+            _sync_one(client, cache, spec),
+            *(_ensure_synced(client, cache, related) for related in spec.related_specs),
+        )
+        return
+    await _sync_one(client, cache, spec)
+
+
+async def _sync_one(
+    client: KatanaClient, cache: TypedCacheEngine, spec: EntitySpec
+) -> None:
+    """Sync exactly one entity (no related-spec fan-out).
+
+    Split out from ``_ensure_synced`` so the related-spec gather doesn't
+    re-enter the parent's lock recursively when a future child carries
+    its own ``related_specs`` chain — each entity's sync runs under its
+    own per-entity lock, no nesting.
     """
     async with cache.lock_for(spec.entity_key):
         async with cache.session() as session:
@@ -276,28 +311,34 @@ _STOCK_ADJUSTMENT_SPEC = EntitySpec(
 )
 
 
-# Manufacturing orders: the list endpoint returns summary objects with no
-# nested rows. Recipe rows live at ``/manufacturing_order_recipe_rows`` and
-# aren't cached by this entity's sync — leave the child fields unset.
-_MANUFACTURING_ORDER_SPEC = EntitySpec(
-    entity_key="manufacturing_order",
-    api_fn=get_all_manufacturing_orders,
-    cache_cls=CachedManufacturingOrder,
-    pydantic_cls=PydanticManufacturingOrder,
-)
-
-
 # Manufacturing-order recipe rows: fetched from the separate
 # ``/manufacturing_order_recipe_rows`` endpoint, not nested under the MO
 # parent — so they have their own ``updated_at_min`` watermark and sync
 # lock. Direct conversion via the pydantic intermediary; ``batch_transactions``
 # survives ``model_dump`` as a plain dict list and lands in the cache class's
-# JSON column unchanged.
+# JSON column unchanged. Defined before the MO spec because the MO spec
+# references it via ``related_specs`` (frozen dataclasses can't forward-
+# reference each other).
 _MANUFACTURING_ORDER_RECIPE_ROW_SPEC = EntitySpec(
     entity_key="manufacturing_order_recipe_row",
     api_fn=get_all_manufacturing_order_recipe_rows,
     cache_cls=CachedManufacturingOrderRecipeRow,
     pydantic_cls=PydanticManufacturingOrderRecipeRow,
+)
+
+
+# Manufacturing orders: the list endpoint returns summary objects with no
+# nested rows. Recipe rows live at the sibling endpoint above and are
+# pulled in via ``related_specs`` so any cache consumer that joins MO ↔
+# recipe row (e.g. ``list_blocking_ingredients``) only needs to call
+# ``ensure_manufacturing_orders_synced`` and trusts both watermarks have
+# been advanced.
+_MANUFACTURING_ORDER_SPEC = EntitySpec(
+    entity_key="manufacturing_order",
+    api_fn=get_all_manufacturing_orders,
+    cache_cls=CachedManufacturingOrder,
+    pydantic_cls=PydanticManufacturingOrder,
+    related_specs=(_MANUFACTURING_ORDER_RECIPE_ROW_SPEC,),
 )
 
 
@@ -377,8 +418,11 @@ async def ensure_manufacturing_order_recipe_rows_synced(
     """Pull updated MO recipe rows from Katana and upsert into the cache.
 
     Recipe rows are fetched from the separate
-    ``/manufacturing_order_recipe_rows`` endpoint (not nested under the MO
-    parent), so they have their own ``updated_at_min`` watermark and sync
-    lock — distinct from the manufacturing-orders sync.
+    ``/manufacturing_order_recipe_rows`` endpoint (not nested under the
+    MO parent), so they have their own ``updated_at_min`` watermark and
+    sync lock. ``ensure_manufacturing_orders_synced`` already fans out to
+    this spec via ``related_specs``, so most callers don't need to call
+    this helper directly — it's exposed for tools that specifically want
+    only the recipe-row watermark advanced.
     """
     await _ensure_synced(client, cache, _MANUFACTURING_ORDER_RECIPE_ROW_SPEC)

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -34,7 +34,11 @@ from katana_public_api_client.api.manufacturing_order_recipe import (
     get_all_manufacturing_order_recipe_rows,
 )
 from katana_public_api_client.api.purchase_order import find_purchase_orders
+from katana_public_api_client.api.purchase_order_row import (
+    get_all_purchase_order_rows,
+)
 from katana_public_api_client.api.sales_order import get_all_sales_orders
+from katana_public_api_client.api.sales_order_row import get_all_sales_order_rows
 from katana_public_api_client.api.stock_adjustment import get_all_stock_adjustments
 from katana_public_api_client.api.stock_transfer import get_all_stock_transfers
 from katana_public_api_client.models_pydantic._generated import (
@@ -51,7 +55,9 @@ from katana_public_api_client.models_pydantic._generated import (
     ManufacturingOrder as PydanticManufacturingOrder,
     ManufacturingOrderRecipeRow as PydanticManufacturingOrderRecipeRow,
     PurchaseOrderBase as PydanticPurchaseOrderBase,
+    PurchaseOrderRow as PydanticPurchaseOrderRow,
     SalesOrder as PydanticSalesOrder,
+    SalesOrderRow as PydanticSalesOrderRow,
     StockAdjustment as PydanticStockAdjustment,
     StockTransfer as PydanticStockTransfer,
 )
@@ -289,6 +295,23 @@ async def _sync_one(
 # ---------------------------------------------------------------------------
 
 
+# Sales-order rows: nested under their parent in the ``find_sales_orders``
+# response, but the response *hides* soft-deleted rows even with
+# ``include_deleted=True`` (that flag controls top-level inclusion only).
+# Without an independent row sync, a row deleted via ``delete_sales_order_row``
+# on a still-live parent stays in the cache as a ghost. The dedicated
+# ``/sales_order_rows`` endpoint exposes ``include_deleted`` + the same
+# ``updated_at_min`` watermark mechanism, so we can pick up tombstones the
+# parent response omits. Defined before ``_SALES_ORDER_SPEC`` so the parent's
+# ``related_specs`` can reference it (frozen dataclasses can't forward-ref).
+_SALES_ORDER_ROW_SPEC = EntitySpec(
+    entity_key="sales_order_row",
+    api_fn=get_all_sales_order_rows,
+    cache_cls=CachedSalesOrderRow,
+    pydantic_cls=PydanticSalesOrderRow,
+)
+
+
 _SALES_ORDER_SPEC = EntitySpec(
     entity_key="sales_order",
     api_fn=get_all_sales_orders,
@@ -297,6 +320,7 @@ _SALES_ORDER_SPEC = EntitySpec(
     child_cls=CachedSalesOrderRow,
     rows_field="sales_order_rows",
     fk_field="sales_order_id",
+    related_specs=(_SALES_ORDER_ROW_SPEC,),
 )
 
 
@@ -342,6 +366,21 @@ _MANUFACTURING_ORDER_SPEC = EntitySpec(
 )
 
 
+# Purchase-order rows: like sales-order rows, ``find_purchase_orders``
+# hides soft-deleted nested rows even with ``include_deleted=True`` set
+# at the parent level. The ``/purchase_order_rows`` sibling endpoint
+# (added to MCP via ``delete_purchase_order_row`` /
+# ``update_purchase_order_row`` in #461) exposes ``include_deleted`` and
+# its own watermark, so we sync rows independently to catch tombstones
+# the parent response omits.
+_PURCHASE_ORDER_ROW_SPEC = EntitySpec(
+    entity_key="purchase_order_row",
+    api_fn=get_all_purchase_order_rows,
+    cache_cls=CachedPurchaseOrderRow,
+    pydantic_cls=PydanticPurchaseOrderRow,
+)
+
+
 # Purchase orders: discriminated-union entity. The cache class shadows
 # ``PurchaseOrderBase`` (renamed via ``CACHE_TABLE_RENAMES``) and carries
 # an extra ``tracking_location_id`` column hoisted from the outsourced
@@ -358,6 +397,7 @@ _PURCHASE_ORDER_SPEC = EntitySpec(
     rows_field="purchase_order_rows",
     fk_field="purchase_order_id",
     pydantic_resolver=_resolve_purchase_order_class,
+    related_specs=(_PURCHASE_ORDER_ROW_SPEC,),
 )
 
 

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from katana_public_api_client.api.manufacturing_order import (
@@ -58,19 +58,6 @@ from katana_public_api_client.models_pydantic._registry import get_pydantic_clas
 from katana_public_api_client.utils import unwrap_data
 
 from .sync_state import SyncState
-
-# Skip the API call when the cache was synced this recently. Mirrors the
-# legacy ``cache_sync._NO_INCREMENTAL_DEBOUNCE`` so back-to-back tool
-# calls don't each kick off an HTTP RTT for an empty delta.
-_SYNC_DEBOUNCE = timedelta(seconds=300)
-
-
-def _is_fresh(last_synced: datetime | None) -> bool:
-    """True when the cache was synced within ``_SYNC_DEBOUNCE``."""
-    if last_synced is None:
-        return False
-    return (datetime.now(tz=UTC).replace(tzinfo=None) - last_synced) < _SYNC_DEBOUNCE
-
 
 if TYPE_CHECKING:
     from katana_public_api_client import KatanaClient
@@ -193,29 +180,43 @@ async def _ensure_synced(
 ) -> None:
     """Pull updated rows for one entity from Katana and upsert into the cache.
 
-    Cold-start fetches the full history (cost scales with row count);
-    subsequent calls pass ``updated_at_min=<last_synced>`` and typically
-    return zero rows. The per-entity lock guarantees only one sync runs
-    at a time even if multiple tool calls land concurrently. The
-    ``_SYNC_DEBOUNCE`` short-circuit avoids an HTTP RTT for back-to-back
-    tool calls.
+    Every call hits the API. Cold-start fetches the full history (cost
+    scales with row count); subsequent calls pass
+    ``updated_at_min=<last_synced>`` so the API returns only the delta
+    since the previous sync — typically zero rows, ~100-200ms RTT for
+    the empty response. The per-entity lock guarantees only one sync
+    runs at a time even when multiple tool calls land concurrently
+    (the second waits, then issues its own — also typically empty —
+    delta fetch). We deliberately do not debounce: an explicit TTL
+    layer hides MCP-driven mutations and out-of-band UI edits behind
+    a stale window for no real saving, since the delta fetch is
+    already cheap.
+
+    Soft-deletes are folded in by passing ``include_deleted=True``: when
+    a row is deleted in the Katana UI, the next incremental fetch returns
+    it with ``deleted_at`` populated, and the upsert path naturally
+    propagates that timestamp into the cache row. The cache classes all
+    extend ``DeletableEntity`` (a ``deleted_at`` column ships natively),
+    and every ``list_*`` query already filters ``deleted_at IS NULL``, so
+    no ghost rows leak to callers and the historical record survives in
+    the cache for any future audit/reporting need. We mirror Katana's own
+    soft-delete model rather than hard-deleting locally.
     """
     async with cache.lock_for(spec.entity_key):
         async with cache.session() as session:
             state = await session.get(SyncState, spec.entity_key)
             last_synced = state.last_synced if state is not None else None
 
-        if _is_fresh(last_synced):
-            return
-
         # ``last_synced`` is persisted as naive UTC (SQLite's default
         # DateTime column strips tzinfo). Re-attach UTC before sending to
         # the API so the generated client serializes an explicit offset.
-        kwargs = (
-            {"updated_at_min": last_synced.replace(tzinfo=UTC)}
-            if last_synced is not None
-            else {}
-        )
+        # ``include_deleted=True`` is always sent so soft-deletes after
+        # the watermark surface in the response (Katana bumps
+        # ``updated_at`` when ``deleted_at`` is set), letting the upsert
+        # propagate the tombstone into the cache row.
+        kwargs: dict[str, Any] = {"include_deleted": True}
+        if last_synced is not None:
+            kwargs["updated_at_min"] = last_synced.replace(tzinfo=UTC)
         response = await spec.api_fn.asyncio_detailed(client=client, **kwargs)
         attrs_objs = unwrap_data(response, default=[])
 

--- a/katana_mcp_server/tests/test_typed_cache.py
+++ b/katana_mcp_server/tests/test_typed_cache.py
@@ -306,9 +306,24 @@ class TestSyncShippingFeeEmpty:
 
         mock_client = MagicMock()
 
-        with patch(
-            "katana_mcp.typed_cache.sync.get_all_sales_orders.asyncio_detailed",
-            new=AsyncMock(return_value=mock_response),
+        # SO sync fans out to ``/sales_order_rows`` via ``related_specs``,
+        # so stub that endpoint with an empty response — this test pins
+        # the parent's shipping_fee handling, not row sync.
+        empty_rows_parsed = MagicMock()
+        empty_rows_parsed.data = []
+        empty_rows_response = MagicMock()
+        empty_rows_response.status_code = 200
+        empty_rows_response.parsed = empty_rows_parsed
+
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.get_all_sales_orders.asyncio_detailed",
+                new=AsyncMock(return_value=mock_response),
+            ),
+            patch(
+                "katana_mcp.typed_cache.sync.get_all_sales_order_rows.asyncio_detailed",
+                new=AsyncMock(return_value=empty_rows_response),
+            ),
         ):
             # Should complete without raising.
             await ensure_sales_orders_synced(

--- a/katana_mcp_server/tests/test_typed_cache_invalidation.py
+++ b/katana_mcp_server/tests/test_typed_cache_invalidation.py
@@ -170,3 +170,45 @@ class TestSoftDeleteSync:
             await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
 
         assert mock_api.call_count == 3
+
+
+class TestRelatedSpecsFanOut:
+    """``EntitySpec.related_specs`` syncs sibling entities in parallel."""
+
+    @pytest.mark.asyncio
+    async def test_mo_sync_fans_out_to_recipe_rows(self, typed_cache_engine):
+        """``ensure_manufacturing_orders_synced`` must also advance the recipe-row watermark.
+
+        Recipe rows live at a separate endpoint with their own watermark
+        but are conceptually nested under MO; consumers that join MO ↔
+        recipe rows in cache (e.g. ``list_blocking_ingredients``) should
+        not need to remember a second sync call. This test pins that
+        contract so a future "let's split the syncs" change doesn't
+        silently break joins.
+        """
+        from katana_mcp.typed_cache.sync import ensure_manufacturing_orders_synced
+
+        mock_parsed = MagicMock()
+        mock_parsed.data = []
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.parsed = mock_parsed
+
+        mo_api = AsyncMock(return_value=mock_response)
+        rows_api = AsyncMock(return_value=mock_response)
+
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.get_all_manufacturing_orders.asyncio_detailed",
+                new=mo_api,
+            ),
+            patch(
+                "katana_mcp.typed_cache.sync.get_all_manufacturing_order_recipe_rows.asyncio_detailed",
+                new=rows_api,
+            ),
+        ):
+            await ensure_manufacturing_orders_synced(MagicMock(), typed_cache_engine)
+
+        # Both endpoints called exactly once during one ensure_*_synced call.
+        assert mo_api.call_count == 1
+        assert rows_api.call_count == 1

--- a/katana_mcp_server/tests/test_typed_cache_invalidation.py
+++ b/katana_mcp_server/tests/test_typed_cache_invalidation.py
@@ -1,0 +1,172 @@
+"""Tests for soft-delete handling in typed-cache sync.
+
+Reproduces the user-reported "ghost record" symptom: a record deleted
+in the Katana UI used to remain in the cache without ``deleted_at`` set,
+because the API hides soft-deletes by default and our sync inherited
+that hiding. With ``include_deleted=True``, the tombstone propagates
+into the cache row, and the existing ``deleted_at IS NULL`` filter on
+every ``list_*`` query naturally excludes it from results — while the
+row itself persists for any future audit/history need (mirroring
+Katana's own soft-delete model).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from katana_mcp.typed_cache.sync import ensure_purchase_orders_synced
+
+from katana_public_api_client.models import PurchaseOrderBase as AttrsPurchaseOrder
+from katana_public_api_client.models_pydantic._generated import CachedPurchaseOrder
+
+
+class TestSoftDeleteSync:
+    """Tombstone propagation: API ``deleted_at`` lands on the cache row."""
+
+    @pytest.mark.asyncio
+    async def test_deleted_at_propagates_to_cache(self, typed_cache_engine):
+        """A row the API reports as deleted lands in the cache with ``deleted_at`` set.
+
+        Reproduces the user-reported symptom: a PO deleted in the Katana
+        UI used to remain in the cache as a "live" row because the API
+        hides soft-deletes by default. With ``include_deleted=True`` the
+        tombstone surfaces, the upsert propagates ``deleted_at``, and the
+        ``list_*`` query's existing ``deleted_at IS NULL`` filter hides
+        the row from callers — without us losing the historical record.
+        """
+        # Seed the cache with a "live" PO that the API is about to report deleted.
+        async with typed_cache_engine.session() as session:
+            session.add(CachedPurchaseOrder(id=42, order_no="PO-GHOST-42"))
+            await session.commit()
+
+        # Build the attrs response: same id, but with deleted_at populated.
+        deleted_attrs = AttrsPurchaseOrder.from_dict(
+            {
+                "id": 42,
+                "order_no": "PO-GHOST-42",
+                "entity_type": "regular",
+                "supplier_id": 1,
+                "currency": "USD",
+                "status": "NOT_RECEIVED",
+                "billing_status": "NOT_BILLED",
+                "deleted_at": "2026-01-15T10:00:00.000Z",
+            }
+        )
+        mock_parsed = MagicMock()
+        mock_parsed.data = [deleted_attrs]
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.parsed = mock_parsed
+
+        with patch(
+            "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+
+        # Row persists for history; deleted_at is set so list queries hide it.
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedPurchaseOrder, 42)
+            assert cached is not None
+            assert cached.deleted_at is not None
+
+    @pytest.mark.asyncio
+    async def test_sync_passes_include_deleted_true(self, typed_cache_engine):
+        """Without ``include_deleted=True`` the API hides soft-deletes — pin the call."""
+        mock_parsed = MagicMock()
+        mock_parsed.data = []
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.parsed = mock_parsed
+
+        mock_api = AsyncMock(return_value=mock_response)
+        with patch(
+            "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+            new=mock_api,
+        ):
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+
+        assert mock_api.call_args.kwargs["include_deleted"] is True
+
+    @pytest.mark.asyncio
+    async def test_live_row_alongside_deleted_round_trips_correctly(
+        self, typed_cache_engine
+    ):
+        """Mixed response: live row updates without deleted_at; deleted row gets tombstone."""
+        async with typed_cache_engine.session() as session:
+            session.add(CachedPurchaseOrder(id=1, order_no="PO-LIVE-1"))
+            session.add(CachedPurchaseOrder(id=2, order_no="PO-DEL-2"))
+            await session.commit()
+
+        live_attrs = AttrsPurchaseOrder.from_dict(
+            {
+                "id": 1,
+                "order_no": "PO-LIVE-1-UPDATED",
+                "entity_type": "regular",
+                "supplier_id": 1,
+                "currency": "USD",
+                "status": "NOT_RECEIVED",
+                "billing_status": "NOT_BILLED",
+                "deleted_at": None,
+            }
+        )
+        deleted_attrs = AttrsPurchaseOrder.from_dict(
+            {
+                "id": 2,
+                "order_no": "PO-DEL-2",
+                "entity_type": "regular",
+                "supplier_id": 1,
+                "currency": "USD",
+                "status": "NOT_RECEIVED",
+                "billing_status": "NOT_BILLED",
+                "deleted_at": "2026-01-15T10:00:00.000Z",
+            }
+        )
+        mock_parsed = MagicMock()
+        mock_parsed.data = [live_attrs, deleted_attrs]
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.parsed = mock_parsed
+
+        with patch(
+            "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            live = await session.get(CachedPurchaseOrder, 1)
+            assert live is not None
+            assert live.order_no == "PO-LIVE-1-UPDATED"
+            assert live.deleted_at is None
+
+            tombstoned = await session.get(CachedPurchaseOrder, 2)
+            assert tombstoned is not None
+            assert tombstoned.deleted_at is not None
+
+    @pytest.mark.asyncio
+    async def test_every_call_re_fetches(self, typed_cache_engine):
+        """No debounce: back-to-back calls each issue an API request.
+
+        The API call is cheap (incremental delta with ``updated_at_min``
+        usually returns 0 rows). Trading that RTT for cache freshness is
+        the explicit design choice — pin it so a future "let's add a
+        debounce" change doesn't silently regress freshness.
+        """
+        mock_parsed = MagicMock()
+        mock_parsed.data = []
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.parsed = mock_parsed
+
+        mock_api = AsyncMock(return_value=mock_response)
+        with patch(
+            "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+            new=mock_api,
+        ):
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+
+        assert mock_api.call_count == 3

--- a/katana_mcp_server/tests/test_typed_cache_invalidation.py
+++ b/katana_mcp_server/tests/test_typed_cache_invalidation.py
@@ -12,6 +12,7 @@ Katana's own soft-delete model).
 
 from __future__ import annotations
 
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,6 +20,33 @@ from katana_mcp.typed_cache.sync import ensure_purchase_orders_synced
 
 from katana_public_api_client.models import PurchaseOrderBase as AttrsPurchaseOrder
 from katana_public_api_client.models_pydantic._generated import CachedPurchaseOrder
+
+
+def _empty_response() -> MagicMock:
+    """Build a stock 200/empty-data API response for stubbing related-spec fetches."""
+    parsed = MagicMock()
+    parsed.data = []
+    response = MagicMock()
+    response.status_code = 200
+    response.parsed = parsed
+    return response
+
+
+@contextlib.contextmanager
+def _stub_po_row_sync():
+    """Stub the ``/purchase_order_rows`` fetch so PO-spec tests don't need to model it.
+
+    The PO sync fans out to the row sync via ``related_specs`` (added to
+    catch tombstones the parent response omits). Tests focused on the
+    parent path patch only ``find_purchase_orders``; without this stub,
+    the related row sync would attempt a real HTTP call against a
+    ``MagicMock`` client.
+    """
+    with patch(
+        "katana_mcp.typed_cache.sync.get_all_purchase_order_rows.asyncio_detailed",
+        new=AsyncMock(return_value=_empty_response()),
+    ):
+        yield
 
 
 class TestSoftDeleteSync:
@@ -59,9 +87,12 @@ class TestSoftDeleteSync:
         mock_response.status_code = 200
         mock_response.parsed = mock_parsed
 
-        with patch(
-            "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
-            new=AsyncMock(return_value=mock_response),
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+                new=AsyncMock(return_value=mock_response),
+            ),
+            _stub_po_row_sync(),
         ):
             await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
 
@@ -81,9 +112,12 @@ class TestSoftDeleteSync:
         mock_response.parsed = mock_parsed
 
         mock_api = AsyncMock(return_value=mock_response)
-        with patch(
-            "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
-            new=mock_api,
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+                new=mock_api,
+            ),
+            _stub_po_row_sync(),
         ):
             await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
 
@@ -129,9 +163,12 @@ class TestSoftDeleteSync:
         mock_response.status_code = 200
         mock_response.parsed = mock_parsed
 
-        with patch(
-            "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
-            new=AsyncMock(return_value=mock_response),
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+                new=AsyncMock(return_value=mock_response),
+            ),
+            _stub_po_row_sync(),
         ):
             await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
 
@@ -161,15 +198,106 @@ class TestSoftDeleteSync:
         mock_response.parsed = mock_parsed
 
         mock_api = AsyncMock(return_value=mock_response)
-        with patch(
-            "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
-            new=mock_api,
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+                new=mock_api,
+            ),
+            _stub_po_row_sync(),
         ):
             await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
             await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
             await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
 
         assert mock_api.call_count == 3
+
+
+class TestRowLevelTombstoneSync:
+    """PR #461 added row-level mutations (delete_purchase_order_row etc.).
+
+    The parent ``find_purchase_orders`` response *hides* soft-deleted nested
+    rows (top-level ``include_deleted=true`` doesn't propagate to nested),
+    so a row deleted via ``delete_purchase_order_row`` would otherwise stay
+    in the cache as a ghost. The dedicated row endpoint surfaces the
+    tombstone via its own ``include_deleted`` + watermark, and our
+    ``related_specs`` wiring fans out the sync.
+    """
+
+    @pytest.mark.asyncio
+    async def test_po_row_tombstone_lands_via_separate_endpoint(
+        self, typed_cache_engine
+    ):
+        """A row reported deleted by ``/purchase_order_rows`` lands in cache with deleted_at set."""
+        from katana_public_api_client.models import PurchaseOrderRow as AttrsPORow
+        from katana_public_api_client.models_pydantic._generated import (
+            CachedPurchaseOrderRow,
+        )
+
+        # Seed the cache with a "live" row that the row endpoint is about
+        # to report deleted.
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedPurchaseOrderRow(id=99, purchase_order_id=42, variant_id=7)
+            )
+            await session.commit()
+
+        deleted_row = AttrsPORow.from_dict(
+            {
+                "id": 99,
+                "purchase_order_id": 42,
+                "variant_id": 7,
+                "quantity": 1,
+                "deleted_at": "2026-01-15T10:00:00.000Z",
+            }
+        )
+        mock_parsed = MagicMock()
+        mock_parsed.data = [deleted_row]
+        rows_response = MagicMock()
+        rows_response.status_code = 200
+        rows_response.parsed = mock_parsed
+
+        # Parent endpoint returns nothing (no PO updates); rows endpoint
+        # returns the tombstone — this is the wire shape we expect when
+        # only a row was deleted.
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+                new=AsyncMock(return_value=_empty_response()),
+            ),
+            patch(
+                "katana_mcp.typed_cache.sync.get_all_purchase_order_rows.asyncio_detailed",
+                new=AsyncMock(return_value=rows_response),
+            ),
+        ):
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached_row = await session.get(CachedPurchaseOrderRow, 99)
+            assert cached_row is not None
+            assert cached_row.deleted_at is not None
+
+    @pytest.mark.asyncio
+    async def test_po_sync_calls_both_parent_and_row_endpoints(
+        self, typed_cache_engine
+    ):
+        """Pin the fan-out: one ``ensure_purchase_orders_synced`` → one fetch each."""
+        po_api = AsyncMock(return_value=_empty_response())
+        rows_api = AsyncMock(return_value=_empty_response())
+
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+                new=po_api,
+            ),
+            patch(
+                "katana_mcp.typed_cache.sync.get_all_purchase_order_rows.asyncio_detailed",
+                new=rows_api,
+            ),
+        ):
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+
+        assert po_api.call_count == 1
+        assert rows_api.call_count == 1
 
 
 class TestRelatedSpecsFanOut:

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.46.1"
+version = "0.47.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Two structural fixes to the typed cache, exposed by the user-reported "ghost record" symptom (PO-TEST-002 etc. lingering in `list_purchase_orders` after deletion in the Katana UI).

### 1. Mirror Katana's soft-delete semantics

The cache previously hard-deleted nothing and never saw soft-deletes:

- ``_ensure_synced`` called Katana **without** ``include_deleted=True``, so the API hid soft-deleted rows from us. Tombstones never reached the cache.
- The 5-minute ``_SYNC_DEBOUNCE`` short-circuit suppressed sync attempts entirely for that window — even when we knew (via writes through this server) the cache was wrong.

Fix:
- Pass ``include_deleted=True`` on every sync call. Soft-deletes surface, the existing upsert path propagates ``deleted_at`` into the cache row.
- Drop the debounce. Every list call issues an incremental ``updated_at_min`` fetch (~100-200ms RTT, typically 0-row payload). The freshness/RTT tradeoff is heavily skewed toward freshness for interactive use, and the per-entity lock already serializes truly-concurrent syncs.
- Every cached parent we hold extends ``DeletableEntity`` and every ``list_*`` query already filters ``WHERE deleted_at IS NULL``, so ghosts disappear from results without us hard-deleting locally — historical record preserved, mirroring Katana's own model.

### 2. Fan out parent sync to related entity specs

Manufacturing-order recipe rows live at a separate ``/manufacturing_order_recipe_rows`` endpoint with their own watermark, but conceptually they're nested under MO. Two consumers (``list_blocking_ingredients``, ``inventory_velocity``) ``asyncio.gather``-ed both syncs by hand — fragile, easy to forget when adding a new tool that joins MO ↔ recipe rows in cache.

Fix: ``EntitySpec.related_specs`` carries sibling specs that should sync alongside the parent. ``_ensure_synced`` fans them out under disjoint per-entity locks, so callers invoke one ``ensure_<parent>_synced`` and trust both watermarks have advanced. Wired ``_MANUFACTURING_ORDER_SPEC.related_specs = (_MANUFACTURING_ORDER_RECIPE_ROW_SPEC,)`` and dropped the manual gather in the two consumers.

## What's in

- `katana_mcp/typed_cache/sync.py`:
  - Removed ``_SYNC_DEBOUNCE`` / ``_is_fresh`` and the freshness short-circuit.
  - Added ``include_deleted=True`` to every API call.
  - Added ``EntitySpec.related_specs`` and the ``_ensure_synced`` → ``_sync_one`` fan-out split.
  - Wired MO → recipe rows.
- `katana_mcp/tools/foundation/{reporting,manufacturing_orders}.py`: dropped two manual ``asyncio.gather`` blocks now that the fan-out happens in the sync layer.
- `katana_mcp/resources/help.py`: updated cache-freshness blurb.
- 5 new tests pin tombstone propagation, ``include_deleted=True`` always sent, mixed live/deleted partition, every-call-re-fetches contract, and MO→recipe-row fan-out.

## Out of scope

Legacy ``CatalogCache`` variant↔product↔material coupling — variants embed ``product_or_material.{name,type}`` for search, and no current tool joins separately-cached parents in cache. If we add such a tool, ``cache_read`` already accepts multi-arg ``(VARIANT, PRODUCT, MATERIAL)`` to handle it.

## Limitations

- **Detection assumes Katana bumps ``updated_at`` when ``deleted_at`` is set.** If it doesn't, an incremental sync with ``updated_at_min=<watermark>`` won't include the deletion. Test pins the contract; if production behaves differently we'd need a periodic full-sync fallback.
- **Hard vs. soft per entity is determined by the cache schema.** All 6 typed-cache parents are ``DeletableEntity``, matching Katana. Stock-adjustment / stock-transfer rows aren't (Katana doesn't independently delete them), so they get hidden via the parent's filter rather than carrying their own ``deleted_at``.

## Test plan

- [x] `uv run poe check` — passes (2586 tests, 2 skipped)
- [x] 5 new tests in `test_typed_cache_invalidation.py`
- [ ] Manual: delete a PO in the Katana UI, then call `list_purchase_orders` — confirm the row is gone.
- [ ] Manual: call `update_purchase_order` then `list_purchase_orders` immediately — confirm the new total is reflected.
- [ ] Manual: confirm `list_blocking_ingredients` and `inventory_velocity` still return correct rollups (they no longer ``gather`` syncs explicitly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)