### PR TITLE
feat(mcp)!: unified modify_<entity> + delete_<entity> tool surface (PR 2)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -98,9 +98,11 @@ the same shape:
   transactional across endpoints; the dispatcher fail-fasts on the
   first error, leaving earlier successful actions applied.
 - **Prior-state snapshot** — on a confirmed call, the response carries
-  a `prior_state` snapshot of the pre-modification entity so callers
-  can compose a follow-up modify call to manually revert if needed.
-  We don't auto-revert via inverse calls — those have their own failure
+  a `prior_state` snapshot of the pre-modification entity (best-effort:
+  `prior_state` is `null` when the entity has no GET-by-id endpoint,
+  e.g. stock transfer, or the diff-context fetch failed). Callers can
+  compose a follow-up modify call to manually revert if needed. We
+  don't auto-revert via inverse calls — those have their own failure
   modes; visible partial application beats silent inconsistency.
 - **Post-action verification** — for actions where the API returns the
   mutated entity, the dispatcher confirms the requested fields match

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -39,6 +39,7 @@ Manufacturing ERP tools for inventory, orders, and production management.
 
 ### Inventory & Catalog
 - **search_items** - Find products, materials, services by name/SKU
+- **get_item** / **modify_item** / **delete_item** - Full CRUD on items (products / materials / services). `modify_item` carries header + variant CRUD in one call via typed sub-payload slots.
 - **get_variant_details** - Get full details for a specific item
 - **check_inventory** - Check stock levels for one or more SKUs or variant IDs (pass a list for a summary table)
 - **list_low_stock_items** - Find items needing reorder
@@ -50,24 +51,26 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **receive_purchase_order** - Receive items and update inventory
 - **verify_order_document** - Verify supplier documents against POs (returns the full PO alongside match/discrepancy details)
 - **get_purchase_order** - Look up a PO by number or ID — exhaustive detail (every PO/row field, additional cost rows, accounting metadata)
-- **update_purchase_order** - Update header fields (incl. status, expected_arrival_date)
-- **delete_purchase_order** - Delete a PO (preview/confirm)
-- **add_purchase_order_row / update_purchase_order_row / delete_purchase_order_row** - Full row-level CRUD with per-field diff previews
-- **add_purchase_order_additional_cost / update_purchase_order_additional_cost / delete_purchase_order_additional_cost** - Manage freight/duty/handling cost rows
+- **modify_purchase_order** - Unified modify: header, rows, additional-cost rows in one call (typed sub-payload slots, multi-action, preview/confirm)
+- **delete_purchase_order** - Delete a PO (Katana cascades child rows)
 
 ### Manufacturing & Sales
 - **create_manufacturing_order** - Create production work orders
 - **list_manufacturing_orders** - List MOs with status/location/date filters
 - **get_manufacturing_order** - Look up an MO with full details
+- **modify_manufacturing_order** - Unified modify: header, recipe rows, operation rows, production records (multi-action, preview/confirm)
+- **delete_manufacturing_order** - Delete an MO (Katana cascades child rows)
 - **fulfill_order** - Complete manufacturing or sales orders
 - **create_sales_order** - Create sales orders with preview/confirm
 - **list_sales_orders** - List SOs with customer/status/date filters
+- **get_sales_order** - Look up an SO with full details
+- **modify_sales_order** - Unified modify: header, rows, addresses, fulfillments, shipping fees (multi-action, preview/confirm)
+- **delete_sales_order** - Delete an SO (Katana cascades child rows)
 
 ### Stock Transfers
 - **create_stock_transfer** - Move inventory between locations (preview/confirm)
 - **list_stock_transfers** - List transfers with status / location / date filters
-- **update_stock_transfer** - Update transfer body fields
-- **update_stock_transfer_status** - Transition status (DRAFT → IN_TRANSIT → RECEIVED)
+- **modify_stock_transfer** - Unified modify: header body fields and/or status transition in one call (preview/confirm). Hides Katana's two-endpoint split.
 - **delete_stock_transfer** - Delete a transfer
 
 ## Safety Pattern
@@ -79,6 +82,33 @@ All create/modify operations use a **two-step confirm pattern**:
 Destructive tools advertise this via the standard MCP `destructiveHint`
 tool annotation; hosts that respect the annotation prompt the user before
 invoking. The server does not gate further.
+
+## Unified-Modify Pattern
+
+Five entities (PO, SO, MO, stock transfer, item) expose a unified
+`modify_<entity>` tool that lets you do header / row / sub-resource CRUD
+in a single call via typed sub-payload slots. Every modify tool follows
+the same shape:
+
+- **Typed sub-payload slots** — one optional field per kind of action
+  the entity supports (e.g. `update_header`, `add_rows`, `update_rows`,
+  `delete_row_ids`). Set any subset; combinations are valid.
+- **Multi-action confirm** — actions execute in canonical order
+  (header → adds → updates → deletes → status). The Katana API is not
+  transactional across endpoints; the dispatcher fail-fasts on the
+  first error, leaving earlier successful actions applied.
+- **Prior-state snapshot** — on a confirmed call, the response carries
+  a `prior_state` snapshot of the pre-modification entity so callers
+  can compose a follow-up modify call to manually revert if needed.
+  We don't auto-revert via inverse calls — those have their own failure
+  modes; visible partial application beats silent inconsistency.
+- **Post-action verification** — for actions where the API returns the
+  mutated entity, the dispatcher confirms the requested fields match
+  the response. Verification failures surface as
+  `verified=False` with `actual_after` snapshot — they don't raise.
+
+Destructive `delete_<entity>` tools are siblings of the modify tools —
+keeping them separate makes the destructiveHint annotation honest.
 
 ## Output Format
 
@@ -659,17 +689,57 @@ Create a new item (product, material, or service).
 
 ---
 
-### get_item / update_item / delete_item
-CRUD operations for items by ID and type.
-
-**get_item** is exhaustive — it surfaces every field Katana exposes on the
+### get_item
+Look up an item by ID and type — exhaustive detail across the
 polymorphic Product / Material / Service record, plus nested `variants`
 (summary), `configs`, and `supplier`. Type-specific fields
 (`is_producible` on products, etc.) stay `null` for the other types.
-Parameters: `id` (required), `type` (required — "product" | "material" |
-"service"), `format` (optional, "markdown" | "json"). For per-variant
-detail (barcodes, supplier codes, custom fields), follow up with
-`get_variant_details`.
+
+**Parameters:**
+- `id` (required): Item ID
+- `type` (required): "product" | "material" | "service"
+- `format` (optional, default "markdown"): "markdown" | "json"
+
+For per-variant detail (barcodes, supplier codes, custom fields), follow
+up with `get_variant_details`.
+
+---
+
+### modify_item
+Unified modification surface for an item — header + variant CRUD in one
+call. The required `type` discriminator routes header updates to the
+matching `/products/{id}` / `/materials/{id}` / `/services/{id}`
+endpoint; variant sub-payloads route to the shared `/variant` family.
+
+**Sub-payloads (all optional, any subset combinable):**
+- `update_header` — patch header fields. Field set is type-specific:
+  `is_producible` / `is_purchasable` / `is_auto_assembly` /
+  `serial_tracked` / `operations_in_sequence` are PRODUCT-only;
+  `default_supplier_id` / `batch_tracked` / `purchase_uom` /
+  `purchase_uom_conversion_rate` are PRODUCT/MATERIAL only;
+  `sales_price` / `default_cost` / `sku` are SERVICE-only. Misrouted
+  fields fail fast with a clear error.
+- `add_variants` — POST `/variant`. Parent `product_id` / `material_id`
+  is injected automatically from the request's `type`. Not supported
+  for SERVICE (services carry pricing on the header, not on variants).
+- `update_variants` / `delete_variant_ids` — variant CRUD. Not supported
+  for SERVICE.
+
+**Parameters:**
+- `id` (required): Item ID
+- `type` (required): "product" | "material" | "service"
+- Any subset of the sub-payloads above
+- `confirm` (optional, default false): false=preview, true=execute
+
+---
+
+### delete_item
+Delete an item. Destructive — Katana cascades child variants server-side.
+
+**Parameters:**
+- `id` (required): Item ID
+- `type` (required): "product" | "material" | "service"
+- `confirm` (optional, default false): false=preview, true=delete
 
 ---
 
@@ -795,112 +865,43 @@ detail is needed; use `list_purchase_orders` for discovery.
 
 ---
 
-### update_purchase_order
-Update header fields on an existing PO. Status transitions are folded in
-here as a regular field — there's no separate `update_purchase_order_status`
-tool because Katana's API treats it as a normal PATCH field.
+### modify_purchase_order
+Unified modification surface for a PO — header, line rows, and
+additional-cost rows in one call. Replaces the prior 8 separate
+`update_purchase_order` / `add_purchase_order_row` etc. tools.
+
+**Sub-payloads (all optional, any subset combinable):**
+- `update_header` — patch header fields (`order_no`, `supplier_id`,
+  `currency`, `location_id`, `tracking_location_id`,
+  `expected_arrival_date`, `order_created_date`, `additional_info`,
+  `status`). Status uses the PATCH endpoint; to flip to RECEIVED with
+  inventory updates use `receive_purchase_order` instead.
+- `add_rows` / `update_rows` / `delete_row_ids` — line item CRUD.
+  `update_rows` entries each carry their own row id + patch.
+- `add_additional_costs` / `update_additional_costs` /
+  `delete_additional_cost_ids` — freight / duty / handling cost rows.
+  The tool resolves the PO's `default_group_id` automatically.
 
 **Parameters:**
 - `id` (required): Purchase order ID
-- `order_no`, `supplier_id`, `currency`, `location_id`,
-  `tracking_location_id`, `expected_arrival_date`, `order_created_date`,
-  `additional_info` (optional): Header fields to overwrite
-- `status` (optional): DRAFT / NOT_RECEIVED / PARTIALLY_RECEIVED / RECEIVED.
-  To flip to RECEIVED with inventory updates use `receive_purchase_order`
-  instead.
-- `confirm` (optional, default false): false=preview with per-field diff,
-  true=apply
+- Any subset of the sub-payloads above
+- `confirm` (optional, default false): false=preview with per-action diff,
+  true=execute the action plan in canonical order (header → adds → updates
+  → deletes); fail-fast on first error
 
-**Returns:** A `ModificationResponse` with `is_preview`, the per-field
-`changes` list (old/new for every supplied field), `katana_url`, and
-`next_actions`.
+**Returns:** A `ModificationResponse` with `is_preview`, an `actions` list
+(one entry per planned API call with `operation`, `target_id`, `changes`,
+`succeeded`, `verified`, `actual_after`), `prior_state` snapshot, and
+`katana_url`.
 
 ---
 
 ### delete_purchase_order
-Delete a purchase order. Destructive — the order record is removed.
+Delete a purchase order. Destructive — Katana cascades child rows server-side.
 
 **Parameters:**
 - `id` (required): Purchase order ID
 - `confirm` (optional, default false): false=preview, true=delete
-
----
-
-### add_purchase_order_row
-Add a new line item to an existing PO.
-
-**Parameters:**
-- `purchase_order_id` (required): Parent PO ID
-- `variant_id`, `quantity`, `price_per_unit` (required): Core line item
-- `tax_rate_id`, `tax_name`, `tax_rate`, `currency`, `purchase_uom`,
-  `purchase_uom_conversion_rate`, `arrival_date` (optional)
-- `confirm` (optional, default false)
-
----
-
-### update_purchase_order_row
-Update fields on an existing PO row. Accepts any subset of `quantity`,
-`variant_id`, taxes, `price_per_unit`, UOM fields, `received_date`, and the
-row-level `arrival_date` (separate from the PO header's arrival date — Katana
-tracks per-row dates so different lines on the same PO can arrive on
-different days).
-
-**Parameters:**
-- `id` (required): Row ID
-- Any subset of: `quantity`, `variant_id`, `tax_rate_id`, `tax_name`,
-  `tax_rate`, `price_per_unit`, `purchase_uom`,
-  `purchase_uom_conversion_rate`, `received_date`, `arrival_date`
-- `confirm` (optional, default false): false=preview with per-field diff,
-  true=apply
-
----
-
-### delete_purchase_order_row
-Delete a PO row. Destructive.
-
-**Parameters:**
-- `id` (required): Row ID
-- `confirm` (optional, default false)
-
----
-
-### add_purchase_order_additional_cost
-Add an additional-cost row (freight, duties, handling fees) to a PO. Katana
-models additional-cost rows as members of a *cost group*; the PO carries a
-`default_group_id` that the rows attach to. The tool accepts the parent PO
-id (familiar) and resolves the group id internally — pass `group_id`
-directly only if the PO has multiple groups and you need a non-default one.
-
-**Parameters:**
-- `purchase_order_id` *or* `group_id` (one is required): Parent linkage.
-  Tool resolves `default_group_id` from the PO when only `purchase_order_id`
-  is given.
-- `additional_cost_id` (required): Catalog entry ID for the cost type
-- `tax_rate_id` (required): Tax rate ID
-- `price` (required): Cost amount
-- `distribution_method` (optional): BY_VALUE distributes proportionally
-  to row value; NON_DISTRIBUTED leaves it unallocated
-- `confirm` (optional, default false)
-
----
-
-### update_purchase_order_additional_cost
-Update a PO additional-cost row. Per-field diff against the existing row.
-
-**Parameters:**
-- `id` (required): Cost row ID
-- Any subset of: `additional_cost_id`, `tax_rate_id`, `price`,
-  `distribution_method`
-- `confirm` (optional, default false)
-
----
-
-### delete_purchase_order_additional_cost
-Delete a PO additional-cost row. Destructive.
-
-**Parameters:**
-- `id` (required): Cost row ID
-- `confirm` (optional, default false)
 
 ---
 
@@ -958,49 +959,46 @@ SKU. Markdown labels use canonical Pydantic field names.
 
 ---
 
-### add_manufacturing_order_recipe_row
-Add a new ingredient to a manufacturing order's recipe.
+### modify_manufacturing_order
+Unified modification surface for an MO — header, recipe rows
+(ingredients), operation rows (production steps), and production records
+(completion logs) in one call. Replaces the prior recipe-row CRUD tools.
+
+**Sub-payloads (all optional, any subset combinable):**
+- `update_header` — patch header fields (`order_no`, `variant_id`,
+  `location_id`, `status`, `planned_quantity`, `actual_quantity`, dates,
+  `additional_info`). Status uses the PATCH endpoint
+  (NOT_STARTED / IN_PROGRESS / DONE / BLOCKED / PARTIALLY_COMPLETED).
+- `add_recipe_rows` / `update_recipe_rows` / `delete_recipe_row_ids` —
+  ingredient CRUD. Each `add_recipe_rows` entry carries `variant_id` +
+  `planned_quantity_per_unit` + optional notes.
+- `add_operation_rows` / `update_operation_rows` /
+  `delete_operation_row_ids` — production step CRUD. Operation rows
+  carry status (NOT_STARTED / IN_PROGRESS / PAUSED / BLOCKED /
+  COMPLETED) and type (fixed / perUnit / process / setup).
+- `add_productions` / `update_productions` / `delete_production_ids` —
+  completion-log entries.
 
 **Parameters:**
-- `manufacturing_order_id` (required): MO ID
-- `sku` (optional): SKU of ingredient (resolved via cache)
-- `variant_id` (optional): Variant ID directly (use when SKU isn't in cache)
-- `planned_quantity_per_unit` (required): Qty needed per manufactured unit
-- `notes` (optional): Notes
-- `confirm` (optional, default false): false=preview, true=add
+- `id` (required): Manufacturing order ID
+- Any subset of the sub-payloads above
+- `confirm` (optional, default false): false=preview, true=execute the
+  action plan in canonical order; fail-fast on first error
 
-Provide either `sku` or `variant_id`.
+**Returns:** A `ModificationResponse` carrying per-action results and a
+`prior_state` snapshot. To swap a variant across many MOs at once, run
+multiple `modify_manufacturing_order` calls — there is no batch shape
+in the unified surface.
 
 ---
 
-### delete_manufacturing_order_recipe_row
-Remove an ingredient from a manufacturing order's recipe.
+### delete_manufacturing_order
+Delete a manufacturing order. Destructive — Katana cascades child recipe
+rows / operation rows / production records server-side.
 
 **Parameters:**
-- `recipe_row_id` (required): Recipe row ID (from get_manufacturing_order_recipe)
+- `id` (required): Manufacturing order ID
 - `confirm` (optional, default false): false=preview, true=delete
-
----
-
-### batch_update_manufacturing_order_recipes
-Batch-update recipe rows across one or more MOs with ONE confirmation.
-
-**Use modes (mixable):**
-- `replacements`: "replace variant X with [Y, Z] across these MOs" — ideal
-  for swapping a component across many MOs in one shot.
-- `changes`: explicit per-MO row deletes and additions (escape hatch).
-
-**Parameters:**
-- `replacements` (optional): list of `{manufacturing_order_ids, old_sku or
-  old_variant_id, new_components, strict}`
-- `changes` (optional): list of `{manufacturing_order_id, remove_row_ids,
-  add_variants}`
-- `continue_on_error` (optional, default true): run all ops even if some fail
-- `confirm` (optional, default false): false=preview, true=execute (single batch confirmation)
-
-**Returns:** All sub-operations with individual status (success/failed/skipped),
-grouped by replacement. Old rows are deleted first, then new rows added in
-reverse order so they appear adjacent in Katana's natural sort order.
 
 ---
 
@@ -1088,6 +1086,41 @@ discounts, tax, cogs, linked MO, batch/serial tracking, timestamps).
 
 ---
 
+### modify_sales_order
+Unified modification surface for an SO — header, rows, addresses,
+fulfillments, and shipping fees in one call.
+
+**Sub-payloads (all optional, any subset combinable):**
+- `update_header` — patch header fields (incl. status:
+  NOT_SHIPPED / PENDING / PACKED / DELIVERED).
+- `add_rows` / `update_rows` / `delete_row_ids` — line item CRUD.
+- `add_addresses` / `update_addresses` / `delete_address_ids` — billing
+  / shipping addresses. Note: Katana doesn't expose a per-address GET,
+  so address-update previews show every supplied field as
+  `(prior unknown) → new`.
+- `add_fulfillments` / `update_fulfillments` /
+  `delete_fulfillment_ids` — fulfillments (each carries its own status
+  + tracking).
+- `add_shipping_fees` / `update_shipping_fees` /
+  `delete_shipping_fee_ids` — shipping/freight charges.
+
+**Parameters:**
+- `id` (required): Sales order ID
+- Any subset of the sub-payloads above
+- `confirm` (optional, default false): false=preview, true=execute
+
+---
+
+### delete_sales_order
+Delete a sales order. Destructive — Katana cascades child rows /
+addresses / fulfillments / shipping fees server-side.
+
+**Parameters:**
+- `id` (required): Sales order ID
+- `confirm` (optional, default false): false=preview, true=delete
+
+---
+
 ### create_product / create_material
 Dedicated catalog tools for creating products or materials with a single variant.
 
@@ -1147,45 +1180,41 @@ expected_arrival). `pagination` metadata is populated when `page` is set.
 
 ---
 
-### update_stock_transfer
-Update body fields on an existing stock transfer.
+### modify_stock_transfer
+Unified modification surface for a stock transfer — header body fields
+and/or status transition in one call. Hides the fact that Katana exposes
+these as two separate PATCH endpoints
+(`/stock_transfers/{id}` and `/stock_transfers/{id}/status`).
+
+**Sub-payloads (all optional, any subset combinable):**
+- `update_header` — patch body fields (`stock_transfer_number`,
+  `transfer_date`, `expected_arrival_date`, `additional_info`).
+- `update_status` — `new_status: "DRAFT" | "IN_TRANSIT" | "RECEIVED"`
+  (mapped to the Katana wire values `draft` / `inTransit` / `received`).
+  Typical flow: DRAFT → IN_TRANSIT → RECEIVED. Katana rejects invalid
+  transitions (e.g. RECEIVED → IN_TRANSIT); the action's error surfaces
+  in the response.
 
 **Parameters:**
 - `id` (required): Stock transfer ID
-- `stock_transfer_number` (optional): New transfer number
-- `transfer_date` (optional): New transfer datetime (ISO-8601)
-- `expected_arrival_date` (optional): New expected arrival datetime (ISO-8601)
-- `additional_info` (optional): Updated notes
-- `confirm` (optional, default false): false=preview, true=apply
+- Any subset of the sub-payloads above
+- `confirm` (optional, default false): false=preview, true=execute the
+  action plan in canonical order (header first, then status); fail-fast
+  on first error
 
-At least one updatable field must be provided. Use `update_stock_transfer_status`
-to change the transfer's status — it's a separate endpoint.
-
----
-
-### update_stock_transfer_status
-Transition a stock transfer through the 3-state machine.
-
-**Parameters:**
-- `id` (required): Stock transfer ID
-- `new_status` (required): "DRAFT", "IN_TRANSIT", or "RECEIVED" (mapped to
-  the Katana wire values "draft" / "inTransit" / "received")
-- `confirm` (optional, default false): false=preview, true=apply
-
-**Typical flow:** DRAFT → IN_TRANSIT → RECEIVED. Katana rejects invalid
-transitions (e.g. RECEIVED → IN_TRANSIT); the tool surfaces the API error
-message as a ValueError.
+Stock-transfer rows are immutable post-creation — Katana doesn't expose
+row-CRUD endpoints. Note: Katana doesn't expose a GET-by-id endpoint for
+stock transfers either, so previews show every supplied field as
+`(prior unknown) → new`.
 
 ---
 
 ### delete_stock_transfer
-Delete a stock transfer.
+Delete a stock transfer. Destructive — the transfer record is removed.
 
 **Parameters:**
 - `id` (required): Stock transfer ID
 - `confirm` (optional, default false): false=preview, true=delete
-
-Destructive — removes the transfer record.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -35,6 +35,20 @@ from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.domain.converters import unwrap_unset
 
 
+class ConfirmableRequest(BaseModel):
+    """Base for top-level ``Modify<Entity>Request`` and ``Delete<Entity>Request``
+    Pydantic models. Carries the ``confirm`` field used by every modification
+    tool's preview/apply gate."""
+
+    confirm: bool = Field(
+        default=False,
+        description=(
+            "If false, returns a preview with planned actions. "
+            "If true, executes the action plan."
+        ),
+    )
+
+
 class FieldChange(BaseModel):
     """A single field-level change in a modification preview/result.
 

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -22,7 +22,7 @@ operating on the same response model.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime
 from enum import Enum
 from typing import Any, ClassVar
@@ -209,6 +209,38 @@ def compute_field_diff(
         else:
             changes.append(FieldChange(field=name, old=old, new=new))
     return changes
+
+
+def make_response_verifier(
+    diff: list[FieldChange], *, field_map: dict[str, str] | None = None
+) -> Callable[[Any], Awaitable[tuple[bool, dict[str, Any] | None]]]:
+    """Build a verify closure that checks the API response body against ``diff``.
+
+    Most Katana mutation endpoints echo the post-state of the affected
+    entity in the response body — this verifier reads each requested
+    field off ``outcome`` and confirms it matches the requested ``new``
+    value. No extra fetch needed. ``field_map`` mirrors the
+    :func:`compute_field_diff` parameter for fields with names that
+    differ between request and response. Used by every
+    ``modify_<entity>`` update action's ``ActionSpec.verify``.
+    """
+    name_map = field_map or {}
+
+    async def verify(outcome: Any) -> tuple[bool, dict[str, Any] | None]:
+        if outcome is None:
+            return False, None
+        actual: dict[str, Any] = {}
+        verified = True
+        for change in diff:
+            attr = name_map.get(change.field, change.field)
+            raw = getattr(outcome, attr, None)
+            actual_val = _normalize(unwrap_unset(raw, None))
+            actual[change.field] = actual_val
+            if change.new is not None and actual_val != change.new:
+                verified = False
+        return verified, (actual if not verified else None)
+
+    return verify
 
 
 def _render_changes_block(changes: list[FieldChange]) -> list[str]:

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -22,6 +22,7 @@ operating on the same response model.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime
 from enum import Enum
@@ -298,7 +299,7 @@ def _render_action_block(idx: int, action: ActionResult) -> list[str]:
         lines.extend(_render_changes_block(action.changes))
     if action.actual_after is not None and action.verified is False:
         # Surface the actual-vs-requested mismatch so the caller can act
-        lines.append(f"- **Actual after re-fetch**: `{action.actual_after}`")
+        lines.append(f"- **Actual after verification**: `{action.actual_after}`")
     return lines
 
 
@@ -344,13 +345,28 @@ def render_modification_md(response: ModificationResponse) -> str:
 
     if response.prior_state is not None:
         lines.append("")
-        lines.append("### Prior State (for manual revert)")
-        lines.append(
-            "- Snapshot of pre-modification entity captured before applying. "
-            "Pass these values back through a follow-up modify call to revert "
-            "if needed — Katana's API is not transactional, so verify each "
-            "field manually."
-        )
+        if response.is_preview:
+            lines.append("### Current State (preview snapshot)")
+            lines.append(
+                "Snapshot of the entity in its current state — verify this is "
+                "the right target before setting `confirm=true`."
+            )
+        else:
+            lines.append("### Prior State (for manual revert)")
+            lines.append(
+                "Snapshot of pre-modification entity captured before applying. "
+                "Pass these values back through a follow-up modify call to revert "
+                "if needed — Katana's API is not transactional, so verify each "
+                "field manually."
+            )
+        lines.append("")
+        lines.append("```json")
+        # ``default=str`` collapses datetime / Enum / Decimal sentinels to
+        # strings so the snapshot serializes deterministically. The dict is
+        # already pre-serialized via ``serialize_for_prior_state``; this is
+        # a belt-and-suspenders for any remaining non-JSON-native values.
+        lines.append(json.dumps(response.prior_state, indent=2, default=str))
+        lines.append("```")
 
     if response.warnings:
         lines.append("")

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -67,20 +67,63 @@ class FieldChange(BaseModel):
     is_unknown_prior: bool = False
 
 
+class ActionResult(BaseModel):
+    """Per-action result block on a multi-action modification call.
+
+    Populated for each :class:`ActionSpec` in an action plan executed by
+    :func:`katana_mcp.tools._modification_dispatch.execute_plan`. Used by
+    the unified ``modify_<entity>`` tools to report on each sub-payload's
+    outcome independently.
+
+    Three states:
+
+    - **Preview** (``confirm=False`` on the parent request): ``succeeded``
+      and ``verified`` are both ``None`` — the action hasn't been executed,
+      only planned. ``changes`` carries the diff that *would* be applied.
+    - **Confirmed success**: ``succeeded=True``. ``verified`` may be
+      ``True`` (post-action re-fetch confirmed the change), ``False``
+      (re-fetch showed a different value — silent server-side rejection
+      or race), or ``None`` (no verification was registered for this
+      action).
+    - **Confirmed failure**: ``succeeded=False``, ``error`` populated.
+      Subsequent actions in the plan are not attempted (fail-fast).
+    """
+
+    operation: str
+    target_id: int | None = None
+    changes: list[FieldChange] = Field(default_factory=list)
+    succeeded: bool | None = None
+    error: str | None = None
+    verified: bool | None = None
+    actual_after: dict[str, Any] | None = None
+
+
 class ModificationResponse(BaseModel):
     """Uniform response for every modification tool.
 
-    The same shape covers update / delete / row-create / row-update /
-    row-delete operations. Tool-specific impls populate the fields that
-    apply; callers can rely on the common envelope.
+    Two shapes coexist:
+
+    - **Single-action** (legacy, kept for the few non-unified tools that
+      still return one operation per call): ``operation`` and ``changes``
+      are populated; ``actions`` is empty.
+    - **Multi-action** (the unified ``modify_<entity>`` tools): ``actions``
+      is a list of :class:`ActionResult` and ``operation``/``changes`` are
+      left at their defaults. ``prior_state`` is populated on the confirm
+      branch so the caller can manually revert if needed.
+
+    The renderer (:func:`render_modification_md`) checks which shape is in
+    use and emits markdown accordingly. New tools should always populate
+    ``actions``.
     """
 
     entity_type: str
     entity_id: int | None = None
     parent_entity_id: int | None = None
-    operation: str
     is_preview: bool
+    operation: str = ""
     changes: list[FieldChange] = Field(default_factory=list)
+    actions: list[ActionResult] = Field(default_factory=list)
+    prior_state: dict[str, Any] | None = None
     warnings: list[str] = Field(default_factory=list)
     next_actions: list[str] = Field(default_factory=list)
     katana_url: str | None = None
@@ -168,13 +211,66 @@ def compute_field_diff(
     return changes
 
 
-def render_modification_md(response: ModificationResponse) -> str:
-    """Render a :class:`ModificationResponse` as the markdown content body."""
-    op_title = response.operation.replace("_", " ").title()
-    entity_title = response.entity_type.replace("_", " ").title()
-    state_label = "PREVIEW" if response.is_preview else op_title.upper()
+def _render_changes_block(changes: list[FieldChange]) -> list[str]:
+    """Render a flat list of field changes as markdown bullet lines."""
+    lines: list[str] = []
+    for change in changes:
+        if change.is_unchanged:
+            lines.append(f"- `{change.field}`: (unchanged) {change.new}")
+        elif change.is_unknown_prior:
+            lines.append(f"- `{change.field}`: (prior unknown) → {change.new}")
+        elif change.is_added:
+            lines.append(f"- `{change.field}`: (set) → {change.new}")
+        else:
+            lines.append(f"- `{change.field}`: {change.old} → {change.new}")
+    return lines
 
-    lines = [f"## {entity_title} {op_title} ({state_label})"]
+
+def _render_action_block(idx: int, action: ActionResult) -> list[str]:
+    """Render one action's status + diff as a markdown sub-section."""
+    op_title = action.operation.replace("_", " ").title()
+    target = f" #{action.target_id}" if action.target_id is not None else ""
+    if action.succeeded is None:
+        status = "PLANNED"
+    elif action.succeeded is True:
+        if action.verified is False:
+            status = "APPLIED (verification mismatch)"
+        elif action.verified is None:
+            status = "APPLIED"
+        else:
+            status = "APPLIED (verified)"
+    else:
+        status = "FAILED"
+
+    lines = [f"#### {idx}. {op_title}{target} — {status}"]
+    if action.error:
+        lines.append(f"- **Error**: {action.error}")
+    if action.changes:
+        lines.extend(_render_changes_block(action.changes))
+    if action.actual_after is not None and action.verified is False:
+        # Surface the actual-vs-requested mismatch so the caller can act
+        lines.append(f"- **Actual after re-fetch**: `{action.actual_after}`")
+    return lines
+
+
+def render_modification_md(response: ModificationResponse) -> str:
+    """Render a :class:`ModificationResponse` as the markdown content body.
+
+    Handles both the legacy single-action shape (``operation`` + ``changes``)
+    and the multi-action shape (``actions``). When ``actions`` is non-empty,
+    that takes precedence and each action gets its own sub-section.
+    """
+    entity_title = response.entity_type.replace("_", " ").title()
+
+    if response.actions:
+        state_label = "PREVIEW" if response.is_preview else "APPLIED"
+        n = len(response.actions)
+        plural = "action" if n == 1 else "actions"
+        lines = [f"## Modify {entity_title} ({state_label}) — {n} {plural}"]
+    else:
+        op_title = response.operation.replace("_", " ").title()
+        state_label = "PREVIEW" if response.is_preview else op_title.upper()
+        lines = [f"## {entity_title} {op_title} ({state_label})"]
 
     if response.entity_id is not None:
         lines.append(f"- **ID**: {response.entity_id}")
@@ -184,18 +280,28 @@ def render_modification_md(response: ModificationResponse) -> str:
     if response.katana_url:
         lines.append(f"- **Katana URL**: {response.katana_url}")
 
-    if response.changes:
+    # Multi-action: per-action sections
+    if response.actions:
+        lines.append("")
+        lines.append("### Actions")
+        for idx, action in enumerate(response.actions, start=1):
+            lines.append("")
+            lines.extend(_render_action_block(idx, action))
+    # Legacy single-action: top-level changes block
+    elif response.changes:
         lines.append("")
         lines.append("### Changes")
-        for change in response.changes:
-            if change.is_unchanged:
-                lines.append(f"- `{change.field}`: (unchanged) {change.new}")
-            elif change.is_unknown_prior:
-                lines.append(f"- `{change.field}`: (prior unknown) → {change.new}")
-            elif change.is_added:
-                lines.append(f"- `{change.field}`: (set) → {change.new}")
-            else:
-                lines.append(f"- `{change.field}`: {change.old} → {change.new}")
+        lines.extend(_render_changes_block(response.changes))
+
+    if response.prior_state is not None:
+        lines.append("")
+        lines.append("### Prior State (for manual revert)")
+        lines.append(
+            "- Snapshot of pre-modification entity captured before applying. "
+            "Pass these values back through a follow-up modify call to revert "
+            "if needed — Katana's API is not transactional, so verify each "
+            "field manually."
+        )
 
     if response.warnings:
         lines.append("")

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -37,9 +37,12 @@ from katana_public_api_client.domain.converters import unwrap_unset
 
 class ConfirmableRequest(BaseModel):
     """Base for top-level ``Modify<Entity>Request`` and ``Delete<Entity>Request``
-    Pydantic models. Carries the ``confirm`` field used by every modification
-    tool's preview/apply gate."""
+    Pydantic models. Carries the primary entity ``id`` and the ``confirm``
+    field used by every modification tool's preview/apply gate. Subclasses
+    add their entity-specific sub-payload slots and override ``id``'s
+    description with an entity-appropriate label."""
 
+    id: int = Field(..., description="Entity ID")
     confirm: bool = Field(
         default=False,
         description=(

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -581,7 +581,7 @@ async def run_modify_plan(
     entity_type: str,
     entity_label: str,
     tool_name: str,
-    web_url_kind: EntityKind,
+    web_url_kind: EntityKind | None,
     existing: Any | None,
     plan: list[ActionSpec],
     has_get_endpoint: bool = True,
@@ -601,8 +601,9 @@ async def run_modify_plan(
             order 42"``). Used in messages and warnings.
         tool_name: Tool name for the manual-revert hint in the failure path
             (e.g. ``"modify_purchase_order"``).
-        web_url_kind: Argument to :func:`katana_web_url` (typically same as
-            ``entity_type``).
+        web_url_kind: Argument to :func:`katana_web_url`. Pass ``None`` for
+            entities without a Katana web page (e.g. services); the response's
+            ``katana_url`` will be ``None``.
         existing: The pre-fetched entity, or ``None`` on fetch failure.
             Drives ``prior_state`` capture and the diff-context warning.
         plan: Built ActionSpec list, in canonical order.
@@ -612,7 +613,7 @@ async def run_modify_plan(
             stock transfer) and ``existing=None`` is the expected steady
             state — suppresses the spurious "could not fetch" warning.
     """
-    katana_url = katana_web_url(web_url_kind, request.id)
+    katana_url = katana_web_url(web_url_kind, request.id) if web_url_kind else None
     warnings = (
         [
             f"Could not fetch {entity_label} for diff context — "
@@ -662,7 +663,7 @@ async def run_delete_plan(
     services: Any,
     entity_type: str,
     entity_label: str,
-    web_url_kind: EntityKind,
+    web_url_kind: EntityKind | None,
     fetcher: Callable[[Any, int], Awaitable[Any | None]],
     delete_endpoint: Any,
     operation: str,
@@ -679,7 +680,8 @@ async def run_delete_plan(
             human-readable noun ("purchase order") is derived by replacing
             ``_`` with `` `` for the preview message.
         entity_label: Human-readable with id (e.g. ``"purchase order 42"``).
-        web_url_kind: ``katana_web_url`` argument.
+        web_url_kind: ``katana_web_url`` argument. Pass ``None`` for entities
+            without a Katana web page (e.g. services).
         fetcher: ``(services, id) -> Awaitable[entity | None]`` — for
             prior_state capture.
         delete_endpoint: The generated client's DELETE module (e.g.
@@ -693,7 +695,7 @@ async def run_delete_plan(
         operation,
         lambda eid: make_delete_apply(delete_endpoint, services, eid),
     )
-    katana_url = katana_web_url(web_url_kind, request.id)
+    katana_url = katana_web_url(web_url_kind, request.id) if web_url_kind else None
 
     if not request.confirm:
         return ModificationResponse(

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -60,6 +60,7 @@ from pydantic import BaseModel
 from katana_mcp.logging import get_logger
 from katana_mcp.tools._modification import (
     ActionResult,
+    ConfirmableRequest,
     FieldChange,
     ModificationResponse,
     compute_field_diff,
@@ -126,8 +127,6 @@ async def execute_plan(plan: list[ActionSpec]) -> list[ActionResult]:
 
     for spec in plan:
         if spec.apply is None:
-            # Should never happen — preview-only specs go through
-            # ``to_planned_result`` directly, not execute_plan. Fail loudly.
             raise RuntimeError(
                 f"ActionSpec for {spec.operation} (target {spec.target_id}) "
                 "has no apply callable; cannot execute."
@@ -149,7 +148,7 @@ async def execute_plan(plan: list[ActionSpec]) -> list[ActionResult]:
                     error=f"{type(exc).__name__}: {exc}",
                 )
             )
-            return results  # fail-fast — do not attempt later actions
+            return results
 
         verified: bool | None = None
         actual_after: dict[str, Any] | None = None
@@ -230,7 +229,9 @@ def unset_dict(
 
 
 def has_any_subpayload(
-    request: BaseModel, *, exclude: tuple[str, ...] = ("id", "confirm")
+    request: BaseModel,
+    *,
+    exclude: tuple[str, ...] = ModificationResponse.DEFAULT_EXCLUDED,
 ) -> bool:
     """True if the request has any sub-payload set (any field outside ``exclude``).
 
@@ -577,7 +578,7 @@ def summarize_delete_outcome(
 
 async def run_modify_plan(
     *,
-    request: Any,
+    request: ConfirmableRequest,
     entity_type: str,
     entity_label: str,
     tool_name: str,
@@ -659,12 +660,12 @@ async def run_modify_plan(
 
 async def run_delete_plan(
     *,
-    request: Any,
+    request: ConfirmableRequest,
     services: Any,
     entity_type: str,
     entity_label: str,
     web_url_kind: EntityKind | None,
-    fetcher: Callable[[Any, int], Awaitable[Any | None]],
+    fetcher: Callable[[Any, int], Awaitable[Any | None]] | None,
     delete_endpoint: Any,
     operation: str,
 ) -> ModificationResponse:
@@ -682,14 +683,15 @@ async def run_delete_plan(
         entity_label: Human-readable with id (e.g. ``"purchase order 42"``).
         web_url_kind: ``katana_web_url`` argument. Pass ``None`` for entities
             without a Katana web page (e.g. services).
-        fetcher: ``(services, id) -> Awaitable[entity | None]`` — for
-            prior_state capture.
+        fetcher: ``(services, id) -> Awaitable[entity | None]`` for
+            prior_state capture, or ``None`` for entities with no GET-by-id
+            endpoint (stock transfer) — ``prior_state`` will be ``None``.
         delete_endpoint: The generated client's DELETE module (e.g.
             ``api_delete_purchase_order``).
         operation: Operation name for the ActionSpec (typically the entity's
             ``Operation.DELETE`` enum value).
     """
-    existing = await fetcher(services, request.id)
+    existing = await fetcher(services, request.id) if fetcher is not None else None
     plan = plan_deletes(
         [request.id],
         operation,
@@ -741,11 +743,17 @@ def serialize_for_prior_state(value: Any) -> dict[str, Any] | None:
     if hasattr(value, "to_dict"):
         try:
             return dict(value.to_dict())
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.info(
+                f"prior_state to_dict serialization failed for {type(value).__name__}: "
+                f"{type(exc).__name__}: {exc} — falling back to model_dump"
+            )
     if hasattr(value, "model_dump"):
         try:
             return dict(value.model_dump())
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.info(
+                f"prior_state model_dump serialization failed for {type(value).__name__}: "
+                f"{type(exc).__name__}: {exc} — prior_state will be None"
+            )
     return None

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -54,8 +54,15 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from pydantic import BaseModel
+
 from katana_mcp.logging import get_logger
-from katana_mcp.tools._modification import ActionResult, FieldChange
+from katana_mcp.tools._modification import (
+    ActionResult,
+    FieldChange,
+    compute_field_diff,
+    make_response_verifier,
+)
 
 logger = get_logger(__name__)
 
@@ -174,6 +181,95 @@ def plan_to_preview_results(plan: list[ActionSpec]) -> list[ActionResult]:
     ``succeeded=None`` to signal "planned, not yet executed".
     """
     return [spec.to_planned_result() for spec in plan]
+
+
+def has_any_subpayload(
+    request: BaseModel, *, exclude: tuple[str, ...] = ("id", "confirm")
+) -> bool:
+    """True if the request has any sub-payload set (any field outside ``exclude``).
+
+    Generic across every ``modify_<entity>`` tool — each has a top-level
+    request with a primary id, ``confirm``, and a set of optional
+    sub-payload slots. This checks whether the caller asked for at least
+    one action.
+    """
+    for name, value in request.model_dump(exclude_none=True).items():
+        if name in exclude:
+            continue
+        if value is False or value == [] or value == {}:
+            continue
+        return True
+    return False
+
+
+def make_create_action(
+    operation: str,
+    payload: BaseModel,
+    apply: ApplyCallable,
+    *,
+    exclude: tuple[str, ...] = ("confirm",),
+) -> ActionSpec:
+    """Build an ActionSpec for a create-style operation (POST).
+
+    Diff is every field on ``payload`` reported as added (no prior state).
+    No verify — ``unwrap_as`` raises on parse failure and creation
+    succeeds iff the response carries an id, which is implicit in the
+    apply outcome.
+    """
+    return ActionSpec(
+        operation=operation,
+        target_id=None,
+        diff=compute_field_diff(None, payload, exclude=exclude),
+        apply=apply,
+        verify=None,
+    )
+
+
+async def make_update_action(
+    operation: str,
+    target_id: int,
+    payload: BaseModel,
+    fetcher: Callable[[int], Awaitable[Any | None]],
+    apply: ApplyCallable,
+    *,
+    exclude: tuple[str, ...] = ("id", "confirm"),
+) -> ActionSpec:
+    """Build an ActionSpec for an update-style operation (PATCH).
+
+    Pre-fetches the existing entity for diff context. When the fetch
+    fails, fields are marked ``is_unknown_prior=True`` so previews
+    distinguish "field was empty" from "we couldn't read prior state".
+    Verify reads back the API response and confirms the requested
+    fields landed.
+    """
+    existing = await fetcher(target_id)
+    diff = compute_field_diff(
+        existing, payload, unknown_prior=existing is None, exclude=exclude
+    )
+    return ActionSpec(
+        operation=operation,
+        target_id=target_id,
+        diff=diff,
+        apply=apply,
+        verify=make_response_verifier(diff),
+    )
+
+
+def make_delete_action(
+    operation: str,
+    target_id: int,
+    apply: ApplyCallable,
+) -> ActionSpec:
+    """Build an ActionSpec for a delete-style operation (DELETE).
+
+    No verify — the entity is gone, can't fetch.
+    """
+    return ActionSpec(
+        operation=operation,
+        target_id=target_id,
+        apply=apply,
+        verify=None,
+    )
 
 
 def serialize_for_prior_state(value: Any) -> dict[str, Any] | None:

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -696,6 +696,7 @@ async def run_delete_plan(
             ``Operation.DELETE`` enum value).
     """
     existing = await fetcher(services, request.id) if fetcher is not None else None
+    prior_state = serialize_for_prior_state(existing)
     plan = plan_deletes(
         [request.id],
         operation,
@@ -704,11 +705,19 @@ async def run_delete_plan(
     katana_url = katana_web_url(web_url_kind, request.id) if web_url_kind else None
 
     if not request.confirm:
+        # Populate prior_state on the preview path so the rendered markdown
+        # shows callers a snapshot of what they're about to delete — gives
+        # them a chance to verify they targeted the right entity before
+        # confirming. The fetch is already best-effort: per-entity fetchers
+        # wrap ``safe_fetch_for_diff`` which swallows errors to ``None``,
+        # so a failed fetch leaves prior_state=None and the preview still
+        # renders without raising.
         return ModificationResponse(
             entity_type=entity_type,
             entity_id=request.id,
             is_preview=True,
             actions=plan_to_preview_results(plan),
+            prior_state=prior_state,
             next_actions=[
                 "Review the deletion",
                 f"Set confirm=true to delete the {entity_type.replace('_', ' ')}",
@@ -717,7 +726,6 @@ async def run_delete_plan(
             message=f"Preview: delete {entity_label}",
         )
 
-    prior_state = serialize_for_prior_state(existing)
     actions = await execute_plan(plan)
     message, next_actions = summarize_delete_outcome(actions, entity_label=entity_label)
 

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -61,9 +61,11 @@ from katana_mcp.logging import get_logger
 from katana_mcp.tools._modification import (
     ActionResult,
     FieldChange,
+    ModificationResponse,
     compute_field_diff,
     make_response_verifier,
 )
+from katana_mcp.web_urls import EntityKind, katana_web_url
 from katana_public_api_client.utils import is_success, unwrap, unwrap_as
 
 logger = get_logger(__name__)
@@ -523,6 +525,159 @@ def summarize_delete_outcome(
         message = f"Successfully deleted {entity_label}"
         next_actions = [f"{entity_label.capitalize()} has been deleted"]
     return message, next_actions
+
+
+# ============================================================================
+# Drivers — wrap the preview/confirm scaffolding so per-entity impls are
+# left with just ``build the plan`` plus a couple of identifying strings.
+# ============================================================================
+
+
+async def run_modify_plan(
+    *,
+    request: Any,
+    entity_type: str,
+    entity_label: str,
+    tool_name: str,
+    web_url_kind: EntityKind,
+    existing: Any | None,
+    plan: list[ActionSpec],
+) -> ModificationResponse:
+    """Wrap a built plan in a preview-or-execute :class:`ModificationResponse`.
+
+    The per-entity impl is responsible for the entity-specific bits:
+    validating sub-payloads with a domain-friendly error message, fetching
+    the existing entity, and assembling the plan list. Everything from
+    "compute katana_url and warnings" through "summarize the outcome" lives
+    here, identically across PO/SO/MO/etc.
+
+    Args:
+        request: The Pydantic request — must have ``id`` and ``confirm`` fields.
+        entity_type: Stable machine-readable type tag (e.g. ``"purchase_order"``).
+        entity_label: Human-readable label including the id (e.g. ``"purchase
+            order 42"``). Used in messages and warnings.
+        tool_name: Tool name for the manual-revert hint in the failure path
+            (e.g. ``"modify_purchase_order"``).
+        web_url_kind: Argument to :func:`katana_web_url` (typically same as
+            ``entity_type``).
+        existing: The pre-fetched entity, or ``None`` on fetch failure.
+            Drives ``prior_state`` capture and the diff-context warning.
+        plan: Built ActionSpec list, in canonical order.
+    """
+    katana_url = katana_web_url(web_url_kind, request.id)
+    warnings = (
+        [
+            f"Could not fetch {entity_label} for diff context — "
+            "preview shows requested values without prior state."
+        ]
+        if existing is None
+        else []
+    )
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type=entity_type,
+            entity_id=request.id,
+            is_preview=True,
+            actions=plan_to_preview_results(plan),
+            warnings=warnings,
+            next_actions=[
+                f"Review {len(plan)} planned action(s)",
+                "Set confirm=true to execute the plan",
+            ],
+            katana_url=katana_url,
+            message=f"Preview: {len(plan)} action(s) planned for {entity_label}",
+        )
+
+    prior_state = serialize_for_prior_state(existing)
+    actions = await execute_plan(plan)
+    message, next_actions = summarize_modify_outcome(
+        actions, len(plan), entity_label=entity_label, tool_name=tool_name
+    )
+
+    return ModificationResponse(
+        entity_type=entity_type,
+        entity_id=request.id,
+        is_preview=False,
+        actions=actions,
+        prior_state=prior_state,
+        warnings=warnings,
+        next_actions=next_actions,
+        katana_url=katana_url,
+        message=message,
+    )
+
+
+async def run_delete_plan(
+    *,
+    request: Any,
+    services: Any,
+    entity_type: str,
+    entity_label: str,
+    web_url_kind: EntityKind,
+    fetcher: Callable[[Any, int], Awaitable[Any | None]],
+    delete_endpoint: Any,
+    operation: str,
+) -> ModificationResponse:
+    """Single-action delete driver — used by every ``delete_<entity>`` tool.
+
+    Captures prior_state, runs a one-action plan, and returns the
+    ModificationResponse. Katana cascades child deletes server-side.
+
+    Args:
+        request: The Pydantic request — needs ``id`` and ``confirm``.
+        services: Result of ``get_services(context)``.
+        entity_type: Machine tag (e.g. ``"purchase_order"``). The
+            human-readable noun ("purchase order") is derived by replacing
+            ``_`` with `` `` for the preview message.
+        entity_label: Human-readable with id (e.g. ``"purchase order 42"``).
+        web_url_kind: ``katana_web_url`` argument.
+        fetcher: ``(services, id) -> Awaitable[entity | None]`` — for
+            prior_state capture.
+        delete_endpoint: The generated client's DELETE module (e.g.
+            ``api_delete_purchase_order``).
+        operation: Operation name for the ActionSpec (typically the entity's
+            ``Operation.DELETE`` enum value).
+    """
+    from katana_mcp.web_urls import katana_web_url
+
+    existing = await fetcher(services, request.id)
+    plan = plan_deletes(
+        [request.id],
+        operation,
+        lambda eid: make_delete_apply(delete_endpoint, services, eid),
+    )
+    katana_url = katana_web_url(web_url_kind, request.id)
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type=entity_type,
+            entity_id=request.id,
+            is_preview=True,
+            actions=plan_to_preview_results(plan),
+            next_actions=[
+                "Review the deletion",
+                f"Set confirm=true to delete the {entity_type.replace('_', ' ')}",
+            ],
+            katana_url=katana_url,
+            message=f"Preview: delete {entity_label}",
+        )
+
+    prior_state = serialize_for_prior_state(existing)
+    actions = await execute_plan(plan)
+    message, next_actions = summarize_delete_outcome(actions, entity_label=entity_label)
+
+    return ModificationResponse(
+        entity_type=entity_type,
+        entity_id=request.id,
+        is_preview=False,
+        actions=actions,
+        prior_state=prior_state,
+        next_actions=next_actions,
+        # On successful delete the entity URL no longer resolves.
+        katana_url=None if all(a.succeeded for a in actions) else katana_url,
+        message=message,
+    )
 
 
 def serialize_for_prior_state(value: Any) -> dict[str, Any] | None:

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -584,6 +584,7 @@ async def run_modify_plan(
     web_url_kind: EntityKind,
     existing: Any | None,
     plan: list[ActionSpec],
+    has_get_endpoint: bool = True,
 ) -> ModificationResponse:
     """Wrap a built plan in a preview-or-execute :class:`ModificationResponse`.
 
@@ -605,6 +606,11 @@ async def run_modify_plan(
         existing: The pre-fetched entity, or ``None`` on fetch failure.
             Drives ``prior_state`` capture and the diff-context warning.
         plan: Built ActionSpec list, in canonical order.
+        has_get_endpoint: ``True`` when the entity exposes a GET-by-id endpoint
+            and ``existing=None`` therefore signals a *fetch failure* worth
+            warning about. ``False`` when the entity has no GET-by-id (e.g.
+            stock transfer) and ``existing=None`` is the expected steady
+            state — suppresses the spurious "could not fetch" warning.
     """
     katana_url = katana_web_url(web_url_kind, request.id)
     warnings = (
@@ -612,7 +618,7 @@ async def run_modify_plan(
             f"Could not fetch {entity_label} for diff context — "
             "preview shows requested values without prior state."
         ]
-        if existing is None
+        if existing is None and has_get_endpoint
         else []
     )
 
@@ -681,8 +687,6 @@ async def run_delete_plan(
         operation: Operation name for the ActionSpec (typically the entity's
             ``Operation.DELETE`` enum value).
     """
-    from katana_mcp.web_urls import katana_web_url
-
     existing = await fetcher(services, request.id)
     plan = plan_deletes(
         [request.id],

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -66,6 +66,7 @@ from katana_mcp.tools._modification import (
     make_response_verifier,
 )
 from katana_mcp.web_urls import EntityKind, katana_web_url
+from katana_public_api_client.domain.converters import to_unset
 from katana_public_api_client.utils import is_success, unwrap, unwrap_as
 
 logger = get_logger(__name__)
@@ -185,6 +186,47 @@ def plan_to_preview_results(plan: list[ActionSpec]) -> list[ActionResult]:
     ``succeeded=None`` to signal "planned, not yet executed".
     """
     return [spec.to_planned_result() for spec in plan]
+
+
+def unset_dict(
+    model: BaseModel,
+    *,
+    field_map: dict[str, str] | None = None,
+    transforms: dict[str, Callable[[Any], Any]] | None = None,
+    exclude: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Convert a Pydantic patch model into kwargs for an attrs request constructor.
+
+    For every field on ``model``: ``None`` becomes ``UNSET`` (so PATCH bodies
+    omit unset fields), and concrete values pass through unchanged. Used to
+    collapse the ``field=to_unset(patch.field)`` per-field repetition in
+    every ``_build_*_request`` helper to a single ``**unset_dict(patch)``.
+
+    Args:
+        model: A Pydantic patch/payload model.
+        field_map: Optional ``pydantic_name -> attrs_name`` rename map for
+            fields that don't share names across the layers (e.g.
+            ``{"zip": "zip_"}`` for the address ``zip`` field, since
+            ``zip`` is a Python builtin and the attrs field is ``zip_``).
+        transforms: Optional ``pydantic_name -> callable`` map for value
+            conversions applied **before** UNSET-wrapping. Typical use:
+            ``{"status": PurchaseOrderStatus}`` to coerce a status literal
+            into the API enum. Transforms only fire when the field is
+            non-None — None falls straight through to UNSET.
+        exclude: Field names on the model to skip entirely (typically
+            ``("id",)`` to drop the patch's id when the API request body
+            doesn't carry it as a field).
+    """
+    field_map = field_map or {}
+    transforms = transforms or {}
+    out: dict[str, Any] = {}
+    for k, v in model.model_dump(exclude_none=False).items():
+        if k in exclude:
+            continue
+        value = transforms[k](v) if v is not None and k in transforms else v
+        attr_name = field_map.get(k, k)
+        out[attr_name] = to_unset(value)
+    return out
 
 
 def has_any_subpayload(

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -1,0 +1,199 @@
+"""Action-plan dispatcher for unified ``modify_<entity>`` tools.
+
+This module provides the generic execution layer used by every
+``modify_<entity>`` tool (modify_purchase_order, modify_sales_order,
+modify_manufacturing_order, modify_stock_transfer, modify_item).
+
+## Tool authoring contract
+
+Every ``modify_<entity>`` tool follows this shape:
+
+1. Define a Pydantic ``ModifyXyzRequest`` with one optional sub-payload slot
+   per kind of action the entity supports (``update_header``,
+   ``add_rows``, ``update_rows``, ``delete_row_ids``, ``delete``, etc.).
+2. In the impl, fetch the existing entity (best-effort) for diff context.
+3. Build a ``list[ActionSpec]`` translating sub-payloads into planned API
+   calls — each ActionSpec carries the operation name, target id, diff
+   metadata, and async closures for ``apply`` and (optional) ``verify``.
+4. **Preview branch** (``confirm=False``): wrap the plan in
+   :class:`ActionResult` entries with ``succeeded=None`` (planned, not run)
+   and return the :class:`ModificationResponse`.
+5. **Confirm branch** (``confirm=True``): call :func:`execute_plan` to run
+   the actions in order, fail-fast on the first error. Capture
+   ``prior_state`` before invoking. Return the same response shape with
+   ``actions`` populated.
+
+## Why fail-fast + manual revert (not auto-rollback)
+
+The Katana API is not transactional across endpoints. If action 3 of 5
+fails, actions 1-2 are already applied server-side. We chose:
+
+- **Fail-fast** — stop at the first error so the caller knows exactly which
+  actions ran. Subsequent actions don't get attempted blindly.
+- **Manual revert** — capture pre-modification state into
+  ``response.prior_state`` so the caller has the data needed to compose a
+  follow-up ``modify`` call that restores the prior values. We don't try
+  to auto-revert via inverse calls — those have their own failure modes
+  (network, timing, server-side state changes between apply and undo) and
+  silent inconsistencies are worse than visible partial application.
+
+## Why post-action verification
+
+A 200 response from Katana doesn't always mean the change took effect —
+some endpoints silently coerce or reject inputs. Each ActionSpec can
+register a ``verify`` callable that re-fetches the targeted entity and
+confirms the change actually landed. Verification failure surfaces as
+``ActionResult.verified=False`` with an ``actual_after`` snapshot — it
+doesn't raise, because the action *did* succeed at the API layer; the
+caller just needs to know the post-state diverged from the request.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from katana_mcp.logging import get_logger
+from katana_mcp.tools._modification import ActionResult, FieldChange
+
+logger = get_logger(__name__)
+
+
+# ``apply`` callable: returns whatever the API call yields (typically the
+# parsed response model). Returned to ``verify`` so verification can use it
+# (e.g. confirm a created row's id matches what we expected).
+ApplyCallable = Callable[[], Awaitable[Any]]
+
+# ``verify`` callable: takes the apply result, returns
+# ``(verified, actual_after_dict_or_None)``. Verification failures should
+# return ``(False, snapshot)`` rather than raising — the action itself
+# succeeded; the caller just needs the divergence visible.
+VerifyCallable = Callable[[Any], Awaitable[tuple[bool, dict[str, Any] | None]]]
+
+
+@dataclass
+class ActionSpec:
+    """A single planned action — preview metadata + execution closures.
+
+    Constructed by per-entity tool code; consumed by :func:`execute_plan`.
+    """
+
+    operation: str
+    target_id: int | None
+    diff: list[FieldChange] = field(default_factory=list)
+    apply: ApplyCallable | None = None
+    verify: VerifyCallable | None = None
+
+    def to_planned_result(self) -> ActionResult:
+        """Build an ActionResult for the preview branch (action not yet run)."""
+        return ActionResult(
+            operation=self.operation,
+            target_id=self.target_id,
+            changes=list(self.diff),
+            succeeded=None,
+            verified=None,
+        )
+
+
+async def execute_plan(plan: list[ActionSpec]) -> list[ActionResult]:
+    """Execute an action plan in order, fail-fast on first error.
+
+    Each :class:`ActionSpec` is awaited via its ``apply`` callable. After a
+    successful apply, the optional ``verify`` callable is awaited to confirm
+    the change landed; verification failure does NOT halt the plan or
+    raise — it surfaces as ``ActionResult.verified=False`` so the caller
+    sees the divergence.
+
+    Returns a list of :class:`ActionResult` of length 1..len(plan) — equal
+    to the plan length on full success, shorter when fail-fast halted
+    after action N (the result list ends at the failed action; later
+    actions are not represented).
+    """
+    results: list[ActionResult] = []
+
+    for spec in plan:
+        if spec.apply is None:
+            # Should never happen — preview-only specs go through
+            # ``to_planned_result`` directly, not execute_plan. Fail loudly.
+            raise RuntimeError(
+                f"ActionSpec for {spec.operation} (target {spec.target_id}) "
+                "has no apply callable; cannot execute."
+            )
+
+        try:
+            outcome = await spec.apply()
+        except Exception as exc:
+            logger.warning(
+                f"Action {spec.operation} (target {spec.target_id}) failed: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            results.append(
+                ActionResult(
+                    operation=spec.operation,
+                    target_id=spec.target_id,
+                    changes=list(spec.diff),
+                    succeeded=False,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+            )
+            return results  # fail-fast — do not attempt later actions
+
+        verified: bool | None = None
+        actual_after: dict[str, Any] | None = None
+        if spec.verify is not None:
+            try:
+                verified, actual_after = await spec.verify(outcome)
+            except Exception as exc:
+                logger.info(
+                    f"Verification of {spec.operation} (target {spec.target_id}) "
+                    f"errored: {type(exc).__name__}: {exc} — marking verified=False"
+                )
+                verified = False
+                actual_after = None
+
+        results.append(
+            ActionResult(
+                operation=spec.operation,
+                target_id=spec.target_id,
+                changes=list(spec.diff),
+                succeeded=True,
+                verified=verified,
+                actual_after=actual_after,
+            )
+        )
+
+    return results
+
+
+def plan_to_preview_results(plan: list[ActionSpec]) -> list[ActionResult]:
+    """Convert a plan to preview-shaped :class:`ActionResult` entries.
+
+    Used by the preview branch (``confirm=False``) where no API calls run.
+    Each ActionResult carries the operation/target/diff but
+    ``succeeded=None`` to signal "planned, not yet executed".
+    """
+    return [spec.to_planned_result() for spec in plan]
+
+
+def serialize_for_prior_state(value: Any) -> dict[str, Any] | None:
+    """Best-effort serialization of an attrs/pydantic entity for prior_state.
+
+    Tries ``.to_dict()`` (attrs) first, then ``.model_dump()`` (pydantic),
+    falling back to ``None`` for values we can't serialize. The resulting
+    dict goes into :attr:`ModificationResponse.prior_state` so the caller
+    has the pre-modification snapshot for manual revert.
+    """
+    if value is None:
+        return None
+    if hasattr(value, "to_dict"):
+        try:
+            return dict(value.to_dict())
+        except Exception:
+            pass
+    if hasattr(value, "model_dump"):
+        try:
+            return dict(value.model_dump())
+        except Exception:
+            pass
+    return None

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -50,9 +50,10 @@ caller just needs to know the post-state diverged from the request.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel
 
@@ -63,6 +64,7 @@ from katana_mcp.tools._modification import (
     compute_field_diff,
     make_response_verifier,
 )
+from katana_public_api_client.utils import is_success, unwrap, unwrap_as
 
 logger = get_logger(__name__)
 
@@ -270,6 +272,257 @@ def make_delete_action(
         apply=apply,
         verify=None,
     )
+
+
+# ============================================================================
+# Generic API-call helpers shared by every ``modify_<entity>`` tool.
+#
+# Three layers stacked together cover ~80% of per-entity boilerplate:
+#
+# 1. ``safe_fetch_for_diff`` — best-effort GET that returns None on failure.
+# 2. ``make_post_apply`` / ``make_patch_apply`` / ``make_delete_apply`` —
+#    closure factories for ActionSpec.apply.
+# 3. ``plan_creates`` / ``plan_updates`` / ``plan_deletes`` — plan-builder
+#    factories that consume sub-payloads + a request-builder + an apply-builder
+#    and yield ``list[ActionSpec]``.
+# ============================================================================
+
+
+async def safe_fetch_for_diff[T](
+    endpoint: Any,
+    services: Any,
+    target_id: int,
+    *,
+    return_type: type[T],
+    label: str,
+) -> T | None:
+    """Best-effort GET for diff context. Returns None on any error.
+
+    Centralizes the try/except/log pattern every per-entity ``_fetch_<x>``
+    helper used to repeat. ``label`` is the human-readable noun for the
+    info-log on failure (e.g. ``"PO row"``, ``"SO fulfillment"``).
+    """
+    try:
+        response = await endpoint.asyncio_detailed(id=target_id, client=services.client)
+        return unwrap_as(response, return_type)
+    except Exception as exc:
+        logger.info(
+            f"Could not fetch {label} {target_id} for diff context: {exc} — "
+            "preview will report changes without prior values."
+        )
+        return None
+
+
+def make_post_apply[T](
+    endpoint: Any, services: Any, body: Any, *, return_type: type[T]
+) -> ApplyCallable:
+    """Build an ``apply`` closure for a POST endpoint that returns a model.
+
+    Used by every ``add_*`` action: the generated client's POST endpoints
+    take ``client=`` + ``body=`` and return a parsed entity. ``return_type``
+    is the attrs class the response is asserted against by ``unwrap_as``.
+    """
+
+    async def apply() -> T:
+        response = await endpoint.asyncio_detailed(client=services.client, body=body)
+        # ``unwrap_as`` raises on error by default; narrow ``T | None`` → ``T``.
+        return cast(T, unwrap_as(response, return_type))
+
+    return apply
+
+
+def make_patch_apply[T](
+    endpoint: Any,
+    services: Any,
+    target_id: int,
+    body: Any,
+    *,
+    return_type: type[T],
+) -> ApplyCallable:
+    """Build an ``apply`` closure for a PATCH endpoint that returns a model.
+
+    Used by every ``update_*`` action: PATCH endpoints take ``id=``,
+    ``client=``, ``body=`` and return the updated entity.
+    """
+
+    async def apply() -> T:
+        response = await endpoint.asyncio_detailed(
+            id=target_id, client=services.client, body=body
+        )
+        return cast(T, unwrap_as(response, return_type))
+
+    return apply
+
+
+def make_delete_apply(endpoint: Any, services: Any, target_id: int) -> ApplyCallable:
+    """Build an ``apply`` closure for a DELETE endpoint with no body.
+
+    Used by every ``delete_*`` action and the ``delete_<entity>`` tools.
+    DELETE endpoints return 204 No Content on success; ``is_success`` +
+    ``unwrap`` translates non-success into a typed error.
+    """
+
+    async def apply() -> None:
+        response = await endpoint.asyncio_detailed(id=target_id, client=services.client)
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    return apply
+
+
+# ============================================================================
+# Plan builders — consume sub-payloads and emit ``list[ActionSpec]``.
+# ============================================================================
+
+
+def plan_creates[Payload: BaseModel](
+    items: list[Payload] | None,
+    operation: str,
+    build_request: Callable[[Payload], Any],
+    build_apply: Callable[[Any], ApplyCallable],
+) -> list[ActionSpec]:
+    """Build ActionSpecs for an ``add_*`` sub-payload.
+
+    Args:
+        items: The sub-payload list (or None).
+        operation: Operation name (StrEnum value).
+        build_request: ``Payload -> attrs request body`` (per-entity).
+        build_apply: ``request_body -> ApplyCallable`` (per-entity).
+    """
+    if not items:
+        return []
+    return [
+        make_create_action(operation, item, build_apply(build_request(item)))
+        for item in items
+    ]
+
+
+async def plan_updates[Patch: BaseModel, Existing](
+    patches: list[Patch] | None,
+    operation: str,
+    fetcher: Callable[[int], Awaitable[Existing | None]] | None,
+    build_request: Callable[[Patch], Any],
+    build_apply: Callable[[int, Any], ApplyCallable],
+    *,
+    target_id_attr: str = "id",
+) -> list[ActionSpec]:
+    """Build ActionSpecs for an ``update_*`` sub-payload.
+
+    When ``fetcher`` is provided, prefetches the existing target for each
+    patch via ``asyncio.gather`` (parallel) and computes a real diff. When
+    ``fetcher`` is ``None``, every diff is marked ``is_unknown_prior=True``
+    — used for resources without a get-by-id endpoint.
+
+    Args:
+        patches: The sub-payload list (or None).
+        operation: Operation name (StrEnum value).
+        fetcher: ``target_id -> Awaitable[existing | None]`` or ``None``.
+        build_request: ``patch -> attrs request body``.
+        build_apply: ``(target_id, body) -> ApplyCallable``.
+        target_id_attr: Attribute on ``patch`` carrying the target id
+            (default ``"id"``).
+    """
+    if not patches:
+        return []
+
+    target_ids = [getattr(p, target_id_attr) for p in patches]
+    if fetcher is not None:
+        existing_list = await asyncio.gather(*[fetcher(tid) for tid in target_ids])
+    else:
+        existing_list = [None] * len(patches)
+
+    specs: list[ActionSpec] = []
+    for patch, target_id, existing in zip(
+        patches, target_ids, existing_list, strict=True
+    ):
+        diff = compute_field_diff(existing, patch, unknown_prior=existing is None)
+        specs.append(
+            ActionSpec(
+                operation=operation,
+                target_id=target_id,
+                diff=diff,
+                apply=build_apply(target_id, build_request(patch)),
+                verify=make_response_verifier(diff),
+            )
+        )
+    return specs
+
+
+def plan_deletes(
+    ids: list[int] | None,
+    operation: str,
+    build_apply: Callable[[int], ApplyCallable],
+) -> list[ActionSpec]:
+    """Build ActionSpecs for a ``delete_*_ids`` sub-payload."""
+    if not ids:
+        return []
+    return [
+        make_delete_action(operation, target_id, build_apply(target_id))
+        for target_id in ids
+    ]
+
+
+# ============================================================================
+# Response summary helpers — collapse the duplicated message + next_actions
+# blocks at the end of every ``_modify_*_impl`` and ``_delete_*_impl``.
+# ============================================================================
+
+
+def summarize_modify_outcome(
+    actions: list[ActionResult],
+    plan_len: int,
+    *,
+    entity_label: str,
+    tool_name: str,
+) -> tuple[str, list[str]]:
+    """Build (message, next_actions) for a multi-action modify result.
+
+    ``entity_label`` is the human-readable noun (e.g. ``"purchase order 42"``).
+    ``tool_name`` names the tool the caller would re-invoke for revert
+    (e.g. ``"modify_purchase_order"``).
+    """
+    succeeded_count = sum(1 for a in actions if a.succeeded is True)
+    failed_count = sum(1 for a in actions if a.succeeded is False)
+
+    if failed_count > 0:
+        message = (
+            f"Partial: {succeeded_count}/{plan_len} action(s) applied to "
+            f"{entity_label} before fail-fast halt; see actions for details "
+            "and prior_state for revert reference."
+        )
+        next_actions = [
+            f"{succeeded_count} action(s) succeeded; {failed_count} failed",
+            "Review the FAILED action's error and the prior_state snapshot",
+            f"Compose a follow-up {tool_name} call to revert if needed",
+        ]
+    else:
+        message = (
+            f"Successfully applied {succeeded_count}/{plan_len} action(s) "
+            f"to {entity_label}"
+        )
+        next_actions = [
+            f"{entity_label.capitalize()} modified — "
+            f"{succeeded_count} action(s) verified"
+        ]
+    return message, next_actions
+
+
+def summarize_delete_outcome(
+    actions: list[ActionResult], *, entity_label: str
+) -> tuple[str, list[str]]:
+    """Build (message, next_actions) for a single-action delete result."""
+    failed = any(a.succeeded is False for a in actions)
+    if failed:
+        message = f"Failed to delete {entity_label}"
+        next_actions = [
+            "Delete failed — see action error",
+            "prior_state carries the pre-delete snapshot",
+        ]
+    else:
+        message = f"Successfully deleted {entity_label}"
+        next_actions = [f"{entity_label.capitalize()} has been deleted"]
+    return message, next_actions
 
 
 def serialize_for_prior_state(value: Any) -> dict[str, Any] | None:

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -542,14 +542,18 @@ def summarize_modify_outcome(
             f"Compose a follow-up {tool_name} call to revert if needed",
         ]
     else:
+        verified_count = sum(1 for a in actions if a.verified is True)
         message = (
             f"Successfully applied {succeeded_count}/{plan_len} action(s) "
             f"to {entity_label}"
         )
-        next_actions = [
-            f"{entity_label.capitalize()} modified — "
-            f"{succeeded_count} action(s) verified"
-        ]
+        next_action = f"{entity_label.capitalize()} modified — {succeeded_count} action(s) applied"
+        if verified_count != succeeded_count:
+            # Some actions either skipped verify (verifier=None) or post-action
+            # re-fetch reported a mismatch (verified=False). Surface the gap so
+            # callers know not every applied action was confirmed end-to-end.
+            next_action += f" ({verified_count} verified)"
+        next_actions = [next_action]
     return message, next_actions
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -874,13 +874,11 @@ def _build_update_header_request(patch: ItemHeaderPatch, item_type: ItemType) ->
     the actual fields the API accepts after we've validated routing.
     """
     request_cls = _TYPE_ENDPOINTS[item_type]["update_request"]
-    # Compute the type-specific allowed field set by excluding fields that
-    # don't apply.
     if item_type == ItemType.PRODUCT:
         exclude = _SERVICE_ONLY_FIELDS
     elif item_type == ItemType.MATERIAL:
         exclude = _PRODUCT_ONLY_FIELDS + _SERVICE_ONLY_FIELDS
-    else:  # SERVICE
+    else:
         exclude = _PRODUCT_ONLY_FIELDS + _PRODUCT_AND_MATERIAL_FIELDS
     return request_cls(**unset_dict(patch, exclude=exclude))
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -17,6 +17,27 @@ from pydantic import BaseModel, Field
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
+from katana_mcp.tools._modification import (
+    ConfirmableRequest,
+    ModificationResponse,
+    compute_field_diff,
+    make_response_verifier,
+    to_tool_result,
+)
+from katana_mcp.tools._modification_dispatch import (
+    ActionSpec,
+    has_any_subpayload,
+    make_delete_apply,
+    make_patch_apply,
+    make_post_apply,
+    plan_creates,
+    plan_deletes,
+    plan_updates,
+    run_delete_plan,
+    run_modify_plan,
+    safe_fetch_for_diff,
+    unset_dict,
+)
 from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.list_coercion import CoercedIntListOpt, CoercedStrListOpt
 from katana_mcp.tools.tool_result_utils import (
@@ -27,29 +48,45 @@ from katana_mcp.tools.tool_result_utils import (
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import EntityKind, katana_web_url
+from katana_public_api_client.api.material import (
+    delete_material as api_delete_material,
+    get_material as api_get_material,
+    update_material as api_update_material,
+)
+from katana_public_api_client.api.product import (
+    delete_product as api_delete_product,
+    get_product as api_get_product,
+    update_product as api_update_product,
+)
+from katana_public_api_client.api.services import (
+    delete_service as api_delete_service,
+    get_service as api_get_service,
+    update_service as api_update_service,
+)
+from katana_public_api_client.api.variant import (
+    create_variant as api_create_variant,
+    delete_variant as api_delete_variant,
+    get_variant as api_get_variant,
+    update_variant as api_update_variant,
+)
 from katana_public_api_client.domain.converters import to_unset
 from katana_public_api_client.models import (
     CreateMaterialRequest,
     CreateProductRequest,
     CreateServiceRequest,
     CreateServiceVariantRequest,
-    CreateVariantRequest,
+    CreateVariantRequest as APICreateVariantRequest,
+    Material,
+    Product,
+    Service,
+    UpdateMaterialRequest as APIUpdateMaterialRequest,
+    UpdateProductRequest as APIUpdateProductRequest,
+    UpdateServiceRequest as APIUpdateServiceRequest,
+    UpdateVariantRequest as APIUpdateVariantRequest,
+    Variant,
 )
 
 logger = get_logger(__name__)
-
-
-def _get_type_helper(client: Any, item_type: ItemType) -> Any:
-    """Get the client helper for an item type (products, materials, or services)."""
-    helpers = {
-        ItemType.PRODUCT: "products",
-        ItemType.MATERIAL: "materials",
-        ItemType.SERVICE: "services",
-    }
-    attr = helpers.get(item_type)
-    if not attr:
-        raise ValueError(f"Invalid item type: {item_type}")
-    return getattr(client, attr)
 
 
 # ============================================================================
@@ -255,7 +292,7 @@ async def _create_item_impl(
         )
         result = await services.client.services.create(api_request)
     else:
-        variant = CreateVariantRequest(
+        variant = APICreateVariantRequest(
             sku=request.sku,
             sales_price=to_unset(request.sales_price),
             purchase_price=to_unset(request.purchase_price),
@@ -625,260 +662,451 @@ async def get_item(
 
 
 # ============================================================================
-# Tool 4: update_item
+# Tool: modify_item — unified modification surface
 # ============================================================================
 
 
-class UpdateItemRequest(BaseModel):
-    """Request to update an item."""
+class ItemOperation(StrEnum):
+    """Operation names emitted on ActionSpecs by ``modify_item`` /
+    ``delete_item`` plan builders."""
 
-    id: int = Field(..., description="Item ID")
-    type: ItemType = Field(..., description="Type of item")
-    name: str | None = Field(None, description="New item name")
-    uom: str | None = Field(None, description="New unit of measure")
-    category_name: str | None = Field(None, description="New category")
-    is_sellable: bool | None = Field(None, description="Whether item can be sold")
-    is_producible: bool | None = Field(
-        None, description="Can be manufactured (products only)"
-    )
-    is_purchasable: bool | None = Field(None, description="Can be purchased")
-    default_supplier_id: int | None = Field(None, description="Default supplier ID")
-    additional_info: str | None = Field(None, description="Additional notes")
-    # Variant-level fields — resolved automatically via SKU or first variant
+    UPDATE_HEADER = "update_header"
+    DELETE = "delete"
+    ADD_VARIANT = "add_variant"
+    UPDATE_VARIANT = "update_variant"
+    DELETE_VARIANT = "delete_variant"
+
+
+# Per-type endpoint routing for header update / get / delete. The variant
+# endpoints (``/variant`` family) are shared across types, so they're not
+# part of this table.
+_TYPE_ENDPOINTS: dict[ItemType, dict[str, Any]] = {
+    ItemType.PRODUCT: {
+        "get": api_get_product,
+        "update": api_update_product,
+        "delete": api_delete_product,
+        "return_type": Product,
+        "update_request": APIUpdateProductRequest,
+        "label": "product",
+        "web_url_kind": "product",
+    },
+    ItemType.MATERIAL: {
+        "get": api_get_material,
+        "update": api_update_material,
+        "delete": api_delete_material,
+        "return_type": Material,
+        "update_request": APIUpdateMaterialRequest,
+        "label": "material",
+        "web_url_kind": "material",
+    },
+    ItemType.SERVICE: {
+        "get": api_get_service,
+        "update": api_update_service,
+        "delete": api_delete_service,
+        "return_type": Service,
+        "update_request": APIUpdateServiceRequest,
+        "label": "service",
+        # Services have no Katana web page; downstream callers handle a
+        # ``None`` web_url_kind by emitting ``katana_url=None``.
+        "web_url_kind": None,
+    },
+}
+
+
+# Header-patch fields that are valid only for specific types. Used by
+# ``ItemHeaderPatch.validate_for_type`` to reject obviously-misrouted
+# fields (e.g. ``is_producible`` on a SERVICE) before they reach the API.
+_PRODUCT_ONLY_FIELDS = (
+    "is_producible",
+    "is_purchasable",
+    "is_auto_assembly",
+    "serial_tracked",
+    "operations_in_sequence",
+)
+_PRODUCT_AND_MATERIAL_FIELDS = (
+    "default_supplier_id",
+    "batch_tracked",
+    "purchase_uom",
+    "purchase_uom_conversion_rate",
+)
+_SERVICE_ONLY_FIELDS = ("sales_price", "default_cost", "sku")
+
+
+class ItemHeaderPatch(BaseModel):
+    """Header fields to patch on an item.
+
+    The schema is a super-set across all three item types (product / material /
+    service); ``ModifyItemRequest`` validates that the supplied fields match
+    the chosen ``type`` at runtime. The split is in
+    ``_PRODUCT_ONLY_FIELDS`` / ``_PRODUCT_AND_MATERIAL_FIELDS`` /
+    ``_SERVICE_ONLY_FIELDS``.
+    """
+
+    name: str | None = Field(default=None, description="New item name")
+    uom: str | None = Field(default=None, description="New unit of measure")
+    category_name: str | None = Field(default=None, description="New category")
+    is_sellable: bool | None = Field(default=None)
+    is_archived: bool | None = Field(default=None)
+    additional_info: str | None = Field(default=None)
+    custom_field_collection_id: int | None = Field(default=None)
+
+    # Product + Material only:
+    default_supplier_id: int | None = Field(default=None)
+    batch_tracked: bool | None = Field(default=None)
+    purchase_uom: str | None = Field(default=None)
+    purchase_uom_conversion_rate: float | None = Field(default=None)
+
+    # Product only:
+    is_producible: bool | None = Field(default=None)
+    is_purchasable: bool | None = Field(default=None)
+    is_auto_assembly: bool | None = Field(default=None)
+    serial_tracked: bool | None = Field(default=None)
+    operations_in_sequence: bool | None = Field(default=None)
+
+    # Service only:
+    sales_price: float | None = Field(default=None)
+    default_cost: float | None = Field(default=None)
     sku: str | None = Field(
-        None,
-        description="SKU to identify which variant to update (uses first variant if omitted)",
-    )
-    supplier_item_codes: CoercedStrListOpt = Field(
         default=None,
-        description=(
-            'JSON array of supplier item codes, e.g. ["10654627", "10654628"]. '
-            "Replaces all existing codes for the variant."
-        ),
+        description="(SERVICE only) — services carry SKU on the header itself.",
     )
-    registered_barcode: str | None = Field(None, description="UPC / registered barcode")
-    internal_barcode: str | None = Field(None, description="Internal barcode")
-    sales_price: float | None = Field(None, description="Sales price")
-    purchase_price: float | None = Field(None, description="Purchase price")
-    lead_time: int | None = Field(None, description="Lead time in days")
 
-    @property
-    def has_variant_fields(self) -> bool:
-        """Check if any variant-level fields are set."""
-        return any(
-            v is not None
-            for v in [
-                self.supplier_item_codes,
-                self.registered_barcode,
-                self.internal_barcode,
-                self.sales_price,
-                self.purchase_price,
-                self.lead_time,
-            ]
+
+class VariantAdd(BaseModel):
+    """A new variant to attach to a product or material.
+
+    Variants are not supported on services — services carry their pricing
+    on the item header itself. The dispatcher injects ``product_id`` /
+    ``material_id`` based on the parent item type.
+    """
+
+    sku: str = Field(..., description="Variant SKU")
+    sales_price: float | None = Field(default=None)
+    purchase_price: float | None = Field(default=None)
+    supplier_item_codes: list[str] | None = Field(default=None)
+    internal_barcode: str | None = Field(default=None)
+    registered_barcode: str | None = Field(default=None)
+    lead_time: int | None = Field(default=None)
+    minimum_order_quantity: float | None = Field(default=None)
+
+
+class VariantUpdate(BaseModel):
+    """Patch to an existing variant."""
+
+    id: int = Field(..., description="Variant ID")
+    sku: str | None = Field(default=None)
+    sales_price: float | None = Field(default=None)
+    purchase_price: float | None = Field(default=None)
+    supplier_item_codes: list[str] | None = Field(default=None)
+    internal_barcode: str | None = Field(default=None)
+    registered_barcode: str | None = Field(default=None)
+    lead_time: int | None = Field(default=None)
+    minimum_order_quantity: float | None = Field(default=None)
+
+
+class ModifyItemRequest(ConfirmableRequest):
+    """Unified modification request for an item (product / material / service).
+
+    The ``type`` discriminator routes header updates to the matching
+    ``products`` / ``materials`` / ``services`` endpoint family. Variant
+    sub-payloads route to the shared ``/variant`` family — but only for
+    PRODUCT and MATERIAL (services don't expose variant CRUD via that
+    endpoint; their pricing lives on the header itself).
+
+    To remove an item entirely, use ``delete_item``.
+    """
+
+    id: int = Field(..., description="Item ID (parent product / material / service)")
+    type: ItemType = Field(..., description="Item type — drives endpoint routing")
+    update_header: ItemHeaderPatch | None = Field(default=None)
+    add_variants: list[VariantAdd] | None = Field(default=None)
+    update_variants: list[VariantUpdate] | None = Field(default=None)
+    delete_variant_ids: list[int] | None = Field(default=None)
+
+
+class DeleteItemRequest(ConfirmableRequest):
+    """Delete an item. Destructive — Katana cascades child variants."""
+
+    id: int = Field(..., description="Item ID to delete")
+    type: ItemType = Field(..., description="Item type — drives endpoint routing")
+
+
+def _validate_header_for_type(patch: ItemHeaderPatch, item_type: ItemType) -> None:
+    """Reject obviously-misrouted header fields before they reach the API.
+
+    The API will return a 422 for an invalid field anyway, but a ValueError
+    raised in the impl gives the caller a clearer message ("X is not valid
+    for SERVICE") and keeps the dispatcher's fail-fast log cleaner.
+    """
+    set_fields = {k for k, v in patch.model_dump().items() if v is not None}
+    invalid: list[tuple[str, str]] = []
+    if item_type == ItemType.SERVICE:
+        for field in _PRODUCT_ONLY_FIELDS + _PRODUCT_AND_MATERIAL_FIELDS:
+            if field in set_fields:
+                invalid.append((field, "PRODUCT/MATERIAL only"))
+    elif item_type == ItemType.MATERIAL:
+        for field in _PRODUCT_ONLY_FIELDS + _SERVICE_ONLY_FIELDS:
+            if field in set_fields:
+                invalid.append(
+                    (
+                        field,
+                        "PRODUCT-only"
+                        if field in _PRODUCT_ONLY_FIELDS
+                        else "SERVICE-only",
+                    )
+                )
+    elif item_type == ItemType.PRODUCT:
+        for field in _SERVICE_ONLY_FIELDS:
+            if field in set_fields:
+                invalid.append((field, "SERVICE-only"))
+
+    if invalid:
+        details = ", ".join(f"{f} ({reason})" for f, reason in invalid)
+        raise ValueError(
+            f"Header field(s) not valid for type={item_type.value}: {details}"
         )
 
 
-class UpdateItemResponse(BaseModel):
-    """Response from updating an item."""
+def _build_update_header_request(patch: ItemHeaderPatch, item_type: ItemType) -> Any:
+    """Map an ItemHeaderPatch to the right Update*Request attrs class.
 
-    id: int
-    name: str
-    type: ItemType
-    success: bool = True
-    message: str = "Item updated successfully"
-    katana_url: str | None = None
+    Each type has a different field set; ``unset_dict`` filters down to
+    the actual fields the API accepts after we've validated routing.
+    """
+    request_cls = _TYPE_ENDPOINTS[item_type]["update_request"]
+    # Compute the type-specific allowed field set by excluding fields that
+    # don't apply.
+    if item_type == ItemType.PRODUCT:
+        exclude = _SERVICE_ONLY_FIELDS
+    elif item_type == ItemType.MATERIAL:
+        exclude = _PRODUCT_ONLY_FIELDS + _SERVICE_ONLY_FIELDS
+    else:  # SERVICE
+        exclude = _PRODUCT_ONLY_FIELDS + _PRODUCT_AND_MATERIAL_FIELDS
+    return request_cls(**unset_dict(patch, exclude=exclude))
 
 
-async def _update_item_impl(
-    request: UpdateItemRequest, context: Context
-) -> UpdateItemResponse:
-    """Update an item's properties."""
-    from katana_public_api_client.models import (
-        UpdateMaterialRequest,
-        UpdateProductRequest,
-        UpdateServiceRequest,
+def _build_create_variant_request(
+    parent_id: int, item_type: ItemType, variant: VariantAdd
+) -> APICreateVariantRequest:
+    """Build a CreateVariantRequest with parent_id wired into the right slot.
+
+    The Katana ``/variant`` POST takes ``product_id`` *or* ``material_id``
+    on the request body to identify the parent. ``modify_item`` infers
+    that from the item ``type`` so the caller doesn't have to.
+    """
+    extra: dict[str, Any] = {}
+    if item_type == ItemType.PRODUCT:
+        extra["product_id"] = parent_id
+    elif item_type == ItemType.MATERIAL:
+        extra["material_id"] = parent_id
+    return APICreateVariantRequest(**unset_dict(variant), **extra)
+
+
+def _build_update_variant_request(patch: VariantUpdate) -> APIUpdateVariantRequest:
+    return APIUpdateVariantRequest(**unset_dict(patch, exclude=("id",)))
+
+
+async def _fetch_item_for_diff(services: Any, item_id: int, item_type: ItemType) -> Any:
+    """Best-effort fetch of the parent item for diff context."""
+    cfg = _TYPE_ENDPOINTS[item_type]
+    return await safe_fetch_for_diff(
+        cfg["get"],
+        services,
+        item_id,
+        return_type=cfg["return_type"],
+        label=cfg["label"],
     )
 
+
+async def _fetch_variant_for_diff(services: Any, variant_id: int) -> Variant | None:
+    return await safe_fetch_for_diff(
+        api_get_variant,
+        services,
+        variant_id,
+        return_type=Variant,
+        label="variant",
+    )
+
+
+async def _modify_item_impl(
+    request: ModifyItemRequest, context: Context
+) -> ModificationResponse:
+    """Build the action plan for an item modify and either preview or execute.
+
+    Type discriminator routes header endpoints; variant sub-payloads route
+    to the shared ``/variant`` family. SERVICE rejects variant CRUD up
+    front (Katana doesn't expose ``/variant`` POST/PATCH/DELETE for
+    services).
+    """
     services = get_services(context)
-    helper = _get_type_helper(services.client, request.type)
 
-    # Build type-specific update request (each type has different fields)
-    common = {
-        "name": to_unset(request.name),
-        "uom": to_unset(request.uom),
-        "category_name": to_unset(request.category_name),
-        "is_sellable": to_unset(request.is_sellable),
-    }
-
-    if request.type == ItemType.PRODUCT:
-        update_data = UpdateProductRequest(
-            **common,
-            is_producible=to_unset(request.is_producible),
-            is_purchasable=to_unset(request.is_purchasable),
-            default_supplier_id=to_unset(request.default_supplier_id),
-            additional_info=to_unset(request.additional_info),
+    if not has_any_subpayload(request, exclude=("id", "type", "confirm")):
+        raise ValueError(
+            "At least one sub-payload must be set: update_header, "
+            "add_variants, update_variants, or delete_variant_ids. "
+            "To remove the item entirely, use delete_item."
         )
-    elif request.type == ItemType.MATERIAL:
-        update_data = UpdateMaterialRequest(
-            **common,
-            default_supplier_id=to_unset(request.default_supplier_id),
-            additional_info=to_unset(request.additional_info),
+
+    if request.type == ItemType.SERVICE and (
+        request.add_variants or request.update_variants or request.delete_variant_ids
+    ):
+        raise ValueError(
+            "Variant CRUD is not supported for SERVICE items — services "
+            "carry pricing on the header itself (sales_price, default_cost, sku)."
         )
-    else:
-        update_data = UpdateServiceRequest(**common)
 
-    # Check if any item-level fields are set
-    has_item_fields = any(
-        v is not None
-        for v in [
-            request.name,
-            request.uom,
-            request.category_name,
-            request.is_sellable,
-            request.is_producible,
-            request.is_purchasable,
-            request.default_supplier_id,
-            request.additional_info,
-        ]
-    )
+    if request.update_header is not None:
+        _validate_header_for_type(request.update_header, request.type)
 
-    item_name = ""
-    if has_item_fields:
-        result = await helper.update(request.id, update_data)
-        item_name = result.name or ""
+    cfg = _TYPE_ENDPOINTS[request.type]
+    existing_item = await _fetch_item_for_diff(services, request.id, request.type)
 
-    # Update variant-level fields if any are provided
-    if request.has_variant_fields:
-        from katana_public_api_client.api.variant import update_variant
-        from katana_public_api_client.models.update_variant_request import (
-            UpdateVariantRequest,
+    plan: list[ActionSpec] = []
+
+    if request.update_header is not None:
+        diff = compute_field_diff(
+            existing_item, request.update_header, unknown_prior=existing_item is None
         )
-        from katana_public_api_client.utils import unwrap
-
-        # Variant-level fields require SKU to identify which variant to update.
-        # request.id is the parent item ID, not a variant ID.
-        if not request.sku:
-            raise ValueError(
-                "Variant-level updates (barcodes, supplier codes, prices) "
-                "require 'sku' to identify the variant."
+        plan.append(
+            ActionSpec(
+                operation=ItemOperation.UPDATE_HEADER,
+                target_id=request.id,
+                diff=diff,
+                apply=make_patch_apply(
+                    cfg["update"],
+                    services,
+                    request.id,
+                    _build_update_header_request(request.update_header, request.type),
+                    return_type=cfg["return_type"],
+                ),
+                verify=make_response_verifier(diff),
             )
-        variant = await services.cache.get_by_sku(sku=request.sku)
-        if not variant:
-            raise ValueError(f"SKU '{request.sku}' not found")
-        variant_id = variant["id"]
-
-        variant_update = UpdateVariantRequest(
-            supplier_item_codes=to_unset(request.supplier_item_codes),
-            registered_barcode=to_unset(request.registered_barcode),
-            internal_barcode=to_unset(request.internal_barcode),
-            sales_price=to_unset(request.sales_price),
-            purchase_price=to_unset(request.purchase_price),
-            lead_time=to_unset(request.lead_time),
         )
 
-        resp = await update_variant.asyncio_detailed(
-            id=variant_id, client=services.client, body=variant_update
+    plan.extend(
+        plan_creates(
+            request.add_variants,
+            ItemOperation.ADD_VARIANT,
+            lambda variant: _build_create_variant_request(
+                request.id, request.type, variant
+            ),
+            lambda body: make_post_apply(
+                api_create_variant, services, body, return_type=Variant
+            ),
         )
-        variant_result = unwrap(resp)
-        if not item_name and variant_result:
-            item_name = getattr(variant_result, "sku", "") or ""
-
-    # Invalidate only the affected type + variants
-    cache = getattr(services, "cache", None)
-    if cache:
-        await cache.mark_dirty(request.type.value)
-        await cache.mark_dirty(EntityType.VARIANT)
-
-    return UpdateItemResponse(
-        id=request.id,
-        name=item_name or "Unknown",
-        type=request.type,
-        message=f"{request.type.value.title()} (ID {request.id}) updated successfully",
-        katana_url=_item_katana_url(request.type, request.id),
     )
+    plan.extend(
+        await plan_updates(
+            request.update_variants,
+            ItemOperation.UPDATE_VARIANT,
+            lambda vid: _fetch_variant_for_diff(services, vid),
+            _build_update_variant_request,
+            lambda vid, body: make_patch_apply(
+                api_update_variant, services, vid, body, return_type=Variant
+            ),
+        )
+    )
+    plan.extend(
+        plan_deletes(
+            request.delete_variant_ids,
+            ItemOperation.DELETE_VARIANT,
+            lambda vid: make_delete_apply(api_delete_variant, services, vid),
+        )
+    )
+
+    response = await run_modify_plan(
+        request=request,
+        entity_type=request.type.value,
+        entity_label=f"{cfg['label']} {request.id}",
+        tool_name="modify_item",
+        web_url_kind=cfg["web_url_kind"] or "product",  # fallback for SERVICE
+        existing=existing_item,
+        plan=plan,
+    )
+    # Services have no Katana web page; clear the URL the dispatcher synthesized
+    # via the fallback above so callers don't see a broken link.
+    if request.type == ItemType.SERVICE:
+        response.katana_url = None
+
+    # Cache invalidation — the typed cache stores variants and per-type
+    # entities separately. After a confirmed modify, mark both dirty so the
+    # next read sees fresh data.
+    if request.confirm:
+        cache = getattr(services, "cache", None)
+        if cache:
+            await cache.mark_dirty(request.type.value)
+            await cache.mark_dirty(EntityType.VARIANT)
+
+    return response
 
 
 @observe_tool
 @unpack_pydantic_params
-async def update_item(
-    request: Annotated[UpdateItemRequest, Unpack()], context: Context
+async def modify_item(
+    request: Annotated[ModifyItemRequest, Unpack()], context: Context
 ) -> ToolResult:
-    """Update an existing item's properties (product, material, or service).
+    """Modify an item — unified surface across header + variant CRUD.
 
-    Only provided fields are updated; omitted fields remain unchanged.
-    Requires the item ID and type. Use search_items first if you need to find the item.
+    The required ``type`` discriminator (PRODUCT / MATERIAL / SERVICE)
+    routes header updates to the matching API endpoint family. Variant
+    sub-payloads (``add_variants`` / ``update_variants`` /
+    ``delete_variant_ids``) route to the shared ``/variant`` family —
+    available for PRODUCT and MATERIAL only; services carry pricing on
+    the header itself (``sales_price``, ``default_cost``, ``sku``).
+
+    Sub-payloads (any subset, all optional):
+
+    - ``update_header`` — patch header fields. Field set is type-specific:
+      ``is_producible`` etc. are PRODUCT-only, ``default_supplier_id``
+      etc. are PRODUCT/MATERIAL, ``sales_price`` etc. are SERVICE-only.
+      Misrouted fields fail fast with a clear error.
+    - ``add_variants`` — POST /variant. Parent ``product_id`` /
+      ``material_id`` is injected from the request's ``type``.
+    - ``update_variants`` — PATCH /variant/{id}.
+    - ``delete_variant_ids`` — DELETE /variant/{id}.
+
+    To remove an item entirely, use the sibling ``delete_item`` tool.
+
+    Two-step flow: ``confirm=false`` returns a per-action preview;
+    ``confirm=true`` executes the plan in canonical order. Fail-fast on
+    error.
     """
-    from katana_mcp.tools.prefab_ui import build_item_mutation_ui
-
-    response = await _update_item_impl(request, context)
-    ui = build_item_mutation_ui(response.model_dump(), "Updated")
-
-    return make_tool_result(response, ui=ui)
+    response = await _modify_item_impl(request, context)
+    return to_tool_result(response)
 
 
 # ============================================================================
-# Tool 5: delete_item
+# Tool: delete_item
 # ============================================================================
-
-
-class DeleteItemRequest(BaseModel):
-    """Request to delete an item."""
-
-    id: int = Field(..., description="Item ID")
-    type: ItemType = Field(..., description="Type of item")
-    confirm: bool = Field(
-        False, description="If false, returns preview. If true, deletes item."
-    )
-
-
-class DeleteItemResponse(BaseModel):
-    """Response from deleting an item."""
-
-    id: int
-    type: ItemType
-    name: str | None = None
-    is_preview: bool = False
-    success: bool = True
-    message: str = "Item deleted successfully"
 
 
 async def _delete_item_impl(
     request: DeleteItemRequest, context: Context
-) -> DeleteItemResponse:
-    """Delete an item with two-step confirmation (preview/execute)."""
+) -> ModificationResponse:
+    """One-action plan that removes the item. Katana cascades child variants."""
+    cfg = _TYPE_ENDPOINTS[request.type]
     services = get_services(context)
-    helper = _get_type_helper(services.client, request.type)
 
-    # Fetch item name for preview/confirmation message
-    item_name = f"{request.type.value} ID {request.id}"
-    try:
-        item = await helper.get(request.id)
-        item_name = f"{request.type.value} '{item.name}' (ID {request.id})"
-    except Exception:
-        pass  # Use default name if fetch fails
-
-    # Preview mode
-    if not request.confirm:
-        return DeleteItemResponse(
-            id=request.id,
-            type=request.type,
-            is_preview=True,
-            message=f"Preview: Would permanently delete {item_name}. Set confirm=true to proceed.",
-        )
-
-    await helper.delete(request.id)
-
-    # Invalidate only the affected type + variants
-    cache = getattr(services, "cache", None)
-    if cache:
-        await cache.mark_dirty(request.type.value)
-        await cache.mark_dirty(EntityType.VARIANT)
-
-    return DeleteItemResponse(
-        id=request.id,
-        type=request.type,
-        message=f"{request.type.value.title()} ID {request.id} deleted successfully",
+    response = await run_delete_plan(
+        request=request,
+        services=services,
+        entity_type=request.type.value,
+        entity_label=f"{cfg['label']} {request.id}",
+        web_url_kind=cfg["web_url_kind"] or "product",
+        fetcher=lambda svc, eid: _fetch_item_for_diff(svc, eid, request.type),
+        delete_endpoint=cfg["delete"],
+        operation=ItemOperation.DELETE,
     )
+    if request.type == ItemType.SERVICE:
+        response.katana_url = None
+
+    if request.confirm:
+        cache = getattr(services, "cache", None)
+        if cache:
+            await cache.mark_dirty(request.type.value)
+            await cache.mark_dirty(EntityType.VARIANT)
+
+    return response
 
 
 @observe_tool
@@ -888,16 +1116,13 @@ async def delete_item(
 ) -> ToolResult:
     """Permanently delete an item (product, material, or service) from Katana.
 
-    This is a destructive operation. Set confirm=false to preview what would be
-    deleted, or confirm=true to execute (will prompt for confirmation).
-    Requires the item ID and type.
+    The required ``type`` discriminator routes the delete to the matching
+    endpoint family. Destructive — Katana cascades the delete to child
+    variants server-side. The response carries a ``prior_state`` snapshot
+    for manual revert.
     """
-    from katana_mcp.tools.prefab_ui import build_item_mutation_ui
-
     response = await _delete_item_impl(request, context)
-    ui = build_item_mutation_ui(response.model_dump(), "Deleted")
-
-    return make_tool_result(response, ui=ui)
+    return to_tool_result(response)
 
 
 # ============================================================================
@@ -1222,11 +1447,10 @@ def register_tools(mcp: FastMCP) -> None:
     mcp.tool(tags={"catalog", "read"}, annotations=_read, meta=UI_META)(search_items)
     mcp.tool(tags={"catalog", "write"}, annotations=_write, meta=UI_META)(create_item)
     mcp.tool(tags={"catalog", "read"}, annotations=_read, meta=UI_META)(get_item)
-    mcp.tool(tags={"catalog", "write"}, annotations=_update, meta=UI_META)(update_item)
+    mcp.tool(tags={"catalog", "write"}, annotations=_update)(modify_item)
     mcp.tool(
         tags={"catalog", "write", "destructive"},
         annotations=_destructive,
-        meta=UI_META,
     )(delete_item)
     mcp.tool(tags={"catalog", "read"}, annotations=_read, meta=UI_META)(
         get_variant_details

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -928,6 +928,20 @@ async def _fetch_variant_for_diff(services: Any, variant_id: int) -> Variant | N
     )
 
 
+async def _invalidate_item_cache(services: Any, item_type: ItemType) -> None:
+    """Mark the per-type entity row and the variants table dirty.
+
+    The typed cache stores variants and per-type entities (products /
+    materials / services) separately. After a confirmed modify or delete
+    we invalidate both so the next read sees fresh data. Other modify_*
+    tools don't need this because their entity types aren't cache-backed.
+    """
+    cache = getattr(services, "cache", None)
+    if cache:
+        await cache.mark_dirty(item_type.value)
+        await cache.mark_dirty(EntityType.VARIANT)
+
+
 async def _modify_item_impl(
     request: ModifyItemRequest, context: Context
 ) -> ModificationResponse:
@@ -940,6 +954,9 @@ async def _modify_item_impl(
     """
     services = get_services(context)
 
+    # ``type`` is a routing discriminator, not a sub-payload — exclude it from
+    # the "is anything set?" check so a request with only ``type`` set is
+    # still rejected.
     if not has_any_subpayload(request, exclude=("id", "type", "confirm")):
         raise ValueError(
             "At least one sub-payload must be set: update_header, "
@@ -1019,23 +1036,13 @@ async def _modify_item_impl(
         entity_type=request.type.value,
         entity_label=f"{cfg['label']} {request.id}",
         tool_name="modify_item",
-        web_url_kind=cfg["web_url_kind"] or "product",  # fallback for SERVICE
+        web_url_kind=cfg["web_url_kind"],
         existing=existing_item,
         plan=plan,
     )
-    # Services have no Katana web page; clear the URL the dispatcher synthesized
-    # via the fallback above so callers don't see a broken link.
-    if request.type == ItemType.SERVICE:
-        response.katana_url = None
 
-    # Cache invalidation — the typed cache stores variants and per-type
-    # entities separately. After a confirmed modify, mark both dirty so the
-    # next read sees fresh data.
     if request.confirm:
-        cache = getattr(services, "cache", None)
-        if cache:
-            await cache.mark_dirty(request.type.value)
-            await cache.mark_dirty(EntityType.VARIANT)
+        await _invalidate_item_cache(services, request.type)
 
     return response
 
@@ -1092,19 +1099,14 @@ async def _delete_item_impl(
         services=services,
         entity_type=request.type.value,
         entity_label=f"{cfg['label']} {request.id}",
-        web_url_kind=cfg["web_url_kind"] or "product",
+        web_url_kind=cfg["web_url_kind"],
         fetcher=lambda svc, eid: _fetch_item_for_diff(svc, eid, request.type),
         delete_endpoint=cfg["delete"],
         operation=ItemOperation.DELETE,
     )
-    if request.type == ItemType.SERVICE:
-        response.katana_url = None
 
     if request.confirm:
-        cache = getattr(services, "cache", None)
-        if cache:
-            await cache.mark_dirty(request.type.value)
-            await cache.mark_dirty(EntityType.VARIANT)
+        await _invalidate_item_cache(services, request.type)
 
     return response
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -44,6 +44,7 @@ from katana_mcp.tools._modification_dispatch import (
     run_delete_plan,
     run_modify_plan,
     safe_fetch_for_diff,
+    unset_dict,
 )
 from katana_mcp.tools.list_coercion import (
     CoercedIntListOpt,
@@ -2382,9 +2383,11 @@ ManufacturingOrderStatusLiteral = Literal[
     "NOT_STARTED", "IN_PROGRESS", "DONE", "BLOCKED", "PARTIALLY_COMPLETED"
 ]
 ManufacturingOperationStatusLiteral = Literal[
-    "NOT_STARTED", "IN_PROGRESS", "BLOCKED", "COMPLETED"
+    "NOT_STARTED", "IN_PROGRESS", "PAUSED", "BLOCKED", "COMPLETED"
 ]
-ManufacturingOperationTypeLiteral = Literal["LINKED", "STANDARD"]
+# Operation row type mirrors Katana's API enum exactly: ``fixed``,
+# ``perUnit``, ``process``, ``setup`` (lowercase + camelCase mix).
+ManufacturingOperationTypeLiteral = Literal["fixed", "perUnit", "process", "setup"]
 
 
 # ----------------------------------------------------------------------------
@@ -2583,86 +2586,52 @@ class DeleteManufacturingOrderRequest(ConfirmableRequest):
 def _build_update_header_request(
     patch: MOHeaderPatch,
 ) -> APIUpdateManufacturingOrderRequest:
-    api_status = (
-        ManufacturingOrderStatus(patch.status) if patch.status is not None else None
-    )
     return APIUpdateManufacturingOrderRequest(
-        order_no=to_unset(patch.order_no),
-        variant_id=to_unset(patch.variant_id),
-        location_id=to_unset(patch.location_id),
-        status=to_unset(api_status),
-        planned_quantity=to_unset(patch.planned_quantity),
-        actual_quantity=to_unset(patch.actual_quantity),
-        order_created_date=to_unset(patch.order_created_date),
-        production_deadline_date=to_unset(patch.production_deadline_date),
-        done_date=to_unset(patch.done_date),
-        additional_info=to_unset(patch.additional_info),
+        **unset_dict(patch, transforms={"status": ManufacturingOrderStatus})
     )
 
 
 def _build_create_recipe_row_request(
     mo_id: int, row: MORecipeRowAdd
 ) -> APICreateMORecipeRowRequest:
-    return APICreateMORecipeRowRequest(
-        manufacturing_order_id=mo_id,
-        variant_id=row.variant_id,
-        planned_quantity_per_unit=row.planned_quantity_per_unit,
-        notes=to_unset(row.notes),
-        total_actual_quantity=to_unset(row.total_actual_quantity),
-    )
+    return APICreateMORecipeRowRequest(manufacturing_order_id=mo_id, **unset_dict(row))
 
 
 def _build_update_recipe_row_request(
     patch: MORecipeRowUpdate,
 ) -> APIUpdateMORecipeRowRequest:
-    return APIUpdateMORecipeRowRequest(
-        variant_id=to_unset(patch.variant_id),
-        notes=to_unset(patch.notes),
-        planned_quantity_per_unit=to_unset(patch.planned_quantity_per_unit),
-        total_actual_quantity=to_unset(patch.total_actual_quantity),
-    )
+    return APIUpdateMORecipeRowRequest(**unset_dict(patch, exclude=("id",)))
 
 
 def _build_create_operation_row_request(
     mo_id: int, row: MOOperationRowAdd
 ) -> APICreateMOOperationRowRequest:
-    api_type = ManufacturingOperationType(row.type) if row.type is not None else None
     return APICreateMOOperationRowRequest(
         manufacturing_order_id=mo_id,
-        status=ManufacturingOperationStatus(row.status),
-        operation_id=to_unset(row.operation_id),
-        type_=to_unset(api_type),
-        operation_name=to_unset(row.operation_name),
-        resource_id=to_unset(row.resource_id),
-        resource_name=to_unset(row.resource_name),
-        planned_time_parameter=to_unset(row.planned_time_parameter),
-        planned_time_per_unit=to_unset(row.planned_time_per_unit),
-        cost_parameter=to_unset(row.cost_parameter),
-        cost_per_hour=to_unset(row.cost_per_hour),
+        **unset_dict(
+            row,
+            field_map={"type": "type_"},
+            transforms={
+                "status": ManufacturingOperationStatus,
+                "type": ManufacturingOperationType,
+            },
+        ),
     )
 
 
 def _build_update_operation_row_request(
     patch: MOOperationRowUpdate,
 ) -> APIUpdateMOOperationRowRequest:
-    api_status = (
-        ManufacturingOperationStatus(patch.status) if patch.status is not None else None
-    )
-    api_type = (
-        ManufacturingOperationType(patch.type) if patch.type is not None else None
-    )
     return APIUpdateMOOperationRowRequest(
-        operation_id=to_unset(patch.operation_id),
-        type_=to_unset(api_type),
-        operation_name=to_unset(patch.operation_name),
-        resource_id=to_unset(patch.resource_id),
-        resource_name=to_unset(patch.resource_name),
-        planned_time_parameter=to_unset(patch.planned_time_parameter),
-        planned_time_per_unit=to_unset(patch.planned_time_per_unit),
-        total_actual_time=to_unset(patch.total_actual_time),
-        cost_parameter=to_unset(patch.cost_parameter),
-        cost_per_hour=to_unset(patch.cost_per_hour),
-        status=to_unset(api_status),
+        **unset_dict(
+            patch,
+            exclude=("id",),
+            field_map={"type": "type_"},
+            transforms={
+                "status": ManufacturingOperationStatus,
+                "type": ManufacturingOperationType,
+            },
+        )
     )
 
 
@@ -2670,20 +2639,14 @@ def _build_create_production_request(
     mo_id: int, prod: MOProductionAdd
 ) -> APICreateMOProductionRequest:
     return APICreateMOProductionRequest(
-        manufacturing_order_id=mo_id,
-        completed_quantity=prod.completed_quantity,
-        completed_date=to_unset(prod.completed_date),
-        is_final=to_unset(prod.is_final),
-        serial_numbers=to_unset(prod.serial_numbers),
+        manufacturing_order_id=mo_id, **unset_dict(prod)
     )
 
 
 def _build_update_production_request(
     patch: MOProductionUpdate,
 ) -> APIUpdateMOProductionRequest:
-    return APIUpdateMOProductionRequest(
-        production_date=to_unset(patch.production_date),
-    )
+    return APIUpdateMOProductionRequest(**unset_dict(patch, exclude=("id",)))
 
 
 # ----------------------------------------------------------------------------

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -1,9 +1,13 @@
 """Manufacturing order management tools for Katana MCP Server.
 
-Foundation tools for creating manufacturing orders to initiate production.
-
-These tools provide:
-- create_manufacturing_order: Create manufacturing orders with preview/confirm pattern
+Tools:
+- create_manufacturing_order / get_manufacturing_order /
+  list_manufacturing_orders / list_blocking_ingredients /
+  get_manufacturing_order_recipe — read-mostly + create.
+- modify_manufacturing_order: header + recipe rows + operation rows +
+  production records via typed sub-payload slots.
+- delete_manufacturing_order: destructive sibling of
+  modify_manufacturing_order.
 """
 
 from __future__ import annotations
@@ -21,8 +25,30 @@ from pydantic import BaseModel, Field
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
+from katana_mcp.tools._modification import (
+    ConfirmableRequest,
+    ModificationResponse,
+    compute_field_diff,
+    make_response_verifier,
+    to_tool_result,
+)
+from katana_mcp.tools._modification_dispatch import (
+    ActionSpec,
+    execute_plan,
+    has_any_subpayload,
+    make_delete_apply,
+    make_patch_apply,
+    make_post_apply,
+    plan_creates,
+    plan_deletes,
+    plan_to_preview_results,
+    plan_updates,
+    safe_fetch_for_diff,
+    serialize_for_prior_state,
+    summarize_delete_outcome,
+    summarize_modify_outcome,
+)
 from katana_mcp.tools.list_coercion import (
-    CoercedIntList,
     CoercedIntListOpt,
     CoercedStrListOpt,
 )
@@ -42,11 +68,50 @@ from katana_mcp.tools.tool_result_utils import (
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
+
+# Modify/delete API endpoints used by ``modify_manufacturing_order`` /
+# ``delete_manufacturing_order``. Hoisted to module scope.
+from katana_public_api_client.api.manufacturing_order import (
+    delete_manufacturing_order as api_delete_manufacturing_order,
+    get_manufacturing_order as api_get_manufacturing_order,
+    update_manufacturing_order as api_update_manufacturing_order,
+)
+from katana_public_api_client.api.manufacturing_order_operation import (
+    create_manufacturing_order_operation_row as api_create_mo_operation_row,
+    delete_manufacturing_order_operation_row as api_delete_mo_operation_row,
+    get_manufacturing_order_operation_row as api_get_mo_operation_row,
+    update_manufacturing_order_operation_row as api_update_mo_operation_row,
+)
+from katana_public_api_client.api.manufacturing_order_production import (
+    create_manufacturing_order_production as api_create_mo_production,
+    delete_manufacturing_order_production as api_delete_mo_production,
+    get_manufacturing_order_production as api_get_mo_production,
+    update_manufacturing_order_production as api_update_mo_production,
+)
+from katana_public_api_client.api.manufacturing_order_recipe import (
+    create_manufacturing_order_recipe_rows as api_create_mo_recipe_row,
+    delete_manufacturing_order_recipe_row as api_delete_mo_recipe_row,
+    get_manufacturing_order_recipe_row as api_get_mo_recipe_row,
+    update_manufacturing_order_recipe_rows as api_update_mo_recipe_row,
+)
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
+    CreateManufacturingOrderOperationRowRequest as APICreateMOOperationRowRequest,
+    CreateManufacturingOrderProductionRequest as APICreateMOProductionRequest,
+    CreateManufacturingOrderRecipeRowRequest as APICreateMORecipeRowRequest,
     CreateManufacturingOrderRequest as APICreateManufacturingOrderRequest,
     GetAllManufacturingOrdersStatus,
+    ManufacturingOperationStatus,
+    ManufacturingOperationType,
     ManufacturingOrder,
+    ManufacturingOrderOperationRow,
+    ManufacturingOrderProduction,
+    ManufacturingOrderRecipeRow,
+    ManufacturingOrderStatus,
+    UpdateManufacturingOrderOperationRowRequest as APIUpdateMOOperationRowRequest,
+    UpdateManufacturingOrderProductionRequest as APIUpdateMOProductionRequest,
+    UpdateManufacturingOrderRecipeRowRequest as APIUpdateMORecipeRowRequest,
+    UpdateManufacturingOrderRequest as APIUpdateManufacturingOrderRequest,
 )
 from katana_public_api_client.models_pydantic._generated import (
     OutsourcedPurchaseOrderIngredientAvailability,
@@ -1484,729 +1549,6 @@ async def get_manufacturing_order_recipe(
 
 
 # ============================================================================
-# Tool 4: add_manufacturing_order_recipe_row
-# ============================================================================
-
-
-class AddRecipeRowRequest(BaseModel):
-    """Request to add an ingredient row to a manufacturing order."""
-
-    manufacturing_order_id: int = Field(..., description="Manufacturing order ID")
-    sku: str | None = Field(
-        default=None,
-        description="SKU of the variant to add (resolved via cache). Use this OR variant_id.",
-    )
-    variant_id: int | None = Field(
-        default=None,
-        description="Variant ID to add directly. Use when the SKU isn't in the cache.",
-    )
-    planned_quantity_per_unit: float = Field(
-        ..., description="Planned quantity needed per manufactured unit", gt=0
-    )
-    notes: str | None = Field(default=None, description="Optional notes")
-    confirm: bool = Field(
-        default=False,
-        description="Set false to preview, true to add",
-    )
-
-
-class AddRecipeRowResponse(BaseModel):
-    """Response from adding a recipe row."""
-
-    id: int | None
-    manufacturing_order_id: int
-    variant_id: int
-    sku: str | None
-    planned_quantity_per_unit: float
-    is_preview: bool
-    message: str
-
-
-# ----- Low-level API helpers (shared by single-row and batch tools) -----
-
-
-async def _api_create_recipe_row(
-    services: Any,
-    *,
-    manufacturing_order_id: int,
-    variant_id: int,
-    planned_quantity_per_unit: float,
-    notes: str | None,
-) -> Any:
-    """Raw API call to create a recipe row. Raises ValueError on API failure."""
-    from katana_public_api_client.api.manufacturing_order_recipe import (
-        create_manufacturing_order_recipe_rows,
-    )
-    from katana_public_api_client.models.create_manufacturing_order_recipe_row_request import (
-        CreateManufacturingOrderRecipeRowRequest,
-    )
-    from katana_public_api_client.utils import APIError, unwrap
-
-    api_request = CreateManufacturingOrderRecipeRowRequest(
-        manufacturing_order_id=manufacturing_order_id,
-        variant_id=variant_id,
-        planned_quantity_per_unit=planned_quantity_per_unit,
-        notes=to_unset(notes),
-    )
-
-    response = await create_manufacturing_order_recipe_rows.asyncio_detailed(
-        client=services.client, body=api_request
-    )
-    try:
-        return unwrap(response)
-    except APIError as e:
-        raise ValueError(str(e)) from e
-
-
-async def _api_delete_recipe_row(services: Any, recipe_row_id: int) -> None:
-    """Raw API call to delete a recipe row. Raises ValueError on API failure."""
-    from katana_public_api_client.api.manufacturing_order_recipe import (
-        delete_manufacturing_order_recipe_row as api_delete,
-    )
-    from katana_public_api_client.utils import APIError, is_success, unwrap
-
-    response = await api_delete.asyncio_detailed(
-        client=services.client, id=recipe_row_id
-    )
-    if is_success(response):
-        return
-    try:
-        unwrap(response)
-    except APIError as e:
-        raise ValueError(str(e)) from e
-    raise ValueError(f"Failed to delete recipe row {recipe_row_id}")
-
-
-async def _resolve_variant_ref(
-    services: Any, *, sku: str | None, variant_id: int | None
-) -> tuple[int, str | None, str]:
-    """Resolve ``(sku, variant_id)`` inputs to ``(variant_id, sku, display_name)``.
-
-    At least one of ``sku`` or ``variant_id`` must be provided. If both are
-    provided, ``variant_id`` takes precedence and ``sku`` is returned as given
-    without re-validating that it matches the variant. Raises ``ValueError``
-    if neither is provided or if a provided SKU is not found in the cache.
-    """
-    if variant_id is not None:
-        return variant_id, sku, sku or f"variant {variant_id}"
-    if not sku:
-        raise ValueError("At least one of sku or variant_id must be provided")
-    variant = await services.cache.get_by_sku(sku=sku)
-    if not variant:
-        raise ValueError(f"SKU '{sku}' not found")
-    return variant["id"], sku, variant.get("display_name") or sku
-
-
-async def _add_recipe_row_impl(
-    request: AddRecipeRowRequest, context: Context
-) -> AddRecipeRowResponse:
-    """Add a new ingredient row to a manufacturing order."""
-    if not request.sku and not request.variant_id:
-        raise ValueError("Either sku or variant_id must be provided")
-
-    services = get_services(context)
-    variant_id, sku, display_name = await _resolve_variant_ref(
-        services, sku=request.sku, variant_id=request.variant_id
-    )
-
-    if not request.confirm:
-        return AddRecipeRowResponse(
-            id=None,
-            manufacturing_order_id=request.manufacturing_order_id,
-            variant_id=variant_id,
-            sku=sku,
-            planned_quantity_per_unit=request.planned_quantity_per_unit,
-            is_preview=True,
-            message=(
-                f"Preview: Would add {request.planned_quantity_per_unit}x "
-                f"{display_name} to MO {request.manufacturing_order_id}"
-            ),
-        )
-
-    result = await _api_create_recipe_row(
-        services,
-        manufacturing_order_id=request.manufacturing_order_id,
-        variant_id=variant_id,
-        planned_quantity_per_unit=request.planned_quantity_per_unit,
-        notes=request.notes,
-    )
-    new_id = getattr(result, "id", None) if result else None
-    return AddRecipeRowResponse(
-        id=new_id,
-        manufacturing_order_id=request.manufacturing_order_id,
-        variant_id=variant_id,
-        sku=sku,
-        planned_quantity_per_unit=request.planned_quantity_per_unit,
-        is_preview=False,
-        message=f"Added recipe row (ID {new_id}) to MO {request.manufacturing_order_id}",
-    )
-
-
-@observe_tool
-@unpack_pydantic_params
-async def add_manufacturing_order_recipe_row(
-    request: Annotated[AddRecipeRowRequest, Unpack()], context: Context
-) -> ToolResult:
-    """Add a new ingredient row to a manufacturing order's recipe.
-
-    Two-step flow: confirm=false to preview, confirm=true to add (prompts
-    for confirmation). Provide either `sku` (resolved to variant_id via the
-    cache) or `variant_id` directly.
-
-    Use this to add missing ingredients to an MO or build up a custom recipe.
-    To remove an ingredient, use delete_manufacturing_order_recipe_row.
-    """
-    from katana_mcp.tools.tool_result_utils import make_simple_result
-
-    response = await _add_recipe_row_impl(request, context)
-    status = "PREVIEW" if response.is_preview else "ADDED"
-    md = f"## Recipe Row ({status})\n\n{response.message}"
-    return make_simple_result(md, structured_data=response.model_dump())
-
-
-# ============================================================================
-# Tool 5: delete_manufacturing_order_recipe_row
-# ============================================================================
-
-
-class DeleteRecipeRowRequest(BaseModel):
-    """Request to delete an ingredient row from a manufacturing order."""
-
-    recipe_row_id: int = Field(..., description="Recipe row ID to delete")
-    confirm: bool = Field(
-        default=False,
-        description="Set false to preview, true to delete",
-    )
-
-
-class DeleteRecipeRowResponse(BaseModel):
-    """Response from deleting a recipe row."""
-
-    recipe_row_id: int
-    is_preview: bool
-    message: str
-
-
-async def _delete_recipe_row_impl(
-    request: DeleteRecipeRowRequest, context: Context
-) -> DeleteRecipeRowResponse:
-    """Delete an ingredient row from a manufacturing order."""
-    services = get_services(context)
-
-    if not request.confirm:
-        return DeleteRecipeRowResponse(
-            recipe_row_id=request.recipe_row_id,
-            is_preview=True,
-            message=f"Preview: Would delete recipe row {request.recipe_row_id}",
-        )
-
-    await _api_delete_recipe_row(services, request.recipe_row_id)
-
-    return DeleteRecipeRowResponse(
-        recipe_row_id=request.recipe_row_id,
-        is_preview=False,
-        message=f"Removed recipe row {request.recipe_row_id}",
-    )
-
-
-@observe_tool
-@unpack_pydantic_params
-async def delete_manufacturing_order_recipe_row(
-    request: Annotated[DeleteRecipeRowRequest, Unpack()], context: Context
-) -> ToolResult:
-    """Delete an ingredient row from a manufacturing order's recipe.
-
-    Two-step flow: confirm=false to preview, confirm=true to delete (prompts
-    for confirmation). Find the recipe_row_id with get_manufacturing_order_recipe.
-
-    Use with add_manufacturing_order_recipe_row to replace an ingredient.
-    """
-    from katana_mcp.tools.tool_result_utils import make_simple_result
-
-    response = await _delete_recipe_row_impl(request, context)
-    status = "PREVIEW" if response.is_preview else "DELETED"
-    md = f"## Recipe Row ({status})\n\n{response.message}"
-    return make_simple_result(md, structured_data=response.model_dump())
-
-
-# ============================================================================
-# Tool 6: batch_update_manufacturing_order_recipes
-# ============================================================================
-
-
-MAX_BATCH_OPS = 100
-
-
-class VariantSpec(BaseModel):
-    """A variant reference plus the planned quantity per manufactured unit."""
-
-    sku: str | None = Field(default=None, description="SKU of the variant")
-    variant_id: int | None = Field(
-        default=None, description="Variant ID (used directly if set)"
-    )
-    planned_quantity_per_unit: float = Field(
-        ..., gt=0, description="Qty per manufactured unit"
-    )
-    notes: str | None = Field(default=None, description="Optional recipe row notes")
-
-
-class VariantReplacement(BaseModel):
-    """Replace a variant across multiple MOs with one or more new components."""
-
-    manufacturing_order_ids: CoercedIntList = Field(
-        ...,
-        min_length=1,
-        description=(
-            "JSON array of manufacturing order IDs to apply this replacement to, "
-            "e.g. [101, 202, 303]."
-        ),
-    )
-    old_sku: str | None = Field(
-        default=None, description="SKU of the variant to remove"
-    )
-    old_variant_id: int | None = Field(
-        default=None, description="Variant ID to remove (alternative to old_sku)"
-    )
-    new_components: list[VariantSpec] = Field(
-        default_factory=list,
-        description="Replacement components to add. Empty list = pure removal.",
-    )
-    strict: bool = Field(
-        default=False,
-        description="If true, missing old variant in any MO is an error. "
-        "If false (default), missing is a skipped warning.",
-    )
-
-
-class ExplicitChange(BaseModel):
-    """Explicit per-MO list of row deletions and additions."""
-
-    manufacturing_order_id: int
-    remove_row_ids: CoercedIntList = Field(
-        default_factory=list,
-        description="JSON array of recipe row IDs to delete, e.g. [42, 87].",
-    )
-    add_variants: list[VariantSpec] = Field(default_factory=list)
-
-
-class BatchUpdateRecipesRequest(BaseModel):
-    """Batch update recipe rows across one or more manufacturing orders."""
-
-    replacements: list[VariantReplacement] = Field(default_factory=list)
-    changes: list[ExplicitChange] = Field(default_factory=list)
-    continue_on_error: bool = Field(
-        default=True,
-        description="If true, log and continue past failed sub-operations. "
-        "If false, abort on the first failure.",
-    )
-    confirm: bool = Field(
-        default=False,
-        description="Set false to preview, true to execute (single confirmation for batch)",
-    )
-
-
-class SubOpStatus(StrEnum):
-    PENDING = "pending"
-    SUCCESS = "success"
-    FAILED = "failed"
-    SKIPPED = "skipped"
-
-
-class OpType(StrEnum):
-    """Sub-operation type within a batch recipe update."""
-
-    DELETE = "delete"
-    ADD = "add"
-
-
-class SubOpResult(BaseModel):
-    """Result of a single delete or add within the batch."""
-
-    op_type: OpType
-    manufacturing_order_id: int
-    recipe_row_id: int | None = None  # existing row (delete) or new row (add result)
-    variant_id: int | None = None
-    sku: str | None = None
-    planned_quantity_per_unit: float | None = None
-    notes: str | None = None
-    status: SubOpStatus = SubOpStatus.PENDING
-    error: str | None = None
-    group_label: str | None = None
-
-
-class BatchUpdateRecipesResponse(BaseModel):
-    is_preview: bool
-    total_ops: int
-    success_count: int
-    failed_count: int
-    skipped_count: int
-    results: list[SubOpResult]
-    warnings: list[str] = Field(default_factory=list)
-    message: str
-
-
-def _format_group_label(
-    old_sku: str | None, old_variant_id: int, new_components: list[VariantSpec]
-) -> str:
-    """Build a human-readable label for a replacement group."""
-    old_label = old_sku or f"variant {old_variant_id}"
-    new_labels = [c.sku or f"variant {c.variant_id}" for c in new_components]
-    if not new_labels:
-        return f"Remove {old_label}"
-    return f"{old_label} → [{', '.join(new_labels)}]"
-
-
-async def _plan_batch_update(
-    request: BatchUpdateRecipesRequest, context: Context
-) -> tuple[list[SubOpResult], list[str]]:
-    """Resolve intent into a concrete, ordered sub-operation plan."""
-    services = get_services(context)
-    planned: list[SubOpResult] = []
-    warnings: list[str] = []
-
-    # Cache recipe fetches within this plan phase — if multiple replacements
-    # target the same MO, we only fetch its recipe once.
-    recipe_cache: dict[int, GetManufacturingOrderRecipeResponse] = {}
-
-    async def _get_cached_recipe(mo_id: int) -> GetManufacturingOrderRecipeResponse:
-        if mo_id not in recipe_cache:
-            recipe_cache[mo_id] = await _get_manufacturing_order_recipe_impl(
-                GetManufacturingOrderRecipeRequest(manufacturing_order_id=mo_id),
-                context,
-            )
-        return recipe_cache[mo_id]
-
-    # Phase A: expand replacements into per-MO delete+add ops
-    for rep in request.replacements:
-        # Resolve old variant
-        if rep.old_variant_id is not None:
-            old_variant_id = rep.old_variant_id
-        elif rep.old_sku:
-            variant = await services.cache.get_by_sku(sku=rep.old_sku)
-            if not variant:
-                raise ValueError(f"Old SKU '{rep.old_sku}' not found in cache")
-            old_variant_id = variant["id"]
-        else:
-            raise ValueError("Replacement requires old_sku or old_variant_id")
-
-        # Pre-resolve new components (eager validation)
-        resolved_new: list[tuple[int, str | None, float, str | None]] = []
-        for spec in rep.new_components:
-            v_id, sku, _ = await _resolve_variant_ref(
-                services, sku=spec.sku, variant_id=spec.variant_id
-            )
-            resolved_new.append((v_id, sku, spec.planned_quantity_per_unit, spec.notes))
-
-        group_label = _format_group_label(
-            rep.old_sku, old_variant_id, rep.new_components
-        )
-
-        for mo_id in rep.manufacturing_order_ids:
-            # Fetch the MO's recipe (cached per-MO to avoid duplicates)
-            try:
-                recipe = await _get_cached_recipe(mo_id)
-            except Exception as e:
-                msg = f"MO {mo_id}: failed to fetch recipe: {e}"
-                if rep.strict:
-                    raise ValueError(msg) from e
-                warnings.append(msg)
-                continue
-
-            matching_rows = [r for r in recipe.rows if r.variant_id == old_variant_id]
-
-            if not matching_rows:
-                msg = f"MO {mo_id}: old variant {old_variant_id} not in recipe"
-                if rep.strict:
-                    raise ValueError(msg)
-                warnings.append(msg + " — skipping")
-                for v_id, sku, qty, notes in resolved_new:
-                    planned.append(
-                        SubOpResult(
-                            op_type=OpType.ADD,
-                            manufacturing_order_id=mo_id,
-                            variant_id=v_id,
-                            sku=sku,
-                            planned_quantity_per_unit=qty,
-                            notes=notes,
-                            status=SubOpStatus.SKIPPED,
-                            group_label=group_label,
-                            error="Old variant not present in this MO",
-                        )
-                    )
-                continue
-
-            for row in matching_rows:
-                planned.append(
-                    SubOpResult(
-                        op_type=OpType.DELETE,
-                        manufacturing_order_id=mo_id,
-                        recipe_row_id=row.id,
-                        variant_id=row.variant_id,
-                        sku=row.sku,
-                        group_label=group_label,
-                    )
-                )
-            for v_id, sku, qty, notes in resolved_new:
-                planned.append(
-                    SubOpResult(
-                        op_type=OpType.ADD,
-                        manufacturing_order_id=mo_id,
-                        variant_id=v_id,
-                        sku=sku,
-                        planned_quantity_per_unit=qty,
-                        notes=notes,
-                        group_label=group_label,
-                    )
-                )
-
-    # Phase B: explicit changes (escape hatch)
-    for ch in request.changes:
-        group_label = f"MO {ch.manufacturing_order_id} explicit"
-        for row_id in ch.remove_row_ids:
-            planned.append(
-                SubOpResult(
-                    op_type=OpType.DELETE,
-                    manufacturing_order_id=ch.manufacturing_order_id,
-                    recipe_row_id=row_id,
-                    group_label=group_label,
-                )
-            )
-        for spec in ch.add_variants:
-            v_id, sku, _ = await _resolve_variant_ref(
-                services, sku=spec.sku, variant_id=spec.variant_id
-            )
-            planned.append(
-                SubOpResult(
-                    op_type=OpType.ADD,
-                    manufacturing_order_id=ch.manufacturing_order_id,
-                    variant_id=v_id,
-                    sku=sku,
-                    planned_quantity_per_unit=spec.planned_quantity_per_unit,
-                    notes=spec.notes,
-                    group_label=group_label,
-                )
-            )
-
-    return planned, warnings
-
-
-async def _execute_batch_update(
-    planned: list[SubOpResult],
-    request: BatchUpdateRecipesRequest,
-    context: Context,
-) -> list[SubOpResult]:
-    """Execute the planned sub-ops, grouped by (mo_id, group_label).
-
-    Deletes first, then adds in REVERSE order so the final created_at DESC
-    ordering matches the user's intended sequence.
-    """
-    services = get_services(context)
-
-    # Bucket by (mo_id, group_label) preserving insertion order
-    buckets: dict[tuple[int, str], list[SubOpResult]] = {}
-    for op in planned:
-        if op.status == SubOpStatus.SKIPPED:
-            continue
-        key = (op.manufacturing_order_id, op.group_label or "")
-        buckets.setdefault(key, []).append(op)
-
-    aborted = False
-    for (mo_id, _group_label), ops in buckets.items():
-        if aborted:
-            for op in ops:
-                if op.status == SubOpStatus.PENDING:
-                    op.status = SubOpStatus.SKIPPED
-                    op.error = "Aborted after earlier failure"
-            continue
-
-        deletes = [o for o in ops if o.op_type == OpType.DELETE]
-        adds = [o for o in ops if o.op_type == OpType.ADD]
-
-        # Deletes first
-        for op in deletes:
-            try:
-                if op.recipe_row_id is None:
-                    raise ValueError("DELETE op requires recipe_row_id")
-                await _api_delete_recipe_row(services, op.recipe_row_id)
-                op.status = SubOpStatus.SUCCESS
-            except Exception as e:
-                op.status = SubOpStatus.FAILED
-                op.error = str(e)
-                logger.error(
-                    "batch_delete_failed",
-                    row_id=op.recipe_row_id,
-                    mo_id=mo_id,
-                    error=str(e),
-                )
-                if not request.continue_on_error:
-                    aborted = True
-                    break
-
-        if aborted:
-            for op in adds:
-                if op.status == SubOpStatus.PENDING:
-                    op.status = SubOpStatus.SKIPPED
-                    op.error = "Aborted after earlier failure"
-            continue
-
-        # Adds in REVERSE order — because GET returns by created_at DESC,
-        # the last-created row appears first, matching the user's intended order.
-        for op in reversed(adds):
-            try:
-                if op.variant_id is None:
-                    raise ValueError("ADD op requires variant_id")
-                if op.planned_quantity_per_unit is None:
-                    raise ValueError("ADD op requires planned_quantity_per_unit")
-                result = await _api_create_recipe_row(
-                    services,
-                    manufacturing_order_id=mo_id,
-                    variant_id=op.variant_id,
-                    planned_quantity_per_unit=op.planned_quantity_per_unit,
-                    notes=op.notes,
-                )
-                op.recipe_row_id = getattr(result, "id", None) if result else None
-                op.status = SubOpStatus.SUCCESS
-            except Exception as e:
-                op.status = SubOpStatus.FAILED
-                op.error = str(e)
-                logger.error(
-                    "batch_add_failed",
-                    variant_id=op.variant_id,
-                    mo_id=mo_id,
-                    error=str(e),
-                )
-                if not request.continue_on_error:
-                    aborted = True
-
-    return planned
-
-
-async def _batch_update_impl(
-    request: BatchUpdateRecipesRequest, context: Context
-) -> BatchUpdateRecipesResponse:
-    """Implementation of batch_update_manufacturing_order_recipes."""
-    if not request.replacements and not request.changes:
-        raise ValueError("Must provide at least one replacement or change")
-
-    # 0. Upfront estimate — reject oversized batches BEFORE planning fetches
-    # recipes for every MO. Each replacement generates (num_components + 1)
-    # ops per MO, doubled for delete+add pairing. The threshold is 4x
-    # MAX_BATCH_OPS because this estimate deliberately over-counts (the real
-    # plan may be smaller once duplicate rows are merged).
-    estimate = sum(
-        len(rep.manufacturing_order_ids) * (len(rep.new_components) + 1) * 2
-        for rep in request.replacements
-    ) + sum(len(ch.remove_row_ids) + len(ch.add_variants) for ch in request.changes)
-    if estimate > MAX_BATCH_OPS * 4:
-        raise ValueError(
-            f"Batch estimate is {estimate} operations, which exceeds "
-            f"{MAX_BATCH_OPS * 4} before planning. Split into smaller batches "
-            "so we don't fetch recipes for hundreds of MOs up front."
-        )
-
-    # 1. Plan
-    planned, warnings = await _plan_batch_update(request, context)
-    total = len(planned)
-
-    if total > MAX_BATCH_OPS:
-        raise ValueError(
-            f"Batch has {total} operations, exceeding MAX_BATCH_OPS={MAX_BATCH_OPS}. "
-            "Split into smaller batches."
-        )
-
-    # 2. Preview mode
-    if not request.confirm:
-        skipped = sum(1 for o in planned if o.status == SubOpStatus.SKIPPED)
-        return BatchUpdateRecipesResponse(
-            is_preview=True,
-            total_ops=total,
-            success_count=0,
-            failed_count=0,
-            skipped_count=skipped,
-            results=planned,
-            warnings=warnings,
-            message=f"Preview: {total} sub-operations planned. Set confirm=true to execute.",
-        )
-
-    results = await _execute_batch_update(planned, request, context)
-
-    # 5. Tally
-    success = sum(1 for r in results if r.status == SubOpStatus.SUCCESS)
-    failed = sum(1 for r in results if r.status == SubOpStatus.FAILED)
-    skipped = sum(1 for r in results if r.status == SubOpStatus.SKIPPED)
-    return BatchUpdateRecipesResponse(
-        is_preview=False,
-        total_ops=total,
-        success_count=success,
-        failed_count=failed,
-        skipped_count=skipped,
-        results=results,
-        warnings=warnings,
-        message=(
-            f"Batch update completed: {success} succeeded, "
-            f"{failed} failed, {skipped} skipped"
-        ),
-    )
-
-
-@observe_tool
-@unpack_pydantic_params
-async def batch_update_manufacturing_order_recipes(
-    request: Annotated[BatchUpdateRecipesRequest, Unpack()], context: Context
-) -> ToolResult:
-    """Batch update recipe rows across one or more manufacturing orders.
-
-    Two expression modes (mixable in one request):
-
-    - **replacements**: "replace variant X with [Y, Z] across these MOs" — ideal
-      for swapping a component across many MOs in one shot. Accepts old_sku or
-      old_variant_id, with a list of new_components (each with sku/variant_id
-      and planned_quantity_per_unit).
-    - **changes**: explicit per-MO row deletes and additions — escape hatch
-      for arbitrary edits.
-
-    Two-step flow: confirm=false to preview (resolves row IDs, shows full plan),
-    confirm=true to execute (single batch operation).
-
-    Semantics:
-    - Within a replacement group, old rows are deleted first, then new rows are
-      added in reverse order so they appear before the replaced row in Katana's
-      natural created_at DESC sort.
-    - Old variant appearing multiple times in an MO → all matches are deleted.
-    - Old variant not in an MO → skipped with warning (unless strict=true).
-    - No rollback. Every sub-op's final status is reported.
-    - continue_on_error=true (default): run all sub-ops, mixed results ok.
-    - continue_on_error=false: stop at first failure; remaining ops become SKIPPED.
-    """
-    from fastmcp.tools import ToolResult
-
-    from katana_mcp.tools.prefab_ui import (
-        build_batch_recipe_update_ui,
-        call_tool_from_request,
-    )
-
-    response = await _batch_update_impl(request, context)
-    ui = build_batch_recipe_update_ui(
-        response.model_dump(),
-        request=request.model_dump() if response.is_preview else None,
-        confirm_action=(
-            call_tool_from_request(
-                "batch_update_manufacturing_order_recipes",
-                BatchUpdateRecipesRequest,
-                overrides={"confirm": True},
-            )
-            if response.is_preview
-            else None
-        ),
-    )
-
-    return ToolResult(
-        content=response.model_dump_json(),
-        structured_content=ui,
-    )
-
-
-# ============================================================================
 # Tool: list_manufacturing_orders (list-tool pattern v2)
 # ============================================================================
 
@@ -3015,6 +2357,657 @@ async def list_blocking_ingredients(
     )
 
 
+# ============================================================================
+# Tool: modify_manufacturing_order — unified modification surface
+# ============================================================================
+
+
+class MOOperation(StrEnum):
+    """Operation names emitted on ActionSpecs by ``modify_manufacturing_order``
+    / ``delete_manufacturing_order`` plan builders."""
+
+    UPDATE_HEADER = "update_header"
+    DELETE = "delete"
+    ADD_RECIPE_ROW = "add_recipe_row"
+    UPDATE_RECIPE_ROW = "update_recipe_row"
+    DELETE_RECIPE_ROW = "delete_recipe_row"
+    ADD_OPERATION_ROW = "add_operation_row"
+    UPDATE_OPERATION_ROW = "update_operation_row"
+    DELETE_OPERATION_ROW = "delete_operation_row"
+    ADD_PRODUCTION = "add_production"
+    UPDATE_PRODUCTION = "update_production"
+    DELETE_PRODUCTION = "delete_production"
+
+
+# Tool-facing status literal — mirrors ManufacturingOrderStatus enum values.
+ManufacturingOrderStatusLiteral = Literal[
+    "NOT_STARTED", "IN_PROGRESS", "DONE", "BLOCKED", "PARTIALLY_COMPLETED"
+]
+
+_MO_STATUS_API_VALUE: dict[
+    ManufacturingOrderStatusLiteral, ManufacturingOrderStatus
+] = {
+    "NOT_STARTED": ManufacturingOrderStatus.NOT_STARTED,
+    "IN_PROGRESS": ManufacturingOrderStatus.IN_PROGRESS,
+    "DONE": ManufacturingOrderStatus.DONE,
+    "BLOCKED": ManufacturingOrderStatus.BLOCKED,
+    "PARTIALLY_COMPLETED": ManufacturingOrderStatus.PARTIALLY_COMPLETED,
+}
+
+# Operation-row status + type literals.
+ManufacturingOperationStatusLiteral = Literal[
+    "NOT_STARTED", "IN_PROGRESS", "BLOCKED", "COMPLETED"
+]
+
+ManufacturingOperationTypeLiteral = Literal["LINKED", "STANDARD"]
+
+
+# ----------------------------------------------------------------------------
+# Diff-context fetchers
+# ----------------------------------------------------------------------------
+
+
+async def _fetch_manufacturing_order_attrs(
+    services: Any, mo_id: int
+) -> ManufacturingOrder | None:
+    return await safe_fetch_for_diff(
+        api_get_manufacturing_order,
+        services,
+        mo_id,
+        return_type=ManufacturingOrder,
+        label="manufacturing order",
+    )
+
+
+async def _fetch_mo_recipe_row(
+    services: Any, row_id: int
+) -> ManufacturingOrderRecipeRow | None:
+    return await safe_fetch_for_diff(
+        api_get_mo_recipe_row,
+        services,
+        row_id,
+        return_type=ManufacturingOrderRecipeRow,
+        label="MO recipe row",
+    )
+
+
+async def _fetch_mo_operation_row(
+    services: Any, row_id: int
+) -> ManufacturingOrderOperationRow | None:
+    return await safe_fetch_for_diff(
+        api_get_mo_operation_row,
+        services,
+        row_id,
+        return_type=ManufacturingOrderOperationRow,
+        label="MO operation row",
+    )
+
+
+async def _fetch_mo_production(
+    services: Any, prod_id: int
+) -> ManufacturingOrderProduction | None:
+    return await safe_fetch_for_diff(
+        api_get_mo_production,
+        services,
+        prod_id,
+        return_type=ManufacturingOrderProduction,
+        label="MO production",
+    )
+
+
+# ----------------------------------------------------------------------------
+# Sub-payload models
+# ----------------------------------------------------------------------------
+
+
+class MOHeaderPatch(BaseModel):
+    """Header fields to patch on an MO. Status is included here — Katana's
+    PATCH /manufacturing_orders/{id} accepts it as a regular field."""
+
+    order_no: str | None = Field(default=None)
+    variant_id: int | None = Field(default=None)
+    location_id: int | None = Field(default=None)
+    status: ManufacturingOrderStatusLiteral | None = Field(
+        default=None,
+        description=(
+            "New status — NOT_STARTED / IN_PROGRESS / DONE / BLOCKED / "
+            "PARTIALLY_COMPLETED. Katana validates transitions server-side."
+        ),
+    )
+    planned_quantity: float | None = Field(default=None, gt=0)
+    actual_quantity: float | None = Field(default=None, ge=0)
+    order_created_date: datetime | None = Field(default=None)
+    production_deadline_date: datetime | None = Field(default=None)
+    done_date: datetime | None = Field(default=None)
+    additional_info: str | None = Field(default=None)
+
+
+class MORecipeRowAdd(BaseModel):
+    """A new recipe row (ingredient) on the MO."""
+
+    variant_id: int = Field(..., description="Variant ID of the ingredient")
+    planned_quantity_per_unit: float = Field(..., description="Quantity per unit", gt=0)
+    notes: str | None = Field(default=None)
+    total_actual_quantity: float | None = Field(default=None, ge=0)
+
+
+class MORecipeRowUpdate(BaseModel):
+    """Patch to an existing MO recipe row."""
+
+    id: int = Field(..., description="Recipe row ID")
+    variant_id: int | None = Field(default=None)
+    planned_quantity_per_unit: float | None = Field(default=None, gt=0)
+    notes: str | None = Field(default=None)
+    total_actual_quantity: float | None = Field(default=None, ge=0)
+
+
+class MOOperationRowAdd(BaseModel):
+    """A new operation row (production step) on the MO."""
+
+    status: ManufacturingOperationStatusLiteral = Field(
+        ..., description="Initial operation status"
+    )
+    operation_id: int | None = Field(default=None)
+    type: ManufacturingOperationTypeLiteral | None = Field(
+        default=None, description="LINKED (template) or STANDARD"
+    )
+    operation_name: str | None = Field(default=None)
+    resource_id: int | None = Field(default=None)
+    resource_name: str | None = Field(default=None)
+    planned_time_parameter: float | None = Field(default=None)
+    planned_time_per_unit: float | None = Field(default=None)
+    cost_parameter: float | None = Field(default=None)
+    cost_per_hour: float | None = Field(default=None)
+
+
+class MOOperationRowUpdate(BaseModel):
+    """Patch to an existing MO operation row."""
+
+    id: int = Field(..., description="Operation row ID")
+    status: ManufacturingOperationStatusLiteral | None = Field(default=None)
+    operation_id: int | None = Field(default=None)
+    type: ManufacturingOperationTypeLiteral | None = Field(default=None)
+    operation_name: str | None = Field(default=None)
+    resource_id: int | None = Field(default=None)
+    resource_name: str | None = Field(default=None)
+    planned_time_parameter: float | None = Field(default=None)
+    planned_time_per_unit: float | None = Field(default=None)
+    total_actual_time: float | None = Field(default=None)
+    cost_parameter: float | None = Field(default=None)
+    cost_per_hour: float | None = Field(default=None)
+
+
+class MOProductionAdd(BaseModel):
+    """A new production record on the MO (output completed quantity)."""
+
+    completed_quantity: float = Field(
+        ..., description="Quantity produced in this production record", gt=0
+    )
+    completed_date: datetime | None = Field(default=None)
+    is_final: bool | None = Field(
+        default=None,
+        description="When true, marks this as the final production record",
+    )
+    serial_numbers: list[str] | None = Field(
+        default=None, description="Serial numbers for serial-tracked variants"
+    )
+
+
+class MOProductionUpdate(BaseModel):
+    """Patch to an existing MO production record."""
+
+    id: int = Field(..., description="Production record ID")
+    production_date: datetime | None = Field(default=None)
+
+
+class ModifyManufacturingOrderRequest(ConfirmableRequest):
+    """Unified modification request for a manufacturing order.
+
+    Sub-payload slots span header + recipe rows (ingredients) + operation
+    rows (production steps) + production records (completion logs).
+    Multiple slots can be combined; actions execute in canonical order. To
+    remove the MO entirely, use ``delete_manufacturing_order``.
+    """
+
+    id: int = Field(..., description="Manufacturing order ID")
+    update_header: MOHeaderPatch | None = Field(default=None)
+    add_recipe_rows: list[MORecipeRowAdd] | None = Field(default=None)
+    update_recipe_rows: list[MORecipeRowUpdate] | None = Field(default=None)
+    delete_recipe_row_ids: list[int] | None = Field(default=None)
+    add_operation_rows: list[MOOperationRowAdd] | None = Field(default=None)
+    update_operation_rows: list[MOOperationRowUpdate] | None = Field(default=None)
+    delete_operation_row_ids: list[int] | None = Field(default=None)
+    add_productions: list[MOProductionAdd] | None = Field(default=None)
+    update_productions: list[MOProductionUpdate] | None = Field(default=None)
+    delete_production_ids: list[int] | None = Field(default=None)
+
+
+class DeleteManufacturingOrderRequest(ConfirmableRequest):
+    """Delete a manufacturing order. Destructive — Katana cascades child
+    recipe rows / operation rows / production records server-side.
+    """
+
+    id: int = Field(..., description="Manufacturing order ID to delete")
+
+
+# ----------------------------------------------------------------------------
+# API request builders
+# ----------------------------------------------------------------------------
+
+
+def _build_update_header_request(
+    patch: MOHeaderPatch,
+) -> APIUpdateManufacturingOrderRequest:
+    api_status = (
+        _MO_STATUS_API_VALUE[patch.status] if patch.status is not None else None
+    )
+    return APIUpdateManufacturingOrderRequest(
+        order_no=to_unset(patch.order_no),
+        variant_id=to_unset(patch.variant_id),
+        location_id=to_unset(patch.location_id),
+        status=to_unset(api_status),
+        planned_quantity=to_unset(patch.planned_quantity),
+        actual_quantity=to_unset(patch.actual_quantity),
+        order_created_date=to_unset(patch.order_created_date),
+        production_deadline_date=to_unset(patch.production_deadline_date),
+        done_date=to_unset(patch.done_date),
+        additional_info=to_unset(patch.additional_info),
+    )
+
+
+def _build_create_recipe_row_request(
+    mo_id: int, row: MORecipeRowAdd
+) -> APICreateMORecipeRowRequest:
+    return APICreateMORecipeRowRequest(
+        manufacturing_order_id=mo_id,
+        variant_id=row.variant_id,
+        planned_quantity_per_unit=row.planned_quantity_per_unit,
+        notes=to_unset(row.notes),
+        total_actual_quantity=to_unset(row.total_actual_quantity),
+    )
+
+
+def _build_update_recipe_row_request(
+    patch: MORecipeRowUpdate,
+) -> APIUpdateMORecipeRowRequest:
+    return APIUpdateMORecipeRowRequest(
+        variant_id=to_unset(patch.variant_id),
+        notes=to_unset(patch.notes),
+        planned_quantity_per_unit=to_unset(patch.planned_quantity_per_unit),
+        total_actual_quantity=to_unset(patch.total_actual_quantity),
+    )
+
+
+def _build_create_operation_row_request(
+    mo_id: int, row: MOOperationRowAdd
+) -> APICreateMOOperationRowRequest:
+    api_status_class = ManufacturingOperationStatus  # alias to keep line short
+    api_status = api_status_class(row.status)
+    api_type = ManufacturingOperationType(row.type) if row.type is not None else None
+    return APICreateMOOperationRowRequest(
+        manufacturing_order_id=mo_id,
+        status=api_status,
+        operation_id=to_unset(row.operation_id),
+        type_=to_unset(api_type),
+        operation_name=to_unset(row.operation_name),
+        resource_id=to_unset(row.resource_id),
+        resource_name=to_unset(row.resource_name),
+        planned_time_parameter=to_unset(row.planned_time_parameter),
+        planned_time_per_unit=to_unset(row.planned_time_per_unit),
+        cost_parameter=to_unset(row.cost_parameter),
+        cost_per_hour=to_unset(row.cost_per_hour),
+    )
+
+
+def _build_update_operation_row_request(
+    patch: MOOperationRowUpdate,
+) -> APIUpdateMOOperationRowRequest:
+    api_status = (
+        ManufacturingOperationStatus(patch.status) if patch.status is not None else None
+    )
+    api_type = (
+        ManufacturingOperationType(patch.type) if patch.type is not None else None
+    )
+    return APIUpdateMOOperationRowRequest(
+        operation_id=to_unset(patch.operation_id),
+        type_=to_unset(api_type),
+        operation_name=to_unset(patch.operation_name),
+        resource_id=to_unset(patch.resource_id),
+        resource_name=to_unset(patch.resource_name),
+        planned_time_parameter=to_unset(patch.planned_time_parameter),
+        planned_time_per_unit=to_unset(patch.planned_time_per_unit),
+        total_actual_time=to_unset(patch.total_actual_time),
+        cost_parameter=to_unset(patch.cost_parameter),
+        cost_per_hour=to_unset(patch.cost_per_hour),
+        status=to_unset(api_status),
+    )
+
+
+def _build_create_production_request(
+    mo_id: int, prod: MOProductionAdd
+) -> APICreateMOProductionRequest:
+    return APICreateMOProductionRequest(
+        manufacturing_order_id=mo_id,
+        completed_quantity=prod.completed_quantity,
+        completed_date=to_unset(prod.completed_date),
+        is_final=to_unset(prod.is_final),
+        serial_numbers=to_unset(prod.serial_numbers),
+    )
+
+
+def _build_update_production_request(
+    patch: MOProductionUpdate,
+) -> APIUpdateMOProductionRequest:
+    return APIUpdateMOProductionRequest(
+        production_date=to_unset(patch.production_date),
+    )
+
+
+# ----------------------------------------------------------------------------
+# Implementation
+# ----------------------------------------------------------------------------
+
+
+async def _modify_manufacturing_order_impl(
+    request: ModifyManufacturingOrderRequest, context: Context
+) -> ModificationResponse:
+    """Build the action plan from sub-payloads and either preview or execute."""
+    services = get_services(context)
+
+    if not has_any_subpayload(request):
+        raise ValueError(
+            "At least one sub-payload must be set: update_header, "
+            "add/update/delete_recipe_rows, "
+            "add/update/delete_operation_rows, or "
+            "add/update/delete_productions. To remove the MO entirely, use "
+            "delete_manufacturing_order."
+        )
+
+    existing_mo = await _fetch_manufacturing_order_attrs(services, request.id)
+
+    plan: list[ActionSpec] = []
+
+    if request.update_header is not None:
+        diff = compute_field_diff(
+            existing_mo, request.update_header, unknown_prior=existing_mo is None
+        )
+        plan.append(
+            ActionSpec(
+                operation=MOOperation.UPDATE_HEADER,
+                target_id=request.id,
+                diff=diff,
+                apply=make_patch_apply(
+                    api_update_manufacturing_order,
+                    services,
+                    request.id,
+                    _build_update_header_request(request.update_header),
+                    return_type=ManufacturingOrder,
+                ),
+                verify=make_response_verifier(diff),
+            )
+        )
+
+    # Recipe rows.
+    plan.extend(
+        plan_creates(
+            request.add_recipe_rows,
+            MOOperation.ADD_RECIPE_ROW,
+            lambda row: _build_create_recipe_row_request(request.id, row),
+            lambda body: make_post_apply(
+                api_create_mo_recipe_row,
+                services,
+                body,
+                return_type=ManufacturingOrderRecipeRow,
+            ),
+        )
+    )
+    plan.extend(
+        await plan_updates(
+            request.update_recipe_rows,
+            MOOperation.UPDATE_RECIPE_ROW,
+            lambda rid: _fetch_mo_recipe_row(services, rid),
+            _build_update_recipe_row_request,
+            lambda rid, body: make_patch_apply(
+                api_update_mo_recipe_row,
+                services,
+                rid,
+                body,
+                return_type=ManufacturingOrderRecipeRow,
+            ),
+        )
+    )
+    plan.extend(
+        plan_deletes(
+            request.delete_recipe_row_ids,
+            MOOperation.DELETE_RECIPE_ROW,
+            lambda rid: make_delete_apply(api_delete_mo_recipe_row, services, rid),
+        )
+    )
+
+    # Operation rows.
+    plan.extend(
+        plan_creates(
+            request.add_operation_rows,
+            MOOperation.ADD_OPERATION_ROW,
+            lambda row: _build_create_operation_row_request(request.id, row),
+            lambda body: make_post_apply(
+                api_create_mo_operation_row,
+                services,
+                body,
+                return_type=ManufacturingOrderOperationRow,
+            ),
+        )
+    )
+    plan.extend(
+        await plan_updates(
+            request.update_operation_rows,
+            MOOperation.UPDATE_OPERATION_ROW,
+            lambda rid: _fetch_mo_operation_row(services, rid),
+            _build_update_operation_row_request,
+            lambda rid, body: make_patch_apply(
+                api_update_mo_operation_row,
+                services,
+                rid,
+                body,
+                return_type=ManufacturingOrderOperationRow,
+            ),
+        )
+    )
+    plan.extend(
+        plan_deletes(
+            request.delete_operation_row_ids,
+            MOOperation.DELETE_OPERATION_ROW,
+            lambda rid: make_delete_apply(api_delete_mo_operation_row, services, rid),
+        )
+    )
+
+    # Production records.
+    plan.extend(
+        plan_creates(
+            request.add_productions,
+            MOOperation.ADD_PRODUCTION,
+            lambda prod: _build_create_production_request(request.id, prod),
+            lambda body: make_post_apply(
+                api_create_mo_production,
+                services,
+                body,
+                return_type=ManufacturingOrderProduction,
+            ),
+        )
+    )
+    plan.extend(
+        await plan_updates(
+            request.update_productions,
+            MOOperation.UPDATE_PRODUCTION,
+            lambda pid: _fetch_mo_production(services, pid),
+            _build_update_production_request,
+            lambda pid, body: make_patch_apply(
+                api_update_mo_production,
+                services,
+                pid,
+                body,
+                return_type=ManufacturingOrderProduction,
+            ),
+        )
+    )
+    plan.extend(
+        plan_deletes(
+            request.delete_production_ids,
+            MOOperation.DELETE_PRODUCTION,
+            lambda pid: make_delete_apply(api_delete_mo_production, services, pid),
+        )
+    )
+
+    katana_url = katana_web_url("manufacturing_order", request.id)
+    warnings = (
+        [
+            f"Could not fetch manufacturing order {request.id} for diff context — "
+            "preview shows requested values without prior state."
+        ]
+        if existing_mo is None
+        else []
+    )
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="manufacturing_order",
+            entity_id=request.id,
+            is_preview=True,
+            actions=plan_to_preview_results(plan),
+            warnings=warnings,
+            next_actions=[
+                f"Review {len(plan)} planned action(s)",
+                "Set confirm=true to execute the plan",
+            ],
+            katana_url=katana_url,
+            message=(
+                f"Preview: {len(plan)} action(s) planned for manufacturing order "
+                f"{request.id}"
+            ),
+        )
+
+    prior_state = serialize_for_prior_state(existing_mo)
+    actions = await execute_plan(plan)
+    message, next_actions = summarize_modify_outcome(
+        actions,
+        len(plan),
+        entity_label=f"manufacturing order {request.id}",
+        tool_name="modify_manufacturing_order",
+    )
+
+    return ModificationResponse(
+        entity_type="manufacturing_order",
+        entity_id=request.id,
+        is_preview=False,
+        actions=actions,
+        prior_state=prior_state,
+        warnings=warnings,
+        next_actions=next_actions,
+        katana_url=katana_url,
+        message=message,
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def modify_manufacturing_order(
+    request: Annotated[ModifyManufacturingOrderRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Modify a manufacturing order — unified surface across header, recipe
+    rows (ingredients), operation rows (production steps), and production
+    records (completion logs).
+
+    Sub-payloads (any subset, all optional):
+
+    - ``update_header`` — patch header fields (incl. status)
+    - ``add_recipe_rows`` / ``update_recipe_rows`` /
+      ``delete_recipe_row_ids`` — ingredients
+    - ``add_operation_rows`` / ``update_operation_rows`` /
+      ``delete_operation_row_ids`` — production steps
+    - ``add_productions`` / ``update_productions`` /
+      ``delete_production_ids`` — completion logs (output records)
+
+    To remove an MO entirely, use the sibling ``delete_manufacturing_order``
+    tool.
+
+    Two-step flow: ``confirm=false`` returns a per-action preview;
+    ``confirm=true`` executes the plan in canonical order. Fail-fast on
+    error; the response carries a ``prior_state`` snapshot for manual
+    revert.
+    """
+    response = await _modify_manufacturing_order_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
+# Tool: delete_manufacturing_order
+# ============================================================================
+
+
+async def _delete_manufacturing_order_impl(
+    request: DeleteManufacturingOrderRequest, context: Context
+) -> ModificationResponse:
+    """One-action plan that removes the MO. Katana cascades child rows
+    server-side."""
+    services = get_services(context)
+
+    existing_mo = await _fetch_manufacturing_order_attrs(services, request.id)
+    plan = plan_deletes(
+        [request.id],
+        MOOperation.DELETE,
+        lambda mo_id: make_delete_apply(
+            api_delete_manufacturing_order, services, mo_id
+        ),
+    )
+    katana_url = katana_web_url("manufacturing_order", request.id)
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="manufacturing_order",
+            entity_id=request.id,
+            is_preview=True,
+            actions=plan_to_preview_results(plan),
+            next_actions=[
+                "Review the deletion",
+                "Set confirm=true to delete the manufacturing order",
+            ],
+            katana_url=katana_url,
+            message=f"Preview: delete manufacturing order {request.id}",
+        )
+
+    prior_state = serialize_for_prior_state(existing_mo)
+    actions = await execute_plan(plan)
+    message, next_actions = summarize_delete_outcome(
+        actions, entity_label=f"manufacturing order {request.id}"
+    )
+
+    return ModificationResponse(
+        entity_type="manufacturing_order",
+        entity_id=request.id,
+        is_preview=False,
+        actions=actions,
+        prior_state=prior_state,
+        next_actions=next_actions,
+        katana_url=None if all(a.succeeded for a in actions) else katana_url,
+        message=message,
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def delete_manufacturing_order(
+    request: Annotated[DeleteManufacturingOrderRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Delete a manufacturing order. Destructive — Katana cascades the
+    delete to child recipe rows / operation rows / production records
+    server-side.
+
+    The response carries a ``prior_state`` snapshot for manual revert.
+    """
+    response = await _delete_manufacturing_order_impl(request, context)
+    return to_tool_result(response)
+
+
 def register_tools(mcp: FastMCP) -> None:
     """Register all manufacturing order tools with the FastMCP instance.
 
@@ -3057,16 +3050,17 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "manufacturing", "read"},
         annotations=_read,
     )(get_manufacturing_order_recipe)
+
+    _update = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+    mcp.tool(tags={"orders", "manufacturing", "write"}, annotations=_update)(
+        modify_manufacturing_order
+    )
     mcp.tool(
-        tags={"orders", "manufacturing", "write"},
-        annotations=_write,
-    )(add_manufacturing_order_recipe_row)
-    mcp.tool(
-        tags={"orders", "manufacturing", "write"},
+        tags={"orders", "manufacturing", "write", "destructive"},
         annotations=_destructive_write,
-    )(delete_manufacturing_order_recipe_row)
-    mcp.tool(
-        tags={"orders", "manufacturing", "write", "batch"},
-        annotations=_destructive_write,
-        meta=UI_META,
-    )(batch_update_manufacturing_order_recipes)
+    )(delete_manufacturing_order)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -34,19 +34,16 @@ from katana_mcp.tools._modification import (
 )
 from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
-    execute_plan,
     has_any_subpayload,
     make_delete_apply,
     make_patch_apply,
     make_post_apply,
     plan_creates,
     plan_deletes,
-    plan_to_preview_results,
     plan_updates,
+    run_delete_plan,
+    run_modify_plan,
     safe_fetch_for_diff,
-    serialize_for_prior_state,
-    summarize_delete_outcome,
-    summarize_modify_outcome,
 )
 from katana_mcp.tools.list_coercion import (
     CoercedIntListOpt,
@@ -122,7 +119,7 @@ logger = get_logger(__name__)
 
 
 # ============================================================================
-# Tool 1: create_manufacturing_order
+# Tool: create_manufacturing_order
 # ============================================================================
 
 
@@ -486,7 +483,7 @@ async def create_manufacturing_order(
 
 
 # ============================================================================
-# Tool 2: get_manufacturing_order
+# Tool: get_manufacturing_order
 # ============================================================================
 
 # Recipe-row metadata fields stripped from the compact response. These have
@@ -1463,7 +1460,7 @@ async def get_manufacturing_order(
 
 
 # ============================================================================
-# Tool 3: get_manufacturing_order_recipe
+# Tool: get_manufacturing_order_recipe
 # ============================================================================
 
 
@@ -2379,26 +2376,14 @@ class MOOperation(StrEnum):
     DELETE_PRODUCTION = "delete_production"
 
 
-# Tool-facing status literal — mirrors ManufacturingOrderStatus enum values.
+# Tool-facing literals — values match the API StrEnum's ``.value`` directly,
+# so ``EnumClass(literal)`` resolves the enum without a lookup table.
 ManufacturingOrderStatusLiteral = Literal[
     "NOT_STARTED", "IN_PROGRESS", "DONE", "BLOCKED", "PARTIALLY_COMPLETED"
 ]
-
-_MO_STATUS_API_VALUE: dict[
-    ManufacturingOrderStatusLiteral, ManufacturingOrderStatus
-] = {
-    "NOT_STARTED": ManufacturingOrderStatus.NOT_STARTED,
-    "IN_PROGRESS": ManufacturingOrderStatus.IN_PROGRESS,
-    "DONE": ManufacturingOrderStatus.DONE,
-    "BLOCKED": ManufacturingOrderStatus.BLOCKED,
-    "PARTIALLY_COMPLETED": ManufacturingOrderStatus.PARTIALLY_COMPLETED,
-}
-
-# Operation-row status + type literals.
 ManufacturingOperationStatusLiteral = Literal[
     "NOT_STARTED", "IN_PROGRESS", "BLOCKED", "COMPLETED"
 ]
-
 ManufacturingOperationTypeLiteral = Literal["LINKED", "STANDARD"]
 
 
@@ -2599,7 +2584,7 @@ def _build_update_header_request(
     patch: MOHeaderPatch,
 ) -> APIUpdateManufacturingOrderRequest:
     api_status = (
-        _MO_STATUS_API_VALUE[patch.status] if patch.status is not None else None
+        ManufacturingOrderStatus(patch.status) if patch.status is not None else None
     )
     return APIUpdateManufacturingOrderRequest(
         order_no=to_unset(patch.order_no),
@@ -2641,12 +2626,10 @@ def _build_update_recipe_row_request(
 def _build_create_operation_row_request(
     mo_id: int, row: MOOperationRowAdd
 ) -> APICreateMOOperationRowRequest:
-    api_status_class = ManufacturingOperationStatus  # alias to keep line short
-    api_status = api_status_class(row.status)
     api_type = ManufacturingOperationType(row.type) if row.type is not None else None
     return APICreateMOOperationRowRequest(
         manufacturing_order_id=mo_id,
-        status=api_status,
+        status=ManufacturingOperationStatus(row.status),
         operation_id=to_unset(row.operation_id),
         type_=to_unset(api_type),
         operation_name=to_unset(row.operation_name),
@@ -2858,53 +2841,14 @@ async def _modify_manufacturing_order_impl(
         )
     )
 
-    katana_url = katana_web_url("manufacturing_order", request.id)
-    warnings = (
-        [
-            f"Could not fetch manufacturing order {request.id} for diff context — "
-            "preview shows requested values without prior state."
-        ]
-        if existing_mo is None
-        else []
-    )
-
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="manufacturing_order",
-            entity_id=request.id,
-            is_preview=True,
-            actions=plan_to_preview_results(plan),
-            warnings=warnings,
-            next_actions=[
-                f"Review {len(plan)} planned action(s)",
-                "Set confirm=true to execute the plan",
-            ],
-            katana_url=katana_url,
-            message=(
-                f"Preview: {len(plan)} action(s) planned for manufacturing order "
-                f"{request.id}"
-            ),
-        )
-
-    prior_state = serialize_for_prior_state(existing_mo)
-    actions = await execute_plan(plan)
-    message, next_actions = summarize_modify_outcome(
-        actions,
-        len(plan),
+    return await run_modify_plan(
+        request=request,
+        entity_type="manufacturing_order",
         entity_label=f"manufacturing order {request.id}",
         tool_name="modify_manufacturing_order",
-    )
-
-    return ModificationResponse(
-        entity_type="manufacturing_order",
-        entity_id=request.id,
-        is_preview=False,
-        actions=actions,
-        prior_state=prior_state,
-        warnings=warnings,
-        next_actions=next_actions,
-        katana_url=katana_url,
-        message=message,
+        web_url_kind="manufacturing_order",
+        existing=existing_mo,
+        plan=plan,
     )
 
 
@@ -2949,47 +2893,15 @@ async def _delete_manufacturing_order_impl(
 ) -> ModificationResponse:
     """One-action plan that removes the MO. Katana cascades child rows
     server-side."""
-    services = get_services(context)
-
-    existing_mo = await _fetch_manufacturing_order_attrs(services, request.id)
-    plan = plan_deletes(
-        [request.id],
-        MOOperation.DELETE,
-        lambda mo_id: make_delete_apply(
-            api_delete_manufacturing_order, services, mo_id
-        ),
-    )
-    katana_url = katana_web_url("manufacturing_order", request.id)
-
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="manufacturing_order",
-            entity_id=request.id,
-            is_preview=True,
-            actions=plan_to_preview_results(plan),
-            next_actions=[
-                "Review the deletion",
-                "Set confirm=true to delete the manufacturing order",
-            ],
-            katana_url=katana_url,
-            message=f"Preview: delete manufacturing order {request.id}",
-        )
-
-    prior_state = serialize_for_prior_state(existing_mo)
-    actions = await execute_plan(plan)
-    message, next_actions = summarize_delete_outcome(
-        actions, entity_label=f"manufacturing order {request.id}"
-    )
-
-    return ModificationResponse(
+    return await run_delete_plan(
+        request=request,
+        services=get_services(context),
         entity_type="manufacturing_order",
-        entity_id=request.id,
-        is_preview=False,
-        actions=actions,
-        prior_state=prior_state,
-        next_actions=next_actions,
-        katana_url=None if all(a.succeeded for a in actions) else katana_url,
-        message=message,
+        entity_label=f"manufacturing order {request.id}",
+        web_url_kind="manufacturing_order",
+        fetcher=_fetch_manufacturing_order_attrs,
+        delete_endpoint=api_delete_manufacturing_order,
+        operation=MOOperation.DELETE,
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -11,6 +11,7 @@ These tools provide:
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Annotated, Any, Literal
@@ -53,6 +54,28 @@ from katana_mcp.tools.tool_result_utils import (
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
+
+# Modify/delete API endpoints used by the unified ``modify_purchase_order`` +
+# ``delete_purchase_order`` tools. Hoisted out of per-action closures both for
+# clarity (declarative dependency list) and consistency with the rest of the
+# codebase. These resolve once at import time instead of on every action.
+from katana_public_api_client.api.purchase_order import (
+    delete_purchase_order as api_delete_purchase_order,
+    get_purchase_order as api_get_purchase_order,
+    update_purchase_order as api_update_purchase_order,
+)
+from katana_public_api_client.api.purchase_order_additional_cost_row import (
+    create_po_additional_cost_row as api_create_po_additional_cost_row,
+    delete_po_additional_cost as api_delete_po_additional_cost,
+    get_po_additional_cost_row as api_get_po_additional_cost_row,
+    update_additional_cost_row as api_update_additional_cost_row,
+)
+from katana_public_api_client.api.purchase_order_row import (
+    create_purchase_order_row as api_create_purchase_order_row,
+    delete_purchase_order_row as api_delete_purchase_order_row,
+    get_purchase_order_row as api_get_purchase_order_row,
+    update_purchase_order_row as api_update_purchase_order_row,
+)
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
@@ -2056,6 +2079,25 @@ async def list_purchase_orders(
 # ============================================================================
 
 
+class POOperation(StrEnum):
+    """Operation names that ``modify_purchase_order`` /
+    ``delete_purchase_order`` plan builders emit on their ActionSpecs.
+
+    Used as the ``operation`` field on each :class:`ActionResult` in the
+    response — values are the canonical strings the rendering layer and
+    LLM consumers see.
+    """
+
+    UPDATE_HEADER = "update_header"
+    DELETE = "delete"
+    ADD_ROW = "add_row"
+    UPDATE_ROW = "update_row"
+    DELETE_ROW = "delete_row"
+    ADD_ADDITIONAL_COST = "add_additional_cost"
+    UPDATE_ADDITIONAL_COST = "update_additional_cost"
+    DELETE_ADDITIONAL_COST = "delete_additional_cost"
+
+
 # Tool-facing uppercase status literal — accepts every value Katana defines.
 PurchaseOrderStatusLiteral = Literal[
     "DRAFT", "NOT_RECEIVED", "PARTIALLY_RECEIVED", "RECEIVED"
@@ -2082,10 +2124,10 @@ async def _fetch_purchase_order_attrs(
     services: Any, po_id: int
 ) -> RegularPurchaseOrder | None:
     """Fetch the PO attrs object for diff context. Returns None on failure."""
-    from katana_public_api_client.api.purchase_order import get_purchase_order as _get
-
     try:
-        response = await _get.asyncio_detailed(id=po_id, client=services.client)
+        response = await api_get_purchase_order.asyncio_detailed(
+            id=po_id, client=services.client
+        )
         return unwrap_as(response, RegularPurchaseOrder)
     except Exception as exc:
         logger.info(
@@ -2099,12 +2141,10 @@ async def _fetch_purchase_order_row(
     services: Any, row_id: int
 ) -> PurchaseOrderRow | None:
     """Fetch a PO row attrs object for diff context. Returns None on failure."""
-    from katana_public_api_client.api.purchase_order_row import (
-        get_purchase_order_row as _get,
-    )
-
     try:
-        response = await _get.asyncio_detailed(id=row_id, client=services.client)
+        response = await api_get_purchase_order_row.asyncio_detailed(
+            id=row_id, client=services.client
+        )
         return unwrap_as(response, PurchaseOrderRow)
     except Exception as exc:
         logger.info(
@@ -2118,12 +2158,10 @@ async def _fetch_po_additional_cost_row(
     services: Any, row_id: int
 ) -> PurchaseOrderAdditionalCostRow | None:
     """Fetch a PO additional-cost row for diff context. Returns None on failure."""
-    from katana_public_api_client.api.purchase_order_additional_cost_row import (
-        get_po_additional_cost_row as _get,
-    )
-
     try:
-        response = await _get.asyncio_detailed(id=row_id, client=services.client)
+        response = await api_get_po_additional_cost_row.asyncio_detailed(
+            id=row_id, client=services.client
+        )
         return unwrap_as(response, PurchaseOrderAdditionalCostRow)
     except Exception as exc:
         logger.info(
@@ -2138,7 +2176,7 @@ async def _fetch_po_additional_cost_row(
 # ----------------------------------------------------------------------------
 
 
-class PurchaseOrderHeaderPatch(BaseModel):
+class POHeaderPatch(BaseModel):
     """Optional fields to patch on the PO header. Status is included here —
     Katana's PATCH /purchase_orders/{id} accepts it as a regular field, so
     no separate status sub-payload is needed."""
@@ -2170,7 +2208,7 @@ class PurchaseOrderHeaderPatch(BaseModel):
     )
 
 
-class NewPORow(BaseModel):
+class PORowAdd(BaseModel):
     """A new line item to add to the PO."""
 
     variant_id: int = Field(..., description="Variant ID")
@@ -2211,7 +2249,7 @@ class PORowUpdate(BaseModel):
     )
 
 
-class NewAdditionalCost(BaseModel):
+class POAdditionalCostAdd(BaseModel):
     """A new additional-cost row (freight, duties, handling fees).
 
     Either ``group_id`` or ``purchase_order_id`` (carried at the top-level
@@ -2235,7 +2273,7 @@ class NewAdditionalCost(BaseModel):
     )
 
 
-class AdditionalCostUpdate(BaseModel):
+class POAdditionalCostUpdate(BaseModel):
     """Patch to an existing additional-cost row."""
 
     id: int = Field(..., description="Cost row ID to update")
@@ -2266,12 +2304,12 @@ class ModifyPurchaseOrderRequest(BaseModel):
 
     id: int = Field(..., description="Purchase order ID")
 
-    update_header: PurchaseOrderHeaderPatch | None = Field(
+    update_header: POHeaderPatch | None = Field(
         default=None,
         description="Header fields to patch (PATCH /purchase_orders/{id})",
     )
 
-    add_rows: list[NewPORow] | None = Field(
+    add_rows: list[PORowAdd] | None = Field(
         default=None, description="New line items to POST"
     )
     update_rows: list[PORowUpdate] | None = Field(
@@ -2281,10 +2319,10 @@ class ModifyPurchaseOrderRequest(BaseModel):
         default=None, description="Row IDs to DELETE"
     )
 
-    add_additional_costs: list[NewAdditionalCost] | None = Field(
+    add_additional_costs: list[POAdditionalCostAdd] | None = Field(
         default=None, description="New additional-cost rows to POST"
     )
-    update_additional_costs: list[AdditionalCostUpdate] | None = Field(
+    update_additional_costs: list[POAdditionalCostUpdate] | None = Field(
         default=None, description="Additional-cost row patches"
     )
     delete_additional_cost_ids: list[int] | None = Field(
@@ -2313,7 +2351,7 @@ class DeletePurchaseOrderRequest(BaseModel):
 
 
 def _build_update_header_request(
-    patch: PurchaseOrderHeaderPatch,
+    patch: POHeaderPatch,
 ) -> APIUpdatePurchaseOrderRequest:
     api_status = (
         _PO_STATUS_API_VALUE[patch.status] if patch.status is not None else None
@@ -2332,7 +2370,7 @@ def _build_update_header_request(
 
 
 def _build_create_row_request(
-    po_id: int, row: NewPORow
+    po_id: int, row: PORowAdd
 ) -> APICreatePurchaseOrderRowRequest:
     return APICreatePurchaseOrderRowRequest(
         purchase_order_id=po_id,
@@ -2367,7 +2405,7 @@ def _build_update_row_request(
 
 
 def _build_create_cost_request(
-    cost: NewAdditionalCost, group_id: int
+    cost: POAdditionalCostAdd, group_id: int
 ) -> APICreatePOAdditionalCostRowRequest:
     api_distribution = (
         _DISTRIBUTION_METHOD_API_VALUE[cost.distribution_method]
@@ -2384,7 +2422,7 @@ def _build_create_cost_request(
 
 
 def _build_update_cost_request(
-    patch: AdditionalCostUpdate,
+    patch: POAdditionalCostUpdate,
 ) -> APIUpdatePOAdditionalCostRowRequest:
     api_distribution = (
         _DISTRIBUTION_METHOD_API_VALUE[patch.distribution_method]
@@ -2399,6 +2437,114 @@ def _build_update_cost_request(
     )
 
 
+# Apply-closure factories — each builds a fresh closure binding the per-call
+# arguments. Factory functions instead of in-loop ``async def apply(arg=value):``
+# default-arg trricks, which look like real parameters and are easy to misread.
+
+
+def _make_apply_update_header(
+    services: Any, po_id: int, body: APIUpdatePurchaseOrderRequest
+) -> Callable[[], Awaitable[RegularPurchaseOrder]]:
+    async def apply() -> RegularPurchaseOrder:
+        response = await api_update_purchase_order.asyncio_detailed(
+            id=po_id, client=services.client, body=body
+        )
+        return unwrap_as(response, RegularPurchaseOrder)
+
+    return apply
+
+
+def _make_apply_create_row(
+    services: Any, body: APICreatePurchaseOrderRowRequest
+) -> Callable[[], Awaitable[PurchaseOrderRow]]:
+    async def apply() -> PurchaseOrderRow:
+        response = await api_create_purchase_order_row.asyncio_detailed(
+            client=services.client, body=body
+        )
+        return unwrap_as(response, PurchaseOrderRow)
+
+    return apply
+
+
+def _make_apply_update_row(
+    services: Any, row_id: int, body: APIUpdatePurchaseOrderRowRequest
+) -> Callable[[], Awaitable[PurchaseOrderRow]]:
+    async def apply() -> PurchaseOrderRow:
+        response = await api_update_purchase_order_row.asyncio_detailed(
+            id=row_id, client=services.client, body=body
+        )
+        return unwrap_as(response, PurchaseOrderRow)
+
+    return apply
+
+
+def _make_apply_delete_row(services: Any, row_id: int) -> Callable[[], Awaitable[None]]:
+    async def apply() -> None:
+        response = await api_delete_purchase_order_row.asyncio_detailed(
+            id=row_id, client=services.client
+        )
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    return apply
+
+
+def _make_apply_create_cost(
+    services: Any, body: APICreatePOAdditionalCostRowRequest
+) -> Callable[[], Awaitable[PurchaseOrderAdditionalCostRow]]:
+    async def apply() -> PurchaseOrderAdditionalCostRow:
+        response = await api_create_po_additional_cost_row.asyncio_detailed(
+            client=services.client, body=body
+        )
+        return unwrap_as(response, PurchaseOrderAdditionalCostRow)
+
+    return apply
+
+
+def _make_apply_update_cost(
+    services: Any, row_id: int, body: APIUpdatePOAdditionalCostRowRequest
+) -> Callable[[], Awaitable[PurchaseOrderAdditionalCostRow]]:
+    async def apply() -> PurchaseOrderAdditionalCostRow:
+        response = await api_update_additional_cost_row.asyncio_detailed(
+            id=row_id, client=services.client, body=body
+        )
+        return unwrap_as(response, PurchaseOrderAdditionalCostRow)
+
+    return apply
+
+
+def _make_apply_delete_cost(
+    services: Any, row_id: int
+) -> Callable[[], Awaitable[None]]:
+    async def apply() -> None:
+        response = await api_delete_po_additional_cost.asyncio_detailed(
+            id=row_id, client=services.client
+        )
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    return apply
+
+
+def _make_apply_delete_po(services: Any, po_id: int) -> Callable[[], Awaitable[None]]:
+    async def apply() -> None:
+        response = await api_delete_purchase_order.asyncio_detailed(
+            id=po_id, client=services.client
+        )
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    return apply
+
+
+# ----------------------------------------------------------------------------
+# Plan builders — translate sub-payloads into ActionSpec lists.
+# ----------------------------------------------------------------------------
+
+
 def _plan_header_update(
     request: ModifyPurchaseOrderRequest,
     services: Any,
@@ -2406,24 +2552,15 @@ def _plan_header_update(
 ) -> ActionSpec | None:
     if request.update_header is None:
         return None
-
     patch = request.update_header
     diff = compute_field_diff(existing, patch, unknown_prior=existing is None)
-    api_request = _build_update_header_request(patch)
-
-    async def apply() -> RegularPurchaseOrder:
-        from katana_public_api_client.api.purchase_order import update_purchase_order
-
-        response = await update_purchase_order.asyncio_detailed(
-            id=request.id, client=services.client, body=api_request
-        )
-        return unwrap_as(response, RegularPurchaseOrder)
-
     return ActionSpec(
-        operation="update_header",
+        operation=POOperation.UPDATE_HEADER,
         target_id=request.id,
         diff=diff,
-        apply=apply,
+        apply=_make_apply_update_header(
+            services, request.id, _build_update_header_request(patch)
+        ),
         verify=make_response_verifier(diff),
     )
 
@@ -2433,22 +2570,16 @@ def _plan_row_adds(
 ) -> list[ActionSpec]:
     if not request.add_rows:
         return []
-    specs: list[ActionSpec] = []
-    for row in request.add_rows:
-        api_request = _build_create_row_request(request.id, row)
-
-        async def apply(req=api_request) -> PurchaseOrderRow:
-            from katana_public_api_client.api.purchase_order_row import (
-                create_purchase_order_row,
-            )
-
-            response = await create_purchase_order_row.asyncio_detailed(
-                client=services.client, body=req
-            )
-            return unwrap_as(response, PurchaseOrderRow)
-
-        specs.append(make_create_action("add_row", row, apply))
-    return specs
+    return [
+        make_create_action(
+            POOperation.ADD_ROW,
+            row,
+            _make_apply_create_row(
+                services, _build_create_row_request(request.id, row)
+            ),
+        )
+        for row in request.add_rows
+    ]
 
 
 async def _plan_row_updates(
@@ -2456,33 +2587,23 @@ async def _plan_row_updates(
 ) -> list[ActionSpec]:
     if not request.update_rows:
         return []
-    # Parallel prefetch: independent GETs, ordering doesn't matter at plan-build time.
+    # Parallel prefetch: independent GETs, plan-build is pre-execute.
     existing_rows = await asyncio.gather(
         *[_fetch_purchase_order_row(services, p.id) for p in request.update_rows]
     )
     specs: list[ActionSpec] = []
     for row_patch, existing_row in zip(request.update_rows, existing_rows, strict=True):
-        api_request = _build_update_row_request(row_patch)
-
-        async def apply(rid=row_patch.id, req=api_request) -> PurchaseOrderRow:
-            from katana_public_api_client.api.purchase_order_row import (
-                update_purchase_order_row,
-            )
-
-            response = await update_purchase_order_row.asyncio_detailed(
-                id=rid, client=services.client, body=req
-            )
-            return unwrap_as(response, PurchaseOrderRow)
-
         diff = compute_field_diff(
             existing_row, row_patch, unknown_prior=existing_row is None
         )
         specs.append(
             ActionSpec(
-                operation="update_row",
+                operation=POOperation.UPDATE_ROW,
                 target_id=row_patch.id,
                 diff=diff,
-                apply=apply,
+                apply=_make_apply_update_row(
+                    services, row_patch.id, _build_update_row_request(row_patch)
+                ),
                 verify=make_response_verifier(diff),
             )
         )
@@ -2494,23 +2615,12 @@ def _plan_row_deletes(
 ) -> list[ActionSpec]:
     if not request.delete_row_ids:
         return []
-    specs: list[ActionSpec] = []
-    for rid in request.delete_row_ids:
-
-        async def apply(target=rid) -> None:
-            from katana_public_api_client.api.purchase_order_row import (
-                delete_purchase_order_row,
-            )
-
-            response = await delete_purchase_order_row.asyncio_detailed(
-                id=target, client=services.client
-            )
-            if not is_success(response):
-                unwrap(response)
-            return None
-
-        specs.append(make_delete_action("delete_row", rid, apply))
-    return specs
+    return [
+        make_delete_action(
+            POOperation.DELETE_ROW, rid, _make_apply_delete_row(services, rid)
+        )
+        for rid in request.delete_row_ids
+    ]
 
 
 def _plan_additional_cost_adds(
@@ -2520,9 +2630,9 @@ def _plan_additional_cost_adds(
 ) -> list[ActionSpec]:
     if not request.add_additional_costs:
         return []
-    # Cost rows attach to a group_id. When omitted on the row, fall back to
-    # the parent PO's default_group_id — read off the already-fetched ``existing_po``
-    # so we don't re-issue a GET per call.
+    # Cost rows attach to a ``group_id``; fall back to the parent PO's
+    # ``default_group_id`` when the row didn't supply one. Reads off the
+    # already-fetched ``existing_po`` to avoid a redundant GET.
     default_group_id = (
         unwrap_unset(existing_po.default_group_id, None)
         if existing_po is not None
@@ -2537,19 +2647,15 @@ def _plan_additional_cost_adds(
                 f"(additional_cost_id={cost.additional_cost_id}): no "
                 f"default_group_id on PO {request.id} and none provided."
             )
-        api_request = _build_create_cost_request(cost, group_id)
-
-        async def apply(req=api_request) -> PurchaseOrderAdditionalCostRow:
-            from katana_public_api_client.api.purchase_order_additional_cost_row import (
-                create_po_additional_cost_row,
+        specs.append(
+            make_create_action(
+                POOperation.ADD_ADDITIONAL_COST,
+                cost,
+                _make_apply_create_cost(
+                    services, _build_create_cost_request(cost, group_id)
+                ),
             )
-
-            response = await create_po_additional_cost_row.asyncio_detailed(
-                client=services.client, body=req
-            )
-            return unwrap_as(response, PurchaseOrderAdditionalCostRow)
-
-        specs.append(make_create_action("add_additional_cost", cost, apply))
+        )
     return specs
 
 
@@ -2568,29 +2674,17 @@ async def _plan_additional_cost_updates(
     for cost_patch, existing_cost in zip(
         request.update_additional_costs, existing_costs, strict=True
     ):
-        api_request = _build_update_cost_request(cost_patch)
-
-        async def apply(
-            target=cost_patch.id, req=api_request
-        ) -> PurchaseOrderAdditionalCostRow:
-            from katana_public_api_client.api.purchase_order_additional_cost_row import (
-                update_additional_cost_row,
-            )
-
-            response = await update_additional_cost_row.asyncio_detailed(
-                id=target, client=services.client, body=req
-            )
-            return unwrap_as(response, PurchaseOrderAdditionalCostRow)
-
         diff = compute_field_diff(
             existing_cost, cost_patch, unknown_prior=existing_cost is None
         )
         specs.append(
             ActionSpec(
-                operation="update_additional_cost",
+                operation=POOperation.UPDATE_ADDITIONAL_COST,
                 target_id=cost_patch.id,
                 diff=diff,
-                apply=apply,
+                apply=_make_apply_update_cost(
+                    services, cost_patch.id, _build_update_cost_request(cost_patch)
+                ),
                 verify=make_response_verifier(diff),
             )
         )
@@ -2602,23 +2696,14 @@ def _plan_additional_cost_deletes(
 ) -> list[ActionSpec]:
     if not request.delete_additional_cost_ids:
         return []
-    specs: list[ActionSpec] = []
-    for rid in request.delete_additional_cost_ids:
-
-        async def apply(target=rid) -> None:
-            from katana_public_api_client.api.purchase_order_additional_cost_row import (
-                delete_po_additional_cost,
-            )
-
-            response = await delete_po_additional_cost.asyncio_detailed(
-                id=target, client=services.client
-            )
-            if not is_success(response):
-                unwrap(response)
-            return None
-
-        specs.append(make_delete_action("delete_additional_cost", rid, apply))
-    return specs
+    return [
+        make_delete_action(
+            POOperation.DELETE_ADDITIONAL_COST,
+            rid,
+            _make_apply_delete_cost(services, rid),
+        )
+        for rid in request.delete_additional_cost_ids
+    ]
 
 
 # ----------------------------------------------------------------------------
@@ -2780,17 +2865,11 @@ async def _delete_purchase_order_impl(
 
     existing_po = await _fetch_purchase_order_attrs(services, request.id)
 
-    async def apply() -> None:
-        from katana_public_api_client.api.purchase_order import delete_purchase_order
-
-        response = await delete_purchase_order.asyncio_detailed(
-            id=request.id, client=services.client
+    plan = [
+        make_delete_action(
+            POOperation.DELETE, request.id, _make_apply_delete_po(services, request.id)
         )
-        if not is_success(response):
-            unwrap(response)
-        return None
-
-    plan = [ActionSpec(operation="delete", target_id=request.id, apply=apply)]
+    ]
     katana_url = katana_web_url("purchase_order", request.id)
 
     if not request.confirm:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -11,9 +11,8 @@ These tools provide:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
-from enum import Enum, StrEnum
+from enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
@@ -23,14 +22,17 @@ from pydantic import BaseModel, Field
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools._modification import (
-    FieldChange,
     ModificationResponse,
     compute_field_diff,
+    make_response_verifier,
     to_tool_result,
 )
 from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
     execute_plan,
+    has_any_subpayload,
+    make_create_action,
+    make_delete_action,
     plan_to_preview_results,
     serialize_for_prior_state,
 )
@@ -2052,10 +2054,6 @@ async def list_purchase_orders(
 # ============================================================================
 # Tool: modify_purchase_order — unified modification surface
 # ============================================================================
-#
-# Replaces the 8 separate PO modification tools shipped in PR #461. One tool
-# per entity, dispatching internally to the right API endpoints. See
-# ``katana_mcp.tools._modification_dispatch`` for the shared infrastructure.
 
 
 # Tool-facing uppercase status literal — accepts every value Katana defines.
@@ -2133,16 +2131,6 @@ async def _fetch_po_additional_cost_row(
             f"{exc} — preview will report changes without prior values."
         )
         return None
-
-
-async def _resolve_default_group_id(
-    services: Any, purchase_order_id: int
-) -> int | None:
-    """Look up a PO's ``default_group_id`` for additional-cost rows."""
-    existing = await _fetch_purchase_order_attrs(services, purchase_order_id)
-    if existing is None:
-        return None
-    return unwrap_unset(existing.default_group_id, None)
 
 
 # ----------------------------------------------------------------------------
@@ -2320,66 +2308,17 @@ class DeletePurchaseOrderRequest(BaseModel):
 
 
 # ----------------------------------------------------------------------------
-# Verification helper
-# ----------------------------------------------------------------------------
-
-
-def _make_response_verifier(
-    diff: list[FieldChange], field_map: dict[str, str] | None = None
-) -> Callable[[Any], Awaitable[tuple[bool, dict[str, Any] | None]]]:
-    """Build a verify closure that compares the API response body to ``diff``.
-
-    Most Katana mutation endpoints echo the post-state of the affected
-    entity in the response body — this verifier reads each requested
-    field off ``outcome`` and confirms it matches the requested ``new``
-    value. No extra fetch needed. ``field_map`` mirrors the
-    :func:`compute_field_diff` parameter for fields with names that
-    differ between request and response.
-    """
-    name_map = field_map or {}
-
-    async def verify(outcome: Any) -> tuple[bool, dict[str, Any] | None]:
-        if outcome is None:
-            return False, None
-        actual: dict[str, Any] = {}
-        verified = True
-        for change in diff:
-            attr = name_map.get(change.field, change.field)
-            raw = getattr(outcome, attr, None)
-            actual_val = unwrap_unset(raw, None)
-            if isinstance(actual_val, datetime):
-                actual_val = actual_val.isoformat()
-            elif isinstance(actual_val, Enum):
-                actual_val = actual_val.value
-            actual[change.field] = actual_val
-            if change.new is not None and actual_val != change.new:
-                verified = False
-        return verified, (actual if not verified else None)
-
-    return verify
-
-
-# ----------------------------------------------------------------------------
 # Plan builders — one per sub-payload kind
 # ----------------------------------------------------------------------------
 
 
-def _plan_header_update(
-    request: ModifyPurchaseOrderRequest,
-    services: Any,
-    existing: RegularPurchaseOrder | None,
-    fetch_failed: bool,
-) -> ActionSpec | None:
-    if request.update_header is None:
-        return None
-
-    patch = request.update_header
-    diff = compute_field_diff(existing, patch, unknown_prior=fetch_failed)
-
+def _build_update_header_request(
+    patch: PurchaseOrderHeaderPatch,
+) -> APIUpdatePurchaseOrderRequest:
     api_status = (
         _PO_STATUS_API_VALUE[patch.status] if patch.status is not None else None
     )
-    api_request = APIUpdatePurchaseOrderRequest(
+    return APIUpdatePurchaseOrderRequest(
         order_no=to_unset(patch.order_no),
         supplier_id=to_unset(patch.supplier_id),
         currency=to_unset(patch.currency),
@@ -2391,6 +2330,87 @@ def _plan_header_update(
         additional_info=to_unset(patch.additional_info),
     )
 
+
+def _build_create_row_request(
+    po_id: int, row: NewPORow
+) -> APICreatePurchaseOrderRowRequest:
+    return APICreatePurchaseOrderRowRequest(
+        purchase_order_id=po_id,
+        quantity=row.quantity,
+        variant_id=row.variant_id,
+        price_per_unit=row.price_per_unit,
+        tax_rate_id=to_unset(row.tax_rate_id),
+        tax_name=to_unset(row.tax_name),
+        tax_rate=to_unset(row.tax_rate),
+        currency=to_unset(row.currency),
+        purchase_uom=to_unset(row.purchase_uom),
+        purchase_uom_conversion_rate=to_unset(row.purchase_uom_conversion_rate),
+        arrival_date=to_unset(row.arrival_date),
+    )
+
+
+def _build_update_row_request(
+    patch: PORowUpdate,
+) -> APIUpdatePurchaseOrderRowRequest:
+    return APIUpdatePurchaseOrderRowRequest(
+        quantity=to_unset(patch.quantity),
+        variant_id=to_unset(patch.variant_id),
+        tax_rate_id=to_unset(patch.tax_rate_id),
+        tax_name=to_unset(patch.tax_name),
+        tax_rate=to_unset(patch.tax_rate),
+        price_per_unit=to_unset(patch.price_per_unit),
+        purchase_uom_conversion_rate=to_unset(patch.purchase_uom_conversion_rate),
+        purchase_uom=to_unset(patch.purchase_uom),
+        received_date=to_unset(patch.received_date),
+        arrival_date=to_unset(patch.arrival_date),
+    )
+
+
+def _build_create_cost_request(
+    cost: NewAdditionalCost, group_id: int
+) -> APICreatePOAdditionalCostRowRequest:
+    api_distribution = (
+        _DISTRIBUTION_METHOD_API_VALUE[cost.distribution_method]
+        if cost.distribution_method is not None
+        else None
+    )
+    return APICreatePOAdditionalCostRowRequest(
+        additional_cost_id=cost.additional_cost_id,
+        group_id=group_id,
+        tax_rate_id=cost.tax_rate_id,
+        price=cost.price,
+        distribution_method=to_unset(api_distribution),
+    )
+
+
+def _build_update_cost_request(
+    patch: AdditionalCostUpdate,
+) -> APIUpdatePOAdditionalCostRowRequest:
+    api_distribution = (
+        _DISTRIBUTION_METHOD_API_VALUE[patch.distribution_method]
+        if patch.distribution_method is not None
+        else None
+    )
+    return APIUpdatePOAdditionalCostRowRequest(
+        additional_cost_id=to_unset(patch.additional_cost_id),
+        tax_rate_id=to_unset(patch.tax_rate_id),
+        price=to_unset(patch.price),
+        distribution_method=to_unset(api_distribution),
+    )
+
+
+def _plan_header_update(
+    request: ModifyPurchaseOrderRequest,
+    services: Any,
+    existing: RegularPurchaseOrder | None,
+) -> ActionSpec | None:
+    if request.update_header is None:
+        return None
+
+    patch = request.update_header
+    diff = compute_field_diff(existing, patch, unknown_prior=existing is None)
+    api_request = _build_update_header_request(patch)
+
     async def apply() -> RegularPurchaseOrder:
         from katana_public_api_client.api.purchase_order import update_purchase_order
 
@@ -2399,46 +2419,23 @@ def _plan_header_update(
         )
         return unwrap_as(response, RegularPurchaseOrder)
 
-    # Verifier compares the request payload against the response body — but
-    # PurchaseOrderHeaderPatch's ``status`` is the uppercase literal and the
-    # response carries the API enum value. The Enum normalization in
-    # ``_make_response_verifier`` handles the comparison correctly only when
-    # we project the request side through the same _normalize logic.
-    # ``compute_field_diff`` already normalized the ``new`` side, so the
-    # comparison works as-is.
-    verify = _make_response_verifier(diff)
-
     return ActionSpec(
         operation="update_header",
         target_id=request.id,
         diff=diff,
         apply=apply,
-        verify=verify,
+        verify=make_response_verifier(diff),
     )
 
 
 def _plan_row_adds(
-    request: ModifyPurchaseOrderRequest,
-    services: Any,
+    request: ModifyPurchaseOrderRequest, services: Any
 ) -> list[ActionSpec]:
     if not request.add_rows:
         return []
     specs: list[ActionSpec] = []
     for row in request.add_rows:
-        diff = compute_field_diff(None, row, exclude=("confirm",))
-        api_request = APICreatePurchaseOrderRowRequest(
-            purchase_order_id=request.id,
-            quantity=row.quantity,
-            variant_id=row.variant_id,
-            price_per_unit=row.price_per_unit,
-            tax_rate_id=to_unset(row.tax_rate_id),
-            tax_name=to_unset(row.tax_name),
-            tax_rate=to_unset(row.tax_rate),
-            currency=to_unset(row.currency),
-            purchase_uom=to_unset(row.purchase_uom),
-            purchase_uom_conversion_rate=to_unset(row.purchase_uom_conversion_rate),
-            arrival_date=to_unset(row.arrival_date),
-        )
+        api_request = _build_create_row_request(request.id, row)
 
         async def apply(req=api_request) -> PurchaseOrderRow:
             from katana_public_api_client.api.purchase_order_row import (
@@ -2450,48 +2447,22 @@ def _plan_row_adds(
             )
             return unwrap_as(response, PurchaseOrderRow)
 
-        # Verify creates only that the response carries an id (creation succeeded).
-        async def verify(outcome: PurchaseOrderRow) -> tuple[bool, dict | None]:
-            verified = outcome is not None and getattr(outcome, "id", None) is not None
-            return verified, None if verified else {"id": None}
-
-        specs.append(
-            ActionSpec(
-                operation="add_row",
-                target_id=None,
-                diff=diff,
-                apply=apply,
-                verify=verify,
-            )
-        )
+        specs.append(make_create_action("add_row", row, apply))
     return specs
 
 
 async def _plan_row_updates(
-    request: ModifyPurchaseOrderRequest,
-    services: Any,
+    request: ModifyPurchaseOrderRequest, services: Any
 ) -> list[ActionSpec]:
     if not request.update_rows:
         return []
+    # Parallel prefetch: independent GETs, ordering doesn't matter at plan-build time.
+    existing_rows = await asyncio.gather(
+        *[_fetch_purchase_order_row(services, p.id) for p in request.update_rows]
+    )
     specs: list[ActionSpec] = []
-    for row_patch in request.update_rows:
-        existing_row = await _fetch_purchase_order_row(services, row_patch.id)
-        fetch_failed = existing_row is None
-        diff = compute_field_diff(existing_row, row_patch, unknown_prior=fetch_failed)
-        api_request = APIUpdatePurchaseOrderRowRequest(
-            quantity=to_unset(row_patch.quantity),
-            variant_id=to_unset(row_patch.variant_id),
-            tax_rate_id=to_unset(row_patch.tax_rate_id),
-            tax_name=to_unset(row_patch.tax_name),
-            tax_rate=to_unset(row_patch.tax_rate),
-            price_per_unit=to_unset(row_patch.price_per_unit),
-            purchase_uom_conversion_rate=to_unset(
-                row_patch.purchase_uom_conversion_rate
-            ),
-            purchase_uom=to_unset(row_patch.purchase_uom),
-            received_date=to_unset(row_patch.received_date),
-            arrival_date=to_unset(row_patch.arrival_date),
-        )
+    for row_patch, existing_row in zip(request.update_rows, existing_rows, strict=True):
+        api_request = _build_update_row_request(row_patch)
 
         async def apply(rid=row_patch.id, req=api_request) -> PurchaseOrderRow:
             from katana_public_api_client.api.purchase_order_row import (
@@ -2503,23 +2474,23 @@ async def _plan_row_updates(
             )
             return unwrap_as(response, PurchaseOrderRow)
 
-        verify = _make_response_verifier(diff)
-
+        diff = compute_field_diff(
+            existing_row, row_patch, unknown_prior=existing_row is None
+        )
         specs.append(
             ActionSpec(
                 operation="update_row",
                 target_id=row_patch.id,
                 diff=diff,
                 apply=apply,
-                verify=verify,
+                verify=make_response_verifier(diff),
             )
         )
     return specs
 
 
 def _plan_row_deletes(
-    request: ModifyPurchaseOrderRequest,
-    services: Any,
+    request: ModifyPurchaseOrderRequest, services: Any
 ) -> list[ActionSpec]:
     if not request.delete_row_ids:
         return []
@@ -2538,30 +2509,26 @@ def _plan_row_deletes(
                 unwrap(response)
             return None
 
-        # No verify on delete — entity is gone, can't fetch.
-        specs.append(
-            ActionSpec(
-                operation="delete_row",
-                target_id=rid,
-                apply=apply,
-            )
-        )
+        specs.append(make_delete_action("delete_row", rid, apply))
     return specs
 
 
-async def _plan_additional_cost_adds(
+def _plan_additional_cost_adds(
     request: ModifyPurchaseOrderRequest,
     services: Any,
+    existing_po: RegularPurchaseOrder | None,
 ) -> list[ActionSpec]:
     if not request.add_additional_costs:
         return []
+    # Cost rows attach to a group_id. When omitted on the row, fall back to
+    # the parent PO's default_group_id — read off the already-fetched ``existing_po``
+    # so we don't re-issue a GET per call.
+    default_group_id = (
+        unwrap_unset(existing_po.default_group_id, None)
+        if existing_po is not None
+        else None
+    )
     specs: list[ActionSpec] = []
-    # Resolve default_group_id once if any cost row needs it
-    default_group_id: int | None = None
-    needs_default = any(c.group_id is None for c in request.add_additional_costs)
-    if needs_default:
-        default_group_id = await _resolve_default_group_id(services, request.id)
-
     for cost in request.add_additional_costs:
         group_id = cost.group_id or default_group_id
         if group_id is None:
@@ -2570,19 +2537,7 @@ async def _plan_additional_cost_adds(
                 f"(additional_cost_id={cost.additional_cost_id}): no "
                 f"default_group_id on PO {request.id} and none provided."
             )
-        diff = compute_field_diff(None, cost, exclude=("confirm",))
-        api_distribution = (
-            _DISTRIBUTION_METHOD_API_VALUE[cost.distribution_method]
-            if cost.distribution_method is not None
-            else None
-        )
-        api_request = APICreatePOAdditionalCostRowRequest(
-            additional_cost_id=cost.additional_cost_id,
-            group_id=group_id,
-            tax_rate_id=cost.tax_rate_id,
-            price=cost.price,
-            distribution_method=to_unset(api_distribution),
-        )
+        api_request = _build_create_cost_request(cost, group_id)
 
         async def apply(req=api_request) -> PurchaseOrderAdditionalCostRow:
             from katana_public_api_client.api.purchase_order_additional_cost_row import (
@@ -2594,46 +2549,26 @@ async def _plan_additional_cost_adds(
             )
             return unwrap_as(response, PurchaseOrderAdditionalCostRow)
 
-        async def verify(
-            outcome: PurchaseOrderAdditionalCostRow,
-        ) -> tuple[bool, dict | None]:
-            verified = outcome is not None and getattr(outcome, "id", None) is not None
-            return verified, None if verified else {"id": None}
-
-        specs.append(
-            ActionSpec(
-                operation="add_additional_cost",
-                target_id=None,
-                diff=diff,
-                apply=apply,
-                verify=verify,
-            )
-        )
+        specs.append(make_create_action("add_additional_cost", cost, apply))
     return specs
 
 
 async def _plan_additional_cost_updates(
-    request: ModifyPurchaseOrderRequest,
-    services: Any,
+    request: ModifyPurchaseOrderRequest, services: Any
 ) -> list[ActionSpec]:
     if not request.update_additional_costs:
         return []
+    existing_costs = await asyncio.gather(
+        *[
+            _fetch_po_additional_cost_row(services, p.id)
+            for p in request.update_additional_costs
+        ]
+    )
     specs: list[ActionSpec] = []
-    for cost_patch in request.update_additional_costs:
-        existing_cost = await _fetch_po_additional_cost_row(services, cost_patch.id)
-        fetch_failed = existing_cost is None
-        diff = compute_field_diff(existing_cost, cost_patch, unknown_prior=fetch_failed)
-        api_distribution = (
-            _DISTRIBUTION_METHOD_API_VALUE[cost_patch.distribution_method]
-            if cost_patch.distribution_method is not None
-            else None
-        )
-        api_request = APIUpdatePOAdditionalCostRowRequest(
-            additional_cost_id=to_unset(cost_patch.additional_cost_id),
-            tax_rate_id=to_unset(cost_patch.tax_rate_id),
-            price=to_unset(cost_patch.price),
-            distribution_method=to_unset(api_distribution),
-        )
+    for cost_patch, existing_cost in zip(
+        request.update_additional_costs, existing_costs, strict=True
+    ):
+        api_request = _build_update_cost_request(cost_patch)
 
         async def apply(
             target=cost_patch.id, req=api_request
@@ -2647,23 +2582,23 @@ async def _plan_additional_cost_updates(
             )
             return unwrap_as(response, PurchaseOrderAdditionalCostRow)
 
-        verify = _make_response_verifier(diff)
-
+        diff = compute_field_diff(
+            existing_cost, cost_patch, unknown_prior=existing_cost is None
+        )
         specs.append(
             ActionSpec(
                 operation="update_additional_cost",
                 target_id=cost_patch.id,
                 diff=diff,
                 apply=apply,
-                verify=verify,
+                verify=make_response_verifier(diff),
             )
         )
     return specs
 
 
 def _plan_additional_cost_deletes(
-    request: ModifyPurchaseOrderRequest,
-    services: Any,
+    request: ModifyPurchaseOrderRequest, services: Any
 ) -> list[ActionSpec]:
     if not request.delete_additional_cost_ids:
         return []
@@ -2682,30 +2617,8 @@ def _plan_additional_cost_deletes(
                 unwrap(response)
             return None
 
-        specs.append(
-            ActionSpec(
-                operation="delete_additional_cost",
-                target_id=rid,
-                apply=apply,
-            )
-        )
+        specs.append(make_delete_action("delete_additional_cost", rid, apply))
     return specs
-
-
-def _has_any_subpayload(request: ModifyPurchaseOrderRequest) -> bool:
-    """True if any modify sub-payload is set (caller asked for at least one action)."""
-    return any(
-        v is not None and v != []
-        for v in (
-            request.update_header,
-            request.add_rows,
-            request.update_rows,
-            request.delete_row_ids,
-            request.add_additional_costs,
-            request.update_additional_costs,
-            request.delete_additional_cost_ids,
-        )
-    )
 
 
 # ----------------------------------------------------------------------------
@@ -2724,7 +2637,7 @@ async def _modify_purchase_order_impl(
     """
     services = get_services(context)
 
-    if not _has_any_subpayload(request):
+    if not has_any_subpayload(request):
         raise ValueError(
             "At least one sub-payload must be set: update_header, add_rows, "
             "update_rows, delete_row_ids, add_additional_costs, "
@@ -2732,25 +2645,25 @@ async def _modify_purchase_order_impl(
             "To remove the PO entirely, use delete_purchase_order."
         )
 
-    # Fetch existing PO once for diff context + prior_state snapshot
     existing_po = await _fetch_purchase_order_attrs(services, request.id)
-    fetch_failed = existing_po is None
 
-    # Build the plan in canonical order
+    # Canonical order: header → row adds → row updates → row deletes → cost
+    # adds → cost updates → cost deletes. Plan-build is mostly synchronous,
+    # but row/cost updates parallelize their per-target prefetches internally.
     plan: list[ActionSpec] = []
-    header_spec = _plan_header_update(request, services, existing_po, fetch_failed)
+    header_spec = _plan_header_update(request, services, existing_po)
     if header_spec is not None:
         plan.append(header_spec)
     plan.extend(_plan_row_adds(request, services))
     plan.extend(await _plan_row_updates(request, services))
     plan.extend(_plan_row_deletes(request, services))
-    plan.extend(await _plan_additional_cost_adds(request, services))
+    plan.extend(_plan_additional_cost_adds(request, services, existing_po))
     plan.extend(await _plan_additional_cost_updates(request, services))
     plan.extend(_plan_additional_cost_deletes(request, services))
 
     katana_url = katana_web_url("purchase_order", request.id)
     warnings: list[str] = []
-    if fetch_failed:
+    if existing_po is None:
         warnings.append(
             f"Could not fetch purchase order {request.id} for diff context — "
             "preview shows requested values without prior state."
@@ -2774,7 +2687,6 @@ async def _modify_purchase_order_impl(
             ),
         )
 
-    # Confirm branch — capture prior_state, then execute
     prior_state = serialize_for_prior_state(existing_po)
     actions = await execute_plan(plan)
 
@@ -2955,9 +2867,6 @@ def register_tools(mcp: FastMCP) -> None:
         idempotentHint=True,
         openWorldHint=True,
     )
-    # ``modify_purchase_order`` can also delete (via ``delete=True``), so its
-    # destructive-hint annotation is the right pick — MCP hosts that respect
-    # the hint will prompt the user before running it.
     _destructive = ToolAnnotations(
         readOnlyHint=False,
         destructiveHint=True,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -30,19 +30,16 @@ from katana_mcp.tools._modification import (
 )
 from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
-    execute_plan,
     has_any_subpayload,
     make_delete_apply,
     make_patch_apply,
     make_post_apply,
     plan_creates,
     plan_deletes,
-    plan_to_preview_results,
     plan_updates,
+    run_delete_plan,
+    run_modify_plan,
     safe_fetch_for_diff,
-    serialize_for_prior_state,
-    summarize_delete_outcome,
-    summarize_modify_outcome,
 )
 from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.tool_result_utils import (
@@ -2105,26 +2102,13 @@ class POOperation(StrEnum):
     DELETE_ADDITIONAL_COST = "delete_additional_cost"
 
 
-# Tool-facing uppercase status literal — accepts every value Katana defines.
+# Tool-facing uppercase status literal — values match the API StrEnum's
+# ``.value`` directly, so ``PurchaseOrderStatus(literal)`` resolves the
+# enum without a lookup table.
 PurchaseOrderStatusLiteral = Literal[
     "DRAFT", "NOT_RECEIVED", "PARTIALLY_RECEIVED", "RECEIVED"
 ]
-
-_PO_STATUS_API_VALUE: dict[PurchaseOrderStatusLiteral, PurchaseOrderStatus] = {
-    "DRAFT": PurchaseOrderStatus.DRAFT,
-    "NOT_RECEIVED": PurchaseOrderStatus.NOT_RECEIVED,
-    "PARTIALLY_RECEIVED": PurchaseOrderStatus.PARTIALLY_RECEIVED,
-    "RECEIVED": PurchaseOrderStatus.RECEIVED,
-}
-
 CostDistributionMethodLiteral = Literal["BY_VALUE", "NON_DISTRIBUTED"]
-
-_DISTRIBUTION_METHOD_API_VALUE: dict[
-    CostDistributionMethodLiteral, CostDistributionMethod
-] = {
-    "BY_VALUE": CostDistributionMethod.BY_VALUE,
-    "NON_DISTRIBUTED": CostDistributionMethod.NON_DISTRIBUTED,
-}
 
 
 async def _fetch_purchase_order_attrs(
@@ -2319,9 +2303,7 @@ class DeletePurchaseOrderRequest(ConfirmableRequest):
 def _build_update_header_request(
     patch: POHeaderPatch,
 ) -> APIUpdatePurchaseOrderRequest:
-    api_status = (
-        _PO_STATUS_API_VALUE[patch.status] if patch.status is not None else None
-    )
+    api_status = PurchaseOrderStatus(patch.status) if patch.status is not None else None
     return APIUpdatePurchaseOrderRequest(
         order_no=to_unset(patch.order_no),
         supplier_id=to_unset(patch.supplier_id),
@@ -2374,7 +2356,7 @@ def _build_create_cost_request(
     cost: POAdditionalCostAdd, group_id: int
 ) -> APICreatePOAdditionalCostRowRequest:
     api_distribution = (
-        _DISTRIBUTION_METHOD_API_VALUE[cost.distribution_method]
+        CostDistributionMethod(cost.distribution_method)
         if cost.distribution_method is not None
         else None
     )
@@ -2391,7 +2373,7 @@ def _build_update_cost_request(
     patch: POAdditionalCostUpdate,
 ) -> APIUpdatePOAdditionalCostRowRequest:
     api_distribution = (
-        _DISTRIBUTION_METHOD_API_VALUE[patch.distribution_method]
+        CostDistributionMethod(patch.distribution_method)
         if patch.distribution_method is not None
         else None
     )
@@ -2534,53 +2516,14 @@ async def _modify_purchase_order_impl(
         )
     )
 
-    katana_url = katana_web_url("purchase_order", request.id)
-    warnings = (
-        [
-            f"Could not fetch purchase order {request.id} for diff context — "
-            "preview shows requested values without prior state."
-        ]
-        if existing_po is None
-        else []
-    )
-
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="purchase_order",
-            entity_id=request.id,
-            is_preview=True,
-            actions=plan_to_preview_results(plan),
-            warnings=warnings,
-            next_actions=[
-                f"Review {len(plan)} planned action(s)",
-                "Set confirm=true to execute the plan",
-            ],
-            katana_url=katana_url,
-            message=(
-                f"Preview: {len(plan)} action(s) planned for purchase order "
-                f"{request.id}"
-            ),
-        )
-
-    prior_state = serialize_for_prior_state(existing_po)
-    actions = await execute_plan(plan)
-    message, next_actions = summarize_modify_outcome(
-        actions,
-        len(plan),
+    return await run_modify_plan(
+        request=request,
+        entity_type="purchase_order",
         entity_label=f"purchase order {request.id}",
         tool_name="modify_purchase_order",
-    )
-
-    return ModificationResponse(
-        entity_type="purchase_order",
-        entity_id=request.id,
-        is_preview=False,
-        actions=actions,
-        prior_state=prior_state,
-        warnings=warnings,
-        next_actions=next_actions,
-        katana_url=katana_url,
-        message=message,
+        web_url_kind="purchase_order",
+        existing=existing_po,
+        plan=plan,
     )
 
 
@@ -2628,46 +2571,15 @@ async def _delete_purchase_order_impl(
 ) -> ModificationResponse:
     """One-action plan that removes the PO. Katana cascades child rows +
     additional cost rows server-side."""
-    services = get_services(context)
-
-    existing_po = await _fetch_purchase_order_attrs(services, request.id)
-    plan = plan_deletes(
-        [request.id],
-        POOperation.DELETE,
-        lambda po_id: make_delete_apply(api_delete_purchase_order, services, po_id),
-    )
-    katana_url = katana_web_url("purchase_order", request.id)
-
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="purchase_order",
-            entity_id=request.id,
-            is_preview=True,
-            actions=plan_to_preview_results(plan),
-            next_actions=[
-                "Review the deletion",
-                "Set confirm=true to delete the purchase order",
-            ],
-            katana_url=katana_url,
-            message=f"Preview: delete purchase order {request.id}",
-        )
-
-    prior_state = serialize_for_prior_state(existing_po)
-    actions = await execute_plan(plan)
-    message, next_actions = summarize_delete_outcome(
-        actions, entity_label=f"purchase order {request.id}"
-    )
-
-    return ModificationResponse(
+    return await run_delete_plan(
+        request=request,
+        services=get_services(context),
         entity_type="purchase_order",
-        entity_id=request.id,
-        is_preview=False,
-        actions=actions,
-        prior_state=prior_state,
-        next_actions=next_actions,
-        # On successful delete the entity URL no longer resolves.
-        katana_url=None if all(a.succeeded for a in actions) else katana_url,
-        message=message,
+        entity_label=f"purchase order {request.id}",
+        web_url_kind="purchase_order",
+        fetcher=_fetch_purchase_order_attrs,
+        delete_endpoint=api_delete_purchase_order,
+        operation=POOperation.DELETE,
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -11,7 +11,6 @@ These tools provide:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Annotated, Any, Literal
@@ -23,6 +22,7 @@ from pydantic import BaseModel, Field
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools._modification import (
+    ConfirmableRequest,
     ModificationResponse,
     compute_field_diff,
     make_response_verifier,
@@ -32,10 +32,17 @@ from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
     execute_plan,
     has_any_subpayload,
-    make_create_action,
-    make_delete_action,
+    make_delete_apply,
+    make_patch_apply,
+    make_post_apply,
+    plan_creates,
+    plan_deletes,
     plan_to_preview_results,
+    plan_updates,
+    safe_fetch_for_diff,
     serialize_for_prior_state,
+    summarize_delete_outcome,
+    summarize_modify_outcome,
 )
 from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.tool_result_utils import (
@@ -2123,52 +2130,40 @@ _DISTRIBUTION_METHOD_API_VALUE: dict[
 async def _fetch_purchase_order_attrs(
     services: Any, po_id: int
 ) -> RegularPurchaseOrder | None:
-    """Fetch the PO attrs object for diff context. Returns None on failure."""
-    try:
-        response = await api_get_purchase_order.asyncio_detailed(
-            id=po_id, client=services.client
-        )
-        return unwrap_as(response, RegularPurchaseOrder)
-    except Exception as exc:
-        logger.info(
-            f"Could not fetch PO {po_id} for diff context: {exc} — "
-            "preview will report changes without prior values."
-        )
-        return None
+    """Fetch the PO for diff context. Returns None on failure."""
+    return await safe_fetch_for_diff(
+        api_get_purchase_order,
+        services,
+        po_id,
+        return_type=RegularPurchaseOrder,
+        label="PO",
+    )
 
 
 async def _fetch_purchase_order_row(
     services: Any, row_id: int
 ) -> PurchaseOrderRow | None:
-    """Fetch a PO row attrs object for diff context. Returns None on failure."""
-    try:
-        response = await api_get_purchase_order_row.asyncio_detailed(
-            id=row_id, client=services.client
-        )
-        return unwrap_as(response, PurchaseOrderRow)
-    except Exception as exc:
-        logger.info(
-            f"Could not fetch PO row {row_id} for diff context: {exc} — "
-            "preview will report changes without prior values."
-        )
-        return None
+    """Fetch a PO row for diff context. Returns None on failure."""
+    return await safe_fetch_for_diff(
+        api_get_purchase_order_row,
+        services,
+        row_id,
+        return_type=PurchaseOrderRow,
+        label="PO row",
+    )
 
 
 async def _fetch_po_additional_cost_row(
     services: Any, row_id: int
 ) -> PurchaseOrderAdditionalCostRow | None:
     """Fetch a PO additional-cost row for diff context. Returns None on failure."""
-    try:
-        response = await api_get_po_additional_cost_row.asyncio_detailed(
-            id=row_id, client=services.client
-        )
-        return unwrap_as(response, PurchaseOrderAdditionalCostRow)
-    except Exception as exc:
-        logger.info(
-            f"Could not fetch additional-cost row {row_id} for diff context: "
-            f"{exc} — preview will report changes without prior values."
-        )
-        return None
+    return await safe_fetch_for_diff(
+        api_get_po_additional_cost_row,
+        services,
+        row_id,
+        return_type=PurchaseOrderAdditionalCostRow,
+        label="additional-cost row",
+    )
 
 
 # ----------------------------------------------------------------------------
@@ -2287,7 +2282,7 @@ class POAdditionalCostUpdate(BaseModel):
     )
 
 
-class ModifyPurchaseOrderRequest(BaseModel):
+class ModifyPurchaseOrderRequest(ConfirmableRequest):
     """Unified modification request for a purchase order (non-destructive).
 
     Each sub-payload slot maps to one or more API operations on the PO or
@@ -2297,52 +2292,23 @@ class ModifyPurchaseOrderRequest(BaseModel):
     Fail-fast on first error; the response carries per-action result blocks
     plus a ``prior_state`` snapshot for manual revert.
 
-    To remove a PO entirely, use the sibling ``delete_purchase_order`` tool —
-    delete is split off so the destructive-hint annotation tracks the
-    destructive-vs-non-destructive boundary cleanly.
+    To remove a PO entirely, use the sibling ``delete_purchase_order`` tool.
     """
 
     id: int = Field(..., description="Purchase order ID")
-
-    update_header: POHeaderPatch | None = Field(
-        default=None,
-        description="Header fields to patch (PATCH /purchase_orders/{id})",
-    )
-
-    add_rows: list[PORowAdd] | None = Field(
-        default=None, description="New line items to POST"
-    )
-    update_rows: list[PORowUpdate] | None = Field(
-        default=None, description="Row patches (each carries id + fields to update)"
-    )
-    delete_row_ids: list[int] | None = Field(
-        default=None, description="Row IDs to DELETE"
-    )
-
-    add_additional_costs: list[POAdditionalCostAdd] | None = Field(
-        default=None, description="New additional-cost rows to POST"
-    )
-    update_additional_costs: list[POAdditionalCostUpdate] | None = Field(
-        default=None, description="Additional-cost row patches"
-    )
-    delete_additional_cost_ids: list[int] | None = Field(
-        default=None, description="Additional-cost row IDs to DELETE"
-    )
-
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, executes the action plan.",
-    )
+    update_header: POHeaderPatch | None = Field(default=None)
+    add_rows: list[PORowAdd] | None = Field(default=None)
+    update_rows: list[PORowUpdate] | None = Field(default=None)
+    delete_row_ids: list[int] | None = Field(default=None)
+    add_additional_costs: list[POAdditionalCostAdd] | None = Field(default=None)
+    update_additional_costs: list[POAdditionalCostUpdate] | None = Field(default=None)
+    delete_additional_cost_ids: list[int] | None = Field(default=None)
 
 
-class DeletePurchaseOrderRequest(BaseModel):
+class DeletePurchaseOrderRequest(ConfirmableRequest):
     """Delete an entire purchase order. Destructive — the order is removed."""
 
     id: int = Field(..., description="Purchase order ID to delete")
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, deletes the PO.",
-    )
 
 
 # ----------------------------------------------------------------------------
@@ -2437,289 +2403,11 @@ def _build_update_cost_request(
     )
 
 
-# Apply-closure factories — each builds a fresh closure binding the per-call
-# arguments. Factory functions instead of in-loop ``async def apply(arg=value):``
-# default-arg trricks, which look like real parameters and are easy to misread.
-
-
-def _make_apply_update_header(
-    services: Any, po_id: int, body: APIUpdatePurchaseOrderRequest
-) -> Callable[[], Awaitable[RegularPurchaseOrder]]:
-    async def apply() -> RegularPurchaseOrder:
-        response = await api_update_purchase_order.asyncio_detailed(
-            id=po_id, client=services.client, body=body
-        )
-        return unwrap_as(response, RegularPurchaseOrder)
-
-    return apply
-
-
-def _make_apply_create_row(
-    services: Any, body: APICreatePurchaseOrderRowRequest
-) -> Callable[[], Awaitable[PurchaseOrderRow]]:
-    async def apply() -> PurchaseOrderRow:
-        response = await api_create_purchase_order_row.asyncio_detailed(
-            client=services.client, body=body
-        )
-        return unwrap_as(response, PurchaseOrderRow)
-
-    return apply
-
-
-def _make_apply_update_row(
-    services: Any, row_id: int, body: APIUpdatePurchaseOrderRowRequest
-) -> Callable[[], Awaitable[PurchaseOrderRow]]:
-    async def apply() -> PurchaseOrderRow:
-        response = await api_update_purchase_order_row.asyncio_detailed(
-            id=row_id, client=services.client, body=body
-        )
-        return unwrap_as(response, PurchaseOrderRow)
-
-    return apply
-
-
-def _make_apply_delete_row(services: Any, row_id: int) -> Callable[[], Awaitable[None]]:
-    async def apply() -> None:
-        response = await api_delete_purchase_order_row.asyncio_detailed(
-            id=row_id, client=services.client
-        )
-        if not is_success(response):
-            unwrap(response)
-        return None
-
-    return apply
-
-
-def _make_apply_create_cost(
-    services: Any, body: APICreatePOAdditionalCostRowRequest
-) -> Callable[[], Awaitable[PurchaseOrderAdditionalCostRow]]:
-    async def apply() -> PurchaseOrderAdditionalCostRow:
-        response = await api_create_po_additional_cost_row.asyncio_detailed(
-            client=services.client, body=body
-        )
-        return unwrap_as(response, PurchaseOrderAdditionalCostRow)
-
-    return apply
-
-
-def _make_apply_update_cost(
-    services: Any, row_id: int, body: APIUpdatePOAdditionalCostRowRequest
-) -> Callable[[], Awaitable[PurchaseOrderAdditionalCostRow]]:
-    async def apply() -> PurchaseOrderAdditionalCostRow:
-        response = await api_update_additional_cost_row.asyncio_detailed(
-            id=row_id, client=services.client, body=body
-        )
-        return unwrap_as(response, PurchaseOrderAdditionalCostRow)
-
-    return apply
-
-
-def _make_apply_delete_cost(
-    services: Any, row_id: int
-) -> Callable[[], Awaitable[None]]:
-    async def apply() -> None:
-        response = await api_delete_po_additional_cost.asyncio_detailed(
-            id=row_id, client=services.client
-        )
-        if not is_success(response):
-            unwrap(response)
-        return None
-
-    return apply
-
-
-def _make_apply_delete_po(services: Any, po_id: int) -> Callable[[], Awaitable[None]]:
-    async def apply() -> None:
-        response = await api_delete_purchase_order.asyncio_detailed(
-            id=po_id, client=services.client
-        )
-        if not is_success(response):
-            unwrap(response)
-        return None
-
-    return apply
-
-
-# ----------------------------------------------------------------------------
-# Plan builders — translate sub-payloads into ActionSpec lists.
-# ----------------------------------------------------------------------------
-
-
-def _plan_header_update(
-    request: ModifyPurchaseOrderRequest,
-    services: Any,
-    existing: RegularPurchaseOrder | None,
-) -> ActionSpec | None:
-    if request.update_header is None:
-        return None
-    patch = request.update_header
-    diff = compute_field_diff(existing, patch, unknown_prior=existing is None)
-    return ActionSpec(
-        operation=POOperation.UPDATE_HEADER,
-        target_id=request.id,
-        diff=diff,
-        apply=_make_apply_update_header(
-            services, request.id, _build_update_header_request(patch)
-        ),
-        verify=make_response_verifier(diff),
-    )
-
-
-def _plan_row_adds(
-    request: ModifyPurchaseOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.add_rows:
-        return []
-    return [
-        make_create_action(
-            POOperation.ADD_ROW,
-            row,
-            _make_apply_create_row(
-                services, _build_create_row_request(request.id, row)
-            ),
-        )
-        for row in request.add_rows
-    ]
-
-
-async def _plan_row_updates(
-    request: ModifyPurchaseOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.update_rows:
-        return []
-    # Parallel prefetch: independent GETs, plan-build is pre-execute.
-    existing_rows = await asyncio.gather(
-        *[_fetch_purchase_order_row(services, p.id) for p in request.update_rows]
-    )
-    specs: list[ActionSpec] = []
-    for row_patch, existing_row in zip(request.update_rows, existing_rows, strict=True):
-        diff = compute_field_diff(
-            existing_row, row_patch, unknown_prior=existing_row is None
-        )
-        specs.append(
-            ActionSpec(
-                operation=POOperation.UPDATE_ROW,
-                target_id=row_patch.id,
-                diff=diff,
-                apply=_make_apply_update_row(
-                    services, row_patch.id, _build_update_row_request(row_patch)
-                ),
-                verify=make_response_verifier(diff),
-            )
-        )
-    return specs
-
-
-def _plan_row_deletes(
-    request: ModifyPurchaseOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.delete_row_ids:
-        return []
-    return [
-        make_delete_action(
-            POOperation.DELETE_ROW, rid, _make_apply_delete_row(services, rid)
-        )
-        for rid in request.delete_row_ids
-    ]
-
-
-def _plan_additional_cost_adds(
-    request: ModifyPurchaseOrderRequest,
-    services: Any,
-    existing_po: RegularPurchaseOrder | None,
-) -> list[ActionSpec]:
-    if not request.add_additional_costs:
-        return []
-    # Cost rows attach to a ``group_id``; fall back to the parent PO's
-    # ``default_group_id`` when the row didn't supply one. Reads off the
-    # already-fetched ``existing_po`` to avoid a redundant GET.
-    default_group_id = (
-        unwrap_unset(existing_po.default_group_id, None)
-        if existing_po is not None
-        else None
-    )
-    specs: list[ActionSpec] = []
-    for cost in request.add_additional_costs:
-        group_id = cost.group_id or default_group_id
-        if group_id is None:
-            raise ValueError(
-                f"Cannot resolve group_id for additional-cost row "
-                f"(additional_cost_id={cost.additional_cost_id}): no "
-                f"default_group_id on PO {request.id} and none provided."
-            )
-        specs.append(
-            make_create_action(
-                POOperation.ADD_ADDITIONAL_COST,
-                cost,
-                _make_apply_create_cost(
-                    services, _build_create_cost_request(cost, group_id)
-                ),
-            )
-        )
-    return specs
-
-
-async def _plan_additional_cost_updates(
-    request: ModifyPurchaseOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.update_additional_costs:
-        return []
-    existing_costs = await asyncio.gather(
-        *[
-            _fetch_po_additional_cost_row(services, p.id)
-            for p in request.update_additional_costs
-        ]
-    )
-    specs: list[ActionSpec] = []
-    for cost_patch, existing_cost in zip(
-        request.update_additional_costs, existing_costs, strict=True
-    ):
-        diff = compute_field_diff(
-            existing_cost, cost_patch, unknown_prior=existing_cost is None
-        )
-        specs.append(
-            ActionSpec(
-                operation=POOperation.UPDATE_ADDITIONAL_COST,
-                target_id=cost_patch.id,
-                diff=diff,
-                apply=_make_apply_update_cost(
-                    services, cost_patch.id, _build_update_cost_request(cost_patch)
-                ),
-                verify=make_response_verifier(diff),
-            )
-        )
-    return specs
-
-
-def _plan_additional_cost_deletes(
-    request: ModifyPurchaseOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.delete_additional_cost_ids:
-        return []
-    return [
-        make_delete_action(
-            POOperation.DELETE_ADDITIONAL_COST,
-            rid,
-            _make_apply_delete_cost(services, rid),
-        )
-        for rid in request.delete_additional_cost_ids
-    ]
-
-
-# ----------------------------------------------------------------------------
-# Implementation
-# ----------------------------------------------------------------------------
-
-
 async def _modify_purchase_order_impl(
     request: ModifyPurchaseOrderRequest, context: Context
 ) -> ModificationResponse:
-    """Implementation of modify_purchase_order tool.
-
-    Builds an action plan from the request's sub-payloads in canonical
-    order, returns a preview for ``confirm=False``, and executes the plan
-    via ``execute_plan`` for ``confirm=True``.
-    """
+    """Build the action plan from the request's sub-payloads and either
+    preview or execute based on ``confirm``."""
     services = get_services(context)
 
     if not has_any_subpayload(request):
@@ -2732,27 +2420,129 @@ async def _modify_purchase_order_impl(
 
     existing_po = await _fetch_purchase_order_attrs(services, request.id)
 
-    # Canonical order: header → row adds → row updates → row deletes → cost
-    # adds → cost updates → cost deletes. Plan-build is mostly synchronous,
-    # but row/cost updates parallelize their per-target prefetches internally.
+    # Resolve default_group_id once for any add_additional_costs entries that
+    # didn't supply group_id explicitly. Reads from the already-fetched PO so
+    # we don't re-issue a GET.
+    default_group_id = (
+        unwrap_unset(existing_po.default_group_id, None)
+        if existing_po is not None
+        else None
+    )
+
+    def _enrich_cost(cost: POAdditionalCostAdd) -> APICreatePOAdditionalCostRowRequest:
+        group_id = cost.group_id or default_group_id
+        if group_id is None:
+            raise ValueError(
+                f"Cannot resolve group_id for additional-cost row "
+                f"(additional_cost_id={cost.additional_cost_id}): no "
+                f"default_group_id on PO {request.id} and none provided."
+            )
+        return _build_create_cost_request(cost, group_id)
+
+    # Canonical order: header → row adds → updates → deletes → cost
+    # adds → cost updates → cost deletes.
     plan: list[ActionSpec] = []
-    header_spec = _plan_header_update(request, services, existing_po)
-    if header_spec is not None:
-        plan.append(header_spec)
-    plan.extend(_plan_row_adds(request, services))
-    plan.extend(await _plan_row_updates(request, services))
-    plan.extend(_plan_row_deletes(request, services))
-    plan.extend(_plan_additional_cost_adds(request, services, existing_po))
-    plan.extend(await _plan_additional_cost_updates(request, services))
-    plan.extend(_plan_additional_cost_deletes(request, services))
+
+    if request.update_header is not None:
+        diff = compute_field_diff(
+            existing_po, request.update_header, unknown_prior=existing_po is None
+        )
+        plan.append(
+            ActionSpec(
+                operation=POOperation.UPDATE_HEADER,
+                target_id=request.id,
+                diff=diff,
+                apply=make_patch_apply(
+                    api_update_purchase_order,
+                    services,
+                    request.id,
+                    _build_update_header_request(request.update_header),
+                    return_type=RegularPurchaseOrder,
+                ),
+                verify=make_response_verifier(diff),
+            )
+        )
+
+    plan.extend(
+        plan_creates(
+            request.add_rows,
+            POOperation.ADD_ROW,
+            lambda row: _build_create_row_request(request.id, row),
+            lambda body: make_post_apply(
+                api_create_purchase_order_row,
+                services,
+                body,
+                return_type=PurchaseOrderRow,
+            ),
+        )
+    )
+    plan.extend(
+        await plan_updates(
+            request.update_rows,
+            POOperation.UPDATE_ROW,
+            lambda rid: _fetch_purchase_order_row(services, rid),
+            _build_update_row_request,
+            lambda rid, body: make_patch_apply(
+                api_update_purchase_order_row,
+                services,
+                rid,
+                body,
+                return_type=PurchaseOrderRow,
+            ),
+        )
+    )
+    plan.extend(
+        plan_deletes(
+            request.delete_row_ids,
+            POOperation.DELETE_ROW,
+            lambda rid: make_delete_apply(api_delete_purchase_order_row, services, rid),
+        )
+    )
+    plan.extend(
+        plan_creates(
+            request.add_additional_costs,
+            POOperation.ADD_ADDITIONAL_COST,
+            _enrich_cost,
+            lambda body: make_post_apply(
+                api_create_po_additional_cost_row,
+                services,
+                body,
+                return_type=PurchaseOrderAdditionalCostRow,
+            ),
+        )
+    )
+    plan.extend(
+        await plan_updates(
+            request.update_additional_costs,
+            POOperation.UPDATE_ADDITIONAL_COST,
+            lambda rid: _fetch_po_additional_cost_row(services, rid),
+            _build_update_cost_request,
+            lambda rid, body: make_patch_apply(
+                api_update_additional_cost_row,
+                services,
+                rid,
+                body,
+                return_type=PurchaseOrderAdditionalCostRow,
+            ),
+        )
+    )
+    plan.extend(
+        plan_deletes(
+            request.delete_additional_cost_ids,
+            POOperation.DELETE_ADDITIONAL_COST,
+            lambda rid: make_delete_apply(api_delete_po_additional_cost, services, rid),
+        )
+    )
 
     katana_url = katana_web_url("purchase_order", request.id)
-    warnings: list[str] = []
-    if existing_po is None:
-        warnings.append(
+    warnings = (
+        [
             f"Could not fetch purchase order {request.id} for diff context — "
             "preview shows requested values without prior state."
-        )
+        ]
+        if existing_po is None
+        else []
+    )
 
     if not request.confirm:
         return ModificationResponse(
@@ -2774,31 +2564,12 @@ async def _modify_purchase_order_impl(
 
     prior_state = serialize_for_prior_state(existing_po)
     actions = await execute_plan(plan)
-
-    succeeded_count = sum(1 for a in actions if a.succeeded is True)
-    failed_count = sum(1 for a in actions if a.succeeded is False)
-    failed = failed_count > 0
-
-    if failed:
-        message = (
-            f"Partial: {succeeded_count}/{len(plan)} action(s) applied to "
-            f"purchase order {request.id} before fail-fast halt; see actions "
-            "for details and prior_state for revert reference."
-        )
-        next_actions = [
-            f"{succeeded_count} action(s) succeeded; {failed_count} failed",
-            "Review the FAILED action's error and the prior_state snapshot",
-            "Compose a follow-up modify_purchase_order call to revert if needed",
-        ]
-    else:
-        message = (
-            f"Successfully applied {succeeded_count}/{len(plan)} action(s) to "
-            f"purchase order {request.id}"
-        )
-        next_actions = [
-            f"Purchase order {request.id} modified — "
-            f"{succeeded_count} action(s) verified"
-        ]
+    message, next_actions = summarize_modify_outcome(
+        actions,
+        len(plan),
+        entity_label=f"purchase order {request.id}",
+        tool_name="modify_purchase_order",
+    )
 
     return ModificationResponse(
         entity_type="purchase_order",
@@ -2855,21 +2626,16 @@ async def modify_purchase_order(
 async def _delete_purchase_order_impl(
     request: DeletePurchaseOrderRequest, context: Context
 ) -> ModificationResponse:
-    """Implementation of delete_purchase_order tool.
-
-    Captures prior_state and runs a one-action plan via the same dispatcher
-    so the response shape matches modify_purchase_order. Destructive — the
-    PO record is removed.
-    """
+    """One-action plan that removes the PO. Katana cascades child rows +
+    additional cost rows server-side."""
     services = get_services(context)
 
     existing_po = await _fetch_purchase_order_attrs(services, request.id)
-
-    plan = [
-        make_delete_action(
-            POOperation.DELETE, request.id, _make_apply_delete_po(services, request.id)
-        )
-    ]
+    plan = plan_deletes(
+        [request.id],
+        POOperation.DELETE,
+        lambda po_id: make_delete_apply(api_delete_purchase_order, services, po_id),
+    )
     katana_url = katana_web_url("purchase_order", request.id)
 
     if not request.confirm:
@@ -2888,7 +2654,9 @@ async def _delete_purchase_order_impl(
 
     prior_state = serialize_for_prior_state(existing_po)
     actions = await execute_plan(plan)
-    failed = any(a.succeeded is False for a in actions)
+    message, next_actions = summarize_delete_outcome(
+        actions, entity_label=f"purchase order {request.id}"
+    )
 
     return ModificationResponse(
         entity_type="purchase_order",
@@ -2896,21 +2664,10 @@ async def _delete_purchase_order_impl(
         is_preview=False,
         actions=actions,
         prior_state=prior_state,
-        next_actions=(
-            [f"Purchase order {request.id} has been deleted"]
-            if not failed
-            else [
-                "Delete failed — see action error",
-                "prior_state carries the pre-delete snapshot",
-            ]
-        ),
+        next_actions=next_actions,
         # On successful delete the entity URL no longer resolves.
-        katana_url=None if not failed else katana_url,
-        message=(
-            f"Successfully deleted purchase order {request.id}"
-            if not failed
-            else f"Failed to delete purchase order {request.id}"
-        ),
+        katana_url=None if all(a.succeeded for a in actions) else katana_url,
+        message=message,
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -40,6 +40,7 @@ from katana_mcp.tools._modification_dispatch import (
     run_delete_plan,
     run_modify_plan,
     safe_fetch_for_diff,
+    unset_dict,
 )
 from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.tool_result_utils import (
@@ -2303,85 +2304,47 @@ class DeletePurchaseOrderRequest(ConfirmableRequest):
 def _build_update_header_request(
     patch: POHeaderPatch,
 ) -> APIUpdatePurchaseOrderRequest:
-    api_status = PurchaseOrderStatus(patch.status) if patch.status is not None else None
     return APIUpdatePurchaseOrderRequest(
-        order_no=to_unset(patch.order_no),
-        supplier_id=to_unset(patch.supplier_id),
-        currency=to_unset(patch.currency),
-        location_id=to_unset(patch.location_id),
-        tracking_location_id=to_unset(patch.tracking_location_id),
-        status=to_unset(api_status),
-        expected_arrival_date=to_unset(patch.expected_arrival_date),
-        order_created_date=to_unset(patch.order_created_date),
-        additional_info=to_unset(patch.additional_info),
+        **unset_dict(patch, transforms={"status": PurchaseOrderStatus})
     )
 
 
 def _build_create_row_request(
     po_id: int, row: PORowAdd
 ) -> APICreatePurchaseOrderRowRequest:
-    return APICreatePurchaseOrderRowRequest(
-        purchase_order_id=po_id,
-        quantity=row.quantity,
-        variant_id=row.variant_id,
-        price_per_unit=row.price_per_unit,
-        tax_rate_id=to_unset(row.tax_rate_id),
-        tax_name=to_unset(row.tax_name),
-        tax_rate=to_unset(row.tax_rate),
-        currency=to_unset(row.currency),
-        purchase_uom=to_unset(row.purchase_uom),
-        purchase_uom_conversion_rate=to_unset(row.purchase_uom_conversion_rate),
-        arrival_date=to_unset(row.arrival_date),
-    )
+    return APICreatePurchaseOrderRowRequest(purchase_order_id=po_id, **unset_dict(row))
 
 
 def _build_update_row_request(
     patch: PORowUpdate,
 ) -> APIUpdatePurchaseOrderRowRequest:
-    return APIUpdatePurchaseOrderRowRequest(
-        quantity=to_unset(patch.quantity),
-        variant_id=to_unset(patch.variant_id),
-        tax_rate_id=to_unset(patch.tax_rate_id),
-        tax_name=to_unset(patch.tax_name),
-        tax_rate=to_unset(patch.tax_rate),
-        price_per_unit=to_unset(patch.price_per_unit),
-        purchase_uom_conversion_rate=to_unset(patch.purchase_uom_conversion_rate),
-        purchase_uom=to_unset(patch.purchase_uom),
-        received_date=to_unset(patch.received_date),
-        arrival_date=to_unset(patch.arrival_date),
-    )
+    return APIUpdatePurchaseOrderRowRequest(**unset_dict(patch, exclude=("id",)))
 
 
 def _build_create_cost_request(
     cost: POAdditionalCostAdd, group_id: int
 ) -> APICreatePOAdditionalCostRowRequest:
-    api_distribution = (
-        CostDistributionMethod(cost.distribution_method)
-        if cost.distribution_method is not None
-        else None
-    )
+    # ``cost.group_id`` is dropped — the resolved ``group_id`` parameter
+    # (from PO ``default_group_id`` or the user's row-level override) wins.
     return APICreatePOAdditionalCostRowRequest(
-        additional_cost_id=cost.additional_cost_id,
         group_id=group_id,
-        tax_rate_id=cost.tax_rate_id,
-        price=cost.price,
-        distribution_method=to_unset(api_distribution),
+        **unset_dict(
+            cost,
+            exclude=("group_id",),
+            transforms={"distribution_method": CostDistributionMethod},
+        ),
     )
 
 
 def _build_update_cost_request(
     patch: POAdditionalCostUpdate,
 ) -> APIUpdatePOAdditionalCostRowRequest:
-    api_distribution = (
-        CostDistributionMethod(patch.distribution_method)
-        if patch.distribution_method is not None
-        else None
-    )
     return APIUpdatePOAdditionalCostRowRequest(
-        additional_cost_id=to_unset(patch.additional_cost_id),
-        tax_rate_id=to_unset(patch.tax_rate_id),
-        price=to_unset(patch.price),
-        distribution_method=to_unset(api_distribution),
+        **unset_dict(
+            patch,
+            exclude=("id",),
+            transforms={"distribution_method": CostDistributionMethod},
+        )
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -11,8 +11,9 @@ These tools provide:
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
-from enum import StrEnum
+from enum import Enum, StrEnum
 from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
@@ -22,9 +23,16 @@ from pydantic import BaseModel, Field
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools._modification import (
+    FieldChange,
     ModificationResponse,
     compute_field_diff,
     to_tool_result,
+)
+from katana_mcp.tools._modification_dispatch import (
+    ActionSpec,
+    execute_plan,
+    plan_to_preview_results,
+    serialize_for_prior_state,
 )
 from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.tool_result_utils import (
@@ -2042,18 +2050,18 @@ async def list_purchase_orders(
 
 
 # ============================================================================
-# Tool: update_purchase_order (header fields, including status)
+# Tool: modify_purchase_order — unified modification surface
 # ============================================================================
+#
+# Replaces the 8 separate PO modification tools shipped in PR #461. One tool
+# per entity, dispatching internally to the right API endpoints. See
+# ``katana_mcp.tools._modification_dispatch`` for the shared infrastructure.
 
 
 # Tool-facing uppercase status literal — accepts every value Katana defines.
-# Folded into ``update_purchase_order`` rather than a separate status tool to
-# keep the surface uniform with the canonical entity-modification pattern in
-# ``katana_mcp.tools._modification``.
 PurchaseOrderStatusLiteral = Literal[
     "DRAFT", "NOT_RECEIVED", "PARTIALLY_RECEIVED", "RECEIVED"
 ]
-
 
 _PO_STATUS_API_VALUE: dict[PurchaseOrderStatusLiteral, PurchaseOrderStatus] = {
     "DRAFT": PurchaseOrderStatus.DRAFT,
@@ -2062,21 +2070,94 @@ _PO_STATUS_API_VALUE: dict[PurchaseOrderStatusLiteral, PurchaseOrderStatus] = {
     "RECEIVED": PurchaseOrderStatus.RECEIVED,
 }
 
+CostDistributionMethodLiteral = Literal["BY_VALUE", "NON_DISTRIBUTED"]
 
-class UpdatePurchaseOrderRequest(BaseModel):
-    """Request to update header fields on an existing purchase order.
+_DISTRIBUTION_METHOD_API_VALUE: dict[
+    CostDistributionMethodLiteral, CostDistributionMethod
+] = {
+    "BY_VALUE": CostDistributionMethod.BY_VALUE,
+    "NON_DISTRIBUTED": CostDistributionMethod.NON_DISTRIBUTED,
+}
 
-    Status transitions are folded in here as a regular field — Katana's API
-    accepts ``status`` as part of the same PATCH body, so a separate
-    ``update_purchase_order_status`` tool would only duplicate surface area.
-    """
 
-    id: int = Field(..., description="Purchase order ID")
+async def _fetch_purchase_order_attrs(
+    services: Any, po_id: int
+) -> RegularPurchaseOrder | None:
+    """Fetch the PO attrs object for diff context. Returns None on failure."""
+    from katana_public_api_client.api.purchase_order import get_purchase_order as _get
+
+    try:
+        response = await _get.asyncio_detailed(id=po_id, client=services.client)
+        return unwrap_as(response, RegularPurchaseOrder)
+    except Exception as exc:
+        logger.info(
+            f"Could not fetch PO {po_id} for diff context: {exc} — "
+            "preview will report changes without prior values."
+        )
+        return None
+
+
+async def _fetch_purchase_order_row(
+    services: Any, row_id: int
+) -> PurchaseOrderRow | None:
+    """Fetch a PO row attrs object for diff context. Returns None on failure."""
+    from katana_public_api_client.api.purchase_order_row import (
+        get_purchase_order_row as _get,
+    )
+
+    try:
+        response = await _get.asyncio_detailed(id=row_id, client=services.client)
+        return unwrap_as(response, PurchaseOrderRow)
+    except Exception as exc:
+        logger.info(
+            f"Could not fetch PO row {row_id} for diff context: {exc} — "
+            "preview will report changes without prior values."
+        )
+        return None
+
+
+async def _fetch_po_additional_cost_row(
+    services: Any, row_id: int
+) -> PurchaseOrderAdditionalCostRow | None:
+    """Fetch a PO additional-cost row for diff context. Returns None on failure."""
+    from katana_public_api_client.api.purchase_order_additional_cost_row import (
+        get_po_additional_cost_row as _get,
+    )
+
+    try:
+        response = await _get.asyncio_detailed(id=row_id, client=services.client)
+        return unwrap_as(response, PurchaseOrderAdditionalCostRow)
+    except Exception as exc:
+        logger.info(
+            f"Could not fetch additional-cost row {row_id} for diff context: "
+            f"{exc} — preview will report changes without prior values."
+        )
+        return None
+
+
+async def _resolve_default_group_id(
+    services: Any, purchase_order_id: int
+) -> int | None:
+    """Look up a PO's ``default_group_id`` for additional-cost rows."""
+    existing = await _fetch_purchase_order_attrs(services, purchase_order_id)
+    if existing is None:
+        return None
+    return unwrap_unset(existing.default_group_id, None)
+
+
+# ----------------------------------------------------------------------------
+# Sub-payload models
+# ----------------------------------------------------------------------------
+
+
+class PurchaseOrderHeaderPatch(BaseModel):
+    """Optional fields to patch on the PO header. Status is included here —
+    Katana's PATCH /purchase_orders/{id} accepts it as a regular field, so
+    no separate status sub-payload is needed."""
+
     order_no: str | None = Field(default=None, description="New PO number")
     supplier_id: int | None = Field(default=None, description="New supplier ID")
-    currency: str | None = Field(
-        default=None, description="New currency code (e.g., USD)"
-    )
+    currency: str | None = Field(default=None, description="New currency code")
     location_id: int | None = Field(
         default=None, description="New receiving location ID"
     )
@@ -2099,346 +2180,31 @@ class UpdatePurchaseOrderRequest(BaseModel):
     additional_info: str | None = Field(
         default=None, description="New notes / additional info"
     )
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, applies the update.",
-    )
 
 
-async def _fetch_purchase_order_attrs(
-    services: Any, po_id: int
-) -> RegularPurchaseOrder | None:
-    """Fetch the existing PO attrs object for diff context.
+class NewPORow(BaseModel):
+    """A new line item to add to the PO."""
 
-    Returns ``None`` on failure rather than raising — the diff is best-effort
-    UX and the caller still surfaces the change set the user requested.
-    """
-    from katana_public_api_client.api.purchase_order import get_purchase_order as _get
-
-    try:
-        response = await _get.asyncio_detailed(id=po_id, client=services.client)
-        existing = unwrap_as(response, RegularPurchaseOrder)
-        return existing
-    except Exception as exc:
-        logger.info(
-            f"Could not fetch PO {po_id} for diff context: {exc} — "
-            "preview will report changes without prior values."
-        )
-        return None
-
-
-async def _update_purchase_order_impl(
-    request: UpdatePurchaseOrderRequest, context: Context
-) -> ModificationResponse:
-    """Implementation of update_purchase_order tool."""
-    services = get_services(context)
-
-    has_any_field = any(
-        v is not None
-        for v in (
-            request.order_no,
-            request.supplier_id,
-            request.currency,
-            request.location_id,
-            request.tracking_location_id,
-            request.status,
-            request.expected_arrival_date,
-            request.order_created_date,
-            request.additional_info,
-        )
-    )
-    if not has_any_field:
-        raise ValueError(
-            "At least one field must be provided to update — supply order_no, "
-            "supplier_id, currency, location_id, tracking_location_id, status, "
-            "expected_arrival_date, order_created_date, or additional_info."
-        )
-
-    existing = await _fetch_purchase_order_attrs(services, request.id)
-    fetch_failed = existing is None
-    # An update target is assumed to exist — when the best-effort fetch fails,
-    # the diff renders "(prior unknown) → new" rather than implying the field
-    # was empty. The warning surfaces the same context to the LLM/UI.
-    changes = compute_field_diff(existing, request, unknown_prior=fetch_failed)
-    warnings = (
-        [
-            f"Could not fetch purchase order {request.id} for diff context — "
-            "preview shows requested values without prior state."
-        ]
-        if fetch_failed
-        else []
-    )
-    katana_url = katana_web_url("purchase_order", request.id)
-
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="purchase_order",
-            entity_id=request.id,
-            operation="update",
-            is_preview=True,
-            changes=changes,
-            warnings=warnings,
-            next_actions=[
-                "Review the proposed changes",
-                "Set confirm=true to apply the update",
-            ],
-            katana_url=katana_url,
-            message=(
-                f"Preview: update purchase order {request.id} ({len(changes)} field(s))"
-            ),
-        )
-
-    api_status = (
-        _PO_STATUS_API_VALUE[request.status] if request.status is not None else None
-    )
-    api_request = APIUpdatePurchaseOrderRequest(
-        order_no=to_unset(request.order_no),
-        supplier_id=to_unset(request.supplier_id),
-        currency=to_unset(request.currency),
-        location_id=to_unset(request.location_id),
-        tracking_location_id=to_unset(request.tracking_location_id),
-        status=to_unset(api_status),
-        expected_arrival_date=to_unset(request.expected_arrival_date),
-        order_created_date=to_unset(request.order_created_date),
-        additional_info=to_unset(request.additional_info),
-    )
-
-    from katana_public_api_client.api.purchase_order import update_purchase_order
-
-    api_response = await update_purchase_order.asyncio_detailed(
-        id=request.id, client=services.client, body=api_request
-    )
-    updated = unwrap_as(api_response, RegularPurchaseOrder)
-    logger.info(f"Updated purchase order {updated.id}")
-
-    return ModificationResponse(
-        entity_type="purchase_order",
-        entity_id=updated.id,
-        operation="update",
-        is_preview=False,
-        changes=changes,
-        next_actions=[f"Purchase order {updated.id} updated"],
-        katana_url=katana_url,
-        message=f"Successfully updated purchase order {updated.id}",
-    )
-
-
-@observe_tool
-@unpack_pydantic_params
-async def update_purchase_order(
-    request: Annotated[UpdatePurchaseOrderRequest, Unpack()], context: Context
-) -> ToolResult:
-    """Update header fields on an existing purchase order.
-
-    Two-step flow: ``confirm=false`` returns a preview with a per-field diff
-    against the current PO; ``confirm=true`` applies the PATCH. Accepts any
-    subset of ``order_no``, ``supplier_id``, ``currency``, ``location_id``,
-    ``tracking_location_id``, ``status``, ``expected_arrival_date``,
-    ``order_created_date``, and ``additional_info``. Status transitions are
-    handled via this same tool — there's no separate status endpoint.
-    """
-    response = await _update_purchase_order_impl(request, context)
-    return to_tool_result(response)
-
-
-# ============================================================================
-# Tool: delete_purchase_order
-# ============================================================================
-
-
-class DeletePurchaseOrderRequest(BaseModel):
-    """Request to delete a purchase order."""
-
-    id: int = Field(..., description="Purchase order ID to delete")
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, deletes the PO.",
-    )
-
-
-async def _delete_purchase_order_impl(
-    request: DeletePurchaseOrderRequest, context: Context
-) -> ModificationResponse:
-    """Implementation of delete_purchase_order tool."""
-    katana_url = katana_web_url("purchase_order", request.id)
-
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="purchase_order",
-            entity_id=request.id,
-            operation="delete",
-            is_preview=True,
-            next_actions=[
-                "Review the deletion",
-                "Set confirm=true to delete the purchase order",
-            ],
-            katana_url=katana_url,
-            message=f"Preview: delete purchase order {request.id}",
-        )
-
-    services = get_services(context)
-    from katana_public_api_client.api.purchase_order import delete_purchase_order
-
-    response = await delete_purchase_order.asyncio_detailed(
-        id=request.id, client=services.client
-    )
-    if not is_success(response):
-        unwrap(response)
-
-    logger.info(f"Deleted purchase order {request.id}")
-    return ModificationResponse(
-        entity_type="purchase_order",
-        entity_id=request.id,
-        operation="delete",
-        is_preview=False,
-        next_actions=[f"Purchase order {request.id} has been deleted"],
-        katana_url=None,
-        message=f"Successfully deleted purchase order {request.id}",
-    )
-
-
-@observe_tool
-@unpack_pydantic_params
-async def delete_purchase_order(
-    request: Annotated[DeletePurchaseOrderRequest, Unpack()], context: Context
-) -> ToolResult:
-    """Delete a purchase order.
-
-    Two-step flow: ``confirm=false`` returns a preview, ``confirm=true``
-    deletes the PO. Destructive — the order record is removed.
-    """
-    response = await _delete_purchase_order_impl(request, context)
-    return to_tool_result(response)
-
-
-# ============================================================================
-# Tool: add_purchase_order_row
-# ============================================================================
-
-
-class AddPurchaseOrderRowRequest(BaseModel):
-    """Request to add a new line item to an existing purchase order."""
-
-    purchase_order_id: int = Field(..., description="Parent purchase order ID")
-    variant_id: int = Field(..., description="Variant ID to order")
-    quantity: float = Field(..., description="Quantity to order", gt=0)
+    variant_id: int = Field(..., description="Variant ID")
+    quantity: float = Field(..., description="Quantity", gt=0)
     price_per_unit: float = Field(..., description="Unit price")
     tax_rate_id: int | None = Field(default=None, description="Tax rate ID")
     tax_name: str | None = Field(default=None, description="Tax name")
     tax_rate: str | None = Field(default=None, description="Tax rate value")
     currency: str | None = Field(default=None, description="Currency code")
-    purchase_uom: str | None = Field(
-        default=None, description="Purchase unit of measure"
-    )
+    purchase_uom: str | None = Field(default=None, description="Purchase UOM")
     purchase_uom_conversion_rate: float | None = Field(
         default=None, description="UOM conversion rate"
     )
     arrival_date: datetime | None = Field(
         default=None, description="Expected arrival date for this row"
     )
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, adds the row.",
-    )
 
 
-async def _add_purchase_order_row_impl(
-    request: AddPurchaseOrderRowRequest, context: Context
-) -> ModificationResponse:
-    """Implementation of add_purchase_order_row tool."""
-    parent_url = katana_web_url("purchase_order", request.purchase_order_id)
-    # New row — every supplied field is reported as added (no existing entity).
-    changes = compute_field_diff(
-        None, request, exclude=("confirm", "purchase_order_id")
-    )
+class PORowUpdate(BaseModel):
+    """Patch to an existing PO row. Carries the row id plus optional fields."""
 
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="purchase_order_row",
-            entity_id=None,
-            parent_entity_id=request.purchase_order_id,
-            operation="create_row",
-            is_preview=True,
-            changes=changes,
-            next_actions=[
-                "Review the new row",
-                "Set confirm=true to add the row",
-            ],
-            katana_url=parent_url,
-            message=(
-                f"Preview: add row to purchase order {request.purchase_order_id} "
-                f"(variant {request.variant_id}, qty {request.quantity})"
-            ),
-        )
-
-    services = get_services(context)
-    api_request = APICreatePurchaseOrderRowRequest(
-        purchase_order_id=request.purchase_order_id,
-        quantity=request.quantity,
-        variant_id=request.variant_id,
-        price_per_unit=request.price_per_unit,
-        tax_rate_id=to_unset(request.tax_rate_id),
-        tax_name=to_unset(request.tax_name),
-        tax_rate=to_unset(request.tax_rate),
-        currency=to_unset(request.currency),
-        purchase_uom_conversion_rate=to_unset(request.purchase_uom_conversion_rate),
-        purchase_uom=to_unset(request.purchase_uom),
-        arrival_date=to_unset(request.arrival_date),
-    )
-
-    from katana_public_api_client.api.purchase_order_row import (
-        create_purchase_order_row,
-    )
-
-    api_response = await create_purchase_order_row.asyncio_detailed(
-        client=services.client, body=api_request
-    )
-    new_row = unwrap_as(api_response, PurchaseOrderRow)
-    logger.info(f"Added row {new_row.id} to purchase order {request.purchase_order_id}")
-
-    return ModificationResponse(
-        entity_type="purchase_order_row",
-        entity_id=new_row.id,
-        parent_entity_id=request.purchase_order_id,
-        operation="create_row",
-        is_preview=False,
-        changes=changes,
-        next_actions=[
-            f"Row {new_row.id} added to purchase order {request.purchase_order_id}"
-        ],
-        katana_url=parent_url,
-        message=(
-            f"Successfully added row {new_row.id} to purchase order "
-            f"{request.purchase_order_id}"
-        ),
-    )
-
-
-@observe_tool
-@unpack_pydantic_params
-async def add_purchase_order_row(
-    request: Annotated[AddPurchaseOrderRowRequest, Unpack()], context: Context
-) -> ToolResult:
-    """Add a new line item to an existing purchase order.
-
-    Two-step flow: ``confirm=false`` returns a preview, ``confirm=true``
-    POSTs the new row. Required: ``purchase_order_id``, ``variant_id``,
-    ``quantity``, ``price_per_unit``. Optional fields cover taxes, UOM,
-    and per-row arrival date.
-    """
-    response = await _add_purchase_order_row_impl(request, context)
-    return to_tool_result(response)
-
-
-# ============================================================================
-# Tool: update_purchase_order_row
-# ============================================================================
-
-
-class UpdatePurchaseOrderRowRequest(BaseModel):
-    """Request to update fields on an existing purchase order row."""
-
-    id: int = Field(..., description="Purchase order row ID")
+    id: int = Field(..., description="Row ID to update")
     quantity: float | None = Field(default=None, description="New quantity", gt=0)
     variant_id: int | None = Field(default=None, description="New variant ID")
     tax_rate_id: int | None = Field(default=None, description="New tax rate ID")
@@ -2448,639 +2214,727 @@ class UpdatePurchaseOrderRowRequest(BaseModel):
     purchase_uom_conversion_rate: float | None = Field(
         default=None, description="New UOM conversion rate"
     )
-    purchase_uom: str | None = Field(
-        default=None, description="New purchase unit of measure"
-    )
+    purchase_uom: str | None = Field(default=None, description="New purchase UOM")
     received_date: datetime | None = Field(
         default=None, description="New received date"
     )
     arrival_date: datetime | None = Field(
-        default=None, description="New expected arrival date for this row"
-    )
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, applies the update.",
+        default=None, description="New row-level arrival date"
     )
 
 
-async def _fetch_purchase_order_row(
-    services: Any, row_id: int
-) -> PurchaseOrderRow | None:
-    """Fetch the existing PO row for diff context. Returns ``None`` on failure."""
-    from katana_public_api_client.api.purchase_order_row import (
-        get_purchase_order_row as _get,
-    )
+class NewAdditionalCost(BaseModel):
+    """A new additional-cost row (freight, duties, handling fees).
 
-    try:
-        response = await _get.asyncio_detailed(id=row_id, client=services.client)
-        return unwrap_as(response, PurchaseOrderRow)
-    except Exception as exc:
-        logger.info(
-            f"Could not fetch PO row {row_id} for diff context: {exc} — "
-            "preview will report changes without prior values."
-        )
-        return None
-
-
-async def _update_purchase_order_row_impl(
-    request: UpdatePurchaseOrderRowRequest, context: Context
-) -> ModificationResponse:
-    """Implementation of update_purchase_order_row tool."""
-    services = get_services(context)
-
-    has_any_field = any(
-        v is not None
-        for v in (
-            request.quantity,
-            request.variant_id,
-            request.tax_rate_id,
-            request.tax_name,
-            request.tax_rate,
-            request.price_per_unit,
-            request.purchase_uom_conversion_rate,
-            request.purchase_uom,
-            request.received_date,
-            request.arrival_date,
-        )
-    )
-    if not has_any_field:
-        raise ValueError(
-            "At least one field must be provided to update — supply quantity, "
-            "variant_id, tax_rate_id, tax_name, tax_rate, price_per_unit, "
-            "purchase_uom_conversion_rate, purchase_uom, received_date, or "
-            "arrival_date."
-        )
-
-    existing = await _fetch_purchase_order_row(services, request.id)
-    fetch_failed = existing is None
-    changes = compute_field_diff(existing, request, unknown_prior=fetch_failed)
-    parent_id = (
-        unwrap_unset(existing.purchase_order_id, None) if existing is not None else None
-    )
-    parent_url = (
-        katana_web_url("purchase_order", parent_id) if parent_id is not None else None
-    )
-    warnings = (
-        [
-            f"Could not fetch purchase order row {request.id} for diff context — "
-            "preview shows requested values without prior state."
-        ]
-        if fetch_failed
-        else []
-    )
-
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="purchase_order_row",
-            entity_id=request.id,
-            parent_entity_id=parent_id,
-            operation="update_row",
-            is_preview=True,
-            changes=changes,
-            warnings=warnings,
-            next_actions=[
-                "Review the proposed changes",
-                "Set confirm=true to apply the update",
-            ],
-            katana_url=parent_url,
-            message=(
-                f"Preview: update purchase order row {request.id} "
-                f"({len(changes)} field(s))"
-            ),
-        )
-
-    api_request = APIUpdatePurchaseOrderRowRequest(
-        quantity=to_unset(request.quantity),
-        variant_id=to_unset(request.variant_id),
-        tax_rate_id=to_unset(request.tax_rate_id),
-        tax_name=to_unset(request.tax_name),
-        tax_rate=to_unset(request.tax_rate),
-        price_per_unit=to_unset(request.price_per_unit),
-        purchase_uom_conversion_rate=to_unset(request.purchase_uom_conversion_rate),
-        purchase_uom=to_unset(request.purchase_uom),
-        received_date=to_unset(request.received_date),
-        arrival_date=to_unset(request.arrival_date),
-    )
-
-    from katana_public_api_client.api.purchase_order_row import (
-        update_purchase_order_row,
-    )
-
-    api_response = await update_purchase_order_row.asyncio_detailed(
-        id=request.id, client=services.client, body=api_request
-    )
-    updated = unwrap_as(api_response, PurchaseOrderRow)
-    logger.info(f"Updated purchase order row {updated.id}")
-
-    # When the pre-update fetch failed, parent_id/url are still None — but the
-    # PATCH response echoes purchase_order_id, so we can recover the parent
-    # context from it. This keeps the confirm-path response well-formed even
-    # when the preview-context fetch was best-effort and lossy.
-    final_parent_id = parent_id or unwrap_unset(updated.purchase_order_id, None)
-    final_parent_url = parent_url or (
-        katana_web_url("purchase_order", final_parent_id)
-        if final_parent_id is not None
-        else None
-    )
-
-    return ModificationResponse(
-        entity_type="purchase_order_row",
-        entity_id=updated.id,
-        parent_entity_id=final_parent_id,
-        operation="update_row",
-        is_preview=False,
-        changes=changes,
-        next_actions=[f"Row {updated.id} updated"],
-        katana_url=final_parent_url,
-        message=f"Successfully updated purchase order row {updated.id}",
-    )
-
-
-@observe_tool
-@unpack_pydantic_params
-async def update_purchase_order_row(
-    request: Annotated[UpdatePurchaseOrderRowRequest, Unpack()], context: Context
-) -> ToolResult:
-    """Update fields on an existing purchase order row.
-
-    Two-step flow: ``confirm=false`` returns a preview with per-field diff,
-    ``confirm=true`` applies the PATCH. Accepts any subset of quantity,
-    variant_id, taxes, price_per_unit, UOM fields, received_date, and the
-    row-level arrival_date (separate from the PO header's arrival date).
-    """
-    response = await _update_purchase_order_row_impl(request, context)
-    return to_tool_result(response)
-
-
-# ============================================================================
-# Tool: delete_purchase_order_row
-# ============================================================================
-
-
-class DeletePurchaseOrderRowRequest(BaseModel):
-    """Request to delete a purchase order row."""
-
-    id: int = Field(..., description="Purchase order row ID to delete")
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, deletes the row.",
-    )
-
-
-async def _delete_purchase_order_row_impl(
-    request: DeletePurchaseOrderRowRequest, context: Context
-) -> ModificationResponse:
-    """Implementation of delete_purchase_order_row tool."""
-    services = get_services(context)
-    existing = await _fetch_purchase_order_row(services, request.id)
-    parent_id = (
-        unwrap_unset(existing.purchase_order_id, None) if existing is not None else None
-    )
-    parent_url = (
-        katana_web_url("purchase_order", parent_id) if parent_id is not None else None
-    )
-
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="purchase_order_row",
-            entity_id=request.id,
-            parent_entity_id=parent_id,
-            operation="delete_row",
-            is_preview=True,
-            next_actions=[
-                "Review the deletion",
-                "Set confirm=true to delete the row",
-            ],
-            katana_url=parent_url,
-            message=f"Preview: delete purchase order row {request.id}",
-        )
-
-    from katana_public_api_client.api.purchase_order_row import (
-        delete_purchase_order_row,
-    )
-
-    response = await delete_purchase_order_row.asyncio_detailed(
-        id=request.id, client=services.client
-    )
-    if not is_success(response):
-        unwrap(response)
-
-    logger.info(f"Deleted purchase order row {request.id}")
-    return ModificationResponse(
-        entity_type="purchase_order_row",
-        entity_id=request.id,
-        parent_entity_id=parent_id,
-        operation="delete_row",
-        is_preview=False,
-        next_actions=[f"Row {request.id} has been deleted"],
-        katana_url=parent_url,
-        message=f"Successfully deleted purchase order row {request.id}",
-    )
-
-
-@observe_tool
-@unpack_pydantic_params
-async def delete_purchase_order_row(
-    request: Annotated[DeletePurchaseOrderRowRequest, Unpack()], context: Context
-) -> ToolResult:
-    """Delete a purchase order row.
-
-    Two-step flow: ``confirm=false`` returns a preview, ``confirm=true``
-    deletes the row. Destructive.
-    """
-    response = await _delete_purchase_order_row_impl(request, context)
-    return to_tool_result(response)
-
-
-# ============================================================================
-# Tool: add_purchase_order_additional_cost
-# ============================================================================
-
-
-CostDistributionMethodLiteral = Literal["BY_VALUE", "NON_DISTRIBUTED"]
-
-_DISTRIBUTION_METHOD_API_VALUE: dict[
-    CostDistributionMethodLiteral, CostDistributionMethod
-] = {
-    "BY_VALUE": CostDistributionMethod.BY_VALUE,
-    "NON_DISTRIBUTED": CostDistributionMethod.NON_DISTRIBUTED,
-}
-
-
-class AddPurchaseOrderAdditionalCostRequest(BaseModel):
-    """Request to add a new additional-cost row (freight, duties, etc.) to a PO.
-
-    Katana models additional-cost rows as members of a *cost group* — the PO
-    carries a ``default_group_id`` that the rows attach to. We accept the
-    parent PO id (familiar to users) and resolve the group id internally.
-    Use ``group_id`` instead if the PO has multiple groups and you need to
-    target a specific one.
+    Either ``group_id`` or ``purchase_order_id`` (carried at the top-level
+    request) is needed; if neither is set on the row, the dispatcher
+    resolves the parent PO's ``default_group_id`` automatically.
     """
 
-    purchase_order_id: int | None = Field(
-        default=None,
-        description=(
-            "Parent purchase order ID. The tool resolves the PO's "
-            "``default_group_id`` automatically. Either this or ``group_id`` "
-            "must be provided."
-        ),
-    )
-    group_id: int | None = Field(
-        default=None,
-        description=(
-            "Cost group ID to attach the row to. Pass directly when the PO "
-            "has multiple groups and you need to target a non-default one. "
-            "Either this or ``purchase_order_id`` must be provided."
-        ),
-    )
     additional_cost_id: int = Field(..., description="Additional-cost catalog entry ID")
     tax_rate_id: int = Field(..., description="Tax rate ID")
     price: float = Field(..., description="Cost amount")
     distribution_method: CostDistributionMethodLiteral | None = Field(
         default=None,
+        description="Cost allocation method (BY_VALUE / NON_DISTRIBUTED)",
+    )
+    group_id: int | None = Field(
+        default=None,
         description=(
-            "How the cost is allocated across rows: BY_VALUE distributes "
-            "proportionally to row value, NON_DISTRIBUTED leaves it unallocated. "
-            "Defaults to Katana's server-side default when omitted."
+            "Cost group ID. When omitted, the dispatcher resolves the parent "
+            "PO's ``default_group_id``."
         ),
     )
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, adds the cost row.",
-    )
 
 
-async def _resolve_default_group_id(
-    services: Any, purchase_order_id: int
-) -> int | None:
-    """Look up a PO's ``default_group_id`` to attach additional-cost rows to."""
-    existing = await _fetch_purchase_order_attrs(services, purchase_order_id)
-    if existing is None:
-        return None
-    return unwrap_unset(existing.default_group_id, None)
+class AdditionalCostUpdate(BaseModel):
+    """Patch to an existing additional-cost row."""
 
-
-async def _add_purchase_order_additional_cost_impl(
-    request: AddPurchaseOrderAdditionalCostRequest, context: Context
-) -> ModificationResponse:
-    """Implementation of add_purchase_order_additional_cost tool."""
-    if request.purchase_order_id is None and request.group_id is None:
-        raise ValueError("Either purchase_order_id or group_id must be provided.")
-
-    services = get_services(context)
-    group_id: int | None = request.group_id
-    if group_id is None and request.purchase_order_id is not None:
-        group_id = await _resolve_default_group_id(services, request.purchase_order_id)
-        if group_id is None:
-            raise ValueError(
-                f"Could not resolve default_group_id for purchase order "
-                f"{request.purchase_order_id} — supply ``group_id`` directly."
-            )
-    # The earlier guard guarantees at least one of (purchase_order_id, group_id)
-    # is set, and the resolve branch raises if it can't fill in group_id — so by
-    # this point group_id is non-None. The narrow keeps the type checker honest.
-    assert group_id is not None
-
-    parent_url = (
-        katana_web_url("purchase_order", request.purchase_order_id)
-        if request.purchase_order_id is not None
-        else None
-    )
-    changes = compute_field_diff(
-        None,
-        request,
-        exclude=("confirm", "purchase_order_id"),
-    )
-
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="purchase_order_additional_cost",
-            entity_id=None,
-            parent_entity_id=request.purchase_order_id,
-            operation="create_additional_cost",
-            is_preview=True,
-            changes=changes,
-            next_actions=[
-                "Review the cost row",
-                "Set confirm=true to add the row",
-            ],
-            katana_url=parent_url,
-            message=(
-                f"Preview: add additional cost (group {group_id}, "
-                f"price {request.price})"
-            ),
-        )
-
-    api_distribution = (
-        _DISTRIBUTION_METHOD_API_VALUE[request.distribution_method]
-        if request.distribution_method is not None
-        else None
-    )
-    api_request = APICreatePOAdditionalCostRowRequest(
-        additional_cost_id=request.additional_cost_id,
-        group_id=group_id,
-        tax_rate_id=request.tax_rate_id,
-        price=request.price,
-        distribution_method=to_unset(api_distribution),
-    )
-
-    from katana_public_api_client.api.purchase_order_additional_cost_row import (
-        create_po_additional_cost_row,
-    )
-
-    api_response = await create_po_additional_cost_row.asyncio_detailed(
-        client=services.client, body=api_request
-    )
-    new_row = unwrap_as(api_response, PurchaseOrderAdditionalCostRow)
-    logger.info(f"Added additional-cost row {new_row.id} to group {group_id}")
-
-    return ModificationResponse(
-        entity_type="purchase_order_additional_cost",
-        entity_id=new_row.id,
-        parent_entity_id=request.purchase_order_id,
-        operation="create_additional_cost",
-        is_preview=False,
-        changes=changes,
-        next_actions=[f"Additional-cost row {new_row.id} added to group {group_id}"],
-        katana_url=parent_url,
-        message=f"Successfully added additional-cost row {new_row.id}",
-    )
-
-
-@observe_tool
-@unpack_pydantic_params
-async def add_purchase_order_additional_cost(
-    request: Annotated[AddPurchaseOrderAdditionalCostRequest, Unpack()],
-    context: Context,
-) -> ToolResult:
-    """Add an additional-cost row (freight, duties, handling fees) to a PO.
-
-    Two-step flow: ``confirm=false`` returns a preview, ``confirm=true``
-    POSTs the new row. Required: ``additional_cost_id``, ``tax_rate_id``,
-    ``price``, and **either** ``purchase_order_id`` **or** ``group_id``.
-    When only ``purchase_order_id`` is provided, the tool resolves the PO's
-    ``default_group_id`` automatically. Optional ``distribution_method``
-    chooses how the cost is allocated across line items.
-    """
-    response = await _add_purchase_order_additional_cost_impl(request, context)
-    return to_tool_result(response)
-
-
-# ============================================================================
-# Tool: update_purchase_order_additional_cost
-# ============================================================================
-
-
-class UpdatePurchaseOrderAdditionalCostRequest(BaseModel):
-    """Request to update an existing PO additional-cost row."""
-
-    id: int = Field(..., description="Additional-cost row ID")
+    id: int = Field(..., description="Cost row ID to update")
     additional_cost_id: int | None = Field(
-        default=None, description="New additional-cost catalog entry ID"
+        default=None, description="New catalog entry ID"
     )
     tax_rate_id: int | None = Field(default=None, description="New tax rate ID")
-    price: float | None = Field(default=None, description="New cost amount")
+    price: float | None = Field(default=None, description="New price")
     distribution_method: CostDistributionMethodLiteral | None = Field(
-        default=None,
-        description="New distribution method (BY_VALUE / NON_DISTRIBUTED)",
+        default=None, description="New distribution method"
     )
+
+
+class ModifyPurchaseOrderRequest(BaseModel):
+    """Unified modification request for a purchase order (non-destructive).
+
+    Each sub-payload slot maps to one or more API operations on the PO or
+    its sub-resources. Multiple slots can be combined in a single call —
+    actions execute sequentially in canonical order (header → row adds →
+    row updates → row deletes → cost adds → cost updates → cost deletes).
+    Fail-fast on first error; the response carries per-action result blocks
+    plus a ``prior_state`` snapshot for manual revert.
+
+    To remove a PO entirely, use the sibling ``delete_purchase_order`` tool —
+    delete is split off so the destructive-hint annotation tracks the
+    destructive-vs-non-destructive boundary cleanly.
+    """
+
+    id: int = Field(..., description="Purchase order ID")
+
+    update_header: PurchaseOrderHeaderPatch | None = Field(
+        default=None,
+        description="Header fields to patch (PATCH /purchase_orders/{id})",
+    )
+
+    add_rows: list[NewPORow] | None = Field(
+        default=None, description="New line items to POST"
+    )
+    update_rows: list[PORowUpdate] | None = Field(
+        default=None, description="Row patches (each carries id + fields to update)"
+    )
+    delete_row_ids: list[int] | None = Field(
+        default=None, description="Row IDs to DELETE"
+    )
+
+    add_additional_costs: list[NewAdditionalCost] | None = Field(
+        default=None, description="New additional-cost rows to POST"
+    )
+    update_additional_costs: list[AdditionalCostUpdate] | None = Field(
+        default=None, description="Additional-cost row patches"
+    )
+    delete_additional_cost_ids: list[int] | None = Field(
+        default=None, description="Additional-cost row IDs to DELETE"
+    )
+
     confirm: bool = Field(
         default=False,
-        description="If false, returns preview. If true, applies the update.",
+        description="If false, returns preview. If true, executes the action plan.",
     )
 
 
-async def _update_purchase_order_additional_cost_impl(
-    request: UpdatePurchaseOrderAdditionalCostRequest, context: Context
+class DeletePurchaseOrderRequest(BaseModel):
+    """Delete an entire purchase order. Destructive — the order is removed."""
+
+    id: int = Field(..., description="Purchase order ID to delete")
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, deletes the PO.",
+    )
+
+
+# ----------------------------------------------------------------------------
+# Verification helper
+# ----------------------------------------------------------------------------
+
+
+def _make_response_verifier(
+    diff: list[FieldChange], field_map: dict[str, str] | None = None
+) -> Callable[[Any], Awaitable[tuple[bool, dict[str, Any] | None]]]:
+    """Build a verify closure that compares the API response body to ``diff``.
+
+    Most Katana mutation endpoints echo the post-state of the affected
+    entity in the response body — this verifier reads each requested
+    field off ``outcome`` and confirms it matches the requested ``new``
+    value. No extra fetch needed. ``field_map`` mirrors the
+    :func:`compute_field_diff` parameter for fields with names that
+    differ between request and response.
+    """
+    name_map = field_map or {}
+
+    async def verify(outcome: Any) -> tuple[bool, dict[str, Any] | None]:
+        if outcome is None:
+            return False, None
+        actual: dict[str, Any] = {}
+        verified = True
+        for change in diff:
+            attr = name_map.get(change.field, change.field)
+            raw = getattr(outcome, attr, None)
+            actual_val = unwrap_unset(raw, None)
+            if isinstance(actual_val, datetime):
+                actual_val = actual_val.isoformat()
+            elif isinstance(actual_val, Enum):
+                actual_val = actual_val.value
+            actual[change.field] = actual_val
+            if change.new is not None and actual_val != change.new:
+                verified = False
+        return verified, (actual if not verified else None)
+
+    return verify
+
+
+# ----------------------------------------------------------------------------
+# Plan builders — one per sub-payload kind
+# ----------------------------------------------------------------------------
+
+
+def _plan_header_update(
+    request: ModifyPurchaseOrderRequest,
+    services: Any,
+    existing: RegularPurchaseOrder | None,
+    fetch_failed: bool,
+) -> ActionSpec | None:
+    if request.update_header is None:
+        return None
+
+    patch = request.update_header
+    diff = compute_field_diff(existing, patch, unknown_prior=fetch_failed)
+
+    api_status = (
+        _PO_STATUS_API_VALUE[patch.status] if patch.status is not None else None
+    )
+    api_request = APIUpdatePurchaseOrderRequest(
+        order_no=to_unset(patch.order_no),
+        supplier_id=to_unset(patch.supplier_id),
+        currency=to_unset(patch.currency),
+        location_id=to_unset(patch.location_id),
+        tracking_location_id=to_unset(patch.tracking_location_id),
+        status=to_unset(api_status),
+        expected_arrival_date=to_unset(patch.expected_arrival_date),
+        order_created_date=to_unset(patch.order_created_date),
+        additional_info=to_unset(patch.additional_info),
+    )
+
+    async def apply() -> RegularPurchaseOrder:
+        from katana_public_api_client.api.purchase_order import update_purchase_order
+
+        response = await update_purchase_order.asyncio_detailed(
+            id=request.id, client=services.client, body=api_request
+        )
+        return unwrap_as(response, RegularPurchaseOrder)
+
+    # Verifier compares the request payload against the response body — but
+    # PurchaseOrderHeaderPatch's ``status`` is the uppercase literal and the
+    # response carries the API enum value. The Enum normalization in
+    # ``_make_response_verifier`` handles the comparison correctly only when
+    # we project the request side through the same _normalize logic.
+    # ``compute_field_diff`` already normalized the ``new`` side, so the
+    # comparison works as-is.
+    verify = _make_response_verifier(diff)
+
+    return ActionSpec(
+        operation="update_header",
+        target_id=request.id,
+        diff=diff,
+        apply=apply,
+        verify=verify,
+    )
+
+
+def _plan_row_adds(
+    request: ModifyPurchaseOrderRequest,
+    services: Any,
+) -> list[ActionSpec]:
+    if not request.add_rows:
+        return []
+    specs: list[ActionSpec] = []
+    for row in request.add_rows:
+        diff = compute_field_diff(None, row, exclude=("confirm",))
+        api_request = APICreatePurchaseOrderRowRequest(
+            purchase_order_id=request.id,
+            quantity=row.quantity,
+            variant_id=row.variant_id,
+            price_per_unit=row.price_per_unit,
+            tax_rate_id=to_unset(row.tax_rate_id),
+            tax_name=to_unset(row.tax_name),
+            tax_rate=to_unset(row.tax_rate),
+            currency=to_unset(row.currency),
+            purchase_uom=to_unset(row.purchase_uom),
+            purchase_uom_conversion_rate=to_unset(row.purchase_uom_conversion_rate),
+            arrival_date=to_unset(row.arrival_date),
+        )
+
+        async def apply(req=api_request) -> PurchaseOrderRow:
+            from katana_public_api_client.api.purchase_order_row import (
+                create_purchase_order_row,
+            )
+
+            response = await create_purchase_order_row.asyncio_detailed(
+                client=services.client, body=req
+            )
+            return unwrap_as(response, PurchaseOrderRow)
+
+        # Verify creates only that the response carries an id (creation succeeded).
+        async def verify(outcome: PurchaseOrderRow) -> tuple[bool, dict | None]:
+            verified = outcome is not None and getattr(outcome, "id", None) is not None
+            return verified, None if verified else {"id": None}
+
+        specs.append(
+            ActionSpec(
+                operation="add_row",
+                target_id=None,
+                diff=diff,
+                apply=apply,
+                verify=verify,
+            )
+        )
+    return specs
+
+
+async def _plan_row_updates(
+    request: ModifyPurchaseOrderRequest,
+    services: Any,
+) -> list[ActionSpec]:
+    if not request.update_rows:
+        return []
+    specs: list[ActionSpec] = []
+    for row_patch in request.update_rows:
+        existing_row = await _fetch_purchase_order_row(services, row_patch.id)
+        fetch_failed = existing_row is None
+        diff = compute_field_diff(existing_row, row_patch, unknown_prior=fetch_failed)
+        api_request = APIUpdatePurchaseOrderRowRequest(
+            quantity=to_unset(row_patch.quantity),
+            variant_id=to_unset(row_patch.variant_id),
+            tax_rate_id=to_unset(row_patch.tax_rate_id),
+            tax_name=to_unset(row_patch.tax_name),
+            tax_rate=to_unset(row_patch.tax_rate),
+            price_per_unit=to_unset(row_patch.price_per_unit),
+            purchase_uom_conversion_rate=to_unset(
+                row_patch.purchase_uom_conversion_rate
+            ),
+            purchase_uom=to_unset(row_patch.purchase_uom),
+            received_date=to_unset(row_patch.received_date),
+            arrival_date=to_unset(row_patch.arrival_date),
+        )
+
+        async def apply(rid=row_patch.id, req=api_request) -> PurchaseOrderRow:
+            from katana_public_api_client.api.purchase_order_row import (
+                update_purchase_order_row,
+            )
+
+            response = await update_purchase_order_row.asyncio_detailed(
+                id=rid, client=services.client, body=req
+            )
+            return unwrap_as(response, PurchaseOrderRow)
+
+        verify = _make_response_verifier(diff)
+
+        specs.append(
+            ActionSpec(
+                operation="update_row",
+                target_id=row_patch.id,
+                diff=diff,
+                apply=apply,
+                verify=verify,
+            )
+        )
+    return specs
+
+
+def _plan_row_deletes(
+    request: ModifyPurchaseOrderRequest,
+    services: Any,
+) -> list[ActionSpec]:
+    if not request.delete_row_ids:
+        return []
+    specs: list[ActionSpec] = []
+    for rid in request.delete_row_ids:
+
+        async def apply(target=rid) -> None:
+            from katana_public_api_client.api.purchase_order_row import (
+                delete_purchase_order_row,
+            )
+
+            response = await delete_purchase_order_row.asyncio_detailed(
+                id=target, client=services.client
+            )
+            if not is_success(response):
+                unwrap(response)
+            return None
+
+        # No verify on delete — entity is gone, can't fetch.
+        specs.append(
+            ActionSpec(
+                operation="delete_row",
+                target_id=rid,
+                apply=apply,
+            )
+        )
+    return specs
+
+
+async def _plan_additional_cost_adds(
+    request: ModifyPurchaseOrderRequest,
+    services: Any,
+) -> list[ActionSpec]:
+    if not request.add_additional_costs:
+        return []
+    specs: list[ActionSpec] = []
+    # Resolve default_group_id once if any cost row needs it
+    default_group_id: int | None = None
+    needs_default = any(c.group_id is None for c in request.add_additional_costs)
+    if needs_default:
+        default_group_id = await _resolve_default_group_id(services, request.id)
+
+    for cost in request.add_additional_costs:
+        group_id = cost.group_id or default_group_id
+        if group_id is None:
+            raise ValueError(
+                f"Cannot resolve group_id for additional-cost row "
+                f"(additional_cost_id={cost.additional_cost_id}): no "
+                f"default_group_id on PO {request.id} and none provided."
+            )
+        diff = compute_field_diff(None, cost, exclude=("confirm",))
+        api_distribution = (
+            _DISTRIBUTION_METHOD_API_VALUE[cost.distribution_method]
+            if cost.distribution_method is not None
+            else None
+        )
+        api_request = APICreatePOAdditionalCostRowRequest(
+            additional_cost_id=cost.additional_cost_id,
+            group_id=group_id,
+            tax_rate_id=cost.tax_rate_id,
+            price=cost.price,
+            distribution_method=to_unset(api_distribution),
+        )
+
+        async def apply(req=api_request) -> PurchaseOrderAdditionalCostRow:
+            from katana_public_api_client.api.purchase_order_additional_cost_row import (
+                create_po_additional_cost_row,
+            )
+
+            response = await create_po_additional_cost_row.asyncio_detailed(
+                client=services.client, body=req
+            )
+            return unwrap_as(response, PurchaseOrderAdditionalCostRow)
+
+        async def verify(
+            outcome: PurchaseOrderAdditionalCostRow,
+        ) -> tuple[bool, dict | None]:
+            verified = outcome is not None and getattr(outcome, "id", None) is not None
+            return verified, None if verified else {"id": None}
+
+        specs.append(
+            ActionSpec(
+                operation="add_additional_cost",
+                target_id=None,
+                diff=diff,
+                apply=apply,
+                verify=verify,
+            )
+        )
+    return specs
+
+
+async def _plan_additional_cost_updates(
+    request: ModifyPurchaseOrderRequest,
+    services: Any,
+) -> list[ActionSpec]:
+    if not request.update_additional_costs:
+        return []
+    specs: list[ActionSpec] = []
+    for cost_patch in request.update_additional_costs:
+        existing_cost = await _fetch_po_additional_cost_row(services, cost_patch.id)
+        fetch_failed = existing_cost is None
+        diff = compute_field_diff(existing_cost, cost_patch, unknown_prior=fetch_failed)
+        api_distribution = (
+            _DISTRIBUTION_METHOD_API_VALUE[cost_patch.distribution_method]
+            if cost_patch.distribution_method is not None
+            else None
+        )
+        api_request = APIUpdatePOAdditionalCostRowRequest(
+            additional_cost_id=to_unset(cost_patch.additional_cost_id),
+            tax_rate_id=to_unset(cost_patch.tax_rate_id),
+            price=to_unset(cost_patch.price),
+            distribution_method=to_unset(api_distribution),
+        )
+
+        async def apply(
+            target=cost_patch.id, req=api_request
+        ) -> PurchaseOrderAdditionalCostRow:
+            from katana_public_api_client.api.purchase_order_additional_cost_row import (
+                update_additional_cost_row,
+            )
+
+            response = await update_additional_cost_row.asyncio_detailed(
+                id=target, client=services.client, body=req
+            )
+            return unwrap_as(response, PurchaseOrderAdditionalCostRow)
+
+        verify = _make_response_verifier(diff)
+
+        specs.append(
+            ActionSpec(
+                operation="update_additional_cost",
+                target_id=cost_patch.id,
+                diff=diff,
+                apply=apply,
+                verify=verify,
+            )
+        )
+    return specs
+
+
+def _plan_additional_cost_deletes(
+    request: ModifyPurchaseOrderRequest,
+    services: Any,
+) -> list[ActionSpec]:
+    if not request.delete_additional_cost_ids:
+        return []
+    specs: list[ActionSpec] = []
+    for rid in request.delete_additional_cost_ids:
+
+        async def apply(target=rid) -> None:
+            from katana_public_api_client.api.purchase_order_additional_cost_row import (
+                delete_po_additional_cost,
+            )
+
+            response = await delete_po_additional_cost.asyncio_detailed(
+                id=target, client=services.client
+            )
+            if not is_success(response):
+                unwrap(response)
+            return None
+
+        specs.append(
+            ActionSpec(
+                operation="delete_additional_cost",
+                target_id=rid,
+                apply=apply,
+            )
+        )
+    return specs
+
+
+def _has_any_subpayload(request: ModifyPurchaseOrderRequest) -> bool:
+    """True if any modify sub-payload is set (caller asked for at least one action)."""
+    return any(
+        v is not None and v != []
+        for v in (
+            request.update_header,
+            request.add_rows,
+            request.update_rows,
+            request.delete_row_ids,
+            request.add_additional_costs,
+            request.update_additional_costs,
+            request.delete_additional_cost_ids,
+        )
+    )
+
+
+# ----------------------------------------------------------------------------
+# Implementation
+# ----------------------------------------------------------------------------
+
+
+async def _modify_purchase_order_impl(
+    request: ModifyPurchaseOrderRequest, context: Context
 ) -> ModificationResponse:
-    """Implementation of update_purchase_order_additional_cost tool."""
+    """Implementation of modify_purchase_order tool.
+
+    Builds an action plan from the request's sub-payloads in canonical
+    order, returns a preview for ``confirm=False``, and executes the plan
+    via ``execute_plan`` for ``confirm=True``.
+    """
     services = get_services(context)
 
-    has_any_field = any(
-        v is not None
-        for v in (
-            request.additional_cost_id,
-            request.tax_rate_id,
-            request.price,
-            request.distribution_method,
-        )
-    )
-    if not has_any_field:
+    if not _has_any_subpayload(request):
         raise ValueError(
-            "At least one field must be provided to update — supply "
-            "additional_cost_id, tax_rate_id, price, or distribution_method."
+            "At least one sub-payload must be set: update_header, add_rows, "
+            "update_rows, delete_row_ids, add_additional_costs, "
+            "update_additional_costs, or delete_additional_cost_ids. "
+            "To remove the PO entirely, use delete_purchase_order."
         )
 
-    # No diff context — there's no get-by-id endpoint dedicated to a single
-    # additional-cost row in the generated client (the existing
-    # `get_po_additional_cost_row` endpoint takes the row id, but the
-    # response shape is the row itself, so we can fetch it). Try and fall
-    # back gracefully.
-    existing: PurchaseOrderAdditionalCostRow | None = None
-    try:
-        from katana_public_api_client.api.purchase_order_additional_cost_row import (
-            get_po_additional_cost_row,
-        )
+    # Fetch existing PO once for diff context + prior_state snapshot
+    existing_po = await _fetch_purchase_order_attrs(services, request.id)
+    fetch_failed = existing_po is None
 
-        get_response = await get_po_additional_cost_row.asyncio_detailed(
-            id=request.id, client=services.client
-        )
-        existing = unwrap_as(get_response, PurchaseOrderAdditionalCostRow)
-    except Exception as exc:
-        logger.info(
-            f"Could not fetch additional-cost row {request.id} for diff "
-            f"context: {exc} — preview will report changes without prior values."
-        )
+    # Build the plan in canonical order
+    plan: list[ActionSpec] = []
+    header_spec = _plan_header_update(request, services, existing_po, fetch_failed)
+    if header_spec is not None:
+        plan.append(header_spec)
+    plan.extend(_plan_row_adds(request, services))
+    plan.extend(await _plan_row_updates(request, services))
+    plan.extend(_plan_row_deletes(request, services))
+    plan.extend(await _plan_additional_cost_adds(request, services))
+    plan.extend(await _plan_additional_cost_updates(request, services))
+    plan.extend(_plan_additional_cost_deletes(request, services))
 
-    fetch_failed = existing is None
-    changes = compute_field_diff(existing, request, unknown_prior=fetch_failed)
-    warnings = (
-        [
-            f"Could not fetch additional-cost row {request.id} for diff context — "
+    katana_url = katana_web_url("purchase_order", request.id)
+    warnings: list[str] = []
+    if fetch_failed:
+        warnings.append(
+            f"Could not fetch purchase order {request.id} for diff context — "
             "preview shows requested values without prior state."
-        ]
-        if fetch_failed
-        else []
-    )
-
-    # Additional-cost rows are scoped by ``group_id``, not ``purchase_order_id`` —
-    # the row schema doesn't expose a back-reference to its parent PO and there's
-    # no list filter to derive it cheaply. Leave parent_entity_id unset.
+        )
 
     if not request.confirm:
         return ModificationResponse(
-            entity_type="purchase_order_additional_cost",
+            entity_type="purchase_order",
             entity_id=request.id,
-            operation="update_additional_cost",
             is_preview=True,
-            changes=changes,
+            actions=plan_to_preview_results(plan),
             warnings=warnings,
             next_actions=[
-                "Review the proposed changes",
-                "Set confirm=true to apply the update",
+                f"Review {len(plan)} planned action(s)",
+                "Set confirm=true to execute the plan",
             ],
+            katana_url=katana_url,
             message=(
-                f"Preview: update additional-cost row {request.id} "
-                f"({len(changes)} field(s))"
+                f"Preview: {len(plan)} action(s) planned for purchase order "
+                f"{request.id}"
             ),
         )
 
-    api_distribution = (
-        _DISTRIBUTION_METHOD_API_VALUE[request.distribution_method]
-        if request.distribution_method is not None
-        else None
-    )
-    api_request = APIUpdatePOAdditionalCostRowRequest(
-        additional_cost_id=to_unset(request.additional_cost_id),
-        tax_rate_id=to_unset(request.tax_rate_id),
-        price=to_unset(request.price),
-        distribution_method=to_unset(api_distribution),
-    )
+    # Confirm branch — capture prior_state, then execute
+    prior_state = serialize_for_prior_state(existing_po)
+    actions = await execute_plan(plan)
 
-    from katana_public_api_client.api.purchase_order_additional_cost_row import (
-        update_additional_cost_row,
-    )
+    succeeded_count = sum(1 for a in actions if a.succeeded is True)
+    failed_count = sum(1 for a in actions if a.succeeded is False)
+    failed = failed_count > 0
 
-    api_response = await update_additional_cost_row.asyncio_detailed(
-        id=request.id, client=services.client, body=api_request
-    )
-    updated = unwrap_as(api_response, PurchaseOrderAdditionalCostRow)
-    logger.info(f"Updated additional-cost row {updated.id}")
+    if failed:
+        message = (
+            f"Partial: {succeeded_count}/{len(plan)} action(s) applied to "
+            f"purchase order {request.id} before fail-fast halt; see actions "
+            "for details and prior_state for revert reference."
+        )
+        next_actions = [
+            f"{succeeded_count} action(s) succeeded; {failed_count} failed",
+            "Review the FAILED action's error and the prior_state snapshot",
+            "Compose a follow-up modify_purchase_order call to revert if needed",
+        ]
+    else:
+        message = (
+            f"Successfully applied {succeeded_count}/{len(plan)} action(s) to "
+            f"purchase order {request.id}"
+        )
+        next_actions = [
+            f"Purchase order {request.id} modified — "
+            f"{succeeded_count} action(s) verified"
+        ]
 
     return ModificationResponse(
-        entity_type="purchase_order_additional_cost",
-        entity_id=updated.id,
-        operation="update_additional_cost",
+        entity_type="purchase_order",
+        entity_id=request.id,
         is_preview=False,
-        changes=changes,
-        next_actions=[f"Additional-cost row {updated.id} updated"],
-        message=f"Successfully updated additional-cost row {updated.id}",
+        actions=actions,
+        prior_state=prior_state,
+        warnings=warnings,
+        next_actions=next_actions,
+        katana_url=katana_url,
+        message=message,
     )
 
 
 @observe_tool
 @unpack_pydantic_params
-async def update_purchase_order_additional_cost(
-    request: Annotated[UpdatePurchaseOrderAdditionalCostRequest, Unpack()],
-    context: Context,
+async def modify_purchase_order(
+    request: Annotated[ModifyPurchaseOrderRequest, Unpack()], context: Context
 ) -> ToolResult:
-    """Update an additional-cost row on a purchase order.
+    """Modify a purchase order — unified surface across header, rows, and additional costs.
 
-    Two-step flow: ``confirm=false`` returns a preview with per-field diff,
-    ``confirm=true`` applies the PATCH. Accepts any subset of
-    ``additional_cost_id``, ``tax_rate_id``, ``price``, and
-    ``distribution_method``.
+    Sub-payloads (any subset, all optional):
+
+    - ``update_header`` — patch header fields (incl. status)
+    - ``add_rows`` / ``update_rows`` / ``delete_row_ids`` — line item CRUD
+    - ``add_additional_costs`` / ``update_additional_costs`` /
+      ``delete_additional_cost_ids`` — freight/duty/handling cost rows
+
+    To remove a PO entirely, use the sibling ``delete_purchase_order`` tool.
+
+    Two-step flow: ``confirm=false`` returns a per-action preview with diffs;
+    ``confirm=true`` executes the plan in canonical order (header → row adds
+    → row updates → row deletes → cost adds → cost updates → cost deletes).
+
+    **Caveats** (Katana's API is not transactional):
+
+    - Actions apply sequentially. The first failure halts execution
+      (fail-fast); earlier actions stay applied server-side.
+    - Each action is verified post-execution by reading the API response
+      body. Verification mismatch surfaces as ``verified=False`` on the
+      action result without raising.
+    - The response carries a ``prior_state`` snapshot of the
+      pre-modification PO so callers can compose a revert call manually.
     """
-    response = await _update_purchase_order_additional_cost_impl(request, context)
+    response = await _modify_purchase_order_impl(request, context)
     return to_tool_result(response)
 
 
 # ============================================================================
-# Tool: delete_purchase_order_additional_cost
+# Tool: delete_purchase_order
 # ============================================================================
 
 
-class DeletePurchaseOrderAdditionalCostRequest(BaseModel):
-    """Request to delete a PO additional-cost row."""
-
-    id: int = Field(..., description="Additional-cost row ID to delete")
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, deletes the row.",
-    )
-
-
-async def _delete_purchase_order_additional_cost_impl(
-    request: DeletePurchaseOrderAdditionalCostRequest, context: Context
+async def _delete_purchase_order_impl(
+    request: DeletePurchaseOrderRequest, context: Context
 ) -> ModificationResponse:
-    """Implementation of delete_purchase_order_additional_cost tool."""
+    """Implementation of delete_purchase_order tool.
+
+    Captures prior_state and runs a one-action plan via the same dispatcher
+    so the response shape matches modify_purchase_order. Destructive — the
+    PO record is removed.
+    """
+    services = get_services(context)
+
+    existing_po = await _fetch_purchase_order_attrs(services, request.id)
+
+    async def apply() -> None:
+        from katana_public_api_client.api.purchase_order import delete_purchase_order
+
+        response = await delete_purchase_order.asyncio_detailed(
+            id=request.id, client=services.client
+        )
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    plan = [ActionSpec(operation="delete", target_id=request.id, apply=apply)]
+    katana_url = katana_web_url("purchase_order", request.id)
+
     if not request.confirm:
         return ModificationResponse(
-            entity_type="purchase_order_additional_cost",
+            entity_type="purchase_order",
             entity_id=request.id,
-            operation="delete_additional_cost",
             is_preview=True,
+            actions=plan_to_preview_results(plan),
             next_actions=[
                 "Review the deletion",
-                "Set confirm=true to delete the row",
+                "Set confirm=true to delete the purchase order",
             ],
-            message=f"Preview: delete additional-cost row {request.id}",
+            katana_url=katana_url,
+            message=f"Preview: delete purchase order {request.id}",
         )
 
-    services = get_services(context)
-    from katana_public_api_client.api.purchase_order_additional_cost_row import (
-        delete_po_additional_cost,
-    )
+    prior_state = serialize_for_prior_state(existing_po)
+    actions = await execute_plan(plan)
+    failed = any(a.succeeded is False for a in actions)
 
-    response = await delete_po_additional_cost.asyncio_detailed(
-        id=request.id, client=services.client
-    )
-    if not is_success(response):
-        unwrap(response)
-
-    logger.info(f"Deleted additional-cost row {request.id}")
     return ModificationResponse(
-        entity_type="purchase_order_additional_cost",
+        entity_type="purchase_order",
         entity_id=request.id,
-        operation="delete_additional_cost",
         is_preview=False,
-        next_actions=[f"Additional-cost row {request.id} has been deleted"],
-        message=f"Successfully deleted additional-cost row {request.id}",
+        actions=actions,
+        prior_state=prior_state,
+        next_actions=(
+            [f"Purchase order {request.id} has been deleted"]
+            if not failed
+            else [
+                "Delete failed — see action error",
+                "prior_state carries the pre-delete snapshot",
+            ]
+        ),
+        # On successful delete the entity URL no longer resolves.
+        katana_url=None if not failed else katana_url,
+        message=(
+            f"Successfully deleted purchase order {request.id}"
+            if not failed
+            else f"Failed to delete purchase order {request.id}"
+        ),
     )
 
 
 @observe_tool
 @unpack_pydantic_params
-async def delete_purchase_order_additional_cost(
-    request: Annotated[DeletePurchaseOrderAdditionalCostRequest, Unpack()],
-    context: Context,
+async def delete_purchase_order(
+    request: Annotated[DeletePurchaseOrderRequest, Unpack()], context: Context
 ) -> ToolResult:
-    """Delete an additional-cost row from a purchase order.
+    """Delete a purchase order. Destructive — the order record is removed.
 
     Two-step flow: ``confirm=false`` returns a preview, ``confirm=true``
-    deletes the row. Destructive.
+    deletes the PO. The response carries a ``prior_state`` snapshot of the
+    pre-delete PO so callers can recreate it manually if needed.
     """
-    response = await _delete_purchase_order_additional_cost_impl(request, context)
+    response = await _delete_purchase_order_impl(request, context)
     return to_tool_result(response)
 
 
@@ -3101,12 +2955,9 @@ def register_tools(mcp: FastMCP) -> None:
         idempotentHint=True,
         openWorldHint=True,
     )
-    _update = ToolAnnotations(
-        readOnlyHint=False,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=True,
-    )
+    # ``modify_purchase_order`` can also delete (via ``delete=True``), so its
+    # destructive-hint annotation is the right pick — MCP hosts that respect
+    # the hint will prompt the user before running it.
     _destructive = ToolAnnotations(
         readOnlyHint=False,
         destructiveHint=True,
@@ -3135,30 +2986,18 @@ def register_tools(mcp: FastMCP) -> None:
     mcp.tool(tags={"orders", "purchasing", "read"}, annotations=_read)(
         get_purchase_order
     )
+    # ``modify_purchase_order`` is non-destructive — it modifies but never
+    # deletes the entity. Hence the ``write`` tag and update-style annotation.
+    _update = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
     mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_update)(
-        update_purchase_order
+        modify_purchase_order
     )
     mcp.tool(
         tags={"orders", "purchasing", "write", "destructive"},
         annotations=_destructive,
     )(delete_purchase_order)
-    mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_write)(
-        add_purchase_order_row
-    )
-    mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_update)(
-        update_purchase_order_row
-    )
-    mcp.tool(
-        tags={"orders", "purchasing", "write", "destructive"},
-        annotations=_destructive,
-    )(delete_purchase_order_row)
-    mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_write)(
-        add_purchase_order_additional_cost
-    )
-    mcp.tool(tags={"orders", "purchasing", "write"}, annotations=_update)(
-        update_purchase_order_additional_cost
-    )
-    mcp.tool(
-        tags={"orders", "purchasing", "write", "destructive"},
-        annotations=_destructive,
-    )(delete_purchase_order_additional_cost)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -2384,8 +2384,6 @@ async def _modify_purchase_order_impl(
             )
         return _build_create_cost_request(cost, group_id)
 
-    # Canonical order: header → row adds → updates → deletes → cost
-    # adds → cost updates → cost deletes.
     plan: list[ActionSpec] = []
 
     if request.update_header is not None:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -1,15 +1,22 @@
 """Sales order management tools for Katana MCP Server.
 
-Foundation tools for creating sales orders.
+Foundation tools covering the sales-order lifecycle: create, list, get
+(read-mostly tools), plus the unified modify/delete pair.
 
-These tools provide:
+Tools:
 - create_sales_order: Create sales orders with preview/confirm pattern
+- list_sales_orders / get_sales_order: discovery + exhaustive read
+- modify_sales_order: header + row CRUD + addresses + fulfillments +
+  shipping-fee CRUD via typed sub-payload slots
+- delete_sales_order: destructive sibling of modify_sales_order
 """
 
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
+from enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
@@ -19,6 +26,21 @@ from pydantic import BaseModel, Field
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
+from katana_mcp.tools._modification import (
+    ModificationResponse,
+    compute_field_diff,
+    make_response_verifier,
+    to_tool_result,
+)
+from katana_mcp.tools._modification_dispatch import (
+    ActionSpec,
+    execute_plan,
+    has_any_subpayload,
+    make_create_action,
+    make_delete_action,
+    plan_to_preview_results,
+    serialize_for_prior_state,
+)
 from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
@@ -34,17 +56,64 @@ from katana_mcp.tools.tool_result_utils import (
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
+
+# Modify/delete API endpoints used by ``modify_sales_order`` /
+# ``delete_sales_order``. Hoisted to module scope for declarative dependency
+# tracking and consistency with the rest of the codebase.
+from katana_public_api_client.api.sales_order import (
+    delete_sales_order as api_delete_sales_order,
+    get_sales_order as api_get_sales_order,
+    update_sales_order as api_update_sales_order,
+)
+from katana_public_api_client.api.sales_order_address import (
+    create_sales_order_address as api_create_so_address,
+    delete_sales_order_address as api_delete_so_address,
+    update_sales_order_address as api_update_so_address,
+)
+from katana_public_api_client.api.sales_order_fulfillment import (
+    create_sales_order_fulfillment as api_create_so_fulfillment,
+    delete_sales_order_fulfillment as api_delete_so_fulfillment,
+    get_sales_order_fulfillment as api_get_so_fulfillment,
+    update_sales_order_fulfillment as api_update_so_fulfillment,
+)
+from katana_public_api_client.api.sales_order_row import (
+    create_sales_order_row as api_create_so_row,
+    delete_sales_order_row as api_delete_so_row,
+    get_sales_order_row as api_get_so_row,
+    update_sales_order_row as api_update_so_row,
+)
+from katana_public_api_client.api.sales_orders import (
+    create_sales_order_shipping_fee as api_create_so_shipping_fee,
+    delete_sales_order_shipping_fee as api_delete_so_shipping_fee,
+    get_sales_order_shipping_fee as api_get_so_shipping_fee,
+    update_sales_order_shipping_fee as api_update_so_shipping_fee,
+)
 from katana_public_api_client.client_types import UNSET, Unset
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     AddressEntityType,
+    CreateSalesOrderAddressRequest as APICreateSOAddressRequest,
+    CreateSalesOrderFulfillmentRequest as APICreateSOFulfillmentRequest,
     CreateSalesOrderRequest as APICreateSalesOrderRequest,
     CreateSalesOrderRequestSalesOrderRowsItem,
+    CreateSalesOrderRowRequest as APICreateSORowRequest,
+    CreateSalesOrderShippingFeeRequest as APICreateSOShippingFeeRequest,
     CreateSalesOrderStatus,
     SalesOrder,
     SalesOrderAddress as APISalesOrderAddress,
+    SalesOrderFulfillment,
+    SalesOrderFulfillmentRowRequest,
+    SalesOrderFulfillmentStatus,
+    SalesOrderRow,
+    SalesOrderShippingFee,
+    UpdateSalesOrderAddressRequest as APIUpdateSOAddressRequest,
+    UpdateSalesOrderFulfillmentRequest as APIUpdateSOFulfillmentRequest,
+    UpdateSalesOrderRequest as APIUpdateSalesOrderRequest,
+    UpdateSalesOrderRowRequest as APIUpdateSORowRequest,
+    UpdateSalesOrderShippingFeeRequest as APIUpdateSOShippingFeeRequest,
+    UpdateSalesOrderStatus,
 )
-from katana_public_api_client.utils import unwrap_as
+from katana_public_api_client.utils import is_success, unwrap, unwrap_as
 
 logger = get_logger(__name__)
 
@@ -1301,6 +1370,1136 @@ async def get_sales_order(
     )
 
 
+# ============================================================================
+# Tool: modify_sales_order — unified modification surface
+# ============================================================================
+
+
+class SOOperation(StrEnum):
+    """Operation names emitted on ActionSpecs by ``modify_sales_order`` /
+    ``delete_sales_order`` plan builders.
+    """
+
+    UPDATE_HEADER = "update_header"
+    DELETE = "delete"
+    ADD_ROW = "add_row"
+    UPDATE_ROW = "update_row"
+    DELETE_ROW = "delete_row"
+    ADD_ADDRESS = "add_address"
+    UPDATE_ADDRESS = "update_address"
+    DELETE_ADDRESS = "delete_address"
+    ADD_FULFILLMENT = "add_fulfillment"
+    UPDATE_FULFILLMENT = "update_fulfillment"
+    DELETE_FULFILLMENT = "delete_fulfillment"
+    ADD_SHIPPING_FEE = "add_shipping_fee"
+    UPDATE_SHIPPING_FEE = "update_shipping_fee"
+    DELETE_SHIPPING_FEE = "delete_shipping_fee"
+
+
+# Tool-facing status literal — mirrors UpdateSalesOrderStatus enum values.
+SalesOrderStatusLiteral = Literal["NOT_SHIPPED", "PENDING", "PACKED", "DELIVERED"]
+
+_SO_STATUS_API_VALUE: dict[SalesOrderStatusLiteral, UpdateSalesOrderStatus] = {
+    "NOT_SHIPPED": UpdateSalesOrderStatus.NOT_SHIPPED,
+    "PENDING": UpdateSalesOrderStatus.PENDING,
+    "PACKED": UpdateSalesOrderStatus.PACKED,
+    "DELIVERED": UpdateSalesOrderStatus.DELIVERED,
+}
+
+# Fulfillment status literal — mirrors SalesOrderFulfillmentStatus.
+FulfillmentStatusLiteral = Literal["DELIVERED", "PACKED"]
+
+_FULFILLMENT_STATUS_API_VALUE: dict[
+    FulfillmentStatusLiteral, SalesOrderFulfillmentStatus
+] = {
+    "DELIVERED": SalesOrderFulfillmentStatus.DELIVERED,
+    "PACKED": SalesOrderFulfillmentStatus.PACKED,
+}
+
+# Address entity-type literal — mirrors AddressEntityType.
+AddressEntityTypeLiteral = Literal["billing", "shipping"]
+
+
+# ----------------------------------------------------------------------------
+# Diff-context fetchers
+# ----------------------------------------------------------------------------
+
+
+async def _fetch_sales_order_attrs(services: Any, so_id: int) -> SalesOrder | None:
+    """Fetch the SO attrs object for diff context. Returns None on failure."""
+    try:
+        response = await api_get_sales_order.asyncio_detailed(
+            id=so_id, client=services.client
+        )
+        return unwrap_as(response, SalesOrder)
+    except Exception as exc:
+        logger.info(
+            f"Could not fetch SO {so_id} for diff context: {exc} — "
+            "preview will report changes without prior values."
+        )
+        return None
+
+
+async def _fetch_so_row(services: Any, row_id: int) -> SalesOrderRow | None:
+    """Fetch an SO row for diff context. Returns None on failure."""
+    try:
+        response = await api_get_so_row.asyncio_detailed(
+            id=row_id, client=services.client
+        )
+        return unwrap_as(response, SalesOrderRow)
+    except Exception as exc:
+        logger.info(
+            f"Could not fetch SO row {row_id} for diff context: {exc} — "
+            "preview will report changes without prior values."
+        )
+        return None
+
+
+async def _fetch_so_fulfillment(
+    services: Any, fulfillment_id: int
+) -> SalesOrderFulfillment | None:
+    """Fetch an SO fulfillment for diff context. Returns None on failure."""
+    try:
+        response = await api_get_so_fulfillment.asyncio_detailed(
+            id=fulfillment_id, client=services.client
+        )
+        return unwrap_as(response, SalesOrderFulfillment)
+    except Exception as exc:
+        logger.info(
+            f"Could not fetch SO fulfillment {fulfillment_id} for diff context: "
+            f"{exc} — preview will report changes without prior values."
+        )
+        return None
+
+
+async def _fetch_so_shipping_fee(
+    services: Any, fee_id: int
+) -> SalesOrderShippingFee | None:
+    """Fetch an SO shipping fee for diff context. Returns None on failure."""
+    try:
+        response = await api_get_so_shipping_fee.asyncio_detailed(
+            id=fee_id, client=services.client
+        )
+        return unwrap_as(response, SalesOrderShippingFee)
+    except Exception as exc:
+        logger.info(
+            f"Could not fetch SO shipping fee {fee_id} for diff context: "
+            f"{exc} — preview will report changes without prior values."
+        )
+        return None
+
+
+# Note: addresses do not have a get-by-id endpoint (only list-by-SO). Updates
+# go through with ``unknown_prior=True`` since we can't cheaply fetch one row.
+
+
+# ----------------------------------------------------------------------------
+# Sub-payload models (typed slots on ModifySalesOrderRequest)
+# ----------------------------------------------------------------------------
+
+
+class SOHeaderPatch(BaseModel):
+    """Header fields to patch on an SO. Status is included here — the Katana
+    PATCH endpoint accepts it as a regular field."""
+
+    order_no: str | None = Field(default=None, description="New SO number")
+    customer_id: int | None = Field(default=None, description="New customer ID")
+    location_id: int | None = Field(default=None, description="New location ID")
+    status: SalesOrderStatusLiteral | None = Field(
+        default=None,
+        description="New status — NOT_SHIPPED / PENDING / PACKED / DELIVERED",
+    )
+    currency: str | None = Field(default=None, description="New currency code")
+    conversion_rate: float | None = Field(
+        default=None, description="New currency conversion rate"
+    )
+    conversion_date: str | None = Field(
+        default=None, description="New conversion date (ISO-8601)"
+    )
+    order_created_date: datetime | None = Field(
+        default=None, description="New order created date"
+    )
+    delivery_date: datetime | None = Field(
+        default=None, description="New delivery date"
+    )
+    picked_date: datetime | None = Field(default=None, description="New picked date")
+    additional_info: str | None = Field(
+        default=None, description="New notes / additional info"
+    )
+    customer_ref: str | None = Field(default=None, description="New customer reference")
+    tracking_number: str | None = Field(default=None, description="Tracking number")
+    tracking_number_url: str | None = Field(default=None, description="Tracking URL")
+
+
+class SORowAdd(BaseModel):
+    """A new line item to add to the SO."""
+
+    variant_id: int = Field(..., description="Variant ID")
+    quantity: float = Field(..., description="Quantity", gt=0)
+    price_per_unit: float | None = Field(default=None, description="Unit price")
+    tax_rate_id: int | None = Field(default=None, description="Tax rate ID")
+    location_id: int | None = Field(default=None, description="Location ID")
+    total_discount: float | None = Field(default=None, description="Total discount")
+
+
+class SORowUpdate(BaseModel):
+    """Patch to an existing SO row."""
+
+    id: int = Field(..., description="Row ID to update")
+    variant_id: int | None = Field(default=None, description="New variant ID")
+    quantity: float | None = Field(default=None, description="New quantity", gt=0)
+    price_per_unit: float | None = Field(default=None, description="New unit price")
+    tax_rate_id: int | None = Field(default=None, description="New tax rate ID")
+    location_id: int | None = Field(default=None, description="New location ID")
+    total_discount: float | None = Field(default=None, description="New discount")
+
+
+class SOAddressAdd(BaseModel):
+    """A new address to attach to the SO."""
+
+    entity_type: AddressEntityTypeLiteral = Field(
+        ..., description="Address kind — billing or shipping"
+    )
+    first_name: str | None = Field(default=None)
+    last_name: str | None = Field(default=None)
+    company: str | None = Field(default=None)
+    city: str | None = Field(default=None)
+    state: str | None = Field(default=None)
+    zip: str | None = Field(default=None)
+    country: str | None = Field(default=None)
+    phone: str | None = Field(default=None)
+
+
+class SOAddressUpdate(BaseModel):
+    """Patch to an existing SO address. Address get-by-id isn't exposed by
+    the Katana API, so previews show every supplied field as
+    ``is_unknown_prior=True`` — we can't read the prior values cheaply."""
+
+    id: int = Field(..., description="Address ID to update")
+    first_name: str | None = Field(default=None)
+    last_name: str | None = Field(default=None)
+    company: str | None = Field(default=None)
+    city: str | None = Field(default=None)
+    state: str | None = Field(default=None)
+    zip: str | None = Field(default=None)
+    country: str | None = Field(default=None)
+    phone: str | None = Field(default=None)
+
+
+class SOFulfillmentRowInput(BaseModel):
+    """A row inside a fulfillment — references an SO row + a quantity to fulfill."""
+
+    sales_order_row_id: int = Field(..., description="SO row being fulfilled")
+    quantity: float = Field(..., description="Quantity fulfilled", gt=0)
+
+
+class SOFulfillmentAdd(BaseModel):
+    """A new fulfillment for the SO."""
+
+    status: FulfillmentStatusLiteral = Field(
+        ..., description="Fulfillment status — DELIVERED or PACKED"
+    )
+    sales_order_fulfillment_rows: list[SOFulfillmentRowInput] = Field(
+        ..., description="Rows being fulfilled (variant + quantity)", min_length=1
+    )
+    picked_date: datetime | None = Field(default=None)
+    conversion_rate: float | None = Field(default=None)
+    conversion_date: datetime | None = Field(default=None)
+    tracking_number: str | None = Field(default=None)
+    tracking_url: str | None = Field(default=None)
+    tracking_carrier: str | None = Field(default=None)
+    tracking_method: str | None = Field(default=None)
+
+
+class SOFulfillmentUpdate(BaseModel):
+    """Patch to an existing SO fulfillment."""
+
+    id: int = Field(..., description="Fulfillment ID to update")
+    status: FulfillmentStatusLiteral | None = Field(default=None)
+    picked_date: datetime | None = Field(default=None)
+    packer_id: int | None = Field(default=None, description="New packer (operator)")
+    conversion_rate: float | None = Field(default=None)
+    conversion_date: datetime | None = Field(default=None)
+    tracking_number: str | None = Field(default=None)
+    tracking_url: str | None = Field(default=None)
+    tracking_carrier: str | None = Field(default=None)
+    tracking_method: str | None = Field(default=None)
+
+
+class SOShippingFeeAdd(BaseModel):
+    """A new shipping fee to attach to the SO."""
+
+    amount: str = Field(..., description="Fee amount (decimal string)")
+    description: str | None = Field(default=None)
+    tax_rate_id: int | None = Field(default=None)
+
+
+class SOShippingFeeUpdate(BaseModel):
+    """Patch to an existing SO shipping fee.
+
+    Note: Katana's API requires ``amount`` even on PATCH — it's a replace
+    semantic on the fee's amount, not a partial update. The other fields
+    are genuinely optional.
+    """
+
+    id: int = Field(..., description="Shipping fee ID to update")
+    amount: str = Field(..., description="Fee amount (required by API)")
+    description: str | None = Field(default=None)
+    tax_rate_id: int | None = Field(default=None)
+
+
+class ModifySalesOrderRequest(BaseModel):
+    """Unified modification request for a sales order.
+
+    Sub-payload slots span header + rows + addresses + fulfillments +
+    shipping fees. Multiple slots can be combined; actions execute in
+    canonical order. To remove the SO entirely, use ``delete_sales_order``.
+    """
+
+    id: int = Field(..., description="Sales order ID")
+
+    update_header: SOHeaderPatch | None = Field(default=None)
+
+    add_rows: list[SORowAdd] | None = Field(default=None)
+    update_rows: list[SORowUpdate] | None = Field(default=None)
+    delete_row_ids: list[int] | None = Field(default=None)
+
+    add_addresses: list[SOAddressAdd] | None = Field(default=None)
+    update_addresses: list[SOAddressUpdate] | None = Field(default=None)
+    delete_address_ids: list[int] | None = Field(default=None)
+
+    add_fulfillments: list[SOFulfillmentAdd] | None = Field(default=None)
+    update_fulfillments: list[SOFulfillmentUpdate] | None = Field(default=None)
+    delete_fulfillment_ids: list[int] | None = Field(default=None)
+
+    add_shipping_fees: list[SOShippingFeeAdd] | None = Field(default=None)
+    update_shipping_fees: list[SOShippingFeeUpdate] | None = Field(default=None)
+    delete_shipping_fee_ids: list[int] | None = Field(default=None)
+
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, executes the action plan.",
+    )
+
+
+class DeleteSalesOrderRequest(BaseModel):
+    """Delete a sales order. Destructive — the order is removed (Katana
+    cascades child rows / addresses / fulfillments / shipping fees server-side).
+    """
+
+    id: int = Field(..., description="Sales order ID to delete")
+    confirm: bool = Field(
+        default=False,
+        description="If false, returns preview. If true, deletes the SO.",
+    )
+
+
+# ----------------------------------------------------------------------------
+# API request builders — pure data shaping per sub-payload kind.
+# ----------------------------------------------------------------------------
+
+
+def _build_update_header_request(patch: SOHeaderPatch) -> APIUpdateSalesOrderRequest:
+    api_status = (
+        _SO_STATUS_API_VALUE[patch.status] if patch.status is not None else None
+    )
+    return APIUpdateSalesOrderRequest(
+        order_no=to_unset(patch.order_no),
+        customer_id=to_unset(patch.customer_id),
+        location_id=to_unset(patch.location_id),
+        status=to_unset(api_status),
+        currency=to_unset(patch.currency),
+        conversion_rate=to_unset(patch.conversion_rate),
+        conversion_date=to_unset(patch.conversion_date),
+        order_created_date=to_unset(patch.order_created_date),
+        delivery_date=to_unset(patch.delivery_date),
+        picked_date=to_unset(patch.picked_date),
+        additional_info=to_unset(patch.additional_info),
+        customer_ref=to_unset(patch.customer_ref),
+        tracking_number=to_unset(patch.tracking_number),
+        tracking_number_url=to_unset(patch.tracking_number_url),
+    )
+
+
+def _build_create_row_request(so_id: int, row: SORowAdd) -> APICreateSORowRequest:
+    return APICreateSORowRequest(
+        sales_order_id=so_id,
+        variant_id=row.variant_id,
+        quantity=row.quantity,
+        price_per_unit=to_unset(row.price_per_unit),
+        tax_rate_id=to_unset(row.tax_rate_id),
+        location_id=to_unset(row.location_id),
+        total_discount=to_unset(row.total_discount),
+    )
+
+
+def _build_update_row_request(patch: SORowUpdate) -> APIUpdateSORowRequest:
+    return APIUpdateSORowRequest(
+        variant_id=to_unset(patch.variant_id),
+        quantity=to_unset(patch.quantity),
+        price_per_unit=to_unset(patch.price_per_unit),
+        tax_rate_id=to_unset(patch.tax_rate_id),
+        location_id=to_unset(patch.location_id),
+        total_discount=to_unset(patch.total_discount),
+    )
+
+
+def _build_create_address_request(
+    so_id: int, addr: SOAddressAdd
+) -> APICreateSOAddressRequest:
+    api_entity_type = (
+        AddressEntityType.BILLING
+        if addr.entity_type == "billing"
+        else AddressEntityType.SHIPPING
+    )
+    return APICreateSOAddressRequest(
+        sales_order_id=so_id,
+        entity_type=api_entity_type,
+        first_name=to_unset(addr.first_name),
+        last_name=to_unset(addr.last_name),
+        company=to_unset(addr.company),
+        city=to_unset(addr.city),
+        state=to_unset(addr.state),
+        zip_=to_unset(addr.zip),
+        country=to_unset(addr.country),
+        phone=to_unset(addr.phone),
+    )
+
+
+def _build_update_address_request(
+    patch: SOAddressUpdate,
+) -> APIUpdateSOAddressRequest:
+    return APIUpdateSOAddressRequest(
+        first_name=to_unset(patch.first_name),
+        last_name=to_unset(patch.last_name),
+        company=to_unset(patch.company),
+        city=to_unset(patch.city),
+        state=to_unset(patch.state),
+        zip_=to_unset(patch.zip),
+        country=to_unset(patch.country),
+        phone=to_unset(patch.phone),
+    )
+
+
+def _build_create_fulfillment_request(
+    so_id: int, fulfillment: SOFulfillmentAdd
+) -> APICreateSOFulfillmentRequest:
+    api_status = _FULFILLMENT_STATUS_API_VALUE[fulfillment.status]
+    rows = [
+        SalesOrderFulfillmentRowRequest(
+            sales_order_row_id=r.sales_order_row_id, quantity=r.quantity
+        )
+        for r in fulfillment.sales_order_fulfillment_rows
+    ]
+    return APICreateSOFulfillmentRequest(
+        sales_order_id=so_id,
+        status=api_status,
+        sales_order_fulfillment_rows=rows,
+        picked_date=to_unset(fulfillment.picked_date),
+        conversion_rate=to_unset(fulfillment.conversion_rate),
+        conversion_date=to_unset(fulfillment.conversion_date),
+        tracking_number=to_unset(fulfillment.tracking_number),
+        tracking_url=to_unset(fulfillment.tracking_url),
+        tracking_carrier=to_unset(fulfillment.tracking_carrier),
+        tracking_method=to_unset(fulfillment.tracking_method),
+    )
+
+
+def _build_update_fulfillment_request(
+    patch: SOFulfillmentUpdate,
+) -> APIUpdateSOFulfillmentRequest:
+    api_status = (
+        _FULFILLMENT_STATUS_API_VALUE[patch.status]
+        if patch.status is not None
+        else None
+    )
+    return APIUpdateSOFulfillmentRequest(
+        status=to_unset(api_status),
+        picked_date=to_unset(patch.picked_date),
+        packer_id=to_unset(patch.packer_id),
+        conversion_rate=to_unset(patch.conversion_rate),
+        conversion_date=to_unset(patch.conversion_date),
+        tracking_number=to_unset(patch.tracking_number),
+        tracking_url=to_unset(patch.tracking_url),
+        tracking_carrier=to_unset(patch.tracking_carrier),
+        tracking_method=to_unset(patch.tracking_method),
+    )
+
+
+def _build_create_shipping_fee_request(
+    so_id: int, fee: SOShippingFeeAdd
+) -> APICreateSOShippingFeeRequest:
+    return APICreateSOShippingFeeRequest(
+        sales_order_id=so_id,
+        amount=fee.amount,
+        description=to_unset(fee.description),
+        tax_rate_id=to_unset(fee.tax_rate_id),
+    )
+
+
+def _build_update_shipping_fee_request(
+    patch: SOShippingFeeUpdate,
+) -> APIUpdateSOShippingFeeRequest:
+    return APIUpdateSOShippingFeeRequest(
+        amount=patch.amount,
+        description=to_unset(patch.description),
+        tax_rate_id=to_unset(patch.tax_rate_id),
+    )
+
+
+# ----------------------------------------------------------------------------
+# Apply-closure factories — bind per-call args without default-arg trickery.
+# ----------------------------------------------------------------------------
+
+
+def _make_apply_update_header(
+    services: Any, so_id: int, body: APIUpdateSalesOrderRequest
+) -> Callable[[], Awaitable[SalesOrder]]:
+    async def apply() -> SalesOrder:
+        response = await api_update_sales_order.asyncio_detailed(
+            id=so_id, client=services.client, body=body
+        )
+        return unwrap_as(response, SalesOrder)
+
+    return apply
+
+
+def _make_apply_create_row(
+    services: Any, body: APICreateSORowRequest
+) -> Callable[[], Awaitable[SalesOrderRow]]:
+    async def apply() -> SalesOrderRow:
+        response = await api_create_so_row.asyncio_detailed(
+            client=services.client, body=body
+        )
+        return unwrap_as(response, SalesOrderRow)
+
+    return apply
+
+
+def _make_apply_update_row(
+    services: Any, row_id: int, body: APIUpdateSORowRequest
+) -> Callable[[], Awaitable[SalesOrderRow]]:
+    async def apply() -> SalesOrderRow:
+        response = await api_update_so_row.asyncio_detailed(
+            id=row_id, client=services.client, body=body
+        )
+        return unwrap_as(response, SalesOrderRow)
+
+    return apply
+
+
+def _make_apply_delete_row(services: Any, row_id: int) -> Callable[[], Awaitable[None]]:
+    async def apply() -> None:
+        response = await api_delete_so_row.asyncio_detailed(
+            id=row_id, client=services.client
+        )
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    return apply
+
+
+def _make_apply_create_address(
+    services: Any, body: APICreateSOAddressRequest
+) -> Callable[[], Awaitable[APISalesOrderAddress]]:
+    async def apply() -> APISalesOrderAddress:
+        response = await api_create_so_address.asyncio_detailed(
+            client=services.client, body=body
+        )
+        return unwrap_as(response, APISalesOrderAddress)
+
+    return apply
+
+
+def _make_apply_update_address(
+    services: Any, addr_id: int, body: APIUpdateSOAddressRequest
+) -> Callable[[], Awaitable[APISalesOrderAddress]]:
+    async def apply() -> APISalesOrderAddress:
+        response = await api_update_so_address.asyncio_detailed(
+            id=addr_id, client=services.client, body=body
+        )
+        return unwrap_as(response, APISalesOrderAddress)
+
+    return apply
+
+
+def _make_apply_delete_address(
+    services: Any, addr_id: int
+) -> Callable[[], Awaitable[None]]:
+    async def apply() -> None:
+        response = await api_delete_so_address.asyncio_detailed(
+            id=addr_id, client=services.client
+        )
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    return apply
+
+
+def _make_apply_create_fulfillment(
+    services: Any, body: APICreateSOFulfillmentRequest
+) -> Callable[[], Awaitable[SalesOrderFulfillment]]:
+    async def apply() -> SalesOrderFulfillment:
+        response = await api_create_so_fulfillment.asyncio_detailed(
+            client=services.client, body=body
+        )
+        return unwrap_as(response, SalesOrderFulfillment)
+
+    return apply
+
+
+def _make_apply_update_fulfillment(
+    services: Any, fulfillment_id: int, body: APIUpdateSOFulfillmentRequest
+) -> Callable[[], Awaitable[SalesOrderFulfillment]]:
+    async def apply() -> SalesOrderFulfillment:
+        response = await api_update_so_fulfillment.asyncio_detailed(
+            id=fulfillment_id, client=services.client, body=body
+        )
+        return unwrap_as(response, SalesOrderFulfillment)
+
+    return apply
+
+
+def _make_apply_delete_fulfillment(
+    services: Any, fulfillment_id: int
+) -> Callable[[], Awaitable[None]]:
+    async def apply() -> None:
+        response = await api_delete_so_fulfillment.asyncio_detailed(
+            id=fulfillment_id, client=services.client
+        )
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    return apply
+
+
+def _make_apply_create_shipping_fee(
+    services: Any, body: APICreateSOShippingFeeRequest
+) -> Callable[[], Awaitable[SalesOrderShippingFee]]:
+    async def apply() -> SalesOrderShippingFee:
+        response = await api_create_so_shipping_fee.asyncio_detailed(
+            client=services.client, body=body
+        )
+        return unwrap_as(response, SalesOrderShippingFee)
+
+    return apply
+
+
+def _make_apply_update_shipping_fee(
+    services: Any, fee_id: int, body: APIUpdateSOShippingFeeRequest
+) -> Callable[[], Awaitable[SalesOrderShippingFee]]:
+    async def apply() -> SalesOrderShippingFee:
+        response = await api_update_so_shipping_fee.asyncio_detailed(
+            id=fee_id, client=services.client, body=body
+        )
+        return unwrap_as(response, SalesOrderShippingFee)
+
+    return apply
+
+
+def _make_apply_delete_shipping_fee(
+    services: Any, fee_id: int
+) -> Callable[[], Awaitable[None]]:
+    async def apply() -> None:
+        response = await api_delete_so_shipping_fee.asyncio_detailed(
+            id=fee_id, client=services.client
+        )
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    return apply
+
+
+def _make_apply_delete_so(services: Any, so_id: int) -> Callable[[], Awaitable[None]]:
+    async def apply() -> None:
+        response = await api_delete_sales_order.asyncio_detailed(
+            id=so_id, client=services.client
+        )
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    return apply
+
+
+# ----------------------------------------------------------------------------
+# Plan builders — translate sub-payloads into ActionSpec lists.
+# ----------------------------------------------------------------------------
+
+
+def _plan_so_header_update(
+    request: ModifySalesOrderRequest,
+    services: Any,
+    existing: SalesOrder | None,
+) -> ActionSpec | None:
+    if request.update_header is None:
+        return None
+    patch = request.update_header
+    diff = compute_field_diff(existing, patch, unknown_prior=existing is None)
+    return ActionSpec(
+        operation=SOOperation.UPDATE_HEADER,
+        target_id=request.id,
+        diff=diff,
+        apply=_make_apply_update_header(
+            services, request.id, _build_update_header_request(patch)
+        ),
+        verify=make_response_verifier(diff),
+    )
+
+
+def _plan_so_row_adds(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    if not request.add_rows:
+        return []
+    return [
+        make_create_action(
+            SOOperation.ADD_ROW,
+            row,
+            _make_apply_create_row(
+                services, _build_create_row_request(request.id, row)
+            ),
+        )
+        for row in request.add_rows
+    ]
+
+
+async def _plan_so_row_updates(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    if not request.update_rows:
+        return []
+    existing_rows = await asyncio.gather(
+        *[_fetch_so_row(services, p.id) for p in request.update_rows]
+    )
+    specs: list[ActionSpec] = []
+    for row_patch, existing_row in zip(request.update_rows, existing_rows, strict=True):
+        diff = compute_field_diff(
+            existing_row, row_patch, unknown_prior=existing_row is None
+        )
+        specs.append(
+            ActionSpec(
+                operation=SOOperation.UPDATE_ROW,
+                target_id=row_patch.id,
+                diff=diff,
+                apply=_make_apply_update_row(
+                    services, row_patch.id, _build_update_row_request(row_patch)
+                ),
+                verify=make_response_verifier(diff),
+            )
+        )
+    return specs
+
+
+def _plan_so_row_deletes(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    if not request.delete_row_ids:
+        return []
+    return [
+        make_delete_action(
+            SOOperation.DELETE_ROW, rid, _make_apply_delete_row(services, rid)
+        )
+        for rid in request.delete_row_ids
+    ]
+
+
+def _plan_so_address_adds(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    if not request.add_addresses:
+        return []
+    return [
+        make_create_action(
+            SOOperation.ADD_ADDRESS,
+            addr,
+            _make_apply_create_address(
+                services, _build_create_address_request(request.id, addr)
+            ),
+        )
+        for addr in request.add_addresses
+    ]
+
+
+def _plan_so_address_updates(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    """Address updates can't prefetch (no get-by-id), so every diff is
+    ``is_unknown_prior=True``. Verification still works against the PATCH
+    response body."""
+    if not request.update_addresses:
+        return []
+    specs: list[ActionSpec] = []
+    for patch in request.update_addresses:
+        diff = compute_field_diff(None, patch, unknown_prior=True)
+        specs.append(
+            ActionSpec(
+                operation=SOOperation.UPDATE_ADDRESS,
+                target_id=patch.id,
+                diff=diff,
+                apply=_make_apply_update_address(
+                    services, patch.id, _build_update_address_request(patch)
+                ),
+                verify=make_response_verifier(diff),
+            )
+        )
+    return specs
+
+
+def _plan_so_address_deletes(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    if not request.delete_address_ids:
+        return []
+    return [
+        make_delete_action(
+            SOOperation.DELETE_ADDRESS,
+            addr_id,
+            _make_apply_delete_address(services, addr_id),
+        )
+        for addr_id in request.delete_address_ids
+    ]
+
+
+def _plan_so_fulfillment_adds(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    if not request.add_fulfillments:
+        return []
+    return [
+        make_create_action(
+            SOOperation.ADD_FULFILLMENT,
+            fulfillment,
+            _make_apply_create_fulfillment(
+                services, _build_create_fulfillment_request(request.id, fulfillment)
+            ),
+        )
+        for fulfillment in request.add_fulfillments
+    ]
+
+
+async def _plan_so_fulfillment_updates(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    if not request.update_fulfillments:
+        return []
+    existing = await asyncio.gather(
+        *[_fetch_so_fulfillment(services, p.id) for p in request.update_fulfillments]
+    )
+    specs: list[ActionSpec] = []
+    for patch, existing_fulfillment in zip(
+        request.update_fulfillments, existing, strict=True
+    ):
+        diff = compute_field_diff(
+            existing_fulfillment, patch, unknown_prior=existing_fulfillment is None
+        )
+        specs.append(
+            ActionSpec(
+                operation=SOOperation.UPDATE_FULFILLMENT,
+                target_id=patch.id,
+                diff=diff,
+                apply=_make_apply_update_fulfillment(
+                    services, patch.id, _build_update_fulfillment_request(patch)
+                ),
+                verify=make_response_verifier(diff),
+            )
+        )
+    return specs
+
+
+def _plan_so_fulfillment_deletes(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    if not request.delete_fulfillment_ids:
+        return []
+    return [
+        make_delete_action(
+            SOOperation.DELETE_FULFILLMENT,
+            fid,
+            _make_apply_delete_fulfillment(services, fid),
+        )
+        for fid in request.delete_fulfillment_ids
+    ]
+
+
+def _plan_so_shipping_fee_adds(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    if not request.add_shipping_fees:
+        return []
+    return [
+        make_create_action(
+            SOOperation.ADD_SHIPPING_FEE,
+            fee,
+            _make_apply_create_shipping_fee(
+                services, _build_create_shipping_fee_request(request.id, fee)
+            ),
+        )
+        for fee in request.add_shipping_fees
+    ]
+
+
+async def _plan_so_shipping_fee_updates(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    if not request.update_shipping_fees:
+        return []
+    existing = await asyncio.gather(
+        *[_fetch_so_shipping_fee(services, p.id) for p in request.update_shipping_fees]
+    )
+    specs: list[ActionSpec] = []
+    for patch, existing_fee in zip(request.update_shipping_fees, existing, strict=True):
+        diff = compute_field_diff(
+            existing_fee, patch, unknown_prior=existing_fee is None
+        )
+        specs.append(
+            ActionSpec(
+                operation=SOOperation.UPDATE_SHIPPING_FEE,
+                target_id=patch.id,
+                diff=diff,
+                apply=_make_apply_update_shipping_fee(
+                    services, patch.id, _build_update_shipping_fee_request(patch)
+                ),
+                verify=make_response_verifier(diff),
+            )
+        )
+    return specs
+
+
+def _plan_so_shipping_fee_deletes(
+    request: ModifySalesOrderRequest, services: Any
+) -> list[ActionSpec]:
+    if not request.delete_shipping_fee_ids:
+        return []
+    return [
+        make_delete_action(
+            SOOperation.DELETE_SHIPPING_FEE,
+            fid,
+            _make_apply_delete_shipping_fee(services, fid),
+        )
+        for fid in request.delete_shipping_fee_ids
+    ]
+
+
+# ----------------------------------------------------------------------------
+# Implementations
+# ----------------------------------------------------------------------------
+
+
+async def _modify_sales_order_impl(
+    request: ModifySalesOrderRequest, context: Context
+) -> ModificationResponse:
+    """Build the action plan from the request's sub-payloads and execute or
+    preview based on ``confirm``."""
+    services = get_services(context)
+
+    if not has_any_subpayload(request):
+        raise ValueError(
+            "At least one sub-payload must be set: update_header, "
+            "add/update/delete_rows, add/update/delete_addresses, "
+            "add/update/delete_fulfillments, or "
+            "add/update/delete_shipping_fees. To remove the SO entirely, "
+            "use delete_sales_order."
+        )
+
+    existing_so = await _fetch_sales_order_attrs(services, request.id)
+
+    plan: list[ActionSpec] = []
+    header_spec = _plan_so_header_update(request, services, existing_so)
+    if header_spec is not None:
+        plan.append(header_spec)
+    plan.extend(_plan_so_row_adds(request, services))
+    plan.extend(await _plan_so_row_updates(request, services))
+    plan.extend(_plan_so_row_deletes(request, services))
+    plan.extend(_plan_so_address_adds(request, services))
+    plan.extend(_plan_so_address_updates(request, services))
+    plan.extend(_plan_so_address_deletes(request, services))
+    plan.extend(_plan_so_fulfillment_adds(request, services))
+    plan.extend(await _plan_so_fulfillment_updates(request, services))
+    plan.extend(_plan_so_fulfillment_deletes(request, services))
+    plan.extend(_plan_so_shipping_fee_adds(request, services))
+    plan.extend(await _plan_so_shipping_fee_updates(request, services))
+    plan.extend(_plan_so_shipping_fee_deletes(request, services))
+
+    katana_url = katana_web_url("sales_order", request.id)
+    warnings: list[str] = []
+    if existing_so is None:
+        warnings.append(
+            f"Could not fetch sales order {request.id} for diff context — "
+            "preview shows requested values without prior state."
+        )
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="sales_order",
+            entity_id=request.id,
+            is_preview=True,
+            actions=plan_to_preview_results(plan),
+            warnings=warnings,
+            next_actions=[
+                f"Review {len(plan)} planned action(s)",
+                "Set confirm=true to execute the plan",
+            ],
+            katana_url=katana_url,
+            message=(
+                f"Preview: {len(plan)} action(s) planned for sales order {request.id}"
+            ),
+        )
+
+    prior_state = serialize_for_prior_state(existing_so)
+    actions = await execute_plan(plan)
+
+    succeeded_count = sum(1 for a in actions if a.succeeded is True)
+    failed_count = sum(1 for a in actions if a.succeeded is False)
+    failed = failed_count > 0
+
+    if failed:
+        message = (
+            f"Partial: {succeeded_count}/{len(plan)} action(s) applied to "
+            f"sales order {request.id} before fail-fast halt; see actions "
+            "for details and prior_state for revert reference."
+        )
+        next_actions = [
+            f"{succeeded_count} action(s) succeeded; {failed_count} failed",
+            "Review the FAILED action's error and the prior_state snapshot",
+            "Compose a follow-up modify_sales_order call to revert if needed",
+        ]
+    else:
+        message = (
+            f"Successfully applied {succeeded_count}/{len(plan)} action(s) to "
+            f"sales order {request.id}"
+        )
+        next_actions = [
+            f"Sales order {request.id} modified — {succeeded_count} action(s) verified"
+        ]
+
+    return ModificationResponse(
+        entity_type="sales_order",
+        entity_id=request.id,
+        is_preview=False,
+        actions=actions,
+        prior_state=prior_state,
+        warnings=warnings,
+        next_actions=next_actions,
+        katana_url=katana_url,
+        message=message,
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def modify_sales_order(
+    request: Annotated[ModifySalesOrderRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Modify a sales order — unified surface across header, rows, addresses,
+    fulfillments, and shipping fees.
+
+    Sub-payloads (any subset, all optional):
+
+    - ``update_header`` — patch header fields (incl. status)
+    - ``add_rows`` / ``update_rows`` / ``delete_row_ids`` — line item CRUD
+    - ``add_addresses`` / ``update_addresses`` / ``delete_address_ids`` —
+      billing/shipping addresses
+    - ``add_fulfillments`` / ``update_fulfillments`` / ``delete_fulfillment_ids`` —
+      fulfillments (each carries its own status + tracking)
+    - ``add_shipping_fees`` / ``update_shipping_fees`` /
+      ``delete_shipping_fee_ids`` — shipping/freight charges
+
+    To remove an SO entirely, use the sibling ``delete_sales_order`` tool.
+
+    Two-step flow: ``confirm=false`` returns a per-action preview;
+    ``confirm=true`` executes the plan in canonical order. Fail-fast on
+    error; per-action ``verified`` reflects post-execution re-fetch
+    confirmation (when supported by the resource).
+
+    The response carries a ``prior_state`` snapshot of the pre-modification
+    SO. Note: address updates can't be diffed pre-execution because Katana
+    doesn't expose a per-address GET; their previews show every supplied
+    field as ``(prior unknown) → new``.
+    """
+    response = await _modify_sales_order_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
+# Tool: delete_sales_order
+# ============================================================================
+
+
+async def _delete_sales_order_impl(
+    request: DeleteSalesOrderRequest, context: Context
+) -> ModificationResponse:
+    """One-action plan that removes the SO. Katana cascades child rows,
+    addresses, fulfillments, and shipping fees server-side."""
+    services = get_services(context)
+
+    existing_so = await _fetch_sales_order_attrs(services, request.id)
+    plan = [
+        make_delete_action(
+            SOOperation.DELETE, request.id, _make_apply_delete_so(services, request.id)
+        )
+    ]
+    katana_url = katana_web_url("sales_order", request.id)
+
+    if not request.confirm:
+        return ModificationResponse(
+            entity_type="sales_order",
+            entity_id=request.id,
+            is_preview=True,
+            actions=plan_to_preview_results(plan),
+            next_actions=[
+                "Review the deletion",
+                "Set confirm=true to delete the sales order",
+            ],
+            katana_url=katana_url,
+            message=f"Preview: delete sales order {request.id}",
+        )
+
+    prior_state = serialize_for_prior_state(existing_so)
+    actions = await execute_plan(plan)
+    failed = any(a.succeeded is False for a in actions)
+
+    return ModificationResponse(
+        entity_type="sales_order",
+        entity_id=request.id,
+        is_preview=False,
+        actions=actions,
+        prior_state=prior_state,
+        next_actions=(
+            [f"Sales order {request.id} has been deleted"]
+            if not failed
+            else [
+                "Delete failed — see action error",
+                "prior_state carries the pre-delete snapshot",
+            ]
+        ),
+        katana_url=None if not failed else katana_url,
+        message=(
+            f"Successfully deleted sales order {request.id}"
+            if not failed
+            else f"Failed to delete sales order {request.id}"
+        ),
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def delete_sales_order(
+    request: Annotated[DeleteSalesOrderRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Delete a sales order. Destructive — Katana cascades the delete to
+    child rows / addresses / fulfillments / shipping fees server-side.
+
+    The response carries a ``prior_state`` snapshot for manual revert.
+    """
+    response = await _delete_sales_order_impl(request, context)
+    return to_tool_result(response)
+
+
 def register_tools(mcp: FastMCP) -> None:
     """Register all sales order tools with the FastMCP instance.
 
@@ -1316,18 +2515,29 @@ def register_tools(mcp: FastMCP) -> None:
         openWorldHint=True,
     )
 
+    _write = ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, openWorldHint=True
+    )
+    _update = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+    _destructive = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+
+    mcp.tool(tags={"orders", "sales", "write"}, annotations=_write, meta=UI_META)(
+        create_sales_order
+    )
+    mcp.tool(tags={"orders", "sales", "read"}, annotations=_read)(list_sales_orders)
+    mcp.tool(tags={"orders", "sales", "read"}, annotations=_read)(get_sales_order)
+    mcp.tool(tags={"orders", "sales", "write"}, annotations=_update)(modify_sales_order)
     mcp.tool(
-        tags={"orders", "sales", "write"},
-        annotations=ToolAnnotations(
-            readOnlyHint=False, destructiveHint=False, openWorldHint=True
-        ),
-        meta=UI_META,
-    )(create_sales_order)
-    mcp.tool(
-        tags={"orders", "sales", "read"},
-        annotations=_read,
-    )(list_sales_orders)
-    mcp.tool(
-        tags={"orders", "sales", "read"},
-        annotations=_read,
-    )(get_sales_order)
+        tags={"orders", "sales", "write", "destructive"},
+        annotations=_destructive,
+    )(delete_sales_order)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -44,6 +44,7 @@ from katana_mcp.tools._modification_dispatch import (
     run_delete_plan,
     run_modify_plan,
     safe_fetch_for_diff,
+    unset_dict,
 )
 from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.tool_result_utils import (
@@ -1645,69 +1646,29 @@ class DeleteSalesOrderRequest(ConfirmableRequest):
 
 
 def _build_update_header_request(patch: SOHeaderPatch) -> APIUpdateSalesOrderRequest:
-    api_status = (
-        UpdateSalesOrderStatus(patch.status) if patch.status is not None else None
-    )
     return APIUpdateSalesOrderRequest(
-        order_no=to_unset(patch.order_no),
-        customer_id=to_unset(patch.customer_id),
-        location_id=to_unset(patch.location_id),
-        status=to_unset(api_status),
-        currency=to_unset(patch.currency),
-        conversion_rate=to_unset(patch.conversion_rate),
-        conversion_date=to_unset(patch.conversion_date),
-        order_created_date=to_unset(patch.order_created_date),
-        delivery_date=to_unset(patch.delivery_date),
-        picked_date=to_unset(patch.picked_date),
-        additional_info=to_unset(patch.additional_info),
-        customer_ref=to_unset(patch.customer_ref),
-        tracking_number=to_unset(patch.tracking_number),
-        tracking_number_url=to_unset(patch.tracking_number_url),
+        **unset_dict(patch, transforms={"status": UpdateSalesOrderStatus})
     )
 
 
 def _build_create_row_request(so_id: int, row: SORowAdd) -> APICreateSORowRequest:
-    return APICreateSORowRequest(
-        sales_order_id=so_id,
-        variant_id=row.variant_id,
-        quantity=row.quantity,
-        price_per_unit=to_unset(row.price_per_unit),
-        tax_rate_id=to_unset(row.tax_rate_id),
-        location_id=to_unset(row.location_id),
-        total_discount=to_unset(row.total_discount),
-    )
+    return APICreateSORowRequest(sales_order_id=so_id, **unset_dict(row))
 
 
 def _build_update_row_request(patch: SORowUpdate) -> APIUpdateSORowRequest:
-    return APIUpdateSORowRequest(
-        variant_id=to_unset(patch.variant_id),
-        quantity=to_unset(patch.quantity),
-        price_per_unit=to_unset(patch.price_per_unit),
-        tax_rate_id=to_unset(patch.tax_rate_id),
-        location_id=to_unset(patch.location_id),
-        total_discount=to_unset(patch.total_discount),
-    )
+    return APIUpdateSORowRequest(**unset_dict(patch, exclude=("id",)))
 
 
 def _build_create_address_request(
     so_id: int, addr: SOAddressAdd
 ) -> APICreateSOAddressRequest:
-    api_entity_type = (
-        AddressEntityType.BILLING
-        if addr.entity_type == "billing"
-        else AddressEntityType.SHIPPING
-    )
     return APICreateSOAddressRequest(
         sales_order_id=so_id,
-        entity_type=api_entity_type,
-        first_name=to_unset(addr.first_name),
-        last_name=to_unset(addr.last_name),
-        company=to_unset(addr.company),
-        city=to_unset(addr.city),
-        state=to_unset(addr.state),
-        zip_=to_unset(addr.zip),
-        country=to_unset(addr.country),
-        phone=to_unset(addr.phone),
+        **unset_dict(
+            addr,
+            field_map={"zip": "zip_"},
+            transforms={"entity_type": AddressEntityType},
+        ),
     )
 
 
@@ -1715,21 +1676,13 @@ def _build_update_address_request(
     patch: SOAddressUpdate,
 ) -> APIUpdateSOAddressRequest:
     return APIUpdateSOAddressRequest(
-        first_name=to_unset(patch.first_name),
-        last_name=to_unset(patch.last_name),
-        company=to_unset(patch.company),
-        city=to_unset(patch.city),
-        state=to_unset(patch.state),
-        zip_=to_unset(patch.zip),
-        country=to_unset(patch.country),
-        phone=to_unset(patch.phone),
+        **unset_dict(patch, exclude=("id",), field_map={"zip": "zip_"})
     )
 
 
 def _build_create_fulfillment_request(
     so_id: int, fulfillment: SOFulfillmentAdd
 ) -> APICreateSOFulfillmentRequest:
-    api_status = SalesOrderFulfillmentStatus(fulfillment.status)
     rows = [
         SalesOrderFulfillmentRowRequest(
             sales_order_row_id=r.sales_order_row_id, quantity=r.quantity
@@ -1738,56 +1691,37 @@ def _build_create_fulfillment_request(
     ]
     return APICreateSOFulfillmentRequest(
         sales_order_id=so_id,
-        status=api_status,
         sales_order_fulfillment_rows=rows,
-        picked_date=to_unset(fulfillment.picked_date),
-        conversion_rate=to_unset(fulfillment.conversion_rate),
-        conversion_date=to_unset(fulfillment.conversion_date),
-        tracking_number=to_unset(fulfillment.tracking_number),
-        tracking_url=to_unset(fulfillment.tracking_url),
-        tracking_carrier=to_unset(fulfillment.tracking_carrier),
-        tracking_method=to_unset(fulfillment.tracking_method),
+        **unset_dict(
+            fulfillment,
+            exclude=("sales_order_fulfillment_rows",),
+            transforms={"status": SalesOrderFulfillmentStatus},
+        ),
     )
 
 
 def _build_update_fulfillment_request(
     patch: SOFulfillmentUpdate,
 ) -> APIUpdateSOFulfillmentRequest:
-    api_status = (
-        SalesOrderFulfillmentStatus(patch.status) if patch.status is not None else None
-    )
     return APIUpdateSOFulfillmentRequest(
-        status=to_unset(api_status),
-        picked_date=to_unset(patch.picked_date),
-        packer_id=to_unset(patch.packer_id),
-        conversion_rate=to_unset(patch.conversion_rate),
-        conversion_date=to_unset(patch.conversion_date),
-        tracking_number=to_unset(patch.tracking_number),
-        tracking_url=to_unset(patch.tracking_url),
-        tracking_carrier=to_unset(patch.tracking_carrier),
-        tracking_method=to_unset(patch.tracking_method),
+        **unset_dict(
+            patch,
+            exclude=("id",),
+            transforms={"status": SalesOrderFulfillmentStatus},
+        )
     )
 
 
 def _build_create_shipping_fee_request(
     so_id: int, fee: SOShippingFeeAdd
 ) -> APICreateSOShippingFeeRequest:
-    return APICreateSOShippingFeeRequest(
-        sales_order_id=so_id,
-        amount=fee.amount,
-        description=to_unset(fee.description),
-        tax_rate_id=to_unset(fee.tax_rate_id),
-    )
+    return APICreateSOShippingFeeRequest(sales_order_id=so_id, **unset_dict(fee))
 
 
 def _build_update_shipping_fee_request(
     patch: SOShippingFeeUpdate,
 ) -> APIUpdateSOShippingFeeRequest:
-    return APIUpdateSOShippingFeeRequest(
-        amount=patch.amount,
-        description=to_unset(patch.description),
-        tax_rate_id=to_unset(patch.tax_rate_id),
-    )
+    return APIUpdateSOShippingFeeRequest(**unset_dict(patch, exclude=("id",)))
 
 
 # ----------------------------------------------------------------------------

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -34,19 +34,16 @@ from katana_mcp.tools._modification import (
 )
 from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
-    execute_plan,
     has_any_subpayload,
     make_delete_apply,
     make_patch_apply,
     make_post_apply,
     plan_creates,
     plan_deletes,
-    plan_to_preview_results,
     plan_updates,
+    run_delete_plan,
+    run_modify_plan,
     safe_fetch_for_diff,
-    serialize_for_prior_state,
-    summarize_delete_outcome,
-    summarize_modify_outcome,
 )
 from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.tool_result_utils import (
@@ -1403,27 +1400,10 @@ class SOOperation(StrEnum):
     DELETE_SHIPPING_FEE = "delete_shipping_fee"
 
 
-# Tool-facing status literal — mirrors UpdateSalesOrderStatus enum values.
+# Tool-facing literals — values match the API StrEnum's ``.value`` directly,
+# so ``EnumClass(literal)`` resolves the enum without a lookup table.
 SalesOrderStatusLiteral = Literal["NOT_SHIPPED", "PENDING", "PACKED", "DELIVERED"]
-
-_SO_STATUS_API_VALUE: dict[SalesOrderStatusLiteral, UpdateSalesOrderStatus] = {
-    "NOT_SHIPPED": UpdateSalesOrderStatus.NOT_SHIPPED,
-    "PENDING": UpdateSalesOrderStatus.PENDING,
-    "PACKED": UpdateSalesOrderStatus.PACKED,
-    "DELIVERED": UpdateSalesOrderStatus.DELIVERED,
-}
-
-# Fulfillment status literal — mirrors SalesOrderFulfillmentStatus.
 FulfillmentStatusLiteral = Literal["DELIVERED", "PACKED"]
-
-_FULFILLMENT_STATUS_API_VALUE: dict[
-    FulfillmentStatusLiteral, SalesOrderFulfillmentStatus
-] = {
-    "DELIVERED": SalesOrderFulfillmentStatus.DELIVERED,
-    "PACKED": SalesOrderFulfillmentStatus.PACKED,
-}
-
-# Address entity-type literal — mirrors AddressEntityType.
 AddressEntityTypeLiteral = Literal["billing", "shipping"]
 
 
@@ -1666,7 +1646,7 @@ class DeleteSalesOrderRequest(ConfirmableRequest):
 
 def _build_update_header_request(patch: SOHeaderPatch) -> APIUpdateSalesOrderRequest:
     api_status = (
-        _SO_STATUS_API_VALUE[patch.status] if patch.status is not None else None
+        UpdateSalesOrderStatus(patch.status) if patch.status is not None else None
     )
     return APIUpdateSalesOrderRequest(
         order_no=to_unset(patch.order_no),
@@ -1749,7 +1729,7 @@ def _build_update_address_request(
 def _build_create_fulfillment_request(
     so_id: int, fulfillment: SOFulfillmentAdd
 ) -> APICreateSOFulfillmentRequest:
-    api_status = _FULFILLMENT_STATUS_API_VALUE[fulfillment.status]
+    api_status = SalesOrderFulfillmentStatus(fulfillment.status)
     rows = [
         SalesOrderFulfillmentRowRequest(
             sales_order_row_id=r.sales_order_row_id, quantity=r.quantity
@@ -1774,9 +1754,7 @@ def _build_update_fulfillment_request(
     patch: SOFulfillmentUpdate,
 ) -> APIUpdateSOFulfillmentRequest:
     api_status = (
-        _FULFILLMENT_STATUS_API_VALUE[patch.status]
-        if patch.status is not None
-        else None
+        SalesOrderFulfillmentStatus(patch.status) if patch.status is not None else None
     )
     return APIUpdateSOFulfillmentRequest(
         status=to_unset(api_status),
@@ -1999,52 +1977,14 @@ async def _modify_sales_order_impl(
         )
     )
 
-    katana_url = katana_web_url("sales_order", request.id)
-    warnings = (
-        [
-            f"Could not fetch sales order {request.id} for diff context — "
-            "preview shows requested values without prior state."
-        ]
-        if existing_so is None
-        else []
-    )
-
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="sales_order",
-            entity_id=request.id,
-            is_preview=True,
-            actions=plan_to_preview_results(plan),
-            warnings=warnings,
-            next_actions=[
-                f"Review {len(plan)} planned action(s)",
-                "Set confirm=true to execute the plan",
-            ],
-            katana_url=katana_url,
-            message=(
-                f"Preview: {len(plan)} action(s) planned for sales order {request.id}"
-            ),
-        )
-
-    prior_state = serialize_for_prior_state(existing_so)
-    actions = await execute_plan(plan)
-    message, next_actions = summarize_modify_outcome(
-        actions,
-        len(plan),
+    return await run_modify_plan(
+        request=request,
+        entity_type="sales_order",
         entity_label=f"sales order {request.id}",
         tool_name="modify_sales_order",
-    )
-
-    return ModificationResponse(
-        entity_type="sales_order",
-        entity_id=request.id,
-        is_preview=False,
-        actions=actions,
-        prior_state=prior_state,
-        warnings=warnings,
-        next_actions=next_actions,
-        katana_url=katana_url,
-        message=message,
+        web_url_kind="sales_order",
+        existing=existing_so,
+        plan=plan,
     )
 
 
@@ -2093,45 +2033,15 @@ async def _delete_sales_order_impl(
 ) -> ModificationResponse:
     """One-action plan that removes the SO. Katana cascades child rows,
     addresses, fulfillments, and shipping fees server-side."""
-    services = get_services(context)
-
-    existing_so = await _fetch_sales_order_attrs(services, request.id)
-    plan = plan_deletes(
-        [request.id],
-        SOOperation.DELETE,
-        lambda so_id: make_delete_apply(api_delete_sales_order, services, so_id),
-    )
-    katana_url = katana_web_url("sales_order", request.id)
-
-    if not request.confirm:
-        return ModificationResponse(
-            entity_type="sales_order",
-            entity_id=request.id,
-            is_preview=True,
-            actions=plan_to_preview_results(plan),
-            next_actions=[
-                "Review the deletion",
-                "Set confirm=true to delete the sales order",
-            ],
-            katana_url=katana_url,
-            message=f"Preview: delete sales order {request.id}",
-        )
-
-    prior_state = serialize_for_prior_state(existing_so)
-    actions = await execute_plan(plan)
-    message, next_actions = summarize_delete_outcome(
-        actions, entity_label=f"sales order {request.id}"
-    )
-
-    return ModificationResponse(
+    return await run_delete_plan(
+        request=request,
+        services=get_services(context),
         entity_type="sales_order",
-        entity_id=request.id,
-        is_preview=False,
-        actions=actions,
-        prior_state=prior_state,
-        next_actions=next_actions,
-        katana_url=None if all(a.succeeded for a in actions) else katana_url,
-        message=message,
+        entity_label=f"sales order {request.id}",
+        web_url_kind="sales_order",
+        fetcher=_fetch_sales_order_attrs,
+        delete_endpoint=api_delete_sales_order,
+        operation=SOOperation.DELETE,
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -14,7 +14,6 @@ Tools:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Annotated, Any, Literal
@@ -27,6 +26,7 @@ from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools._modification import (
+    ConfirmableRequest,
     ModificationResponse,
     compute_field_diff,
     make_response_verifier,
@@ -36,10 +36,17 @@ from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
     execute_plan,
     has_any_subpayload,
-    make_create_action,
-    make_delete_action,
+    make_delete_apply,
+    make_patch_apply,
+    make_post_apply,
+    plan_creates,
+    plan_deletes,
     plan_to_preview_results,
+    plan_updates,
+    safe_fetch_for_diff,
     serialize_for_prior_state,
+    summarize_delete_outcome,
+    summarize_modify_outcome,
 )
 from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.tool_result_utils import (
@@ -113,7 +120,7 @@ from katana_public_api_client.models import (
     UpdateSalesOrderShippingFeeRequest as APIUpdateSOShippingFeeRequest,
     UpdateSalesOrderStatus,
 )
-from katana_public_api_client.utils import is_success, unwrap, unwrap_as
+from katana_public_api_client.utils import unwrap_as
 
 logger = get_logger(__name__)
 
@@ -1426,67 +1433,39 @@ AddressEntityTypeLiteral = Literal["billing", "shipping"]
 
 
 async def _fetch_sales_order_attrs(services: Any, so_id: int) -> SalesOrder | None:
-    """Fetch the SO attrs object for diff context. Returns None on failure."""
-    try:
-        response = await api_get_sales_order.asyncio_detailed(
-            id=so_id, client=services.client
-        )
-        return unwrap_as(response, SalesOrder)
-    except Exception as exc:
-        logger.info(
-            f"Could not fetch SO {so_id} for diff context: {exc} — "
-            "preview will report changes without prior values."
-        )
-        return None
+    return await safe_fetch_for_diff(
+        api_get_sales_order, services, so_id, return_type=SalesOrder, label="SO"
+    )
 
 
 async def _fetch_so_row(services: Any, row_id: int) -> SalesOrderRow | None:
-    """Fetch an SO row for diff context. Returns None on failure."""
-    try:
-        response = await api_get_so_row.asyncio_detailed(
-            id=row_id, client=services.client
-        )
-        return unwrap_as(response, SalesOrderRow)
-    except Exception as exc:
-        logger.info(
-            f"Could not fetch SO row {row_id} for diff context: {exc} — "
-            "preview will report changes without prior values."
-        )
-        return None
+    return await safe_fetch_for_diff(
+        api_get_so_row, services, row_id, return_type=SalesOrderRow, label="SO row"
+    )
 
 
 async def _fetch_so_fulfillment(
     services: Any, fulfillment_id: int
 ) -> SalesOrderFulfillment | None:
-    """Fetch an SO fulfillment for diff context. Returns None on failure."""
-    try:
-        response = await api_get_so_fulfillment.asyncio_detailed(
-            id=fulfillment_id, client=services.client
-        )
-        return unwrap_as(response, SalesOrderFulfillment)
-    except Exception as exc:
-        logger.info(
-            f"Could not fetch SO fulfillment {fulfillment_id} for diff context: "
-            f"{exc} — preview will report changes without prior values."
-        )
-        return None
+    return await safe_fetch_for_diff(
+        api_get_so_fulfillment,
+        services,
+        fulfillment_id,
+        return_type=SalesOrderFulfillment,
+        label="SO fulfillment",
+    )
 
 
 async def _fetch_so_shipping_fee(
     services: Any, fee_id: int
 ) -> SalesOrderShippingFee | None:
-    """Fetch an SO shipping fee for diff context. Returns None on failure."""
-    try:
-        response = await api_get_so_shipping_fee.asyncio_detailed(
-            id=fee_id, client=services.client
-        )
-        return unwrap_as(response, SalesOrderShippingFee)
-    except Exception as exc:
-        logger.info(
-            f"Could not fetch SO shipping fee {fee_id} for diff context: "
-            f"{exc} — preview will report changes without prior values."
-        )
-        return None
+    return await safe_fetch_for_diff(
+        api_get_so_shipping_fee,
+        services,
+        fee_id,
+        return_type=SalesOrderShippingFee,
+        label="SO shipping fee",
+    )
 
 
 # Note: addresses do not have a get-by-id endpoint (only list-by-SO). Updates
@@ -1648,7 +1627,7 @@ class SOShippingFeeUpdate(BaseModel):
     tax_rate_id: int | None = Field(default=None)
 
 
-class ModifySalesOrderRequest(BaseModel):
+class ModifySalesOrderRequest(ConfirmableRequest):
     """Unified modification request for a sales order.
 
     Sub-payload slots span header + rows + addresses + fulfillments +
@@ -1657,41 +1636,27 @@ class ModifySalesOrderRequest(BaseModel):
     """
 
     id: int = Field(..., description="Sales order ID")
-
     update_header: SOHeaderPatch | None = Field(default=None)
-
     add_rows: list[SORowAdd] | None = Field(default=None)
     update_rows: list[SORowUpdate] | None = Field(default=None)
     delete_row_ids: list[int] | None = Field(default=None)
-
     add_addresses: list[SOAddressAdd] | None = Field(default=None)
     update_addresses: list[SOAddressUpdate] | None = Field(default=None)
     delete_address_ids: list[int] | None = Field(default=None)
-
     add_fulfillments: list[SOFulfillmentAdd] | None = Field(default=None)
     update_fulfillments: list[SOFulfillmentUpdate] | None = Field(default=None)
     delete_fulfillment_ids: list[int] | None = Field(default=None)
-
     add_shipping_fees: list[SOShippingFeeAdd] | None = Field(default=None)
     update_shipping_fees: list[SOShippingFeeUpdate] | None = Field(default=None)
     delete_shipping_fee_ids: list[int] | None = Field(default=None)
 
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, executes the action plan.",
-    )
 
-
-class DeleteSalesOrderRequest(BaseModel):
-    """Delete a sales order. Destructive — the order is removed (Katana
-    cascades child rows / addresses / fulfillments / shipping fees server-side).
+class DeleteSalesOrderRequest(ConfirmableRequest):
+    """Delete a sales order. Destructive — Katana cascades child rows /
+    addresses / fulfillments / shipping fees server-side.
     """
 
     id: int = Field(..., description="Sales order ID to delete")
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, deletes the SO.",
-    )
 
 
 # ----------------------------------------------------------------------------
@@ -1848,444 +1813,6 @@ def _build_update_shipping_fee_request(
 
 
 # ----------------------------------------------------------------------------
-# Apply-closure factories — bind per-call args without default-arg trickery.
-# ----------------------------------------------------------------------------
-
-
-def _make_apply_update_header(
-    services: Any, so_id: int, body: APIUpdateSalesOrderRequest
-) -> Callable[[], Awaitable[SalesOrder]]:
-    async def apply() -> SalesOrder:
-        response = await api_update_sales_order.asyncio_detailed(
-            id=so_id, client=services.client, body=body
-        )
-        return unwrap_as(response, SalesOrder)
-
-    return apply
-
-
-def _make_apply_create_row(
-    services: Any, body: APICreateSORowRequest
-) -> Callable[[], Awaitable[SalesOrderRow]]:
-    async def apply() -> SalesOrderRow:
-        response = await api_create_so_row.asyncio_detailed(
-            client=services.client, body=body
-        )
-        return unwrap_as(response, SalesOrderRow)
-
-    return apply
-
-
-def _make_apply_update_row(
-    services: Any, row_id: int, body: APIUpdateSORowRequest
-) -> Callable[[], Awaitable[SalesOrderRow]]:
-    async def apply() -> SalesOrderRow:
-        response = await api_update_so_row.asyncio_detailed(
-            id=row_id, client=services.client, body=body
-        )
-        return unwrap_as(response, SalesOrderRow)
-
-    return apply
-
-
-def _make_apply_delete_row(services: Any, row_id: int) -> Callable[[], Awaitable[None]]:
-    async def apply() -> None:
-        response = await api_delete_so_row.asyncio_detailed(
-            id=row_id, client=services.client
-        )
-        if not is_success(response):
-            unwrap(response)
-        return None
-
-    return apply
-
-
-def _make_apply_create_address(
-    services: Any, body: APICreateSOAddressRequest
-) -> Callable[[], Awaitable[APISalesOrderAddress]]:
-    async def apply() -> APISalesOrderAddress:
-        response = await api_create_so_address.asyncio_detailed(
-            client=services.client, body=body
-        )
-        return unwrap_as(response, APISalesOrderAddress)
-
-    return apply
-
-
-def _make_apply_update_address(
-    services: Any, addr_id: int, body: APIUpdateSOAddressRequest
-) -> Callable[[], Awaitable[APISalesOrderAddress]]:
-    async def apply() -> APISalesOrderAddress:
-        response = await api_update_so_address.asyncio_detailed(
-            id=addr_id, client=services.client, body=body
-        )
-        return unwrap_as(response, APISalesOrderAddress)
-
-    return apply
-
-
-def _make_apply_delete_address(
-    services: Any, addr_id: int
-) -> Callable[[], Awaitable[None]]:
-    async def apply() -> None:
-        response = await api_delete_so_address.asyncio_detailed(
-            id=addr_id, client=services.client
-        )
-        if not is_success(response):
-            unwrap(response)
-        return None
-
-    return apply
-
-
-def _make_apply_create_fulfillment(
-    services: Any, body: APICreateSOFulfillmentRequest
-) -> Callable[[], Awaitable[SalesOrderFulfillment]]:
-    async def apply() -> SalesOrderFulfillment:
-        response = await api_create_so_fulfillment.asyncio_detailed(
-            client=services.client, body=body
-        )
-        return unwrap_as(response, SalesOrderFulfillment)
-
-    return apply
-
-
-def _make_apply_update_fulfillment(
-    services: Any, fulfillment_id: int, body: APIUpdateSOFulfillmentRequest
-) -> Callable[[], Awaitable[SalesOrderFulfillment]]:
-    async def apply() -> SalesOrderFulfillment:
-        response = await api_update_so_fulfillment.asyncio_detailed(
-            id=fulfillment_id, client=services.client, body=body
-        )
-        return unwrap_as(response, SalesOrderFulfillment)
-
-    return apply
-
-
-def _make_apply_delete_fulfillment(
-    services: Any, fulfillment_id: int
-) -> Callable[[], Awaitable[None]]:
-    async def apply() -> None:
-        response = await api_delete_so_fulfillment.asyncio_detailed(
-            id=fulfillment_id, client=services.client
-        )
-        if not is_success(response):
-            unwrap(response)
-        return None
-
-    return apply
-
-
-def _make_apply_create_shipping_fee(
-    services: Any, body: APICreateSOShippingFeeRequest
-) -> Callable[[], Awaitable[SalesOrderShippingFee]]:
-    async def apply() -> SalesOrderShippingFee:
-        response = await api_create_so_shipping_fee.asyncio_detailed(
-            client=services.client, body=body
-        )
-        return unwrap_as(response, SalesOrderShippingFee)
-
-    return apply
-
-
-def _make_apply_update_shipping_fee(
-    services: Any, fee_id: int, body: APIUpdateSOShippingFeeRequest
-) -> Callable[[], Awaitable[SalesOrderShippingFee]]:
-    async def apply() -> SalesOrderShippingFee:
-        response = await api_update_so_shipping_fee.asyncio_detailed(
-            id=fee_id, client=services.client, body=body
-        )
-        return unwrap_as(response, SalesOrderShippingFee)
-
-    return apply
-
-
-def _make_apply_delete_shipping_fee(
-    services: Any, fee_id: int
-) -> Callable[[], Awaitable[None]]:
-    async def apply() -> None:
-        response = await api_delete_so_shipping_fee.asyncio_detailed(
-            id=fee_id, client=services.client
-        )
-        if not is_success(response):
-            unwrap(response)
-        return None
-
-    return apply
-
-
-def _make_apply_delete_so(services: Any, so_id: int) -> Callable[[], Awaitable[None]]:
-    async def apply() -> None:
-        response = await api_delete_sales_order.asyncio_detailed(
-            id=so_id, client=services.client
-        )
-        if not is_success(response):
-            unwrap(response)
-        return None
-
-    return apply
-
-
-# ----------------------------------------------------------------------------
-# Plan builders — translate sub-payloads into ActionSpec lists.
-# ----------------------------------------------------------------------------
-
-
-def _plan_so_header_update(
-    request: ModifySalesOrderRequest,
-    services: Any,
-    existing: SalesOrder | None,
-) -> ActionSpec | None:
-    if request.update_header is None:
-        return None
-    patch = request.update_header
-    diff = compute_field_diff(existing, patch, unknown_prior=existing is None)
-    return ActionSpec(
-        operation=SOOperation.UPDATE_HEADER,
-        target_id=request.id,
-        diff=diff,
-        apply=_make_apply_update_header(
-            services, request.id, _build_update_header_request(patch)
-        ),
-        verify=make_response_verifier(diff),
-    )
-
-
-def _plan_so_row_adds(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.add_rows:
-        return []
-    return [
-        make_create_action(
-            SOOperation.ADD_ROW,
-            row,
-            _make_apply_create_row(
-                services, _build_create_row_request(request.id, row)
-            ),
-        )
-        for row in request.add_rows
-    ]
-
-
-async def _plan_so_row_updates(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.update_rows:
-        return []
-    existing_rows = await asyncio.gather(
-        *[_fetch_so_row(services, p.id) for p in request.update_rows]
-    )
-    specs: list[ActionSpec] = []
-    for row_patch, existing_row in zip(request.update_rows, existing_rows, strict=True):
-        diff = compute_field_diff(
-            existing_row, row_patch, unknown_prior=existing_row is None
-        )
-        specs.append(
-            ActionSpec(
-                operation=SOOperation.UPDATE_ROW,
-                target_id=row_patch.id,
-                diff=diff,
-                apply=_make_apply_update_row(
-                    services, row_patch.id, _build_update_row_request(row_patch)
-                ),
-                verify=make_response_verifier(diff),
-            )
-        )
-    return specs
-
-
-def _plan_so_row_deletes(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.delete_row_ids:
-        return []
-    return [
-        make_delete_action(
-            SOOperation.DELETE_ROW, rid, _make_apply_delete_row(services, rid)
-        )
-        for rid in request.delete_row_ids
-    ]
-
-
-def _plan_so_address_adds(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.add_addresses:
-        return []
-    return [
-        make_create_action(
-            SOOperation.ADD_ADDRESS,
-            addr,
-            _make_apply_create_address(
-                services, _build_create_address_request(request.id, addr)
-            ),
-        )
-        for addr in request.add_addresses
-    ]
-
-
-def _plan_so_address_updates(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    """Address updates can't prefetch (no get-by-id), so every diff is
-    ``is_unknown_prior=True``. Verification still works against the PATCH
-    response body."""
-    if not request.update_addresses:
-        return []
-    specs: list[ActionSpec] = []
-    for patch in request.update_addresses:
-        diff = compute_field_diff(None, patch, unknown_prior=True)
-        specs.append(
-            ActionSpec(
-                operation=SOOperation.UPDATE_ADDRESS,
-                target_id=patch.id,
-                diff=diff,
-                apply=_make_apply_update_address(
-                    services, patch.id, _build_update_address_request(patch)
-                ),
-                verify=make_response_verifier(diff),
-            )
-        )
-    return specs
-
-
-def _plan_so_address_deletes(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.delete_address_ids:
-        return []
-    return [
-        make_delete_action(
-            SOOperation.DELETE_ADDRESS,
-            addr_id,
-            _make_apply_delete_address(services, addr_id),
-        )
-        for addr_id in request.delete_address_ids
-    ]
-
-
-def _plan_so_fulfillment_adds(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.add_fulfillments:
-        return []
-    return [
-        make_create_action(
-            SOOperation.ADD_FULFILLMENT,
-            fulfillment,
-            _make_apply_create_fulfillment(
-                services, _build_create_fulfillment_request(request.id, fulfillment)
-            ),
-        )
-        for fulfillment in request.add_fulfillments
-    ]
-
-
-async def _plan_so_fulfillment_updates(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.update_fulfillments:
-        return []
-    existing = await asyncio.gather(
-        *[_fetch_so_fulfillment(services, p.id) for p in request.update_fulfillments]
-    )
-    specs: list[ActionSpec] = []
-    for patch, existing_fulfillment in zip(
-        request.update_fulfillments, existing, strict=True
-    ):
-        diff = compute_field_diff(
-            existing_fulfillment, patch, unknown_prior=existing_fulfillment is None
-        )
-        specs.append(
-            ActionSpec(
-                operation=SOOperation.UPDATE_FULFILLMENT,
-                target_id=patch.id,
-                diff=diff,
-                apply=_make_apply_update_fulfillment(
-                    services, patch.id, _build_update_fulfillment_request(patch)
-                ),
-                verify=make_response_verifier(diff),
-            )
-        )
-    return specs
-
-
-def _plan_so_fulfillment_deletes(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.delete_fulfillment_ids:
-        return []
-    return [
-        make_delete_action(
-            SOOperation.DELETE_FULFILLMENT,
-            fid,
-            _make_apply_delete_fulfillment(services, fid),
-        )
-        for fid in request.delete_fulfillment_ids
-    ]
-
-
-def _plan_so_shipping_fee_adds(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.add_shipping_fees:
-        return []
-    return [
-        make_create_action(
-            SOOperation.ADD_SHIPPING_FEE,
-            fee,
-            _make_apply_create_shipping_fee(
-                services, _build_create_shipping_fee_request(request.id, fee)
-            ),
-        )
-        for fee in request.add_shipping_fees
-    ]
-
-
-async def _plan_so_shipping_fee_updates(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.update_shipping_fees:
-        return []
-    existing = await asyncio.gather(
-        *[_fetch_so_shipping_fee(services, p.id) for p in request.update_shipping_fees]
-    )
-    specs: list[ActionSpec] = []
-    for patch, existing_fee in zip(request.update_shipping_fees, existing, strict=True):
-        diff = compute_field_diff(
-            existing_fee, patch, unknown_prior=existing_fee is None
-        )
-        specs.append(
-            ActionSpec(
-                operation=SOOperation.UPDATE_SHIPPING_FEE,
-                target_id=patch.id,
-                diff=diff,
-                apply=_make_apply_update_shipping_fee(
-                    services, patch.id, _build_update_shipping_fee_request(patch)
-                ),
-                verify=make_response_verifier(diff),
-            )
-        )
-    return specs
-
-
-def _plan_so_shipping_fee_deletes(
-    request: ModifySalesOrderRequest, services: Any
-) -> list[ActionSpec]:
-    if not request.delete_shipping_fee_ids:
-        return []
-    return [
-        make_delete_action(
-            SOOperation.DELETE_SHIPPING_FEE,
-            fid,
-            _make_apply_delete_shipping_fee(services, fid),
-        )
-        for fid in request.delete_shipping_fee_ids
-    ]
-
-
-# ----------------------------------------------------------------------------
 # Implementations
 # ----------------------------------------------------------------------------
 
@@ -2293,8 +1820,8 @@ def _plan_so_shipping_fee_deletes(
 async def _modify_sales_order_impl(
     request: ModifySalesOrderRequest, context: Context
 ) -> ModificationResponse:
-    """Build the action plan from the request's sub-payloads and execute or
-    preview based on ``confirm``."""
+    """Build the action plan from the request's sub-payloads and either
+    preview or execute based on ``confirm``."""
     services = get_services(context)
 
     if not has_any_subpayload(request):
@@ -2309,29 +1836,178 @@ async def _modify_sales_order_impl(
     existing_so = await _fetch_sales_order_attrs(services, request.id)
 
     plan: list[ActionSpec] = []
-    header_spec = _plan_so_header_update(request, services, existing_so)
-    if header_spec is not None:
-        plan.append(header_spec)
-    plan.extend(_plan_so_row_adds(request, services))
-    plan.extend(await _plan_so_row_updates(request, services))
-    plan.extend(_plan_so_row_deletes(request, services))
-    plan.extend(_plan_so_address_adds(request, services))
-    plan.extend(_plan_so_address_updates(request, services))
-    plan.extend(_plan_so_address_deletes(request, services))
-    plan.extend(_plan_so_fulfillment_adds(request, services))
-    plan.extend(await _plan_so_fulfillment_updates(request, services))
-    plan.extend(_plan_so_fulfillment_deletes(request, services))
-    plan.extend(_plan_so_shipping_fee_adds(request, services))
-    plan.extend(await _plan_so_shipping_fee_updates(request, services))
-    plan.extend(_plan_so_shipping_fee_deletes(request, services))
+
+    # Header — single optional patch.
+    if request.update_header is not None:
+        diff = compute_field_diff(
+            existing_so, request.update_header, unknown_prior=existing_so is None
+        )
+        plan.append(
+            ActionSpec(
+                operation=SOOperation.UPDATE_HEADER,
+                target_id=request.id,
+                diff=diff,
+                apply=make_patch_apply(
+                    api_update_sales_order,
+                    services,
+                    request.id,
+                    _build_update_header_request(request.update_header),
+                    return_type=SalesOrder,
+                ),
+                verify=make_response_verifier(diff),
+            )
+        )
+
+    # Rows.
+    plan.extend(
+        plan_creates(
+            request.add_rows,
+            SOOperation.ADD_ROW,
+            lambda row: _build_create_row_request(request.id, row),
+            lambda body: make_post_apply(
+                api_create_so_row, services, body, return_type=SalesOrderRow
+            ),
+        )
+    )
+    plan.extend(
+        await plan_updates(
+            request.update_rows,
+            SOOperation.UPDATE_ROW,
+            lambda rid: _fetch_so_row(services, rid),
+            _build_update_row_request,
+            lambda rid, body: make_patch_apply(
+                api_update_so_row, services, rid, body, return_type=SalesOrderRow
+            ),
+        )
+    )
+    plan.extend(
+        plan_deletes(
+            request.delete_row_ids,
+            SOOperation.DELETE_ROW,
+            lambda rid: make_delete_apply(api_delete_so_row, services, rid),
+        )
+    )
+
+    # Addresses. Updates have no get-by-id endpoint, so fetcher is None
+    # (every diff marks ``is_unknown_prior=True``).
+    plan.extend(
+        plan_creates(
+            request.add_addresses,
+            SOOperation.ADD_ADDRESS,
+            lambda addr: _build_create_address_request(request.id, addr),
+            lambda body: make_post_apply(
+                api_create_so_address, services, body, return_type=APISalesOrderAddress
+            ),
+        )
+    )
+    plan.extend(
+        await plan_updates(
+            request.update_addresses,
+            SOOperation.UPDATE_ADDRESS,
+            None,  # no get-by-id endpoint
+            _build_update_address_request,
+            lambda aid, body: make_patch_apply(
+                api_update_so_address,
+                services,
+                aid,
+                body,
+                return_type=APISalesOrderAddress,
+            ),
+        )
+    )
+    plan.extend(
+        plan_deletes(
+            request.delete_address_ids,
+            SOOperation.DELETE_ADDRESS,
+            lambda aid: make_delete_apply(api_delete_so_address, services, aid),
+        )
+    )
+
+    # Fulfillments.
+    plan.extend(
+        plan_creates(
+            request.add_fulfillments,
+            SOOperation.ADD_FULFILLMENT,
+            lambda fulfillment: _build_create_fulfillment_request(
+                request.id, fulfillment
+            ),
+            lambda body: make_post_apply(
+                api_create_so_fulfillment,
+                services,
+                body,
+                return_type=SalesOrderFulfillment,
+            ),
+        )
+    )
+    plan.extend(
+        await plan_updates(
+            request.update_fulfillments,
+            SOOperation.UPDATE_FULFILLMENT,
+            lambda fid: _fetch_so_fulfillment(services, fid),
+            _build_update_fulfillment_request,
+            lambda fid, body: make_patch_apply(
+                api_update_so_fulfillment,
+                services,
+                fid,
+                body,
+                return_type=SalesOrderFulfillment,
+            ),
+        )
+    )
+    plan.extend(
+        plan_deletes(
+            request.delete_fulfillment_ids,
+            SOOperation.DELETE_FULFILLMENT,
+            lambda fid: make_delete_apply(api_delete_so_fulfillment, services, fid),
+        )
+    )
+
+    # Shipping fees.
+    plan.extend(
+        plan_creates(
+            request.add_shipping_fees,
+            SOOperation.ADD_SHIPPING_FEE,
+            lambda fee: _build_create_shipping_fee_request(request.id, fee),
+            lambda body: make_post_apply(
+                api_create_so_shipping_fee,
+                services,
+                body,
+                return_type=SalesOrderShippingFee,
+            ),
+        )
+    )
+    plan.extend(
+        await plan_updates(
+            request.update_shipping_fees,
+            SOOperation.UPDATE_SHIPPING_FEE,
+            lambda fid: _fetch_so_shipping_fee(services, fid),
+            _build_update_shipping_fee_request,
+            lambda fid, body: make_patch_apply(
+                api_update_so_shipping_fee,
+                services,
+                fid,
+                body,
+                return_type=SalesOrderShippingFee,
+            ),
+        )
+    )
+    plan.extend(
+        plan_deletes(
+            request.delete_shipping_fee_ids,
+            SOOperation.DELETE_SHIPPING_FEE,
+            lambda fid: make_delete_apply(api_delete_so_shipping_fee, services, fid),
+        )
+    )
 
     katana_url = katana_web_url("sales_order", request.id)
-    warnings: list[str] = []
-    if existing_so is None:
-        warnings.append(
+    warnings = (
+        [
             f"Could not fetch sales order {request.id} for diff context — "
             "preview shows requested values without prior state."
-        )
+        ]
+        if existing_so is None
+        else []
+    )
 
     if not request.confirm:
         return ModificationResponse(
@@ -2352,30 +2028,12 @@ async def _modify_sales_order_impl(
 
     prior_state = serialize_for_prior_state(existing_so)
     actions = await execute_plan(plan)
-
-    succeeded_count = sum(1 for a in actions if a.succeeded is True)
-    failed_count = sum(1 for a in actions if a.succeeded is False)
-    failed = failed_count > 0
-
-    if failed:
-        message = (
-            f"Partial: {succeeded_count}/{len(plan)} action(s) applied to "
-            f"sales order {request.id} before fail-fast halt; see actions "
-            "for details and prior_state for revert reference."
-        )
-        next_actions = [
-            f"{succeeded_count} action(s) succeeded; {failed_count} failed",
-            "Review the FAILED action's error and the prior_state snapshot",
-            "Compose a follow-up modify_sales_order call to revert if needed",
-        ]
-    else:
-        message = (
-            f"Successfully applied {succeeded_count}/{len(plan)} action(s) to "
-            f"sales order {request.id}"
-        )
-        next_actions = [
-            f"Sales order {request.id} modified — {succeeded_count} action(s) verified"
-        ]
+    message, next_actions = summarize_modify_outcome(
+        actions,
+        len(plan),
+        entity_label=f"sales order {request.id}",
+        tool_name="modify_sales_order",
+    )
 
     return ModificationResponse(
         entity_type="sales_order",
@@ -2438,11 +2096,11 @@ async def _delete_sales_order_impl(
     services = get_services(context)
 
     existing_so = await _fetch_sales_order_attrs(services, request.id)
-    plan = [
-        make_delete_action(
-            SOOperation.DELETE, request.id, _make_apply_delete_so(services, request.id)
-        )
-    ]
+    plan = plan_deletes(
+        [request.id],
+        SOOperation.DELETE,
+        lambda so_id: make_delete_apply(api_delete_sales_order, services, so_id),
+    )
     katana_url = katana_web_url("sales_order", request.id)
 
     if not request.confirm:
@@ -2461,7 +2119,9 @@ async def _delete_sales_order_impl(
 
     prior_state = serialize_for_prior_state(existing_so)
     actions = await execute_plan(plan)
-    failed = any(a.succeeded is False for a in actions)
+    message, next_actions = summarize_delete_outcome(
+        actions, entity_label=f"sales order {request.id}"
+    )
 
     return ModificationResponse(
         entity_type="sales_order",
@@ -2469,20 +2129,9 @@ async def _delete_sales_order_impl(
         is_preview=False,
         actions=actions,
         prior_state=prior_state,
-        next_actions=(
-            [f"Sales order {request.id} has been deleted"]
-            if not failed
-            else [
-                "Delete failed — see action error",
-                "prior_state carries the pre-delete snapshot",
-            ]
-        ),
-        katana_url=None if not failed else katana_url,
-        message=(
-            f"Successfully deleted sales order {request.id}"
-            if not failed
-            else f"Failed to delete sales order {request.id}"
-        ),
+        next_actions=next_actions,
+        katana_url=None if all(a.succeeded for a in actions) else katana_url,
+        message=message,
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -968,8 +968,9 @@ async def delete_stock_transfer(
 ) -> ToolResult:
     """Delete a stock transfer. Destructive — the transfer record is removed.
 
-    The response carries a ``prior_state`` snapshot for manual revert (empty
-    for stock transfers, since Katana doesn't expose GET-by-id).
+    The response's ``prior_state`` is ``None`` for stock transfers since
+    Katana exposes no GET-by-id endpoint (other entities populate it
+    with a snapshot for manual revert).
     """
     response = await _delete_stock_transfer_impl(request, context)
     return to_tool_result(response)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -1,16 +1,13 @@
 """Stock transfer management tools for Katana MCP Server.
 
-Foundation tools covering the full stock-transfer lifecycle: create a transfer
-between locations, list transfers with filters, update transfer body fields,
-transition status through the three-state machine
-(DRAFT / IN_TRANSIT / RECEIVED), and delete.
+Foundation tools covering the full stock-transfer lifecycle:
 
-These tools provide:
 - create_stock_transfer: Create a transfer with preview/confirm pattern
 - list_stock_transfers: List transfers with paging, date, status filters
-- update_stock_transfer: Update body fields with preview/confirm pattern
-- update_stock_transfer_status: Transition state with preview/confirm pattern
-- delete_stock_transfer: Delete transfer with preview/confirm pattern
+- modify_stock_transfer: Unified modification — header (body fields) and/or
+  status transition in a single call. Hides the fact that Katana exposes
+  these as two separate PATCH endpoints.
+- delete_stock_transfer: Destructive sibling of modify_stock_transfer.
 """
 
 from __future__ import annotations
@@ -18,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import datetime as _datetime
 from datetime import UTC, datetime
+from enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
@@ -26,6 +24,21 @@ from pydantic import BaseModel, Field
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
+from katana_mcp.tools._modification import (
+    ConfirmableRequest,
+    ModificationResponse,
+    compute_field_diff,
+    make_response_verifier,
+    to_tool_result,
+)
+from katana_mcp.tools._modification_dispatch import (
+    ActionSpec,
+    has_any_subpayload,
+    make_patch_apply,
+    run_delete_plan,
+    run_modify_plan,
+    unset_dict,
+)
 from katana_mcp.tools.tool_result_utils import (
     BLOCK_WARNING_PREFIX,
     PaginationMeta,
@@ -39,6 +52,11 @@ from katana_mcp.tools.tool_result_utils import (
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
+from katana_public_api_client.api.stock_transfer import (
+    delete_stock_transfer as api_delete_stock_transfer,
+    update_stock_transfer as api_update_stock_transfer,
+    update_stock_transfer_status as api_update_stock_transfer_status,
+)
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     CreateStockTransferRequest as APICreateStockTransferRequest,
@@ -49,7 +67,7 @@ from katana_public_api_client.models import (
     UpdateStockTransferRequest as APIUpdateStockTransferRequest,
     UpdateStockTransferStatusRequest as APIUpdateStockTransferStatusRequest,
 )
-from katana_public_api_client.utils import APIError, is_success, unwrap, unwrap_as
+from katana_public_api_client.utils import unwrap_as
 
 logger = get_logger(__name__)
 
@@ -770,14 +788,27 @@ async def list_stock_transfers(
 
 
 # ============================================================================
-# Tool 3: update_stock_transfer
+# Tool: modify_stock_transfer — unified modification surface
 # ============================================================================
 
 
-class UpdateStockTransferRequest(BaseModel):
-    """Request to update body fields on a stock transfer."""
+class StockTransferOperation(StrEnum):
+    """Operation names emitted on ActionSpecs by ``modify_stock_transfer`` /
+    ``delete_stock_transfer`` plan builders."""
 
-    id: int = Field(..., description="Stock transfer ID")
+    UPDATE_HEADER = "update_header"
+    UPDATE_STATUS = "update_status"
+    DELETE = "delete"
+
+
+class StockTransferHeaderPatch(BaseModel):
+    """Body fields to patch on a stock transfer.
+
+    Status is excluded — Katana exposes it via a separate
+    ``PATCH /stock_transfers/{id}/status`` endpoint, surfaced as the
+    ``update_status`` sub-payload.
+    """
+
     stock_transfer_number: str | None = Field(
         default=None, description="New stock transfer number"
     )
@@ -790,277 +821,186 @@ class UpdateStockTransferRequest(BaseModel):
     additional_info: str | None = Field(
         default=None, description="New additional info/notes"
     )
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, applies the update.",
-    )
 
 
-async def _update_stock_transfer_impl(
-    request: UpdateStockTransferRequest, context: Context
-) -> StockTransferResponse:
-    """Implementation of update_stock_transfer tool."""
-    updates = {
-        "stock_transfer_number": request.stock_transfer_number,
-        "transfer_date": (
-            request.transfer_date.isoformat() if request.transfer_date else None
-        ),
-        "expected_arrival_date": (
-            request.expected_arrival_date.isoformat()
-            if request.expected_arrival_date
-            else None
-        ),
-        "additional_info": request.additional_info,
-    }
-    set_fields = {k: v for k, v in updates.items() if v is not None}
+class StockTransferStatusPatch(BaseModel):
+    """Status-transition sub-payload — maps to the dedicated status endpoint.
 
-    if not set_fields:
-        raise ValueError(
-            "At least one field must be provided to update (stock_transfer_number, "
-            "transfer_date, expected_arrival_date, additional_info)"
-        )
-
-    preview_message = (
-        f"Preview: Update stock transfer {request.id} — fields: "
-        + ", ".join(f"{k}={v}" for k, v in set_fields.items())
-    )
-
-    if not request.confirm:
-        return StockTransferResponse(
-            id=request.id,
-            is_preview=True,
-            next_actions=[
-                "Review the update details",
-                "Set confirm=true to apply the update",
-            ],
-            message=preview_message,
-        )
-
-    services = get_services(context)
-    api_request = APIUpdateStockTransferRequest(
-        stock_transfer_number=to_unset(request.stock_transfer_number),
-        transfer_date=to_unset(request.transfer_date),
-        expected_arrival_date=to_unset(request.expected_arrival_date),
-        additional_info=to_unset(request.additional_info),
-    )
-
-    from katana_public_api_client.api.stock_transfer import update_stock_transfer
-
-    response = await update_stock_transfer.asyncio_detailed(
-        id=request.id, client=services.client, body=api_request
-    )
-    transfer = unwrap_as(response, StockTransfer)
-    logger.info(f"Updated stock transfer ID {transfer.id}")
-
-    result = _transfer_to_response(
-        transfer,
-        message=f"Successfully updated stock transfer {transfer.id}",
-    )
-    result.next_actions = [f"Stock transfer {transfer.id} updated"]
-    return result
-
-
-@observe_tool
-@unpack_pydantic_params
-async def update_stock_transfer(
-    request: Annotated[UpdateStockTransferRequest, Unpack()], context: Context
-) -> ToolResult:
-    """Update body fields on an existing stock transfer.
-
-    Two-step flow: confirm=false to preview, confirm=true to apply. Accepts
-    `stock_transfer_number`, `transfer_date`, `expected_arrival_date`, and
-    `additional_info`. Use `update_stock_transfer_status` to change status.
+    Carrying it as its own typed slot (rather than a header field) makes the
+    two-endpoint reality discoverable in the schema while still letting one
+    ``modify_stock_transfer`` call mutate both header and status.
     """
-    response = await _update_stock_transfer_impl(request, context)
 
-    lines = [
-        f"## Update Stock Transfer ({'PREVIEW' if response.is_preview else 'UPDATED'})",
-        f"- **ID**: {response.id}",
-        f"- **Message**: {response.message}",
-    ]
-    if response.stock_transfer_number:
-        lines.append(f"- **Number**: {response.stock_transfer_number}")
-    if response.status:
-        lines.append(f"- **Status**: {response.status}")
-    if response.expected_arrival_date:
-        lines.append(f"- **Expected Arrival**: {response.expected_arrival_date}")
-    if response.next_actions:
-        lines.append("")
-        lines.append("### Next Actions")
-        lines.extend(f"- {action}" for action in response.next_actions)
-
-    return make_simple_result("\n".join(lines), structured_data=response.model_dump())
-
-
-# ============================================================================
-# Tool 4: update_stock_transfer_status
-# ============================================================================
-
-
-class UpdateStockTransferStatusRequest(BaseModel):
-    """Request to transition a stock transfer through the 3-state machine."""
-
-    id: int = Field(..., description="Stock transfer ID")
     new_status: StatusLiteral = Field(
         ...,
         description=(
-            "Target status. Valid transitions are governed by Katana — typical flow "
-            "is DRAFT → IN_TRANSIT → RECEIVED."
+            "Target status. Valid transitions are governed by Katana — typical "
+            "flow is DRAFT → IN_TRANSIT → RECEIVED."
         ),
     )
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, applies the transition.",
+
+
+class ModifyStockTransferRequest(ConfirmableRequest):
+    """Unified modification request for a stock transfer.
+
+    Sub-payload slots cover header body fields and status transition.
+    Multiple slots can be combined; actions execute in canonical order
+    (header first, then status). Stock transfer rows are immutable post-
+    creation — Katana doesn't expose row-CRUD endpoints. To remove a
+    transfer entirely, use ``delete_stock_transfer``.
+    """
+
+    id: int = Field(..., description="Stock transfer ID")
+    update_header: StockTransferHeaderPatch | None = Field(default=None)
+    update_status: StockTransferStatusPatch | None = Field(default=None)
+
+
+class DeleteStockTransferRequest(ConfirmableRequest):
+    """Delete a stock transfer. Destructive — removes the transfer record."""
+
+    id: int = Field(..., description="Stock transfer ID to delete")
+
+
+def _build_update_header_request(
+    patch: StockTransferHeaderPatch,
+) -> APIUpdateStockTransferRequest:
+    return APIUpdateStockTransferRequest(**unset_dict(patch))
+
+
+def _build_update_status_request(
+    patch: StockTransferStatusPatch,
+) -> APIUpdateStockTransferStatusRequest:
+    return APIUpdateStockTransferStatusRequest(
+        status=_status_literal_to_enum(patch.new_status)
     )
 
 
-async def _update_stock_transfer_status_impl(
-    request: UpdateStockTransferStatusRequest, context: Context
-) -> StockTransferResponse:
-    """Implementation of update_stock_transfer_status tool."""
-    preview_message = (
-        f"Preview: Transition stock transfer {request.id} to status "
-        f"{request.new_status}"
-    )
+async def _modify_stock_transfer_impl(
+    request: ModifyStockTransferRequest, context: Context
+) -> ModificationResponse:
+    """Build the action plan from sub-payloads and either preview or execute.
 
-    if not request.confirm:
-        return StockTransferResponse(
-            id=request.id,
-            status=request.new_status,
-            is_preview=True,
-            next_actions=[
-                "Review the transition",
-                "Set confirm=true to apply the status change",
-            ],
-            message=preview_message,
-        )
-
+    The Katana stock-transfer API has no GET-by-id endpoint, so prior-state
+    capture flows through ``unknown_prior=True`` — diff entries show
+    ``(prior unknown) → new`` for every field.
+    """
     services = get_services(context)
-    api_request = APIUpdateStockTransferStatusRequest(
-        status=_status_literal_to_enum(request.new_status),
-    )
 
-    from katana_public_api_client.api.stock_transfer import update_stock_transfer_status
-
-    try:
-        response = await update_stock_transfer_status.asyncio_detailed(
-            id=request.id, client=services.client, body=api_request
-        )
-        transfer = unwrap_as(response, StockTransfer)
-    except APIError as e:
-        # Katana rejects invalid state transitions (e.g. RECEIVED → IN_TRANSIT)
-        # with a typed error. Re-raise as ValueError so the tool surfaces a
-        # clean, caller-actionable message.
-        logger.warning(
-            f"Invalid stock transfer status transition for ID {request.id}: {e}"
-        )
+    if not has_any_subpayload(request):
         raise ValueError(
-            f"Failed to transition stock transfer {request.id} to "
-            f"{request.new_status}: {e}"
-        ) from e
+            "At least one sub-payload must be set: update_header or update_status. "
+            "To remove the stock transfer entirely, use delete_stock_transfer."
+        )
 
-    logger.info(
-        f"Transitioned stock transfer {transfer.id} to status "
-        f"{enum_to_str(unwrap_unset(transfer.status, None))}"
-    )
+    plan: list[ActionSpec] = []
 
-    result = _transfer_to_response(
-        transfer,
-        message=(
-            f"Successfully transitioned stock transfer {transfer.id} to "
-            f"{request.new_status}"
-        ),
+    if request.update_header is not None:
+        diff = compute_field_diff(None, request.update_header, unknown_prior=True)
+        plan.append(
+            ActionSpec(
+                operation=StockTransferOperation.UPDATE_HEADER,
+                target_id=request.id,
+                diff=diff,
+                apply=make_patch_apply(
+                    api_update_stock_transfer,
+                    services,
+                    request.id,
+                    _build_update_header_request(request.update_header),
+                    return_type=StockTransfer,
+                ),
+                verify=make_response_verifier(diff),
+            )
+        )
+
+    if request.update_status is not None:
+        diff = compute_field_diff(None, request.update_status, unknown_prior=True)
+        plan.append(
+            ActionSpec(
+                operation=StockTransferOperation.UPDATE_STATUS,
+                target_id=request.id,
+                diff=diff,
+                apply=make_patch_apply(
+                    api_update_stock_transfer_status,
+                    services,
+                    request.id,
+                    _build_update_status_request(request.update_status),
+                    return_type=StockTransfer,
+                ),
+                # No verify — status returned by the API uses Katana's wire
+                # value (``inTransit``) while the request carries the tool-
+                # facing literal (``IN_TRANSIT``); the response-verifier would
+                # report a spurious mismatch. The action's success/error is
+                # still reflected in ``ActionResult.succeeded``.
+            )
+        )
+
+    return await run_modify_plan(
+        request=request,
+        entity_type="stock_transfer",
+        entity_label=f"stock transfer {request.id}",
+        tool_name="modify_stock_transfer",
+        web_url_kind="stock_transfer",
+        existing=None,
+        plan=plan,
     )
-    result.next_actions = [
-        f"Stock transfer {transfer.id} now in status {request.new_status}"
-    ]
-    return result
 
 
 @observe_tool
 @unpack_pydantic_params
-async def update_stock_transfer_status(
-    request: Annotated[UpdateStockTransferStatusRequest, Unpack()], context: Context
+async def modify_stock_transfer(
+    request: Annotated[ModifyStockTransferRequest, Unpack()], context: Context
 ) -> ToolResult:
-    """Transition a stock transfer through the 3-state machine.
+    """Modify a stock transfer — unified surface across header body fields
+    and status transition.
 
-    Two-step flow: confirm=false to preview, confirm=true to apply. The
-    three valid states are DRAFT, IN_TRANSIT, RECEIVED. Katana rejects
-    invalid transitions (e.g. RECEIVED → IN_TRANSIT); the tool surfaces
-    the API error message as a ValueError.
+    Sub-payloads (any subset, all optional):
+
+    - ``update_header`` — patch body fields (stock_transfer_number,
+      transfer_date, expected_arrival_date, additional_info)
+    - ``update_status`` — transition through the 3-state machine
+      (DRAFT / IN_TRANSIT / RECEIVED). Katana rejects invalid transitions
+      with a 400; the action surfaces the API error in the response.
+
+    Stock-transfer rows are immutable after creation — the Katana API does
+    not expose row-CRUD endpoints. To remove a transfer entirely, use the
+    sibling ``delete_stock_transfer`` tool.
+
+    Two-step flow: ``confirm=false`` returns a per-action preview;
+    ``confirm=true`` executes the plan in canonical order (header before
+    status). Fail-fast on error.
+
+    Note: Katana doesn't expose a GET-by-id endpoint for stock transfers,
+    so previews show every supplied field as ``(prior unknown) → new``.
     """
-    response = await _update_stock_transfer_status_impl(request, context)
-
-    lines = [
-        f"## Stock Transfer Status ({'PREVIEW' if response.is_preview else 'UPDATED'})",
-        f"- **ID**: {response.id}",
-        f"- **Status**: {response.status}",
-        f"- **Message**: {response.message}",
-    ]
-    if response.next_actions:
-        lines.append("")
-        lines.append("### Next Actions")
-        lines.extend(f"- {action}" for action in response.next_actions)
-
-    return make_simple_result("\n".join(lines), structured_data=response.model_dump())
+    response = await _modify_stock_transfer_impl(request, context)
+    return to_tool_result(response)
 
 
 # ============================================================================
-# Tool 5: delete_stock_transfer
+# Tool: delete_stock_transfer
 # ============================================================================
 
 
-class DeleteStockTransferRequest(BaseModel):
-    """Request to delete a stock transfer."""
-
-    id: int = Field(..., description="Stock transfer ID to delete")
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, deletes the transfer.",
-    )
-
-
-class DeleteStockTransferResponse(BaseModel):
-    """Response from a stock transfer delete operation."""
-
-    id: int
-    is_preview: bool
-    next_actions: list[str] = Field(default_factory=list)
-    message: str
+async def _fetch_stock_transfer_for_delete(services: Any, st_id: int) -> None:
+    """Stock transfers have no GET-by-id endpoint, so prior-state capture is
+    a no-op. ``run_delete_plan`` accepts ``None`` from the fetcher; the diff
+    flows through with ``unknown_prior=True``."""
+    return None
 
 
 async def _delete_stock_transfer_impl(
     request: DeleteStockTransferRequest, context: Context
-) -> DeleteStockTransferResponse:
-    """Implementation of delete_stock_transfer tool."""
-    preview_message = f"Preview: Delete stock transfer {request.id}"
-
-    if not request.confirm:
-        return DeleteStockTransferResponse(
-            id=request.id,
-            is_preview=True,
-            next_actions=[
-                "Review the deletion",
-                "Set confirm=true to delete the stock transfer",
-            ],
-            message=preview_message,
-        )
-
-    services = get_services(context)
-    from katana_public_api_client.api.stock_transfer import delete_stock_transfer
-
-    response = await delete_stock_transfer.asyncio_detailed(
-        id=request.id, client=services.client
-    )
-    if not is_success(response):
-        unwrap(response)
-
-    logger.info(f"Deleted stock transfer ID {request.id}")
-    return DeleteStockTransferResponse(
-        id=request.id,
-        is_preview=False,
-        message=f"Successfully deleted stock transfer {request.id}",
-        next_actions=[f"Stock transfer {request.id} has been deleted"],
+) -> ModificationResponse:
+    """One-action plan that removes the stock transfer."""
+    return await run_delete_plan(
+        request=request,
+        services=get_services(context),
+        entity_type="stock_transfer",
+        entity_label=f"stock transfer {request.id}",
+        web_url_kind="stock_transfer",
+        fetcher=_fetch_stock_transfer_for_delete,
+        delete_endpoint=api_delete_stock_transfer,
+        operation=StockTransferOperation.DELETE,
     )
 
 
@@ -1069,24 +1009,13 @@ async def _delete_stock_transfer_impl(
 async def delete_stock_transfer(
     request: Annotated[DeleteStockTransferRequest, Unpack()], context: Context
 ) -> ToolResult:
-    """Delete a stock transfer.
+    """Delete a stock transfer. Destructive — the transfer record is removed.
 
-    Two-step flow: confirm=false to preview, confirm=true to delete (prompts
-    for confirmation). Destructive — the transfer record is removed.
+    The response carries a ``prior_state`` snapshot for manual revert (empty
+    for stock transfers, since Katana doesn't expose GET-by-id).
     """
     response = await _delete_stock_transfer_impl(request, context)
-
-    lines = [
-        f"## Delete Stock Transfer ({'PREVIEW' if response.is_preview else 'DELETED'})",
-        f"- **ID**: {response.id}",
-        f"- **Message**: {response.message}",
-    ]
-    if response.next_actions:
-        lines.append("")
-        lines.append("### Next Actions")
-        lines.extend(f"- {action}" for action in response.next_actions)
-
-    return make_simple_result("\n".join(lines), structured_data=response.model_dump())
+    return to_tool_result(response)
 
 
 # ============================================================================
@@ -1111,6 +1040,12 @@ def register_tools(mcp: FastMCP) -> None:
     _write = ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, openWorldHint=True
     )
+    _update = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
     _destructive = ToolAnnotations(
         readOnlyHint=False, destructiveHint=True, openWorldHint=True
     )
@@ -1121,12 +1056,10 @@ def register_tools(mcp: FastMCP) -> None:
     mcp.tool(tags={"inventory", "stock_transfer", "read"}, annotations=_read)(
         list_stock_transfers
     )
-    mcp.tool(tags={"inventory", "stock_transfer", "write"}, annotations=_write)(
-        update_stock_transfer
+    mcp.tool(tags={"inventory", "stock_transfer", "write"}, annotations=_update)(
+        modify_stock_transfer
     )
-    mcp.tool(tags={"inventory", "stock_transfer", "write"}, annotations=_write)(
-        update_stock_transfer_status
-    )
-    mcp.tool(tags={"inventory", "stock_transfer", "write"}, annotations=_destructive)(
-        delete_stock_transfer
-    )
+    mcp.tool(
+        tags={"inventory", "stock_transfer", "write", "destructive"},
+        annotations=_destructive,
+    )(delete_stock_transfer)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -126,52 +126,6 @@ class StockTransferSummary(BaseModel):
     katana_url: str | None = None
 
 
-def _build_row_info(row: Any) -> StockTransferRowInfo:
-    """Extract a StockTransferRowInfo from an attrs StockTransferRow."""
-    raw_batches = unwrap_unset(row.batch_transactions, None)
-    batches: list[dict[str, Any]] | None = None
-    if raw_batches:
-        batches = [
-            {"batch_id": b.batch_id, "quantity": b.quantity} for b in raw_batches
-        ]
-    return StockTransferRowInfo(
-        id=unwrap_unset(row.id, None),
-        variant_id=unwrap_unset(row.variant_id, None),
-        quantity=unwrap_unset(row.quantity, None),
-        cost_per_unit=unwrap_unset(row.cost_per_unit, None),
-        batch_transactions=batches,
-    )
-
-
-def _build_summary(transfer: Any, *, include_rows: bool) -> StockTransferSummary:
-    """Convert an attrs StockTransfer into a StockTransferSummary."""
-    raw_rows = unwrap_unset(transfer.stock_transfer_rows, []) or []
-    row_infos = [_build_row_info(r) for r in raw_rows] if include_rows else None
-    transfer_date = unwrap_unset(transfer.transfer_date, None)
-    expected = unwrap_unset(transfer.expected_arrival_date, None)
-    created = unwrap_unset(transfer.created_at, None)
-    status = unwrap_unset(transfer.status, None)
-    return StockTransferSummary(
-        id=transfer.id,
-        stock_transfer_number=unwrap_unset(transfer.stock_transfer_number, None),
-        source_location_id=unwrap_unset(transfer.source_location_id, None),
-        target_location_id=unwrap_unset(transfer.target_location_id, None),
-        status=enum_to_str(status),
-        transfer_date=iso_or_none(transfer_date)
-        if isinstance(transfer_date, _datetime.datetime)
-        else None,
-        expected_arrival_date=iso_or_none(expected)
-        if isinstance(expected, _datetime.datetime)
-        else None,
-        created_at=iso_or_none(created)
-        if isinstance(created, _datetime.datetime)
-        else None,
-        row_count=len(raw_rows),
-        rows=row_infos,
-        katana_url=katana_web_url("stock_transfer", transfer.id),
-    )
-
-
 # ============================================================================
 # Tool 1: create_stock_transfer
 # ============================================================================
@@ -426,7 +380,10 @@ async def _create_stock_transfer_impl(
     )
     result.next_actions = [
         f"Stock transfer created with ID {transfer.id}",
-        "Use update_stock_transfer_status to transition it through IN_TRANSIT → RECEIVED",
+        (
+            "Use modify_stock_transfer with update_status to transition it "
+            "through IN_TRANSIT → RECEIVED"
+        ),
     ]
     return result
 
@@ -942,6 +899,9 @@ async def _modify_stock_transfer_impl(
         web_url_kind="stock_transfer",
         existing=None,
         plan=plan,
+        # Katana exposes no GET /stock_transfers/{id}; ``existing=None`` is
+        # the steady state, not a fetch failure — suppress the warning.
+        has_get_endpoint=False,
     )
 
 
@@ -981,7 +941,7 @@ async def modify_stock_transfer(
 # ============================================================================
 
 
-async def _fetch_stock_transfer_for_delete(services: Any, st_id: int) -> None:
+async def _fetch_stock_transfer_for_delete(_services: Any, _st_id: int) -> None:
     """Stock transfers have no GET-by-id endpoint, so prior-state capture is
     a no-op. ``run_delete_plan`` accepts ``None`` from the fetcher; the diff
     flows through with ``unknown_prior=True``."""

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -941,24 +941,21 @@ async def modify_stock_transfer(
 # ============================================================================
 
 
-async def _fetch_stock_transfer_for_delete(_services: Any, _st_id: int) -> None:
-    """Stock transfers have no GET-by-id endpoint, so prior-state capture is
-    a no-op. ``run_delete_plan`` accepts ``None`` from the fetcher; the diff
-    flows through with ``unknown_prior=True``."""
-    return None
-
-
 async def _delete_stock_transfer_impl(
     request: DeleteStockTransferRequest, context: Context
 ) -> ModificationResponse:
-    """One-action plan that removes the stock transfer."""
+    """One-action plan that removes the stock transfer.
+
+    Stock transfers have no GET-by-id endpoint, so ``fetcher=None`` skips
+    prior-state capture; the response carries ``prior_state=None``.
+    """
     return await run_delete_plan(
         request=request,
         services=get_services(context),
         entity_type="stock_transfer",
         entity_label=f"stock transfer {request.id}",
         web_url_kind="stock_transfer",
-        fetcher=_fetch_stock_transfer_for_delete,
+        fetcher=None,
         delete_endpoint=api_delete_stock_transfer,
         operation=StockTransferOperation.DELETE,
     )

--- a/katana_mcp_server/tests/factories.py
+++ b/katana_mcp_server/tests/factories.py
@@ -15,10 +15,13 @@ from __future__ import annotations
 from collections.abc import Iterable
 from datetime import datetime
 from typing import Any
+from unittest.mock import MagicMock
 
+import attrs
 from katana_mcp.tools.tool_result_utils import naive_utc
 from katana_mcp.typed_cache import TypedCacheEngine
 
+from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.models_pydantic._generated import (
     CachedManufacturingOrder,
     CachedManufacturingOrderRecipeRow,
@@ -467,3 +470,45 @@ def make_stock_transfer_row(
         quantity=quantity,
         cost_per_unit=cost_per_unit,
     )
+
+
+# ============================================================================
+# Mock entity builders for ``modify_<entity>`` tests
+# ============================================================================
+#
+# The unified-modify tests need ``MagicMock(spec=EntityCls)`` instances
+# where every attrs field defaults to UNSET (so ``unwrap_unset → None``
+# inside diff computation). Each entity's test file used to maintain a
+# hand-curated list of UNSET-able fields; ``mock_entity_for_modify``
+# walks ``attrs.fields()`` and defaults all of them.
+
+
+def mock_entity_for_modify(spec_cls: type, **overrides: Any) -> MagicMock:
+    """Build a ``MagicMock(spec=spec_cls)`` with every attrs field defaulted.
+
+    For each declared field on ``spec_cls`` (via ``attrs.fields``), defaults
+    to UNSET unless overridden via ``**overrides``. ``MagicMock(spec=...)``
+    enforces the surface — accessing a non-spec attribute raises — but
+    field values aren't auto-populated. We default them to UNSET so
+    diff-computing code (which calls ``unwrap_unset(field, None)``) sees
+    ``None`` and treats the field as absent.
+
+    Example::
+
+        mock_po = mock_entity_for_modify(
+            RegularPurchaseOrder,
+            id=42,
+            order_no="PO-1",
+        )
+        # Every other field is now ``UNSET``.
+
+    Used by the ``modify_<entity>`` test suites; replaces the per-file
+    ``_mock_po`` / ``_mock_so`` / ``_mock_mo`` helpers.
+    """
+    mock = MagicMock(spec=spec_cls)
+    for field in attrs.fields(spec_cls):
+        if field.name in overrides:
+            setattr(mock, field.name, overrides[field.name])
+        else:
+            setattr(mock, field.name, UNSET)
+    return mock

--- a/katana_mcp_server/tests/test_mcp_apps_integration.py
+++ b/katana_mcp_server/tests/test_mcp_apps_integration.py
@@ -28,8 +28,6 @@ UI_TOOL_NAMES = {
     "search_items",
     "create_item",
     "get_item",
-    "update_item",
-    "delete_item",
     "get_variant_details",
     "create_product",
     "create_material",

--- a/katana_mcp_server/tests/test_mcp_apps_integration.py
+++ b/katana_mcp_server/tests/test_mcp_apps_integration.py
@@ -40,7 +40,6 @@ UI_TOOL_NAMES = {
     "receive_purchase_order",
     "verify_order_document",
     "create_manufacturing_order",
-    "batch_update_manufacturing_order_recipes",
     "fulfill_order",
 }
 

--- a/katana_mcp_server/tests/test_server.py
+++ b/katana_mcp_server/tests/test_server.py
@@ -500,7 +500,7 @@ class TestServerRegistration:
             "search_items",
             "create_item",
             "get_item",
-            "update_item",
+            "modify_item",
             "delete_item",
             "get_variant_details",
             "check_inventory",

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -700,6 +700,54 @@ async def test_modify_item_material_header_dispatches_to_materials_endpoint():
 
 
 @pytest.mark.asyncio
+async def test_modify_item_service_header_dispatches_to_services_endpoint():
+    """SERVICE routing must hit ``/services/{id}``, not products or materials.
+    Also pins ``katana_url=None`` for SERVICE (no Katana web page)."""
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        ModifyItemRequest,
+        _modify_item_impl,
+    )
+
+    context, _ = create_mock_context()
+    mock_service = MagicMock()
+    mock_service.id = 7
+    mock_service.name = "Renamed Service"
+    with (
+        patch(
+            "katana_public_api_client.api.services.update_service.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_service_endpoint,
+        patch(
+            "katana_public_api_client.api.product.update_product.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_product_endpoint,
+        patch(
+            "katana_public_api_client.api.material.update_material.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_material_endpoint,
+        patch(
+            "katana_public_api_client.api.services.get_service.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        patch(_MODIFY_ITEM_UNWRAP_AS, return_value=mock_service),
+    ):
+        request = ModifyItemRequest(
+            id=7,
+            type=ItemType.SERVICE,
+            update_header=ItemHeaderPatch(name="Renamed Service", sales_price=12.50),
+            confirm=True,
+        )
+        response = await _modify_item_impl(request, context)
+
+    assert response.entity_type == "service"
+    assert response.katana_url is None  # services have no Katana web page
+    mock_service_endpoint.assert_awaited_once()
+    mock_product_endpoint.assert_not_awaited()
+    mock_material_endpoint.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_modify_item_add_variant_injects_parent_id_for_product():
     from katana_mcp.tools.foundation.items import (
         ModifyItemRequest,

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -550,3 +550,223 @@ def test_item_katana_url_returns_none_for_service_type(_no_web_base_url: None):
         _item_katana_url(ItemType.MATERIAL, 456)
         == "https://factory.katanamrp.com/products/456"
     )
+
+
+# ============================================================================
+# modify_item / delete_item — unified modification surface
+# ============================================================================
+
+_MODIFY_ITEM_UNWRAP_AS = "katana_mcp.tools._modification_dispatch.unwrap_as"
+_MODIFY_ITEM_IS_SUCCESS = "katana_mcp.tools._modification_dispatch.is_success"
+
+
+@pytest.mark.asyncio
+async def test_modify_item_requires_at_least_one_subpayload():
+    from katana_mcp.tools.foundation.items import (
+        ModifyItemRequest,
+        _modify_item_impl,
+    )
+
+    context, _ = create_mock_context()
+    with pytest.raises(ValueError, match="At least one sub-payload"):
+        await _modify_item_impl(
+            ModifyItemRequest(id=42, type=ItemType.PRODUCT, confirm=False), context
+        )
+
+
+@pytest.mark.asyncio
+async def test_modify_item_rejects_misrouted_header_field():
+    """Setting ``is_producible`` (PRODUCT-only) on a SERVICE raises before
+    any API call."""
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        ModifyItemRequest,
+        _modify_item_impl,
+    )
+
+    context, _ = create_mock_context()
+    request = ModifyItemRequest(
+        id=42,
+        type=ItemType.SERVICE,
+        update_header=ItemHeaderPatch(name="Renamed", is_producible=True),
+        confirm=False,
+    )
+    with pytest.raises(ValueError, match="not valid for type=service"):
+        await _modify_item_impl(request, context)
+
+
+@pytest.mark.asyncio
+async def test_modify_item_rejects_variant_crud_for_services():
+    from katana_mcp.tools.foundation.items import (
+        ModifyItemRequest,
+        VariantAdd,
+        _modify_item_impl,
+    )
+
+    context, _ = create_mock_context()
+    request = ModifyItemRequest(
+        id=42,
+        type=ItemType.SERVICE,
+        add_variants=[VariantAdd(sku="V-1")],
+        confirm=False,
+    )
+    with pytest.raises(ValueError, match="not supported for SERVICE"):
+        await _modify_item_impl(request, context)
+
+
+@pytest.mark.asyncio
+async def test_modify_item_product_header_dispatches_to_products_endpoint():
+    """Confirms the type discriminator routes a PRODUCT header update to
+    ``/products/{id}`` (and not ``/materials/{id}``)."""
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        ModifyItemRequest,
+        _modify_item_impl,
+    )
+
+    context, _ = create_mock_context()
+    mock_product = MagicMock(name="UpdatedProduct")
+    mock_product.id = 42
+    mock_product.name = "Renamed Product"
+    with (
+        patch(
+            "katana_public_api_client.api.product.update_product.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_product_endpoint,
+        patch(
+            "katana_public_api_client.api.material.update_material.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_material_endpoint,
+        patch(
+            "katana_public_api_client.api.product.get_product.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        patch(_MODIFY_ITEM_UNWRAP_AS, return_value=mock_product),
+    ):
+        request = ModifyItemRequest(
+            id=42,
+            type=ItemType.PRODUCT,
+            update_header=ItemHeaderPatch(name="Renamed Product", is_producible=True),
+            confirm=True,
+        )
+        response = await _modify_item_impl(request, context)
+
+    assert response.is_preview is False
+    assert response.entity_type == "product"
+    assert response.actions[0].operation == "update_header"
+    mock_product_endpoint.assert_awaited_once()
+    mock_material_endpoint.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_modify_item_material_header_dispatches_to_materials_endpoint():
+    """Same shape as the PRODUCT test — pins the material-side routing."""
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        ModifyItemRequest,
+        _modify_item_impl,
+    )
+
+    context, _ = create_mock_context()
+    mock_material = MagicMock()
+    mock_material.id = 99
+    mock_material.name = "Renamed Material"
+    with (
+        patch(
+            "katana_public_api_client.api.material.update_material.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_material_endpoint,
+        patch(
+            "katana_public_api_client.api.product.update_product.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_product_endpoint,
+        patch(
+            "katana_public_api_client.api.material.get_material.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        patch(_MODIFY_ITEM_UNWRAP_AS, return_value=mock_material),
+    ):
+        request = ModifyItemRequest(
+            id=99,
+            type=ItemType.MATERIAL,
+            update_header=ItemHeaderPatch(name="Renamed Material"),
+            confirm=True,
+        )
+        response = await _modify_item_impl(request, context)
+
+    assert response.entity_type == "material"
+    mock_material_endpoint.assert_awaited_once()
+    mock_product_endpoint.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_modify_item_add_variant_injects_parent_id_for_product():
+    from katana_mcp.tools.foundation.items import (
+        ModifyItemRequest,
+        VariantAdd,
+        _modify_item_impl,
+    )
+
+    context, _ = create_mock_context()
+    mock_variant = MagicMock(id=500)
+    with (
+        patch(
+            "katana_public_api_client.api.variant.create_variant.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_create,
+        patch(
+            "katana_public_api_client.api.product.get_product.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        patch(_MODIFY_ITEM_UNWRAP_AS, return_value=mock_variant),
+    ):
+        request = ModifyItemRequest(
+            id=42,
+            type=ItemType.PRODUCT,
+            add_variants=[VariantAdd(sku="NEW-SKU-1", sales_price=99.99)],
+            confirm=True,
+        )
+        response = await _modify_item_impl(request, context)
+
+    assert response.actions[0].operation == "add_variant"
+    mock_create.assert_awaited_once()
+    body = mock_create.await_args.kwargs["body"]
+    assert body.product_id == 42
+    # material_id should be UNSET, not 42 — it's a PRODUCT.
+    from katana_public_api_client.client_types import UNSET
+
+    assert body.material_id is UNSET
+
+
+@pytest.mark.asyncio
+async def test_delete_item_dispatches_to_typed_delete_endpoint():
+    from katana_mcp.tools.foundation.items import (
+        DeleteItemRequest,
+        _delete_item_impl,
+    )
+
+    context, _ = create_mock_context()
+    mock_response = MagicMock(status_code=204, parsed=None)
+    with (
+        patch(
+            "katana_public_api_client.api.material.delete_material.asyncio_detailed",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_delete,
+        patch(
+            "katana_public_api_client.api.product.delete_product.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_product_delete,
+        patch(
+            "katana_public_api_client.api.material.get_material.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        patch(_MODIFY_ITEM_IS_SUCCESS, return_value=True),
+    ):
+        request = DeleteItemRequest(id=99, type=ItemType.MATERIAL, confirm=True)
+        response = await _delete_item_impl(request, context)
+
+    assert response.is_preview is False
+    assert response.actions[0].succeeded is True
+    mock_delete.assert_awaited_once()
+    mock_product_delete.assert_not_awaited()

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -11,6 +11,8 @@ from katana_mcp.tools.foundation.manufacturing_orders import (
     GetManufacturingOrderRecipeRequest,
     ModifyManufacturingOrderRequest,
     MOHeaderPatch,
+    MOOperationRowAdd,
+    MOProductionAdd,
     MORecipeRowAdd,
     _create_manufacturing_order_impl,
     _delete_manufacturing_order_impl,
@@ -28,7 +30,11 @@ from katana_public_api_client.models import (
 )
 from katana_public_api_client.utils import APIError
 from tests.conftest import create_mock_context, patch_typed_cache_sync
-from tests.factories import make_manufacturing_order, seed_cache
+from tests.factories import (
+    make_manufacturing_order,
+    mock_entity_for_modify,
+    seed_cache,
+)
 
 # ============================================================================
 # Unit Tests (with mocks)
@@ -2235,27 +2241,8 @@ _MODIFY_MO_UNWRAP_AS = "katana_mcp.tools._modification_dispatch.unwrap_as"
 
 
 def _mock_mo(mo_id: int = 1, order_no: str = "MO-1"):
-    """Build a mock ManufacturingOrder with UNSET-able fields default to UNSET."""
-    mo = MagicMock(spec=ManufacturingOrder)
-    mo.id = mo_id
-    mo.order_no = order_no
-    for field in (
-        "variant_id",
-        "location_id",
-        "status",
-        "planned_quantity",
-        "actual_quantity",
-        "order_created_date",
-        "production_deadline_date",
-        "done_date",
-        "additional_info",
-        "batch_transactions",
-        "created_at",
-        "updated_at",
-        "deleted_at",
-    ):
-        setattr(mo, field, UNSET)
-    return mo
+    """Build a mock ManufacturingOrder with all fields defaulted to UNSET."""
+    return mock_entity_for_modify(ManufacturingOrder, id=mo_id, order_no=order_no)
 
 
 @pytest.mark.asyncio
@@ -2405,3 +2392,214 @@ async def test_delete_mo_confirm_calls_api_and_records_prior_state():
     assert response.prior_state is not None
     assert response.katana_url is None
     mock_api.assert_awaited_once()
+
+
+# ============================================================================
+# MO operation rows + production records — coverage gaps
+# ============================================================================
+
+
+_MODIFY_MO_OP_CREATE = (
+    "katana_public_api_client.api.manufacturing_order_operation."
+    "create_manufacturing_order_operation_row"
+)
+_MODIFY_MO_PROD_CREATE = (
+    "katana_public_api_client.api.manufacturing_order_production."
+    "create_manufacturing_order_production"
+)
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_operation_row_add_translates_status_and_type_enums():
+    """Operation rows carry literal status + type that must convert to API enums.
+
+    Exercises the ``_build_create_operation_row_request`` enum-conversion path.
+    """
+    context, _ = create_mock_context()
+    existing = _mock_mo(mo_id=42, order_no="MO-1")
+    new_op = MagicMock()
+    new_op.id = 999
+
+    captured_body = []
+
+    async def fake_create_op(*, client, body):
+        captured_body.append(body)
+        resp = MagicMock()
+        resp.parsed = new_op
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(f"{_MODIFY_MO_OP_CREATE}.asyncio_detailed", side_effect=fake_create_op),
+        patch(_MODIFY_MO_UNWRAP_AS, return_value=new_op),
+    ):
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            add_operation_rows=[
+                MOOperationRowAdd(
+                    status="IN_PROGRESS",
+                    type="perUnit",
+                    operation_name="Cut to length",
+                    planned_time_per_unit=2.5,
+                ),
+            ],
+            confirm=True,
+        )
+        response = await _modify_manufacturing_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "add_operation_row"
+    # Verify the API body has the actual API enum members, not strings
+    from katana_public_api_client.models import (
+        ManufacturingOperationStatus,
+        ManufacturingOperationType,
+    )
+
+    body = captured_body[0]
+    assert body.status == ManufacturingOperationStatus.IN_PROGRESS
+    assert body.type_ == ManufacturingOperationType.PERUNIT
+    assert body.operation_name == "Cut to length"
+    assert body.planned_time_per_unit == 2.5
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_production_record_add_passes_through_to_api():
+    """Production records have a small-but-distinct shape; cover the
+    add path end-to-end."""
+    context, _ = create_mock_context()
+    existing = _mock_mo(mo_id=42, order_no="MO-1")
+    new_prod = MagicMock()
+    new_prod.id = 7777
+
+    captured_body = []
+
+    async def fake_create_prod(*, client, body):
+        captured_body.append(body)
+        resp = MagicMock()
+        resp.parsed = new_prod
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            f"{_MODIFY_MO_PROD_CREATE}.asyncio_detailed",
+            side_effect=fake_create_prod,
+        ),
+        patch(_MODIFY_MO_UNWRAP_AS, return_value=new_prod),
+    ):
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            add_productions=[
+                MOProductionAdd(
+                    completed_quantity=10.0,
+                    is_final=True,
+                    serial_numbers=["SN-001", "SN-002"],
+                ),
+            ],
+            confirm=True,
+        )
+        response = await _modify_manufacturing_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert response.actions[0].operation == "add_production"
+    body = captured_body[0]
+    assert body.manufacturing_order_id == 42
+    assert body.completed_quantity == 10.0
+    assert body.is_final is True
+    assert body.serial_numbers == ["SN-001", "SN-002"]
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_canonical_order_across_all_three_sub_resources():
+    """Header + recipe row + operation row + production all in one call,
+    confirming canonical execution order across all three sub-resource kinds."""
+    context, _ = create_mock_context()
+    existing = _mock_mo(mo_id=42, order_no="MO-1")
+    updated = _mock_mo(mo_id=42, order_no="MO-1")
+    new_recipe = MagicMock()
+    new_recipe.id = 100
+    new_op = MagicMock()
+    new_op.id = 200
+    new_prod = MagicMock()
+    new_prod.id = 300
+
+    call_log: list[str] = []
+
+    async def fake_update_mo(*, id, client, body):
+        call_log.append("update_header")
+        resp = MagicMock()
+        resp.parsed = updated
+        return resp
+
+    async def fake_create_recipe(*, client, body):
+        call_log.append("add_recipe_row")
+        resp = MagicMock()
+        resp.parsed = new_recipe
+        return resp
+
+    async def fake_create_op(*, client, body):
+        call_log.append("add_operation_row")
+        resp = MagicMock()
+        resp.parsed = new_op
+        return resp
+
+    async def fake_create_prod(*, client, body):
+        call_log.append("add_production")
+        resp = MagicMock()
+        resp.parsed = new_prod
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(f"{_MODIFY_MO_UPDATE}.asyncio_detailed", side_effect=fake_update_mo),
+        patch(
+            f"{_MODIFY_MO_RECIPE_CREATE}.asyncio_detailed",
+            side_effect=fake_create_recipe,
+        ),
+        patch(f"{_MODIFY_MO_OP_CREATE}.asyncio_detailed", side_effect=fake_create_op),
+        patch(
+            f"{_MODIFY_MO_PROD_CREATE}.asyncio_detailed",
+            side_effect=fake_create_prod,
+        ),
+        patch(
+            _MODIFY_MO_UNWRAP_AS,
+            side_effect=[updated, new_recipe, new_op, new_prod],
+        ),
+    ):
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            update_header=MOHeaderPatch(status="IN_PROGRESS"),
+            add_recipe_rows=[
+                MORecipeRowAdd(variant_id=100, planned_quantity_per_unit=2.0)
+            ],
+            add_operation_rows=[
+                MOOperationRowAdd(status="NOT_STARTED", operation_name="Assembly")
+            ],
+            add_productions=[MOProductionAdd(completed_quantity=5.0)],
+            confirm=True,
+        )
+        response = await _modify_manufacturing_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert len(response.actions) == 4
+    assert all(a.succeeded is True for a in response.actions)
+    # Canonical order: header → recipe → operation → production
+    assert call_log == [
+        "update_header",
+        "add_recipe_row",
+        "add_operation_row",
+        "add_production",
+    ]

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -6,21 +6,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from katana_mcp.tools.foundation.manufacturing_orders import (
-    AddRecipeRowRequest,
-    BatchUpdateRecipesRequest,
     CreateManufacturingOrderRequest,
-    DeleteRecipeRowRequest,
-    ExplicitChange,
+    DeleteManufacturingOrderRequest,
     GetManufacturingOrderRecipeRequest,
-    SubOpStatus,
-    VariantReplacement,
-    VariantSpec,
-    _add_recipe_row_impl,
-    _batch_update_impl,
+    ModifyManufacturingOrderRequest,
+    MOHeaderPatch,
+    MORecipeRowAdd,
     _create_manufacturing_order_impl,
-    _delete_recipe_row_impl,
+    _delete_manufacturing_order_impl,
     _get_manufacturing_order_recipe_impl,
-    _plan_batch_update,
+    _modify_manufacturing_order_impl,
     get_manufacturing_order,
     get_manufacturing_order_recipe,
     list_manufacturing_orders,
@@ -680,330 +675,6 @@ async def test_get_manufacturing_order_recipe_empty():
 
     assert result.total_count == 0
     assert result.rows == []
-
-
-@pytest.mark.asyncio
-async def test_add_recipe_row_preview():
-    """Preview adding a recipe row returns without calling the API."""
-    context, lifespan_ctx = create_mock_context()
-    lifespan_ctx.cache.get_by_sku = AsyncMock(
-        return_value={"id": 555, "sku": "FORK-NEW", "display_name": "New Fork"}
-    )
-
-    request = AddRecipeRowRequest(
-        manufacturing_order_id=9999,
-        sku="FORK-NEW",
-        planned_quantity_per_unit=1.0,
-        confirm=False,
-    )
-    result = await _add_recipe_row_impl(request, context)
-
-    assert result.is_preview is True
-    assert result.variant_id == 555
-    assert result.sku == "FORK-NEW"
-    assert "Preview" in result.message
-
-
-@pytest.mark.asyncio
-async def test_add_recipe_row_sku_not_found():
-    """Adding a recipe row with an unknown SKU raises."""
-    context, lifespan_ctx = create_mock_context()
-    lifespan_ctx.cache.get_by_sku = AsyncMock(return_value=None)
-
-    request = AddRecipeRowRequest(
-        manufacturing_order_id=9999,
-        sku="UNKNOWN",
-        planned_quantity_per_unit=1.0,
-        confirm=False,
-    )
-    with pytest.raises(ValueError, match="SKU 'UNKNOWN' not found"):
-        await _add_recipe_row_impl(request, context)
-
-
-@pytest.mark.asyncio
-async def test_add_recipe_row_by_variant_id():
-    """Adding a recipe row by variant_id skips the cache lookup."""
-    context, lifespan_ctx = create_mock_context()
-    # Cache.get_by_sku should NOT be called
-    lifespan_ctx.cache.get_by_sku = AsyncMock(
-        side_effect=AssertionError("should not be called")
-    )
-
-    request = AddRecipeRowRequest(
-        manufacturing_order_id=9999,
-        variant_id=40010545,
-        planned_quantity_per_unit=1.0,
-        confirm=False,
-    )
-    result = await _add_recipe_row_impl(request, context)
-
-    assert result.is_preview is True
-    assert result.variant_id == 40010545
-    assert result.sku is None
-
-
-@pytest.mark.asyncio
-async def test_add_recipe_row_requires_identifier():
-    """Must provide sku or variant_id."""
-    context, _ = create_mock_context()
-
-    request = AddRecipeRowRequest(
-        manufacturing_order_id=9999,
-        planned_quantity_per_unit=1.0,
-        confirm=False,
-    )
-    with pytest.raises(ValueError, match="sku or variant_id"):
-        await _add_recipe_row_impl(request, context)
-
-
-@pytest.mark.asyncio
-async def test_delete_recipe_row_preview():
-    """Preview deleting a recipe row returns without calling the API."""
-    context, _ = create_mock_context()
-
-    request = DeleteRecipeRowRequest(recipe_row_id=5001, confirm=False)
-    result = await _delete_recipe_row_impl(request, context)
-
-    assert result.is_preview is True
-    assert result.recipe_row_id == 5001
-    assert "Preview" in result.message
-
-
-# ============================================================================
-# batch_update_manufacturing_order_recipes
-# ============================================================================
-
-
-def _mock_recipe_rows(rows_data: list[dict]) -> list:
-    """Helper to build a list of mock RecipeRowInfo-like objects."""
-    mocks = []
-    for r in rows_data:
-        m = MagicMock()
-        for k, v in r.items():
-            setattr(m, k, v)
-        mocks.append(m)
-    return mocks
-
-
-@pytest.mark.asyncio
-async def test_batch_plan_replacement_basic():
-    """Plan a simple replacement across one MO."""
-    context, lifespan_ctx = create_mock_context()
-    lifespan_ctx.cache.get_by_sku = AsyncMock(
-        side_effect=[
-            {"id": 100, "sku": "OLD-FORK", "display_name": "Old Fork"},
-            {"id": 200, "sku": "NEW-FORK", "display_name": "New Fork"},
-            {"id": 201, "sku": "AIR-SHAFT", "display_name": "Air Shaft"},
-        ]
-    )
-
-    # Mock the recipe fetch
-    from katana_mcp.tools.foundation.manufacturing_orders import RecipeRowInfo
-
-    async def fake_get_recipe(req, ctx):
-        from katana_mcp.tools.foundation.manufacturing_orders import (
-            GetManufacturingOrderRecipeResponse,
-        )
-
-        return GetManufacturingOrderRecipeResponse(
-            manufacturing_order_id=req.manufacturing_order_id,
-            rows=[
-                RecipeRowInfo(
-                    id=5001,
-                    variant_id=100,
-                    sku="OLD-FORK",
-                    planned_quantity_per_unit=1.0,
-                    total_actual_quantity=None,
-                    ingredient_availability="IN_STOCK",
-                    notes=None,
-                    cost=None,
-                ),
-            ],
-            total_count=1,
-        )
-
-    with patch(
-        "katana_mcp.tools.foundation.manufacturing_orders._get_manufacturing_order_recipe_impl",
-        side_effect=fake_get_recipe,
-    ):
-        request = BatchUpdateRecipesRequest(
-            replacements=[
-                VariantReplacement(
-                    manufacturing_order_ids=[9999],
-                    old_sku="OLD-FORK",
-                    new_components=[
-                        VariantSpec(sku="NEW-FORK", planned_quantity_per_unit=1.0),
-                        VariantSpec(sku="AIR-SHAFT", planned_quantity_per_unit=1.0),
-                    ],
-                )
-            ],
-        )
-        planned, warnings = await _plan_batch_update(request, context)
-
-    # Expect: 1 delete + 2 adds
-    assert len(planned) == 3
-    deletes = [p for p in planned if p.op_type == "delete"]
-    adds = [p for p in planned if p.op_type == "add"]
-    assert len(deletes) == 1
-    assert len(adds) == 2
-    assert deletes[0].recipe_row_id == 5001
-    assert adds[0].sku == "NEW-FORK"
-    assert adds[1].sku == "AIR-SHAFT"
-    # All grouped under the same label
-    assert all(p.group_label == "OLD-FORK → [NEW-FORK, AIR-SHAFT]" for p in planned)
-    assert warnings == []
-
-
-@pytest.mark.asyncio
-async def test_batch_plan_skips_mo_missing_old_variant():
-    """Non-strict mode: MOs without the old variant are skipped with a warning."""
-    context, lifespan_ctx = create_mock_context()
-    lifespan_ctx.cache.get_by_sku = AsyncMock(
-        side_effect=[
-            {"id": 100, "sku": "OLD-FORK"},
-            {"id": 200, "sku": "NEW-FORK"},
-        ]
-    )
-
-    from katana_mcp.tools.foundation.manufacturing_orders import (
-        GetManufacturingOrderRecipeResponse,
-    )
-
-    async def fake_get_recipe(req, ctx):
-        return GetManufacturingOrderRecipeResponse(
-            manufacturing_order_id=req.manufacturing_order_id,
-            rows=[],  # empty — old variant not present
-            total_count=0,
-        )
-
-    with patch(
-        "katana_mcp.tools.foundation.manufacturing_orders._get_manufacturing_order_recipe_impl",
-        side_effect=fake_get_recipe,
-    ):
-        request = BatchUpdateRecipesRequest(
-            replacements=[
-                VariantReplacement(
-                    manufacturing_order_ids=[9999],
-                    old_sku="OLD-FORK",
-                    new_components=[
-                        VariantSpec(sku="NEW-FORK", planned_quantity_per_unit=1.0),
-                    ],
-                    strict=False,
-                )
-            ],
-        )
-        planned, warnings = await _plan_batch_update(request, context)
-
-    assert len(warnings) == 1
-    assert "not in recipe" in warnings[0]
-    # Skipped add placeholder emitted for visibility
-    assert len(planned) == 1
-    assert planned[0].status == SubOpStatus.SKIPPED
-
-
-@pytest.mark.asyncio
-async def test_batch_plan_strict_raises_on_missing():
-    """Strict mode: MOs without the old variant raise an error."""
-    context, lifespan_ctx = create_mock_context()
-    lifespan_ctx.cache.get_by_sku = AsyncMock(
-        side_effect=[
-            {"id": 100, "sku": "OLD-FORK"},
-            {"id": 200, "sku": "NEW-FORK"},
-        ]
-    )
-
-    from katana_mcp.tools.foundation.manufacturing_orders import (
-        GetManufacturingOrderRecipeResponse,
-    )
-
-    async def fake_get_recipe(req, ctx):
-        return GetManufacturingOrderRecipeResponse(
-            manufacturing_order_id=req.manufacturing_order_id,
-            rows=[],
-            total_count=0,
-        )
-
-    with patch(
-        "katana_mcp.tools.foundation.manufacturing_orders._get_manufacturing_order_recipe_impl",
-        side_effect=fake_get_recipe,
-    ):
-        request = BatchUpdateRecipesRequest(
-            replacements=[
-                VariantReplacement(
-                    manufacturing_order_ids=[9999],
-                    old_sku="OLD-FORK",
-                    new_components=[
-                        VariantSpec(sku="NEW-FORK", planned_quantity_per_unit=1.0),
-                    ],
-                    strict=True,
-                )
-            ],
-        )
-        with pytest.raises(ValueError, match="not in recipe"):
-            await _plan_batch_update(request, context)
-
-
-@pytest.mark.asyncio
-async def test_batch_plan_empty_request_raises():
-    """Empty request should raise."""
-    context, _ = create_mock_context()
-    request = BatchUpdateRecipesRequest()
-    with pytest.raises(ValueError, match="at least one replacement or change"):
-        await _batch_update_impl(request, context)
-
-
-@pytest.mark.asyncio
-async def test_batch_impl_preview_mode():
-    """Preview mode returns the plan without calling the API."""
-    context, lifespan_ctx = create_mock_context()
-    lifespan_ctx.cache.get_by_sku = AsyncMock(
-        return_value={"id": 200, "sku": "NEW-FORK"}
-    )
-
-    request = BatchUpdateRecipesRequest(
-        changes=[
-            ExplicitChange(
-                manufacturing_order_id=9999,
-                remove_row_ids=[5001],
-                add_variants=[
-                    VariantSpec(sku="NEW-FORK", planned_quantity_per_unit=1.0)
-                ],
-            )
-        ],
-        confirm=False,
-    )
-    response = await _batch_update_impl(request, context)
-
-    assert response.is_preview is True
-    assert response.total_ops == 2
-    assert response.success_count == 0
-    assert "Preview" in response.message
-
-
-@pytest.mark.asyncio
-async def test_batch_plan_explicit_change_with_variant_id():
-    """Explicit changes accept variant_id directly without SKU lookup."""
-    context, lifespan_ctx = create_mock_context()
-    # Should not be called — variant_id is direct
-    lifespan_ctx.cache.get_by_sku = AsyncMock(
-        side_effect=AssertionError("should not be called")
-    )
-
-    request = BatchUpdateRecipesRequest(
-        changes=[
-            ExplicitChange(
-                manufacturing_order_id=9999,
-                remove_row_ids=[5001, 5002],
-                add_variants=[
-                    VariantSpec(variant_id=40010545, planned_quantity_per_unit=1.0),
-                ],
-            )
-        ],
-    )
-    planned, warnings = await _plan_batch_update(request, context)
-
-    assert len(planned) == 3  # 2 deletes + 1 add
-    assert warnings == []
 
 
 @pytest.mark.asyncio
@@ -2543,3 +2214,194 @@ async def test_list_blocking_ingredients_resolves_skus_only_for_kept_variants(
     assert cache_mock.await_count == 1
     awaited_vids = cache_mock.await_args.args[1]
     assert set(awaited_vids) == {500}
+
+
+# ============================================================================
+# modify_manufacturing_order — unified modification surface
+# ============================================================================
+
+
+_MODIFY_MO_UPDATE = (
+    "katana_public_api_client.api.manufacturing_order.update_manufacturing_order"
+)
+_MODIFY_MO_DELETE = (
+    "katana_public_api_client.api.manufacturing_order.delete_manufacturing_order"
+)
+_MODIFY_MO_RECIPE_CREATE = (
+    "katana_public_api_client.api.manufacturing_order_recipe."
+    "create_manufacturing_order_recipe_rows"
+)
+_MODIFY_MO_UNWRAP_AS = "katana_mcp.tools._modification_dispatch.unwrap_as"
+
+
+def _mock_mo(mo_id: int = 1, order_no: str = "MO-1"):
+    """Build a mock ManufacturingOrder with UNSET-able fields default to UNSET."""
+    mo = MagicMock(spec=ManufacturingOrder)
+    mo.id = mo_id
+    mo.order_no = order_no
+    for field in (
+        "variant_id",
+        "location_id",
+        "status",
+        "planned_quantity",
+        "actual_quantity",
+        "order_created_date",
+        "production_deadline_date",
+        "done_date",
+        "additional_info",
+        "batch_transactions",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+    ):
+        setattr(mo, field, UNSET)
+    return mo
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_requires_at_least_one_subpayload():
+    context, _ = create_mock_context()
+    with pytest.raises(ValueError, match="At least one sub-payload"):
+        await _modify_manufacturing_order_impl(
+            ModifyManufacturingOrderRequest(id=42, confirm=False), context
+        )
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_preview_emits_planned_actions():
+    context, _ = create_mock_context()
+    existing = _mock_mo(mo_id=42, order_no="MO-1")
+
+    with patch(
+        "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+        new_callable=AsyncMock,
+        return_value=existing,
+    ):
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            update_header=MOHeaderPatch(status="IN_PROGRESS"),
+            add_recipe_rows=[
+                MORecipeRowAdd(variant_id=100, planned_quantity_per_unit=2.0)
+            ],
+            confirm=False,
+        )
+        response = await _modify_manufacturing_order_impl(request, context)
+
+    assert response.is_preview is True
+    assert response.entity_id == 42
+    assert len(response.actions) == 2
+    assert response.actions[0].operation == "update_header"
+    assert response.actions[1].operation == "add_recipe_row"
+    assert all(a.succeeded is None for a in response.actions)
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_confirm_executes_in_canonical_order():
+    """Header → recipe adds → recipe updates → ..."""
+    context, _ = create_mock_context()
+    existing = _mock_mo(mo_id=42, order_no="MO-1")
+    updated = _mock_mo(mo_id=42, order_no="MO-1")
+    new_row = MagicMock()
+    new_row.id = 555
+
+    call_log: list[str] = []
+
+    async def fake_update_mo(*, id, client, body):
+        call_log.append("PATCH /manufacturing_orders/{id}")
+        resp = MagicMock()
+        resp.parsed = updated
+        return resp
+
+    async def fake_create_recipe(*, client, body):
+        call_log.append("POST /manufacturing_order_recipe_rows")
+        resp = MagicMock()
+        resp.parsed = new_row
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(f"{_MODIFY_MO_UPDATE}.asyncio_detailed", side_effect=fake_update_mo),
+        patch(
+            f"{_MODIFY_MO_RECIPE_CREATE}.asyncio_detailed",
+            side_effect=fake_create_recipe,
+        ),
+        patch(_MODIFY_MO_UNWRAP_AS, side_effect=[updated, new_row]),
+    ):
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            update_header=MOHeaderPatch(status="IN_PROGRESS"),
+            add_recipe_rows=[
+                MORecipeRowAdd(variant_id=100, planned_quantity_per_unit=2.0)
+            ],
+            confirm=True,
+        )
+        response = await _modify_manufacturing_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert all(a.succeeded is True for a in response.actions)
+    assert call_log[0].startswith("PATCH")
+    assert call_log[1].startswith("POST")
+    assert response.prior_state is not None
+
+
+# ============================================================================
+# delete_manufacturing_order
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_mo_preview_returns_planned_action():
+    context, _ = create_mock_context()
+    existing = _mock_mo(mo_id=42, order_no="MO-1")
+
+    with patch(
+        "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+        new_callable=AsyncMock,
+        return_value=existing,
+    ):
+        response = await _delete_manufacturing_order_impl(
+            DeleteManufacturingOrderRequest(id=42, confirm=False), context
+        )
+
+    assert response.is_preview is True
+    assert response.entity_id == 42
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "delete"
+    assert response.actions[0].succeeded is None
+
+
+@pytest.mark.asyncio
+async def test_delete_mo_confirm_calls_api_and_records_prior_state():
+    context, _ = create_mock_context()
+    existing = _mock_mo(mo_id=42, order_no="MO-1")
+    api_response = MagicMock()
+    api_response.status_code = 204
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            f"{_MODIFY_MO_DELETE}.asyncio_detailed", new_callable=AsyncMock
+        ) as mock_api,
+        patch(
+            "katana_mcp.tools._modification_dispatch.is_success",
+            return_value=True,
+        ),
+    ):
+        mock_api.return_value = api_response
+        response = await _delete_manufacturing_order_impl(
+            DeleteManufacturingOrderRequest(id=42, confirm=True), context
+        )
+
+    assert response.is_preview is False
+    assert response.actions[0].succeeded is True
+    assert response.prior_state is not None
+    assert response.katana_url is None
+    mock_api.assert_awaited_once()

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -12,12 +12,20 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from unittest.mock import MagicMock
 
+import pytest
 from katana_mcp.tools._modification import (
+    ActionResult,
     FieldChange,
     ModificationResponse,
     compute_field_diff,
     render_modification_md,
     to_tool_result,
+)
+from katana_mcp.tools._modification_dispatch import (
+    ActionSpec,
+    execute_plan,
+    plan_to_preview_results,
+    serialize_for_prior_state,
 )
 from pydantic import BaseModel
 
@@ -198,3 +206,257 @@ def test_to_tool_result_serializes_response_as_structured_data():
     assert result.structured_content is not None
     assert result.structured_content["entity_type"] == "purchase_order"
     assert result.structured_content["operation"] == "update"
+
+
+# ============================================================================
+# Multi-action shape (ActionResult + dispatcher integration)
+# ============================================================================
+
+
+def test_action_result_preview_shape_succeeded_is_none():
+    """Preview-shaped ActionResults carry succeeded=None to signal 'planned'."""
+    result = ActionResult(operation="update_header", target_id=42)
+    assert result.succeeded is None
+    assert result.verified is None
+    assert result.error is None
+
+
+def test_modification_response_renders_multi_action_when_actions_populated():
+    response = ModificationResponse(
+        entity_type="purchase_order",
+        entity_id=42,
+        is_preview=True,
+        actions=[
+            ActionResult(
+                operation="update_header",
+                changes=[FieldChange(field="status", old="DRAFT", new="RECEIVED")],
+            ),
+            ActionResult(
+                operation="add_row",
+                target_id=None,
+                changes=[
+                    FieldChange(field="variant_id", old=None, new=100, is_added=True)
+                ],
+            ),
+        ],
+        message="Preview: 2 actions",
+    )
+    md = render_modification_md(response)
+    # Multi-action header
+    assert "## Modify Purchase Order (PREVIEW) — 2 actions" in md
+    # Each action rendered as its own sub-section, all PLANNED
+    assert "#### 1. Update Header — PLANNED" in md
+    assert "#### 2. Add Row — PLANNED" in md
+    assert "`status`: DRAFT → RECEIVED" in md
+
+
+def test_modification_response_renders_legacy_single_action_when_actions_empty():
+    """When ``actions`` is empty the legacy ``operation`` + ``changes`` shape renders."""
+    response = ModificationResponse(
+        entity_type="purchase_order",
+        entity_id=42,
+        operation="update",
+        is_preview=False,
+        changes=[FieldChange(field="qty", old=1, new=2)],
+        message="Updated",
+    )
+    md = render_modification_md(response)
+    assert "## Purchase Order Update (UPDATE)" in md
+    assert "`qty`: 1 → 2" in md
+
+
+def test_render_action_block_status_labels():
+    """Action status labels distinguish planned / applied / applied-verified / failed."""
+    cases = [
+        (ActionResult(operation="x", succeeded=None), "PLANNED"),
+        (ActionResult(operation="x", succeeded=True), "APPLIED"),
+        (
+            ActionResult(operation="x", succeeded=True, verified=True),
+            "APPLIED (verified)",
+        ),
+        (
+            ActionResult(operation="x", succeeded=True, verified=False),
+            "APPLIED (verification mismatch)",
+        ),
+        (ActionResult(operation="x", succeeded=False, error="boom"), "FAILED"),
+    ]
+    for action, expected_label in cases:
+        response = ModificationResponse(
+            entity_type="purchase_order",
+            is_preview=False,
+            actions=[action],
+            message="x",
+        )
+        md = render_modification_md(response)
+        assert expected_label in md, f"missing {expected_label} for {action}"
+
+
+def test_render_includes_prior_state_block_when_set():
+    response = ModificationResponse(
+        entity_type="purchase_order",
+        entity_id=1,
+        is_preview=False,
+        actions=[
+            ActionResult(operation="update_header", succeeded=True, verified=True)
+        ],
+        prior_state={"status": "DRAFT", "supplier_id": 4001},
+        message="ok",
+    )
+    md = render_modification_md(response)
+    assert "### Prior State (for manual revert)" in md
+
+
+# ============================================================================
+# execute_plan — dispatcher executor
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_execute_plan_runs_all_actions_in_order():
+    """Plan executes sequentially; each action's verify runs after apply."""
+    call_log: list[str] = []
+
+    async def make_apply(name: str):
+        call_log.append(f"apply:{name}")
+        return name
+
+    async def make_verify(_outcome: object):
+        call_log.append("verify")
+        return True, {"k": "v"}
+
+    plan = [
+        ActionSpec(
+            operation="update_header",
+            target_id=None,
+            apply=lambda: make_apply("a"),
+            verify=make_verify,
+        ),
+        ActionSpec(
+            operation="add_row",
+            target_id=None,
+            apply=lambda: make_apply("b"),
+            verify=make_verify,
+        ),
+    ]
+    results = await execute_plan(plan)
+
+    assert len(results) == 2
+    assert all(r.succeeded is True for r in results)
+    assert all(r.verified is True for r in results)
+    # Verify ordering: apply-a, verify, apply-b, verify
+    assert call_log == ["apply:a", "verify", "apply:b", "verify"]
+
+
+@pytest.mark.asyncio
+async def test_execute_plan_fails_fast_on_first_apply_error():
+    attempted: list[str] = []
+
+    async def good():
+        attempted.append("good")
+        return None
+
+    async def bad():
+        attempted.append("bad")
+        raise ValueError("boom")
+
+    async def never():
+        attempted.append("never")
+        return None
+
+    plan = [
+        ActionSpec(operation="op1", target_id=1, apply=good),
+        ActionSpec(operation="op2", target_id=2, apply=bad),
+        ActionSpec(operation="op3", target_id=3, apply=never),
+    ]
+    results = await execute_plan(plan)
+
+    # First two run; third never attempted (fail-fast)
+    assert attempted == ["good", "bad"]
+    assert len(results) == 2
+    assert results[0].succeeded is True
+    assert results[1].succeeded is False
+    assert "boom" in (results[1].error or "")
+
+
+@pytest.mark.asyncio
+async def test_execute_plan_verification_failure_does_not_halt_plan():
+    """Verification failure surfaces as verified=False, plan keeps going."""
+
+    async def apply_ok():
+        return None
+
+    async def verify_fails(_outcome: object):
+        return False, {"actual": "different"}
+
+    async def verify_succeeds(_outcome: object):
+        return True, None
+
+    plan = [
+        ActionSpec(operation="op1", apply=apply_ok, verify=verify_fails, target_id=1),
+        ActionSpec(
+            operation="op2", apply=apply_ok, verify=verify_succeeds, target_id=2
+        ),
+    ]
+    results = await execute_plan(plan)
+
+    assert len(results) == 2
+    assert results[0].succeeded is True
+    assert results[0].verified is False
+    assert results[0].actual_after == {"actual": "different"}
+    assert results[1].verified is True
+
+
+@pytest.mark.asyncio
+async def test_execute_plan_verification_exception_marks_unverified():
+    async def apply_ok():
+        return None
+
+    async def verify_raises(_outcome: object):
+        raise RuntimeError("fetch failed")
+
+    plan = [
+        ActionSpec(operation="op", apply=apply_ok, verify=verify_raises, target_id=1)
+    ]
+    results = await execute_plan(plan)
+    assert len(results) == 1
+    assert results[0].succeeded is True
+    assert results[0].verified is False
+    assert results[0].actual_after is None
+
+
+def test_plan_to_preview_results_has_all_succeeded_none():
+    plan = [
+        ActionSpec(operation="op1", target_id=1, diff=[FieldChange(field="x", new=1)]),
+        ActionSpec(operation="op2", target_id=None),
+    ]
+    results = plan_to_preview_results(plan)
+    assert len(results) == 2
+    for r in results:
+        assert r.succeeded is None
+        assert r.verified is None
+    assert results[0].changes[0].field == "x"
+
+
+def test_serialize_for_prior_state_uses_to_dict_when_available():
+    class FakeAttrs:
+        def to_dict(self) -> dict:
+            return {"id": 1, "status": "DRAFT"}
+
+    snapshot = serialize_for_prior_state(FakeAttrs())
+    assert snapshot == {"id": 1, "status": "DRAFT"}
+
+
+def test_serialize_for_prior_state_falls_back_to_model_dump():
+    from pydantic import BaseModel as PydanticBase
+
+    class FakePydantic(PydanticBase):
+        id: int
+        status: str
+
+    snapshot = serialize_for_prior_state(FakePydantic(id=1, status="DRAFT"))
+    assert snapshot == {"id": 1, "status": "DRAFT"}
+
+
+def test_serialize_for_prior_state_returns_none_for_unsupported():
+    assert serialize_for_prior_state(None) is None
+    assert serialize_for_prior_state("a string") is None

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -35,6 +35,7 @@ from katana_public_api_client.api.purchase_order import (
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.models import (
     PurchaseOrderReceiveRow,
+    PurchaseOrderRow,
     RegularPurchaseOrder,
 )
 from katana_public_api_client.utils import APIError
@@ -42,6 +43,7 @@ from tests.conftest import create_mock_context, patch_typed_cache_sync
 from tests.factories import (
     make_purchase_order,
     make_purchase_order_row,
+    mock_entity_for_modify,
     seed_cache,
 )
 
@@ -76,44 +78,15 @@ def _auto_mock_po_side_data_fetches():
         yield
 
 
-def create_mock_po_row(variant_id: int, quantity: float, price: float):
-    """Create a mock PO row.
-
-    Exhaustive response model (#346) reads many more row fields than the
-    old shape. Default them all to UNSET so Pydantic validation sees
-    ``None`` rather than a stray ``MagicMock`` instance.
-    """
-    row = MagicMock()
-    row.variant_id = variant_id
-    row.quantity = quantity
-    row.price_per_unit = price
-    # id is required on PurchaseOrderRowInfo — give it a stable default that
-    # callers can ignore.
-    row.id = 1
-    # Fields touched by _po_row_info() but not set by callers — UNSET so
-    # unwrap_unset() collapses them to None.
-    for field in (
-        "created_at",
-        "updated_at",
-        "deleted_at",
-        "tax_rate_id",
-        "price_per_unit_in_base_currency",
-        "purchase_uom_conversion_rate",
-        "purchase_uom",
-        "currency",
-        "conversion_rate",
-        "total",
-        "total_in_base_currency",
-        "conversion_date",
-        "received_date",
-        "arrival_date",
-        "purchase_order_id",
-        "landed_cost",
-        "group_id",
-        "batch_transactions",
-    ):
-        setattr(row, field, UNSET)
-    return row
+def create_mock_po_row(variant_id, quantity, price):
+    """Create a mock PurchaseOrderRow with all fields defaulted to UNSET."""
+    return mock_entity_for_modify(
+        PurchaseOrderRow,
+        id=1,
+        variant_id=variant_id,
+        quantity=quantity,
+        price_per_unit=price,
+    )
 
 
 def create_mock_variant(variant_id: int, sku: str):
@@ -125,38 +98,13 @@ def create_mock_variant(variant_id: int, sku: str):
 
 
 def create_mock_po(order_id: int, order_no: str, rows: list):
-    """Create a mock RegularPurchaseOrder.
-
-    Exhaustive get_purchase_order (#346) reads every PurchaseOrder field.
-    Default optional ones to UNSET so Pydantic sees ``None`` rather than a
-    stray ``MagicMock`` when the response is built during verification.
-    """
-    po = MagicMock(spec=RegularPurchaseOrder)
-    po.id = order_id
-    po.order_no = order_no
-    po.purchase_order_rows = rows
-    for field in (
-        "created_at",
-        "updated_at",
-        "deleted_at",
-        "status",
-        "entity_type",
-        "default_group_id",
-        "supplier_id",
-        "currency",
-        "expected_arrival_date",
-        "order_created_date",
-        "additional_info",
-        "location_id",
-        "total",
-        "total_in_base_currency",
-        "billing_status",
-        "last_document_status",
-        "tracking_location_id",
-        "supplier",
-    ):
-        setattr(po, field, UNSET)
-    return po
+    """Create a mock RegularPurchaseOrder with all fields defaulted to UNSET."""
+    return mock_entity_for_modify(
+        RegularPurchaseOrder,
+        id=order_id,
+        order_no=order_no,
+        purchase_order_rows=rows,
+    )
 
 
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -2549,7 +2549,9 @@ _PO_ROW_UPDATE = (
 _PO_ROW_DELETE = (
     "katana_public_api_client.api.purchase_order_row.delete_purchase_order_row"
 )
-_PO_UNWRAP_AS = "katana_mcp.tools.foundation.purchase_orders.unwrap_as"
+# The modify/delete dispatcher pipes through ``_modification_dispatch.unwrap_as``
+# (apply factories + safe_fetch_for_diff use the dispatcher's binding).
+_PO_UNWRAP_AS = "katana_mcp.tools._modification_dispatch.unwrap_as"
 
 
 @pytest.fixture
@@ -2789,7 +2791,7 @@ async def test_delete_po_confirm_calls_api_and_records_prior_state():
         ),
         patch(f"{_PO_DELETE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
         patch(
-            "katana_mcp.tools.foundation.purchase_orders.is_success",
+            "katana_mcp.tools._modification_dispatch.is_success",
             return_value=True,
         ),
     ):

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -12,9 +12,9 @@ from katana_mcp.tools.foundation.purchase_orders import (
     DocumentItem,
     GetPurchaseOrderRequest,
     ModifyPurchaseOrderRequest,
-    NewPORow,
+    POHeaderPatch,
+    PORowAdd,
     PORowUpdate,
-    PurchaseOrderHeaderPatch,
     ReceiveItemRequest,
     ReceivePurchaseOrderRequest,
     ReceivePurchaseOrderResponse,
@@ -2589,10 +2589,10 @@ async def test_modify_po_preview_emits_planned_actions(patch_fetch_po):
         # Use distinct row ids per update so prefetch helpers see real ids
         request = ModifyPurchaseOrderRequest(
             id=42,
-            update_header=PurchaseOrderHeaderPatch(
+            update_header=POHeaderPatch(
                 expected_arrival_date=datetime(2026, 2, 15, tzinfo=UTC)
             ),
-            add_rows=[NewPORow(variant_id=100, quantity=10, price_per_unit=5.0)],
+            add_rows=[PORowAdd(variant_id=100, quantity=10, price_per_unit=5.0)],
             confirm=False,
         )
         # Stub the row prefetch so update_rows doesn't error here (no update_rows in this case)
@@ -2640,10 +2640,10 @@ async def test_modify_po_confirm_executes_plan_in_canonical_order(patch_fetch_po
     ):
         request = ModifyPurchaseOrderRequest(
             id=42,
-            update_header=PurchaseOrderHeaderPatch(
+            update_header=POHeaderPatch(
                 expected_arrival_date=datetime(2026, 2, 15, tzinfo=UTC)
             ),
-            add_rows=[NewPORow(variant_id=100, quantity=10, price_per_unit=5.0)],
+            add_rows=[PORowAdd(variant_id=100, quantity=10, price_per_unit=5.0)],
             confirm=True,
         )
         response = await _modify_purchase_order_impl(request, context)
@@ -2678,8 +2678,8 @@ async def test_modify_po_fail_fast_halts_on_first_error(patch_fetch_po):
     ):
         request = ModifyPurchaseOrderRequest(
             id=42,
-            update_header=PurchaseOrderHeaderPatch(order_no="PO-NEW"),
-            add_rows=[NewPORow(variant_id=100, quantity=10, price_per_unit=5.0)],
+            update_header=POHeaderPatch(order_no="PO-NEW"),
+            add_rows=[PORowAdd(variant_id=100, quantity=10, price_per_unit=5.0)],
             confirm=True,
         )
         response = await _modify_purchase_order_impl(request, context)
@@ -2703,7 +2703,7 @@ async def test_modify_po_preview_when_fetch_fails_marks_unknown_prior():
     ):
         request = ModifyPurchaseOrderRequest(
             id=42,
-            update_header=PurchaseOrderHeaderPatch(order_no="PO-NEW"),
+            update_header=POHeaderPatch(order_no="PO-NEW"),
             confirm=False,
         )
         response = await _modify_purchase_order_impl(request, context)

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -7,31 +7,22 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from katana_mcp.tools.foundation.purchase_orders import (
-    AddPurchaseOrderAdditionalCostRequest,
-    AddPurchaseOrderRowRequest,
-    DeletePurchaseOrderAdditionalCostRequest,
     DeletePurchaseOrderRequest,
-    DeletePurchaseOrderRowRequest,
     DiscrepancyType,
     DocumentItem,
     GetPurchaseOrderRequest,
+    ModifyPurchaseOrderRequest,
+    NewPORow,
+    PORowUpdate,
+    PurchaseOrderHeaderPatch,
     ReceiveItemRequest,
     ReceivePurchaseOrderRequest,
     ReceivePurchaseOrderResponse,
-    UpdatePurchaseOrderAdditionalCostRequest,
-    UpdatePurchaseOrderRequest,
-    UpdatePurchaseOrderRowRequest,
     VerifyOrderDocumentRequest,
-    _add_purchase_order_additional_cost_impl,
-    _add_purchase_order_row_impl,
-    _delete_purchase_order_additional_cost_impl,
     _delete_purchase_order_impl,
-    _delete_purchase_order_row_impl,
     _get_purchase_order_impl,
+    _modify_purchase_order_impl,
     _receive_purchase_order_impl,
-    _update_purchase_order_additional_cost_impl,
-    _update_purchase_order_impl,
-    _update_purchase_order_row_impl,
     _verify_order_document_impl,
     get_purchase_order,
     list_purchase_orders,
@@ -2541,12 +2532,10 @@ async def test_verify_order_document_format_json_returns_json():
 
 
 # ============================================================================
-# Modification tools — header (update / delete)
+# modify_purchase_order — unified modification surface
 # ============================================================================
 
 
-# Patch path constants for the new modification tools — keep them near the
-# tests so a future move catches the rename in one place.
 _PO_GET = "katana_public_api_client.api.purchase_order.get_purchase_order"
 _PO_UPDATE = "katana_public_api_client.api.purchase_order.update_purchase_order"
 _PO_DELETE = "katana_public_api_client.api.purchase_order.delete_purchase_order"
@@ -2560,71 +2549,151 @@ _PO_ROW_UPDATE = (
 _PO_ROW_DELETE = (
     "katana_public_api_client.api.purchase_order_row.delete_purchase_order_row"
 )
-_PO_COST_CREATE = (
-    "katana_public_api_client.api.purchase_order_additional_cost_row."
-    "create_po_additional_cost_row"
-)
-_PO_COST_UPDATE = (
-    "katana_public_api_client.api.purchase_order_additional_cost_row."
-    "update_additional_cost_row"
-)
-_PO_COST_DELETE = (
-    "katana_public_api_client.api.purchase_order_additional_cost_row."
-    "delete_po_additional_cost"
-)
 _PO_UNWRAP_AS = "katana_mcp.tools.foundation.purchase_orders.unwrap_as"
 
 
-@pytest.mark.asyncio
-async def test_update_purchase_order_preview_diffs_against_existing():
-    """Preview fetches the existing PO so the diff shows old → new values."""
-    context, _ = create_mock_context()
+@pytest.fixture
+def patch_fetch_po():
+    """Yield a patch on _fetch_purchase_order_attrs returning the given PO mock."""
+    from contextlib import contextmanager
 
-    existing = create_mock_po(order_id=42, order_no="PO-OLD", rows=[])
-    existing.expected_arrival_date = datetime(2026, 1, 1, tzinfo=UTC)
+    @contextmanager
+    def _patch(po_mock):
+        with patch(
+            "katana_mcp.tools.foundation.purchase_orders._fetch_purchase_order_attrs",
+            new_callable=AsyncMock,
+            return_value=po_mock,
+        ):
+            yield
 
-    request = UpdatePurchaseOrderRequest(
-        id=42,
-        order_no="PO-NEW",
-        expected_arrival_date=datetime(2026, 2, 15, tzinfo=UTC),
-        confirm=False,
-    )
-
-    with (
-        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_PO_UNWRAP_AS, return_value=existing),
-    ):
-        response = await _update_purchase_order_impl(request, context)
-
-    assert response.is_preview is True
-    assert response.entity_id == 42
-    assert response.entity_type == "purchase_order"
-    assert response.operation == "update"
-    # Both fields show as a real before→after diff
-    by_field = {c.field: c for c in response.changes}
-    assert by_field["order_no"].old == "PO-OLD"
-    assert by_field["order_no"].new == "PO-NEW"
-    assert by_field["expected_arrival_date"].old == "2026-01-01T00:00:00+00:00"
-    assert by_field["expected_arrival_date"].new == "2026-02-15T00:00:00+00:00"
+    return _patch
 
 
 @pytest.mark.asyncio
-async def test_update_purchase_order_requires_at_least_one_field():
+async def test_modify_po_requires_at_least_one_subpayload():
     context, _ = create_mock_context()
-    with pytest.raises(ValueError, match="At least one field"):
-        await _update_purchase_order_impl(
-            UpdatePurchaseOrderRequest(id=42, confirm=False), context
+    with pytest.raises(ValueError, match="At least one sub-payload"):
+        await _modify_purchase_order_impl(
+            ModifyPurchaseOrderRequest(id=42, confirm=False), context
         )
 
 
 @pytest.mark.asyncio
-async def test_update_purchase_order_preview_when_fetch_fails():
-    """When the diff fetch fails, preview marks fields ``is_unknown_prior``.
+async def test_modify_po_preview_emits_planned_actions(patch_fetch_po):
+    """Preview returns one ActionResult per planned API call, all succeeded=None."""
+    context, _ = create_mock_context()
+    existing = create_mock_po(order_id=42, order_no="PO-OLD", rows=[])
+    existing.expected_arrival_date = datetime(2026, 1, 1, tzinfo=UTC)
 
-    Regression test for the original ambiguity where fetch failure was
-    indistinguishable from a missing field — the preview would imply
-    "field was empty before" rather than "we couldn't read prior state".
-    """
+    with patch_fetch_po(existing):
+        # Use distinct row ids per update so prefetch helpers see real ids
+        request = ModifyPurchaseOrderRequest(
+            id=42,
+            update_header=PurchaseOrderHeaderPatch(
+                expected_arrival_date=datetime(2026, 2, 15, tzinfo=UTC)
+            ),
+            add_rows=[NewPORow(variant_id=100, quantity=10, price_per_unit=5.0)],
+            confirm=False,
+        )
+        # Stub the row prefetch so update_rows doesn't error here (no update_rows in this case)
+        response = await _modify_purchase_order_impl(request, context)
+
+    assert response.is_preview is True
+    assert response.entity_id == 42
+    assert len(response.actions) == 2
+    assert response.actions[0].operation == "update_header"
+    assert response.actions[1].operation == "add_row"
+    # All planned (succeeded=None)
+    assert all(a.succeeded is None for a in response.actions)
+
+
+@pytest.mark.asyncio
+async def test_modify_po_confirm_executes_plan_in_canonical_order(patch_fetch_po):
+    """Header → row adds → row updates → row deletes → cost adds/updates/deletes."""
+    context, _ = create_mock_context()
+
+    existing = create_mock_po(order_id=42, order_no="PO-1", rows=[])
+    updated_po = create_mock_po(order_id=42, order_no="PO-1", rows=[])
+    updated_po.expected_arrival_date = datetime(2026, 2, 15, tzinfo=UTC)
+    new_row = MagicMock()
+    new_row.id = 555
+
+    call_log: list[str] = []
+
+    async def fake_update_po(*, id, client, body):
+        call_log.append("PATCH /purchase_orders/{id}")
+        resp = MagicMock()
+        resp.parsed = updated_po
+        return resp
+
+    async def fake_create_row(*, client, body):
+        call_log.append("POST /purchase_order_rows")
+        resp = MagicMock()
+        resp.parsed = new_row
+        return resp
+
+    with (
+        patch_fetch_po(existing),
+        patch(f"{_PO_UPDATE}.asyncio_detailed", side_effect=fake_update_po),
+        patch(f"{_PO_ROW_CREATE}.asyncio_detailed", side_effect=fake_create_row),
+        patch(_PO_UNWRAP_AS, side_effect=[updated_po, new_row]),
+    ):
+        request = ModifyPurchaseOrderRequest(
+            id=42,
+            update_header=PurchaseOrderHeaderPatch(
+                expected_arrival_date=datetime(2026, 2, 15, tzinfo=UTC)
+            ),
+            add_rows=[NewPORow(variant_id=100, quantity=10, price_per_unit=5.0)],
+            confirm=True,
+        )
+        response = await _modify_purchase_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert len(response.actions) == 2
+    assert all(a.succeeded is True for a in response.actions)
+    # Header runs before row add (canonical order)
+    assert call_log[0].startswith("PATCH")
+    assert call_log[1].startswith("POST")
+    # prior_state captured the pre-modification PO snapshot
+    assert response.prior_state is not None
+
+
+@pytest.mark.asyncio
+async def test_modify_po_fail_fast_halts_on_first_error(patch_fetch_po):
+    """When the row-create fails, the header-update result is preserved
+    but no further actions run."""
+    context, _ = create_mock_context()
+    existing = create_mock_po(order_id=42, order_no="PO-1", rows=[])
+    updated_po = create_mock_po(order_id=42, order_no="PO-1", rows=[])
+
+    with (
+        patch_fetch_po(existing),
+        patch(f"{_PO_UPDATE}.asyncio_detailed", new_callable=AsyncMock),
+        patch(
+            f"{_PO_ROW_CREATE}.asyncio_detailed",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ),
+        patch(_PO_UNWRAP_AS, return_value=updated_po),
+    ):
+        request = ModifyPurchaseOrderRequest(
+            id=42,
+            update_header=PurchaseOrderHeaderPatch(order_no="PO-NEW"),
+            add_rows=[NewPORow(variant_id=100, quantity=10, price_per_unit=5.0)],
+            confirm=True,
+        )
+        response = await _modify_purchase_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert len(response.actions) == 2
+    assert response.actions[0].succeeded is True
+    assert response.actions[1].succeeded is False
+    assert "boom" in (response.actions[1].error or "")
+
+
+@pytest.mark.asyncio
+async def test_modify_po_preview_when_fetch_fails_marks_unknown_prior():
+    """Fetch failure → diff fields marked is_unknown_prior + warning surfaced."""
     context, _ = create_mock_context()
 
     with patch(
@@ -2632,62 +2701,92 @@ async def test_update_purchase_order_preview_when_fetch_fails():
         new_callable=AsyncMock,
         return_value=None,
     ):
-        request = UpdatePurchaseOrderRequest(id=42, order_no="PO-NEW", confirm=False)
-        response = await _update_purchase_order_impl(request, context)
+        request = ModifyPurchaseOrderRequest(
+            id=42,
+            update_header=PurchaseOrderHeaderPatch(order_no="PO-NEW"),
+            confirm=False,
+        )
+        response = await _modify_purchase_order_impl(request, context)
 
     assert response.is_preview is True
-    by_field = {c.field: c for c in response.changes}
-    assert by_field["order_no"].is_unknown_prior is True
-    assert by_field["order_no"].is_added is False
     assert any("diff context" in w for w in response.warnings)
+    # The diff entries on the planned action carry is_unknown_prior=True
+    diffs = response.actions[0].changes
+    assert all(c.is_unknown_prior for c in diffs)
 
 
 @pytest.mark.asyncio
-async def test_update_purchase_order_confirm_applies_status_via_same_tool():
-    """Status is folded into update_purchase_order — no separate status tool."""
+async def test_modify_po_row_update_fetches_row_for_diff(patch_fetch_po):
+    """Update-row sub-payload triggers a per-row prefetch for accurate diff."""
     context, _ = create_mock_context()
-
-    updated = create_mock_po(order_id=42, order_no="PO-NEW", rows=[])
+    existing_po = create_mock_po(order_id=42, order_no="PO-1", rows=[])
+    existing_row = MagicMock()
+    existing_row.purchase_order_id = 42
+    existing_row.quantity = 10
+    existing_row.price_per_unit = 5.0
+    updated_row = MagicMock()
+    updated_row.id = 555
+    updated_row.quantity = 15
 
     with (
-        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock),
-        patch(f"{_PO_UPDATE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
-        patch(_PO_UNWRAP_AS, return_value=updated),
+        patch_fetch_po(existing_po),
+        patch(f"{_PO_ROW_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_PO_UNWRAP_AS, return_value=existing_row),
     ):
-        request = UpdatePurchaseOrderRequest(
-            id=42, status="PARTIALLY_RECEIVED", confirm=True
+        request = ModifyPurchaseOrderRequest(
+            id=42,
+            update_rows=[PORowUpdate(id=555, quantity=15)],
+            confirm=False,
         )
-        response = await _update_purchase_order_impl(request, context)
+        response = await _modify_purchase_order_impl(request, context)
 
-    assert response.is_preview is False
-    assert response.entity_id == 42
-    # The PATCH carries the API enum value, not the user-facing literal.
-    body = mock_api.await_args.kwargs["body"]
-    assert body.status.value == "PARTIALLY_RECEIVED"
+    assert response.is_preview is True
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "update_row"
+    assert response.actions[0].target_id == 555
+    diff_by_field = {c.field: c for c in response.actions[0].changes}
+    assert diff_by_field["quantity"].old == 10
+    assert diff_by_field["quantity"].new == 15
+
+
+# ============================================================================
+# delete_purchase_order — destructive sibling
+# ============================================================================
 
 
 @pytest.mark.asyncio
-async def test_delete_purchase_order_preview():
+async def test_delete_po_preview_returns_planned_action():
     context, _ = create_mock_context()
-    response = await _delete_purchase_order_impl(
-        DeletePurchaseOrderRequest(id=42, confirm=False), context
-    )
+    existing = create_mock_po(order_id=42, order_no="PO-1", rows=[])
+    request = DeletePurchaseOrderRequest(id=42, confirm=False)
+
+    with patch(
+        "katana_mcp.tools.foundation.purchase_orders._fetch_purchase_order_attrs",
+        new_callable=AsyncMock,
+        return_value=existing,
+    ):
+        response = await _delete_purchase_order_impl(request, context)
 
     assert response.is_preview is True
     assert response.entity_id == 42
-    assert response.operation == "delete"
-    assert "Preview" in response.message
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "delete"
+    assert response.actions[0].succeeded is None  # planned, not run
 
 
 @pytest.mark.asyncio
-async def test_delete_purchase_order_confirm_calls_api():
+async def test_delete_po_confirm_calls_api_and_records_prior_state():
     context, _ = create_mock_context()
-
+    existing = create_mock_po(order_id=42, order_no="PO-1", rows=[])
     api_response = MagicMock()
     api_response.status_code = 204
-    api_response.parsed = None
 
     with (
+        patch(
+            "katana_mcp.tools.foundation.purchase_orders._fetch_purchase_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
         patch(f"{_PO_DELETE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
         patch(
             "katana_mcp.tools.foundation.purchase_orders.is_success",
@@ -2700,373 +2799,9 @@ async def test_delete_purchase_order_confirm_calls_api():
         )
 
     assert response.is_preview is False
+    assert response.actions[0].succeeded is True
+    # prior_state captured even for delete (so caller can recreate manually)
+    assert response.prior_state is not None
+    # On successful delete the entity URL is dropped (resource is gone)
+    assert response.katana_url is None
     mock_api.assert_awaited_once()
-    assert mock_api.await_args.kwargs["id"] == 42
-
-
-# ============================================================================
-# Modification tools — purchase_order_row (add / update / delete)
-# ============================================================================
-
-
-@pytest.mark.asyncio
-async def test_add_purchase_order_row_preview():
-    context, _ = create_mock_context()
-
-    request = AddPurchaseOrderRowRequest(
-        purchase_order_id=42,
-        variant_id=100,
-        quantity=10,
-        price_per_unit=5.0,
-        confirm=False,
-    )
-    response = await _add_purchase_order_row_impl(request, context)
-
-    assert response.is_preview is True
-    assert response.parent_entity_id == 42
-    assert response.entity_id is None
-    assert response.operation == "create_row"
-    # Every supplied field reports as added (no existing row to diff against)
-    by_field = {c.field: c for c in response.changes}
-    assert by_field["variant_id"].is_added is True
-    assert by_field["variant_id"].new == 100
-
-
-@pytest.mark.asyncio
-async def test_add_purchase_order_row_confirm_calls_api():
-    context, _ = create_mock_context()
-
-    new_row = MagicMock()
-    new_row.id = 555
-
-    with (
-        patch(f"{_PO_ROW_CREATE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
-        patch(_PO_UNWRAP_AS, return_value=new_row),
-    ):
-        request = AddPurchaseOrderRowRequest(
-            purchase_order_id=42,
-            variant_id=100,
-            quantity=10,
-            price_per_unit=5.0,
-            confirm=True,
-        )
-        response = await _add_purchase_order_row_impl(request, context)
-
-    assert response.is_preview is False
-    assert response.entity_id == 555
-    body = mock_api.await_args.kwargs["body"]
-    assert body.purchase_order_id == 42
-    assert body.variant_id == 100
-
-
-@pytest.mark.asyncio
-async def test_update_purchase_order_row_preview_uses_existing_for_diff():
-    context, _ = create_mock_context()
-
-    existing = MagicMock()
-    existing.purchase_order_id = 42
-    existing.quantity = 10
-    existing.price_per_unit = 5.0
-    existing.arrival_date = UNSET
-
-    with (
-        patch(f"{_PO_ROW_GET}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_PO_UNWRAP_AS, return_value=existing),
-    ):
-        request = UpdatePurchaseOrderRowRequest(
-            id=555,
-            quantity=15,
-            arrival_date=datetime(2026, 3, 1, tzinfo=UTC),
-            confirm=False,
-        )
-        response = await _update_purchase_order_row_impl(request, context)
-
-    assert response.is_preview is True
-    assert response.entity_id == 555
-    assert response.parent_entity_id == 42
-    by_field = {c.field: c for c in response.changes}
-    assert by_field["quantity"].old == 10
-    assert by_field["quantity"].new == 15
-    assert by_field["arrival_date"].is_added is True
-
-
-@pytest.mark.asyncio
-async def test_update_purchase_order_row_requires_at_least_one_field():
-    context, _ = create_mock_context()
-    with pytest.raises(ValueError, match="At least one field"):
-        await _update_purchase_order_row_impl(
-            UpdatePurchaseOrderRowRequest(id=555, confirm=False), context
-        )
-
-
-@pytest.mark.asyncio
-async def test_update_purchase_order_row_confirm_calls_api():
-    context, _ = create_mock_context()
-
-    existing = MagicMock()
-    existing.purchase_order_id = 42
-    existing.quantity = 10
-    updated = MagicMock()
-    updated.id = 555
-
-    # First call (in _fetch_purchase_order_row) returns the existing row;
-    # second call (the actual update) returns the updated row. We patch
-    # unwrap_as to feed both deterministically.
-    with (
-        patch(f"{_PO_ROW_GET}.asyncio_detailed", new_callable=AsyncMock),
-        patch(f"{_PO_ROW_UPDATE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
-        patch(_PO_UNWRAP_AS, side_effect=[existing, updated]),
-    ):
-        request = UpdatePurchaseOrderRowRequest(id=555, quantity=20, confirm=True)
-        response = await _update_purchase_order_row_impl(request, context)
-
-    assert response.is_preview is False
-    assert response.entity_id == 555
-    assert response.parent_entity_id == 42
-    body = mock_api.await_args.kwargs["body"]
-    assert body.quantity == 20
-
-
-@pytest.mark.asyncio
-async def test_update_purchase_order_row_recovers_parent_id_when_prefetch_fails():
-    """When the pre-update fetch fails, the confirm response still carries
-    parent_id by reading purchase_order_id off the PATCH response.
-
-    Without this fallback, a successful row update following a fetch failure
-    would return a well-formed entity_id but ``parent_entity_id=None`` and
-    ``katana_url=None`` — missing context that the API just gave us.
-    """
-    context, _ = create_mock_context()
-
-    updated = MagicMock()
-    updated.id = 555
-    updated.purchase_order_id = 42
-
-    with (
-        # Pre-update fetch returns None to simulate failure
-        patch(
-            "katana_mcp.tools.foundation.purchase_orders._fetch_purchase_order_row",
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch(f"{_PO_ROW_UPDATE}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_PO_UNWRAP_AS, return_value=updated),
-    ):
-        request = UpdatePurchaseOrderRowRequest(id=555, quantity=20, confirm=True)
-        response = await _update_purchase_order_row_impl(request, context)
-
-    assert response.is_preview is False
-    assert response.entity_id == 555
-    # Recovered from updated.purchase_order_id rather than the failed prefetch
-    assert response.parent_entity_id == 42
-    assert response.katana_url is not None
-    assert "42" in response.katana_url
-
-
-@pytest.mark.asyncio
-async def test_delete_purchase_order_row_preview():
-    context, _ = create_mock_context()
-
-    existing = MagicMock()
-    existing.purchase_order_id = 42
-
-    with (
-        patch(f"{_PO_ROW_GET}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_PO_UNWRAP_AS, return_value=existing),
-    ):
-        response = await _delete_purchase_order_row_impl(
-            DeletePurchaseOrderRowRequest(id=555, confirm=False), context
-        )
-
-    assert response.is_preview is True
-    assert response.entity_id == 555
-    assert response.parent_entity_id == 42
-
-
-@pytest.mark.asyncio
-async def test_delete_purchase_order_row_confirm_calls_api():
-    context, _ = create_mock_context()
-
-    existing = MagicMock()
-    existing.purchase_order_id = 42
-
-    api_response = MagicMock()
-    api_response.status_code = 204
-    api_response.parsed = None
-
-    with (
-        patch(f"{_PO_ROW_GET}.asyncio_detailed", new_callable=AsyncMock),
-        patch(f"{_PO_ROW_DELETE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
-        patch(_PO_UNWRAP_AS, return_value=existing),
-        patch(
-            "katana_mcp.tools.foundation.purchase_orders.is_success",
-            return_value=True,
-        ),
-    ):
-        mock_api.return_value = api_response
-        response = await _delete_purchase_order_row_impl(
-            DeletePurchaseOrderRowRequest(id=555, confirm=True), context
-        )
-
-    assert response.is_preview is False
-    mock_api.assert_awaited_once()
-    assert mock_api.await_args.kwargs["id"] == 555
-
-
-# ============================================================================
-# Modification tools — purchase_order_additional_cost (add / update / delete)
-# ============================================================================
-
-
-@pytest.mark.asyncio
-async def test_add_additional_cost_resolves_default_group_id():
-    """When given a PO id, the tool looks up its default_group_id."""
-    context, _ = create_mock_context()
-
-    existing_po = create_mock_po(order_id=42, order_no="PO-1", rows=[])
-    existing_po.default_group_id = 21
-    new_row = MagicMock()
-    new_row.id = 999
-
-    with (
-        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock),
-        patch(
-            f"{_PO_COST_CREATE}.asyncio_detailed", new_callable=AsyncMock
-        ) as mock_api,
-        patch(_PO_UNWRAP_AS, side_effect=[existing_po, new_row]),
-    ):
-        request = AddPurchaseOrderAdditionalCostRequest(
-            purchase_order_id=42,
-            additional_cost_id=11,
-            tax_rate_id=31,
-            price=125.0,
-            distribution_method="BY_VALUE",
-            confirm=True,
-        )
-        response = await _add_purchase_order_additional_cost_impl(request, context)
-
-    assert response.is_preview is False
-    assert response.entity_id == 999
-    body = mock_api.await_args.kwargs["body"]
-    assert body.group_id == 21  # from default_group_id
-    assert body.distribution_method.value == "BY_VALUE"
-
-
-@pytest.mark.asyncio
-async def test_add_additional_cost_requires_po_or_group_id():
-    context, _ = create_mock_context()
-    with pytest.raises(ValueError, match="purchase_order_id or group_id"):
-        await _add_purchase_order_additional_cost_impl(
-            AddPurchaseOrderAdditionalCostRequest(
-                additional_cost_id=11,
-                tax_rate_id=31,
-                price=125.0,
-                confirm=False,
-            ),
-            context,
-        )
-
-
-@pytest.mark.asyncio
-async def test_update_additional_cost_preview():
-    context, _ = create_mock_context()
-
-    existing = MagicMock()
-    existing.additional_cost_id = 11
-    existing.tax_rate_id = 31
-    existing.price = 100.0
-    existing.distribution_method = "BY_VALUE"
-
-    with (
-        patch(
-            "katana_public_api_client.api.purchase_order_additional_cost_row."
-            "get_po_additional_cost_row.asyncio_detailed",
-            new_callable=AsyncMock,
-        ),
-        patch(_PO_UNWRAP_AS, return_value=existing),
-    ):
-        request = UpdatePurchaseOrderAdditionalCostRequest(
-            id=99, price=150.0, confirm=False
-        )
-        response = await _update_purchase_order_additional_cost_impl(request, context)
-
-    assert response.is_preview is True
-    assert response.entity_id == 99
-    by_field = {c.field: c for c in response.changes}
-    assert by_field["price"].old == 100.0
-    assert by_field["price"].new == 150.0
-
-
-@pytest.mark.asyncio
-async def test_update_additional_cost_confirm_calls_api():
-    context, _ = create_mock_context()
-    updated = MagicMock()
-    updated.id = 99
-
-    with (
-        patch(
-            "katana_public_api_client.api.purchase_order_additional_cost_row."
-            "get_po_additional_cost_row.asyncio_detailed",
-            new_callable=AsyncMock,
-        ),
-        patch(
-            f"{_PO_COST_UPDATE}.asyncio_detailed", new_callable=AsyncMock
-        ) as mock_api,
-        # The first unwrap_as call (fetch existing) raises — we exercise the
-        # best-effort fallback path. The second returns the updated row.
-        patch(_PO_UNWRAP_AS, side_effect=[Exception("boom"), updated]),
-    ):
-        request = UpdatePurchaseOrderAdditionalCostRequest(
-            id=99, price=150.0, confirm=True
-        )
-        response = await _update_purchase_order_additional_cost_impl(request, context)
-
-    assert response.is_preview is False
-    body = mock_api.await_args.kwargs["body"]
-    assert body.price == 150.0
-
-
-@pytest.mark.asyncio
-async def test_update_additional_cost_requires_at_least_one_field():
-    context, _ = create_mock_context()
-    with pytest.raises(ValueError, match="At least one field"):
-        await _update_purchase_order_additional_cost_impl(
-            UpdatePurchaseOrderAdditionalCostRequest(id=99, confirm=False),
-            context,
-        )
-
-
-@pytest.mark.asyncio
-async def test_delete_additional_cost_preview():
-    context, _ = create_mock_context()
-    response = await _delete_purchase_order_additional_cost_impl(
-        DeletePurchaseOrderAdditionalCostRequest(id=99, confirm=False), context
-    )
-    assert response.is_preview is True
-    assert response.entity_id == 99
-
-
-@pytest.mark.asyncio
-async def test_delete_additional_cost_confirm_calls_api():
-    context, _ = create_mock_context()
-
-    api_response = MagicMock()
-    api_response.status_code = 204
-
-    with (
-        patch(
-            f"{_PO_COST_DELETE}.asyncio_detailed", new_callable=AsyncMock
-        ) as mock_api,
-        patch(
-            "katana_mcp.tools.foundation.purchase_orders.is_success",
-            return_value=True,
-        ),
-    ):
-        mock_api.return_value = api_response
-        response = await _delete_purchase_order_additional_cost_impl(
-            DeletePurchaseOrderAdditionalCostRequest(id=99, confirm=True), context
-        )
-
-    assert response.is_preview is False
-    mock_api.assert_awaited_once()
-    assert mock_api.await_args.kwargs["id"] == 99

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -1558,7 +1558,8 @@ _MODIFY_SO_DELETE = "katana_public_api_client.api.sales_order.delete_sales_order
 _MODIFY_SO_ROW_CREATE = (
     "katana_public_api_client.api.sales_order_row.create_sales_order_row"
 )
-_MODIFY_SO_UNWRAP_AS_LOCAL = "katana_mcp.tools.foundation.sales_orders.unwrap_as"
+# The modify/delete dispatcher pipes through ``_modification_dispatch.unwrap_as``.
+_MODIFY_SO_UNWRAP_AS_LOCAL = "katana_mcp.tools._modification_dispatch.unwrap_as"
 
 
 def _mock_so(order_id: int = 1, order_no: str = "SO-1"):
@@ -1780,7 +1781,7 @@ async def test_delete_so_confirm_calls_api_and_records_prior_state():
             f"{_MODIFY_SO_DELETE}.asyncio_detailed", new_callable=AsyncMock
         ) as mock_api,
         patch(
-            "katana_mcp.tools.foundation.sales_orders.is_success",
+            "katana_mcp.tools._modification_dispatch.is_success",
             return_value=True,
         ),
     ):

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -7,13 +7,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from katana_mcp.tools.foundation.sales_orders import (
     CreateSalesOrderRequest,
+    DeleteSalesOrderRequest,
     GetSalesOrderRequest,
     ListSalesOrdersRequest,
+    ModifySalesOrderRequest,
     SalesOrderAddress,
     SalesOrderItem,
+    SOHeaderPatch,
+    SORowAdd,
     _create_sales_order_impl,
+    _delete_sales_order_impl,
     _get_sales_order_impl,
     _list_sales_orders_impl,
+    _modify_sales_order_impl,
     get_sales_order,
     list_sales_orders,
 )
@@ -1538,3 +1544,253 @@ async def test_get_sales_order_format_json_returns_json():
     data = json.loads(_content_text(result))
     assert data["id"] == 9
     assert data["order_no"] == "SO-9"
+
+
+# ============================================================================
+# modify_sales_order — unified modification surface
+# ============================================================================
+
+
+# Note: _SO_GET, _SO_UNWRAP_AS, _SO_UNWRAP_DATA are defined at top of file
+# (around line 572). Adding only the constants the modify/delete tests need.
+_MODIFY_SO_UPDATE = "katana_public_api_client.api.sales_order.update_sales_order"
+_MODIFY_SO_DELETE = "katana_public_api_client.api.sales_order.delete_sales_order"
+_MODIFY_SO_ROW_CREATE = (
+    "katana_public_api_client.api.sales_order_row.create_sales_order_row"
+)
+_MODIFY_SO_UNWRAP_AS_LOCAL = "katana_mcp.tools.foundation.sales_orders.unwrap_as"
+
+
+def _mock_so(order_id: int = 1, order_no: str = "SO-1"):
+    """Build a mock SalesOrder attrs object — every UNSET-able field defaults
+    to UNSET so unwrap_unset → None during diff computation."""
+    so = MagicMock(spec=SalesOrder)
+    so.id = order_id
+    so.order_no = order_no
+    for field in (
+        "customer_id",
+        "location_id",
+        "status",
+        "currency",
+        "conversion_rate",
+        "conversion_date",
+        "order_created_date",
+        "delivery_date",
+        "picked_date",
+        "additional_info",
+        "customer_ref",
+        "tracking_number",
+        "tracking_number_url",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+    ):
+        setattr(so, field, UNSET)
+    return so
+
+
+@pytest.mark.asyncio
+async def test_modify_so_requires_at_least_one_subpayload():
+    context, _ = create_mock_context()
+    with pytest.raises(ValueError, match="At least one sub-payload"):
+        await _modify_sales_order_impl(
+            ModifySalesOrderRequest(id=42, confirm=False), context
+        )
+
+
+@pytest.mark.asyncio
+async def test_modify_so_preview_emits_planned_actions():
+    """Preview returns one ActionResult per planned API call, all succeeded=None."""
+    context, _ = create_mock_context()
+    existing = _mock_so(order_id=42, order_no="SO-OLD")
+
+    with patch(
+        "katana_mcp.tools.foundation.sales_orders._fetch_sales_order_attrs",
+        new_callable=AsyncMock,
+        return_value=existing,
+    ):
+        request = ModifySalesOrderRequest(
+            id=42,
+            update_header=SOHeaderPatch(status="PACKED"),
+            add_rows=[SORowAdd(variant_id=100, quantity=2)],
+            confirm=False,
+        )
+        response = await _modify_sales_order_impl(request, context)
+
+    assert response.is_preview is True
+    assert response.entity_id == 42
+    assert len(response.actions) == 2
+    assert response.actions[0].operation == "update_header"
+    assert response.actions[1].operation == "add_row"
+    assert all(a.succeeded is None for a in response.actions)
+
+
+@pytest.mark.asyncio
+async def test_modify_so_confirm_executes_in_canonical_order():
+    """Header → row adds → row updates → row deletes → addresses → fulfillments → fees."""
+    context, _ = create_mock_context()
+    existing = _mock_so(order_id=42, order_no="SO-1")
+    updated_so = _mock_so(order_id=42, order_no="SO-1")
+    new_row = MagicMock()
+    new_row.id = 555
+
+    call_log: list[str] = []
+
+    async def fake_update_so(*, id, client, body):
+        call_log.append("PATCH /sales_orders/{id}")
+        resp = MagicMock()
+        resp.parsed = updated_so
+        return resp
+
+    async def fake_create_row(*, client, body):
+        call_log.append("POST /sales_order_rows")
+        resp = MagicMock()
+        resp.parsed = new_row
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.sales_orders._fetch_sales_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(f"{_MODIFY_SO_UPDATE}.asyncio_detailed", side_effect=fake_update_so),
+        patch(f"{_MODIFY_SO_ROW_CREATE}.asyncio_detailed", side_effect=fake_create_row),
+        patch(_MODIFY_SO_UNWRAP_AS_LOCAL, side_effect=[updated_so, new_row]),
+    ):
+        request = ModifySalesOrderRequest(
+            id=42,
+            update_header=SOHeaderPatch(status="PACKED"),
+            add_rows=[SORowAdd(variant_id=100, quantity=2)],
+            confirm=True,
+        )
+        response = await _modify_sales_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert all(a.succeeded is True for a in response.actions)
+    assert call_log[0].startswith("PATCH")
+    assert call_log[1].startswith("POST")
+    assert response.prior_state is not None
+
+
+@pytest.mark.asyncio
+async def test_modify_so_address_update_marks_unknown_prior():
+    """Address has no get-by-id endpoint, so update previews always show
+    ``is_unknown_prior=True`` for the supplied fields."""
+    context, _ = create_mock_context()
+    existing = _mock_so(order_id=42, order_no="SO-1")
+
+    with patch(
+        "katana_mcp.tools.foundation.sales_orders._fetch_sales_order_attrs",
+        new_callable=AsyncMock,
+        return_value=existing,
+    ):
+        from katana_mcp.tools.foundation.sales_orders import SOAddressUpdate
+
+        request = ModifySalesOrderRequest(
+            id=42,
+            update_addresses=[
+                SOAddressUpdate(id=99, city="Springfield", zip="12345"),
+            ],
+            confirm=False,
+        )
+        response = await _modify_sales_order_impl(request, context)
+
+    assert response.is_preview is True
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "update_address"
+    diffs = response.actions[0].changes
+    assert all(c.is_unknown_prior for c in diffs)
+
+
+@pytest.mark.asyncio
+async def test_modify_so_fail_fast_halts_on_first_error():
+    context, _ = create_mock_context()
+    existing = _mock_so(order_id=42, order_no="SO-1")
+    updated_so = _mock_so(order_id=42, order_no="SO-1")
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.sales_orders._fetch_sales_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(f"{_MODIFY_SO_UPDATE}.asyncio_detailed", new_callable=AsyncMock),
+        patch(
+            f"{_MODIFY_SO_ROW_CREATE}.asyncio_detailed",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ),
+        patch(_MODIFY_SO_UNWRAP_AS_LOCAL, return_value=updated_so),
+    ):
+        request = ModifySalesOrderRequest(
+            id=42,
+            update_header=SOHeaderPatch(status="PACKED"),
+            add_rows=[SORowAdd(variant_id=100, quantity=2)],
+            confirm=True,
+        )
+        response = await _modify_sales_order_impl(request, context)
+
+    assert len(response.actions) == 2
+    assert response.actions[0].succeeded is True
+    assert response.actions[1].succeeded is False
+    assert "boom" in (response.actions[1].error or "")
+
+
+# ============================================================================
+# delete_sales_order — destructive sibling
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_so_preview_returns_planned_action():
+    context, _ = create_mock_context()
+    existing = _mock_so(order_id=42, order_no="SO-1")
+
+    with patch(
+        "katana_mcp.tools.foundation.sales_orders._fetch_sales_order_attrs",
+        new_callable=AsyncMock,
+        return_value=existing,
+    ):
+        response = await _delete_sales_order_impl(
+            DeleteSalesOrderRequest(id=42, confirm=False), context
+        )
+
+    assert response.is_preview is True
+    assert response.entity_id == 42
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "delete"
+    assert response.actions[0].succeeded is None
+
+
+@pytest.mark.asyncio
+async def test_delete_so_confirm_calls_api_and_records_prior_state():
+    context, _ = create_mock_context()
+    existing = _mock_so(order_id=42, order_no="SO-1")
+    api_response = MagicMock()
+    api_response.status_code = 204
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.sales_orders._fetch_sales_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            f"{_MODIFY_SO_DELETE}.asyncio_detailed", new_callable=AsyncMock
+        ) as mock_api,
+        patch(
+            "katana_mcp.tools.foundation.sales_orders.is_success",
+            return_value=True,
+        ),
+    ):
+        mock_api.return_value = api_response
+        response = await _delete_sales_order_impl(
+            DeleteSalesOrderRequest(id=42, confirm=True), context
+        )
+
+    assert response.is_preview is False
+    assert response.actions[0].succeeded is True
+    assert response.prior_state is not None
+    assert response.katana_url is None  # entity gone
+    mock_api.assert_awaited_once()

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -31,7 +31,12 @@ from katana_public_api_client.models import (
 )
 from katana_public_api_client.utils import APIError
 from tests.conftest import create_mock_context, patch_typed_cache_sync
-from tests.factories import make_sales_order, make_sales_order_row, seed_cache
+from tests.factories import (
+    make_sales_order,
+    make_sales_order_row,
+    mock_entity_for_modify,
+    seed_cache,
+)
 
 # ============================================================================
 # Unit Tests (with mocks)
@@ -1563,31 +1568,8 @@ _MODIFY_SO_UNWRAP_AS_LOCAL = "katana_mcp.tools._modification_dispatch.unwrap_as"
 
 
 def _mock_so(order_id: int = 1, order_no: str = "SO-1"):
-    """Build a mock SalesOrder attrs object — every UNSET-able field defaults
-    to UNSET so unwrap_unset → None during diff computation."""
-    so = MagicMock(spec=SalesOrder)
-    so.id = order_id
-    so.order_no = order_no
-    for field in (
-        "customer_id",
-        "location_id",
-        "status",
-        "currency",
-        "conversion_rate",
-        "conversion_date",
-        "order_created_date",
-        "delivery_date",
-        "picked_date",
-        "additional_info",
-        "customer_ref",
-        "tracking_number",
-        "tracking_number_url",
-        "created_at",
-        "updated_at",
-        "deleted_at",
-    ):
-        setattr(so, field, UNSET)
-    return so
+    """Build a mock SalesOrder attrs object with all fields defaulted to UNSET."""
+    return mock_entity_for_modify(SalesOrder, id=order_id, order_no=order_no)
 
 
 @pytest.mark.asyncio

--- a/katana_mcp_server/tests/tools/test_stock_transfers.py
+++ b/katana_mcp_server/tests/tools/test_stock_transfers.py
@@ -90,25 +90,6 @@ def _make_mock_transfer(
     return t
 
 
-def _make_mock_row(
-    *,
-    id: int = 1,
-    variant_id: int = 100,
-    quantity: float = 5,
-    cost_per_unit: float | None = None,
-    batch_transactions: list | None = None,
-) -> MagicMock:
-    r = MagicMock()
-    r.id = id
-    r.variant_id = variant_id
-    r.quantity = quantity
-    r.cost_per_unit = cost_per_unit if cost_per_unit is not None else UNSET
-    r.batch_transactions = (
-        batch_transactions if batch_transactions is not None else UNSET
-    )
-    return r
-
-
 # ============================================================================
 # create_stock_transfer
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_stock_transfers.py
+++ b/katana_mcp_server/tests/tools/test_stock_transfers.py
@@ -1,10 +1,9 @@
-"""Tests for stock transfer MCP tools (issue #338).
+"""Tests for stock transfer MCP tools.
 
-Covers the full five-tool surface:
+Covers the unified four-tool surface:
 - create_stock_transfer (preview + confirm)
 - list_stock_transfers (list-tool pattern v2 — limit, page, dates, filters)
-- update_stock_transfer (preview + confirm)
-- update_stock_transfer_status (preview + confirm + invalid-transition error)
+- modify_stock_transfer (header + status, preview + confirm + multi-action)
 - delete_stock_transfer (preview + confirm)
 """
 
@@ -19,15 +18,15 @@ from katana_mcp.tools.foundation.stock_transfers import (
     CreateStockTransferRequest,
     DeleteStockTransferRequest,
     ListStockTransfersRequest,
+    ModifyStockTransferRequest,
     StockTransferBatchTransactionInput,
+    StockTransferHeaderPatch,
     StockTransferRowInput,
-    UpdateStockTransferRequest,
-    UpdateStockTransferStatusRequest,
+    StockTransferStatusPatch,
     _create_stock_transfer_impl,
     _delete_stock_transfer_impl,
     _list_stock_transfers_impl,
-    _update_stock_transfer_impl,
-    _update_stock_transfer_status_impl,
+    _modify_stock_transfer_impl,
     list_stock_transfers,
 )
 
@@ -50,7 +49,11 @@ _ST_DELETE = "katana_public_api_client.api.stock_transfer.delete_stock_transfer"
 
 _ST_UNWRAP_AS = "katana_mcp.tools.foundation.stock_transfers.unwrap_as"
 _ST_UNWRAP_DATA = "katana_public_api_client.utils.unwrap_data"
-_ST_IS_SUCCESS = "katana_mcp.tools.foundation.stock_transfers.is_success"
+
+# The modify/delete dispatcher pipes through ``_modification_dispatch.unwrap_as``
+# and ``is_success`` — modify tests patch those instead of the local re-import.
+_MODIFY_ST_UNWRAP_AS = "katana_mcp.tools._modification_dispatch.unwrap_as"
+_MODIFY_ST_IS_SUCCESS = "katana_mcp.tools._modification_dispatch.is_success"
 
 
 # ============================================================================
@@ -517,127 +520,163 @@ async def test_list_stock_transfers_no_pagination_when_page_not_set(
 
 
 # ============================================================================
-# update_stock_transfer
+# modify_stock_transfer — unified header + status surface
 # ============================================================================
 
 
 @pytest.mark.asyncio
-async def test_update_stock_transfer_preview():
+async def test_modify_st_requires_at_least_one_subpayload():
     context, _ = create_mock_context()
+    with pytest.raises(ValueError, match="At least one sub-payload"):
+        await _modify_stock_transfer_impl(
+            ModifyStockTransferRequest(id=42, confirm=False), context
+        )
 
-    request = UpdateStockTransferRequest(
+
+@pytest.mark.asyncio
+async def test_modify_st_header_preview_emits_planned_action():
+    context, _ = create_mock_context()
+    request = ModifyStockTransferRequest(
         id=42,
-        stock_transfer_number="ST-42-revised",
-        additional_info="Updated notes",
+        update_header=StockTransferHeaderPatch(
+            stock_transfer_number="ST-42-revised",
+            additional_info="Updated notes",
+        ),
         confirm=False,
     )
-    result = await _update_stock_transfer_impl(request, context)
+    response = await _modify_stock_transfer_impl(request, context)
 
-    assert result.is_preview is True
-    assert result.id == 42
-    assert "Preview" in result.message
-    assert "stock_transfer_number" in result.message
-
-
-@pytest.mark.asyncio
-async def test_update_stock_transfer_requires_at_least_one_field():
-    context, _ = create_mock_context()
-
-    request = UpdateStockTransferRequest(id=42, confirm=False)
-    with pytest.raises(ValueError, match="At least one field"):
-        await _update_stock_transfer_impl(request, context)
+    assert response.is_preview is True
+    assert response.entity_id == 42
+    assert len(response.actions) == 1
+    action = response.actions[0]
+    assert action.operation == "update_header"
+    # No GET-by-id endpoint — every change is unknown_prior=True.
+    assert all(c.is_unknown_prior for c in action.changes)
 
 
 @pytest.mark.asyncio
-async def test_update_stock_transfer_confirm_success():
+async def test_modify_st_header_confirm_dispatches_to_update_endpoint():
     context, _ = create_mock_context()
-
     mock_transfer = _make_mock_transfer(
         id=42, stock_transfer_number="ST-42-revised", status="draft"
     )
-
     with (
-        patch(f"{_ST_UPDATE}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
-        patch(_ST_UNWRAP_AS, return_value=mock_transfer),
+        patch(f"{_ST_UPDATE}.asyncio_detailed", new_callable=AsyncMock) as mock_update,
+        patch(_MODIFY_ST_UNWRAP_AS, return_value=mock_transfer),
     ):
-        request = UpdateStockTransferRequest(
-            id=42, stock_transfer_number="ST-42-revised", confirm=True
+        request = ModifyStockTransferRequest(
+            id=42,
+            update_header=StockTransferHeaderPatch(
+                stock_transfer_number="ST-42-revised"
+            ),
+            confirm=True,
         )
-        result = await _update_stock_transfer_impl(request, context)
+        response = await _modify_stock_transfer_impl(request, context)
 
-    assert result.is_preview is False
-    assert result.id == 42
-    assert result.stock_transfer_number == "ST-42-revised"
-    mock_api.assert_awaited_once()
-    kwargs = mock_api.await_args.kwargs
+    assert response.is_preview is False
+    assert response.entity_id == 42
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "update_header"
+    assert response.actions[0].succeeded is True
+    mock_update.assert_awaited_once()
+    kwargs = mock_update.await_args.kwargs
     assert kwargs["id"] == 42
     assert kwargs["body"].stock_transfer_number == "ST-42-revised"
 
 
-# ============================================================================
-# update_stock_transfer_status
-# ============================================================================
-
-
 @pytest.mark.asyncio
-async def test_update_stock_transfer_status_preview():
+async def test_modify_st_status_confirm_dispatches_to_status_endpoint():
     context, _ = create_mock_context()
-
-    request = UpdateStockTransferStatusRequest(
-        id=42, new_status="IN_TRANSIT", confirm=False
-    )
-    result = await _update_stock_transfer_status_impl(request, context)
-
-    assert result.is_preview is True
-    assert result.id == 42
-    assert result.status == "IN_TRANSIT"
-    assert "Preview" in result.message
-
-
-@pytest.mark.asyncio
-async def test_update_stock_transfer_status_confirm_success():
-    context, _ = create_mock_context()
-
     mock_transfer = _make_mock_transfer(id=42, status="inTransit")
-
     with (
         patch(
             f"{_ST_UPDATE_STATUS}.asyncio_detailed", new_callable=AsyncMock
-        ) as mock_api,
-        patch(_ST_UNWRAP_AS, return_value=mock_transfer),
+        ) as mock_status,
+        patch(_MODIFY_ST_UNWRAP_AS, return_value=mock_transfer),
     ):
-        request = UpdateStockTransferStatusRequest(
-            id=42, new_status="IN_TRANSIT", confirm=True
+        request = ModifyStockTransferRequest(
+            id=42,
+            update_status=StockTransferStatusPatch(new_status="IN_TRANSIT"),
+            confirm=True,
         )
-        result = await _update_stock_transfer_status_impl(request, context)
+        response = await _modify_stock_transfer_impl(request, context)
 
-    assert result.is_preview is False
-    assert result.id == 42
-    assert result.status == "inTransit"
-    mock_api.assert_awaited_once()
-    kwargs = mock_api.await_args.kwargs
+    assert response.is_preview is False
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "update_status"
+    assert response.actions[0].succeeded is True
+    mock_status.assert_awaited_once()
+    kwargs = mock_status.await_args.kwargs
     assert kwargs["id"] == 42
-    # Verify the API status enum was set to camelCase ``inTransit`` (the
-    # actual wire value Katana validates against).
+    # The API status enum should be the camelCase wire value ``inTransit``.
     assert kwargs["body"].status.value == "inTransit"
 
 
 @pytest.mark.asyncio
-async def test_update_stock_transfer_status_invalid_transition_surfaces_error():
-    """APIError from invalid transition is surfaced as ValueError with message."""
+async def test_modify_st_canonical_order_header_then_status():
+    """Both sub-payloads in one call — header runs first, status runs last."""
     context, _ = create_mock_context()
-
-    api_error = APIError("Cannot transition from RECEIVED to IN_TRANSIT", 400)
-
+    mock_after_header = _make_mock_transfer(
+        id=42, stock_transfer_number="ST-42-revised", status="draft"
+    )
+    mock_after_status = _make_mock_transfer(
+        id=42, stock_transfer_number="ST-42-revised", status="inTransit"
+    )
     with (
-        patch(f"{_ST_UPDATE_STATUS}.asyncio_detailed", new_callable=AsyncMock),
-        patch(_ST_UNWRAP_AS, side_effect=api_error),
+        patch(f"{_ST_UPDATE}.asyncio_detailed", new_callable=AsyncMock) as mock_update,
+        patch(
+            f"{_ST_UPDATE_STATUS}.asyncio_detailed", new_callable=AsyncMock
+        ) as mock_status,
+        patch(_MODIFY_ST_UNWRAP_AS, side_effect=[mock_after_header, mock_after_status]),
     ):
-        request = UpdateStockTransferStatusRequest(
-            id=42, new_status="IN_TRANSIT", confirm=True
+        request = ModifyStockTransferRequest(
+            id=42,
+            update_header=StockTransferHeaderPatch(
+                stock_transfer_number="ST-42-revised"
+            ),
+            update_status=StockTransferStatusPatch(new_status="IN_TRANSIT"),
+            confirm=True,
         )
-        with pytest.raises(ValueError, match="Cannot transition"):
-            await _update_stock_transfer_status_impl(request, context)
+        response = await _modify_stock_transfer_impl(request, context)
+
+    assert response.is_preview is False
+    assert [a.operation for a in response.actions] == ["update_header", "update_status"]
+    assert all(a.succeeded is True for a in response.actions)
+    mock_update.assert_awaited_once()
+    mock_status.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_modify_st_status_failfast_halts_remaining_actions():
+    """Header fails — status call must not be attempted."""
+    context, _ = create_mock_context()
+    api_error = APIError("update_stock_transfer rejected", 422)
+    with (
+        patch(f"{_ST_UPDATE}.asyncio_detailed", new_callable=AsyncMock),
+        patch(
+            f"{_ST_UPDATE_STATUS}.asyncio_detailed", new_callable=AsyncMock
+        ) as mock_status,
+        patch(_MODIFY_ST_UNWRAP_AS, side_effect=api_error),
+    ):
+        request = ModifyStockTransferRequest(
+            id=42,
+            update_header=StockTransferHeaderPatch(
+                stock_transfer_number="ST-42-revised"
+            ),
+            update_status=StockTransferStatusPatch(new_status="IN_TRANSIT"),
+            confirm=True,
+        )
+        response = await _modify_stock_transfer_impl(request, context)
+
+    assert response.is_preview is False
+    # The dispatcher's fail-fast contract: response.actions reflects what was
+    # attempted. Header failed (recorded), status was never attempted (omitted).
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "update_header"
+    assert response.actions[0].succeeded is False
+    assert response.actions[0].error is not None
+    mock_status.assert_not_awaited()
 
 
 # ============================================================================
@@ -648,39 +687,34 @@ async def test_update_stock_transfer_status_invalid_transition_surfaces_error():
 @pytest.mark.asyncio
 async def test_delete_stock_transfer_preview():
     context, _ = create_mock_context()
-
     request = DeleteStockTransferRequest(id=42, confirm=False)
-    result = await _delete_stock_transfer_impl(request, context)
+    response = await _delete_stock_transfer_impl(request, context)
 
-    assert result.is_preview is True
-    assert result.id == 42
-    assert "Preview" in result.message
+    assert response.is_preview is True
+    assert response.entity_id == 42
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "delete"
 
 
 @pytest.mark.asyncio
 async def test_delete_stock_transfer_confirm_success():
     context, _ = create_mock_context()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 204
-    mock_response.parsed = None
-
+    mock_response = MagicMock(status_code=204, parsed=None)
     with (
         patch(
             f"{_ST_DELETE}.asyncio_detailed",
             new_callable=AsyncMock,
             return_value=mock_response,
-        ) as mock_api,
-        patch(_ST_IS_SUCCESS, return_value=True),
+        ) as mock_delete,
+        patch(_MODIFY_ST_IS_SUCCESS, return_value=True),
     ):
         request = DeleteStockTransferRequest(id=42, confirm=True)
-        result = await _delete_stock_transfer_impl(request, context)
+        response = await _delete_stock_transfer_impl(request, context)
 
-    assert result.is_preview is False
-    assert result.id == 42
-    assert "deleted" in result.message.lower()
-    mock_api.assert_awaited_once()
-    kwargs = mock_api.await_args.kwargs
+    assert response.is_preview is False
+    assert response.actions[0].succeeded is True
+    mock_delete.assert_awaited_once()
+    kwargs = mock_delete.await_args.kwargs
     assert kwargs["id"] == 42
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.47.0"
+version = "0.47.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Introduces the unified ``modify_<entity>`` + ``delete_<entity>`` tool pattern across all five major Katana entities — purchase order, sales order, manufacturing order, stock transfer, and item — replacing 14 separate fine-grained tools with one tool per entity that dispatches internally to the right API endpoint(s).

**Net surface:** -14 retired tools, +10 new tools (5 modify + 5 delete), even as capability grows. Every entity now supports header / row / sub-resource CRUD + status transitions + variant CRUD (where applicable) in a single tool call, with multi-action support, fail-fast semantics, post-action verification, and prior-state snapshots for manual revert.

### Retired tools (14)
- **PO** (8 from PR 1 #461): `update_purchase_order`, `delete_purchase_order`, `add_purchase_order_row`, `update_purchase_order_row`, `delete_purchase_order_row`, `add_purchase_order_additional_cost`, `update_purchase_order_additional_cost`, `delete_purchase_order_additional_cost`
- **MO** (3): `add_manufacturing_order_recipe_row`, `delete_manufacturing_order_recipe_row`, `batch_update_manufacturing_order_recipes`
- **Stock transfer** (3): `update_stock_transfer`, `update_stock_transfer_status`, `delete_stock_transfer`
- **Item** (2): `update_item`, `delete_item`

### New tools (10)
- `modify_purchase_order` + `delete_purchase_order` — header / rows / additional costs
- `modify_sales_order` + `delete_sales_order` — header / rows / addresses / fulfillments / shipping fees
- `modify_manufacturing_order` + `delete_manufacturing_order` — header / recipe rows / operation rows / production records
- `modify_stock_transfer` + `delete_stock_transfer` — header body fields and/or status (hides the two-endpoint split)
- `modify_item` + `delete_item` — type-discriminator routing across product / material / service + variant CRUD

### Architecture
- **`_modification_dispatch.py`** — generic action-plan executor, plan builders (`plan_creates` / `plan_updates` / `plan_deletes`), apply factories (`make_post_apply` / `make_patch_apply` / `make_delete_apply`), shared drivers (`run_modify_plan` / `run_delete_plan`), and the `unset_dict` helper that collapses ~159 `to_unset(value)` repetitions across builder code.
- **`_modification.py`** — `FieldChange`, `ConfirmableRequest`, `ActionResult`, `ModificationResponse`, `compute_field_diff`, `make_response_verifier`, `to_tool_result`.
- **Per-entity foundation files** — ~50-150 line "configurations" rather than 1000+ line implementations: sub-payload Pydantic models, request builders, the impl driver call.

### Behavior contract (every modify_/delete_ tool)
1. **Two-step confirm** — `confirm=false` returns a per-action preview with diffs; `confirm=true` executes.
2. **Fail-fast** — actions execute in canonical order (header → adds → updates → deletes); first error stops execution. Already-applied actions stay applied (the API is not transactional).
3. **Prior-state snapshot** — on confirm, response carries the pre-modification entity for manual revert.
4. **Post-action verification** — re-fetches the mutated entity and confirms each action's target field reflects the requested value (where the resource supports it).
5. **Per-entity quirks hidden** — stock transfer's two PATCH endpoints, item's type-discriminator routing, SO's missing per-address GET, MO's per-resource sub-fetchers — all surfaced through the same `ModifyXyzRequest` shape.

### Help resource
`katana://help/tools` rewritten with consolidated entries for the 5 new modify tools, a "Unified-Modify Pattern" section explaining the contract end-to-end, and zero references to retired tools.

## Test plan
- [x] `uv run poe check` — green (ruff format/check, mdformat, ty type check)
- [x] `uv run poe test` — 2597 passed, 2 skipped
- [x] Per-entity tests: all PO / SO / MO / stock-transfer / item modify tests pass with fresh `mock_entity_for_modify` factory
- [x] Migration smoke: `test_server.py::test_expected_tools_registered` updated to expect the new tool names
- [x] `test_mcp_apps_integration.py` updated to drop UI annotations from retired item tools
- [ ] Manual exercise against a sandbox Katana account (PO multi-action confirm, SO multi-action confirm, MO multi-resource confirm, stock-transfer two-endpoint confirm, item type-discriminator routing) — *to be run before merge*
- [ ] `katana://help/tools` resource render check — *to be run before merge*

## Breaking changes
14 tools retired, 10 added. Migration is mechanical for callers — combine fine-grained calls into one `modify_<entity>` call with the corresponding sub-payload set; the new shape returns `ModificationResponse` with an `actions` list instead of the prior per-tool response shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)