### PR TITLE
feat(mcp): tolerate JSON-stringified tool args via boundary middleware

### DIFF
--- a/katana_mcp_server/src/katana_mcp/middleware/__init__.py
+++ b/katana_mcp_server/src/katana_mcp/middleware/__init__.py
@@ -1,0 +1,12 @@
+"""FastMCP boundary middlewares for the Katana MCP server.
+
+Custom middlewares plugged into the FastMCP server's call-tool pipeline. Layer
+generic harness-compatibility fixes here rather than scattering them across
+per-tool model annotations.
+"""
+
+from __future__ import annotations
+
+from katana_mcp.middleware.json_string_coercion import JsonStringCoercionMiddleware
+
+__all__ = ["JsonStringCoercionMiddleware"]

--- a/katana_mcp_server/src/katana_mcp/middleware/json_string_coercion.py
+++ b/katana_mcp_server/src/katana_mcp/middleware/json_string_coercion.py
@@ -1,0 +1,161 @@
+"""Coerce JSON-stringified tool arguments back into native JSON values.
+
+Some MCP harnesses (and some smaller LLMs) JSON-stringify nested argument
+values before sending the ``tools/call`` request, producing payloads like
+``{"update_rows": "[{...}]"}`` instead of ``{"update_rows": [{...}]}``.
+The MCP/JSON-RPC 2.0 spec calls for native JSON values, so FastMCP rejects
+the string with a pydantic ``Input should be a valid list
+[type=list_type, input_type=str]`` error before tool logic ever runs.
+
+This middleware closes the gap at the FastMCP boundary: it inspects the
+called tool's input JSON schema, finds top-level args whose schema declares
+a structured type (``array``/``object``/``$ref``) but never accepts
+``string``, and ``json.loads()``-decodes any value at those keys that is a
+string starting with ``[`` or ``{`` (the only shapes the bug we're fixing
+produces — stringified arrays and objects). Strings on schema-declared
+string fields are never touched, so a ``description: str`` carrying
+``"[hello]"`` keeps its literal value. Strings that don't start with
+``[``/``{`` (bare ``"null"``, ``"42"``, etc.) are passed through unchanged
+so pydantic emits its normal type-error message rather than us guessing.
+
+Decisions baked in:
+
+- **Schema-aware, not blind.** Without the schema check, a string field
+  whose value happens to start with ``[`` would be mis-parsed. The
+  middleware never decodes strings on fields where the schema also
+  accepts ``string`` (including ambiguous ``type: ["string", "array"]``
+  and ``anyOf`` unions containing a string branch).
+- **Top-level only.** Every tool in this server registers as
+  ``request: Annotated[Model, Unpack()]``, which flattens the model's
+  fields into the tool's input schema as top-level properties. The
+  observed harness stringification is also one level deep
+  (`update_rows` is a string; nested rows inside it are normal). No
+  recursion is needed for the cases we're fixing today.
+- **Fail-soft.** If JSON parsing fails, the value is left untouched so
+  pydantic produces its normal type-error message — we don't mask
+  malformed input.
+- **No mutation of shared state.** A coerced args dict is built and
+  attached to a copied ``MiddlewareContext``; the original message is
+  not mutated.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, override
+
+import mcp.types as mt
+from fastmcp.server.middleware.middleware import (
+    CallNext,
+    Middleware,
+    MiddlewareContext,
+)
+from fastmcp.tools.base import ToolResult
+
+from katana_mcp.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _accepts_string(prop_schema: dict[str, Any]) -> bool:
+    """True if the schema's accepted type set includes ``string`` at any branch."""
+    t = prop_schema.get("type")
+    if t == "string":
+        return True
+    if isinstance(t, list) and "string" in t:
+        return True
+    for branch in prop_schema.get("anyOf", []) or []:
+        if isinstance(branch, dict) and _accepts_string(branch):
+            return True
+    for branch in prop_schema.get("oneOf", []) or []:
+        if isinstance(branch, dict) and _accepts_string(branch):
+            return True
+    return False
+
+
+def _accepts_structured(prop_schema: dict[str, Any]) -> bool:
+    """True if the schema's accepted type set includes ``array``, ``object``,
+    or a ``$ref`` (refs in pydantic-emitted schemas always point at
+    object/model schemas)."""
+    if "$ref" in prop_schema:
+        return True
+    t = prop_schema.get("type")
+    if t in ("array", "object"):
+        return True
+    if isinstance(t, list) and any(x in t for x in ("array", "object")):
+        return True
+    for branch in prop_schema.get("anyOf", []) or []:
+        if isinstance(branch, dict) and _accepts_structured(branch):
+            return True
+    for branch in prop_schema.get("oneOf", []) or []:
+        if isinstance(branch, dict) and _accepts_structured(branch):
+            return True
+    return False
+
+
+def _should_decode(prop_schema: dict[str, Any]) -> bool:
+    """Decode iff the schema expects structured input AND never accepts a string.
+
+    Ambiguous schemas (``type: ["string", "array"]`` etc.) are left alone:
+    pydantic will accept the string branch, which is the safer default.
+    """
+    return _accepts_structured(prop_schema) and not _accepts_string(prop_schema)
+
+
+class JsonStringCoercionMiddleware(Middleware):
+    """Pre-decode JSON-stringified args at the FastMCP boundary.
+
+    See module docstring for rationale and decisions.
+    """
+
+    @override
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        params = context.message
+        args = params.arguments
+        if not args or context.fastmcp_context is None:
+            return await call_next(context)
+
+        # Cheap pre-check — if no value is a string, there's nothing to
+        # decode and we can skip the (async) tool-schema lookup entirely.
+        if not any(isinstance(v, str) for v in args.values()):
+            return await call_next(context)
+
+        tool = await context.fastmcp_context.fastmcp.get_tool(params.name)
+        if tool is None:
+            return await call_next(context)
+
+        properties = tool.parameters.get("properties") or {}
+        if not properties:
+            return await call_next(context)
+
+        coerced: dict[str, Any] = dict(args)
+        decoded_keys: list[str] = []
+        for key, value in args.items():
+            if not isinstance(value, str):
+                continue
+            prop_schema = properties.get(key)
+            if not isinstance(prop_schema, dict) or not _should_decode(prop_schema):
+                continue
+            stripped = value.strip()
+            if not stripped or stripped[0] not in "[{":
+                continue
+            try:
+                coerced[key] = json.loads(stripped)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            decoded_keys.append(key)
+
+        if not decoded_keys:
+            return await call_next(context)
+
+        logger.debug(
+            "json_string_coercion_applied",
+            tool=params.name,
+            keys=decoded_keys,
+        )
+        new_message = params.model_copy(update={"arguments": coerced})
+        return await call_next(context.copy(message=new_message))

--- a/katana_mcp_server/src/katana_mcp/server.py
+++ b/katana_mcp_server/src/katana_mcp/server.py
@@ -32,6 +32,7 @@ from key_value.aio.stores.memory import MemoryStore
 from katana_mcp import __version__
 from katana_mcp._fastmcp_patches import apply_fastmcp_patches as _apply_patches
 from katana_mcp.logging import get_logger, setup_logging
+from katana_mcp.middleware import JsonStringCoercionMiddleware
 from katana_mcp.services import Services
 from katana_public_api_client import KatanaClient
 
@@ -279,6 +280,15 @@ Browse cached reference data:
 For transactional data (orders, stock movements), use the corresponding tools.
 """,
 )
+
+# Pre-decode JSON-stringified tool args before pydantic validation. Some
+# harnesses (and some smaller LLMs) JSON-stringify nested args before
+# sending tools/call; FastMCP's strict pydantic validation rejects them.
+# This middleware is schema-aware and only decodes strings on fields whose
+# schema declares array/object types and never accepts string. Registered
+# before ResponseCachingMiddleware so cache keys reflect normalized args.
+mcp.add_middleware(JsonStringCoercionMiddleware())
+logger.info("middleware_added", middleware="JsonStringCoercionMiddleware")
 
 # Add response caching middleware with TTLs for read-only tools
 _READ_ONLY_TOOLS = [

--- a/katana_mcp_server/tests/test_json_string_coercion_middleware.py
+++ b/katana_mcp_server/tests/test_json_string_coercion_middleware.py
@@ -1,0 +1,375 @@
+"""Tests for ``JsonStringCoercionMiddleware``.
+
+Covers the schema-classification helpers, the middleware's behavior on a
+range of input shapes (decode/skip/passthrough), and integration with the
+real registered MCP server (PO-881 regression).
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import mcp.types as mt
+import pytest
+from fastmcp.server.middleware.middleware import MiddlewareContext
+from katana_mcp.middleware.json_string_coercion import (
+    JsonStringCoercionMiddleware,
+    _accepts_string,
+    _accepts_structured,
+    _should_decode,
+)
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptsString:
+    def test_bare_string(self):
+        assert _accepts_string({"type": "string"}) is True
+
+    def test_bare_array(self):
+        assert _accepts_string({"type": "array"}) is False
+
+    def test_string_in_type_list(self):
+        assert _accepts_string({"type": ["string", "null"]}) is True
+
+    def test_array_only_in_type_list(self):
+        assert _accepts_string({"type": ["array", "null"]}) is False
+
+    def test_string_in_anyof(self):
+        assert (
+            _accepts_string({"anyOf": [{"type": "string"}, {"type": "null"}]}) is True
+        )
+
+    def test_no_string_in_anyof(self):
+        assert (
+            _accepts_string({"anyOf": [{"type": "array"}, {"type": "null"}]}) is False
+        )
+
+    def test_empty_schema(self):
+        assert _accepts_string({}) is False
+
+
+class TestAcceptsStructured:
+    def test_array(self):
+        assert _accepts_structured({"type": "array"}) is True
+
+    def test_object(self):
+        assert _accepts_structured({"type": "object"}) is True
+
+    def test_ref(self):
+        assert _accepts_structured({"$ref": "#/$defs/Foo"}) is True
+
+    def test_string(self):
+        assert _accepts_structured({"type": "string"}) is False
+
+    def test_array_in_anyof(self):
+        assert (
+            _accepts_structured({"anyOf": [{"type": "array"}, {"type": "null"}]})
+            is True
+        )
+
+    def test_ref_in_anyof(self):
+        assert (
+            _accepts_structured({"anyOf": [{"$ref": "#/$defs/Foo"}, {"type": "null"}]})
+            is True
+        )
+
+
+class TestShouldDecode:
+    def test_array_only(self):
+        assert _should_decode({"type": "array"}) is True
+
+    def test_string_only(self):
+        assert _should_decode({"type": "string"}) is False
+
+    def test_array_or_null(self):
+        assert _should_decode({"type": ["array", "null"]}) is True
+
+    def test_array_or_string_is_ambiguous(self):
+        # Schema accepts both — pydantic will keep the string; don't decode.
+        assert _should_decode({"type": ["array", "string"]}) is False
+
+    def test_anyof_array_null(self):
+        assert _should_decode({"anyOf": [{"type": "array"}, {"type": "null"}]}) is True
+
+    def test_anyof_array_string_is_ambiguous(self):
+        assert (
+            _should_decode({"anyOf": [{"type": "array"}, {"type": "string"}]}) is False
+        )
+
+    def test_object_only(self):
+        assert _should_decode({"type": "object"}) is True
+
+    def test_ref_or_null(self):
+        assert (
+            _should_decode({"anyOf": [{"$ref": "#/$defs/X"}, {"type": "null"}]}) is True
+        )
+
+    def test_integer(self):
+        # Scalars don't need JSON decoding.
+        assert _should_decode({"type": "integer"}) is False
+
+
+# ---------------------------------------------------------------------------
+# Middleware behavior tests
+# ---------------------------------------------------------------------------
+
+
+def _make_context(
+    tool_name: str,
+    properties: dict[str, Any],
+    args: dict[str, Any] | None,
+    *,
+    tool_found: bool = True,
+) -> MiddlewareContext[mt.CallToolRequestParams]:
+    """Build a MiddlewareContext whose mock fastmcp_context returns a tool
+    with the given input-schema ``properties``."""
+    tool: MagicMock | None
+    if tool_found:
+        tool = MagicMock()
+        tool.parameters = {"properties": properties}
+    else:
+        tool = None
+
+    fastmcp = MagicMock()
+    fastmcp.get_tool = AsyncMock(return_value=tool)
+
+    fastmcp_context = MagicMock()
+    fastmcp_context.fastmcp = fastmcp
+
+    msg = mt.CallToolRequestParams(name=tool_name, arguments=args)
+    return MiddlewareContext(
+        message=msg,
+        fastmcp_context=fastmcp_context,
+        method="tools/call",
+    )
+
+
+@pytest.mark.asyncio
+class TestMiddlewareBehavior:
+    async def _run(
+        self,
+        ctx: MiddlewareContext[mt.CallToolRequestParams],
+    ) -> dict[str, Any] | None:
+        """Run the middleware and return the args the next handler saw."""
+        captured: dict[str, dict[str, Any] | None] = {"args": None}
+
+        async def call_next(c):
+            captured["args"] = c.message.arguments
+            return MagicMock()
+
+        await JsonStringCoercionMiddleware().on_call_tool(ctx, call_next)
+        return captured["args"]
+
+    async def test_decodes_stringified_int_list(self):
+        ctx = _make_context(
+            "t",
+            {"ids": {"type": "array", "items": {"type": "integer"}}},
+            {"ids": "[1, 2, 3]"},
+        )
+        assert await self._run(ctx) == {"ids": [1, 2, 3]}
+
+    async def test_decodes_stringified_list_of_objects(self):
+        ctx = _make_context(
+            "t",
+            {"update_rows": {"type": "array", "items": {"type": "object"}}},
+            {"update_rows": '[{"id": 1, "quantity": 2}]'},
+        )
+        assert await self._run(ctx) == {"update_rows": [{"id": 1, "quantity": 2}]}
+
+    async def test_decodes_stringified_object(self):
+        ctx = _make_context(
+            "t",
+            {"header": {"type": "object"}},
+            {"header": '{"foo": "bar"}'},
+        )
+        assert await self._run(ctx) == {"header": {"foo": "bar"}}
+
+    async def test_decodes_anyof_ref_or_null(self):
+        # Mirrors `update_header: SomeModel | None` after pydantic schema gen.
+        ctx = _make_context(
+            "t",
+            {"update_header": {"anyOf": [{"$ref": "#/$defs/Patch"}, {"type": "null"}]}},
+            {"update_header": '{"x": 1}'},
+        )
+        assert await self._run(ctx) == {"update_header": {"x": 1}}
+
+    async def test_protects_string_field(self):
+        # A real string field whose value happens to start with `[` must be
+        # preserved literally.
+        ctx = _make_context(
+            "t",
+            {"description": {"type": "string"}},
+            {"description": "[hello]"},
+        )
+        assert await self._run(ctx) == {"description": "[hello]"}
+
+    async def test_native_list_passthrough(self):
+        ctx = _make_context(
+            "t",
+            {"ids": {"type": "array"}},
+            {"ids": [1, 2, 3]},
+        )
+        assert await self._run(ctx) == {"ids": [1, 2, 3]}
+
+    async def test_native_dict_passthrough(self):
+        ctx = _make_context(
+            "t",
+            {"header": {"type": "object"}},
+            {"header": {"foo": "bar"}},
+        )
+        assert await self._run(ctx) == {"header": {"foo": "bar"}}
+
+    async def test_non_json_looking_string_left_alone(self):
+        # Doesn't start with `[` or `{` — middleware skips, pydantic raises.
+        ctx = _make_context(
+            "t",
+            {"ids": {"type": "array"}},
+            {"ids": "not-json"},
+        )
+        assert await self._run(ctx) == {"ids": "not-json"}
+
+    async def test_malformed_json_left_alone(self):
+        # Starts with `[` but unparseable — middleware skips, pydantic raises.
+        ctx = _make_context(
+            "t",
+            {"ids": {"type": "array"}},
+            {"ids": "[1, 2,"},
+        )
+        assert await self._run(ctx) == {"ids": "[1, 2,"}
+
+    async def test_ambiguous_string_or_array_left_alone(self):
+        # Schema accepts both; defer to pydantic (which keeps the string).
+        ctx = _make_context(
+            "t",
+            {"x": {"type": ["string", "array"]}},
+            {"x": "[1,2]"},
+        )
+        assert await self._run(ctx) == {"x": "[1,2]"}
+
+    async def test_empty_args_passthrough(self):
+        ctx = _make_context("t", {"ids": {"type": "array"}}, {})
+        assert await self._run(ctx) == {}
+
+    async def test_no_arguments_passthrough(self):
+        ctx = _make_context("t", {"ids": {"type": "array"}}, None)
+        assert await self._run(ctx) is None
+
+    async def test_unknown_tool_passthrough(self):
+        ctx = _make_context("missing", {}, {"x": "[1]"}, tool_found=False)
+        assert await self._run(ctx) == {"x": "[1]"}
+
+    async def test_mixed_decoded_and_native_args(self):
+        ctx = _make_context(
+            "t",
+            {
+                "id": {"type": "integer"},
+                "ids": {"type": "array"},
+                "name": {"type": "string"},
+            },
+            {"id": 42, "ids": "[1,2]", "name": "[literal]"},
+        )
+        assert await self._run(ctx) == {
+            "id": 42,
+            "ids": [1, 2],
+            "name": "[literal]",
+        }
+
+    async def test_skips_schema_fetch_when_no_string_args(self):
+        # Performance guard: when no arg value is a string, there's nothing
+        # the middleware could ever decode, so it must short-circuit before
+        # the (async) tool-schema lookup.
+        ctx = _make_context(
+            "t",
+            {"ids": {"type": "array"}},
+            {"ids": [1, 2, 3], "id": 42, "confirm": True},
+        )
+        result = await self._run(ctx)
+        assert result == {"ids": [1, 2, 3], "id": 42, "confirm": True}
+        # ``get_tool`` should never have been awaited. ``fastmcp_context`` is
+        # a ``MagicMock`` at runtime; cast lets the test assert through the
+        # mock chain without static-typing friction.
+        get_tool = cast(
+            AsyncMock, cast(MagicMock, ctx.fastmcp_context).fastmcp.get_tool
+        )
+        get_tool.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests against the real registered MCP server
+# ---------------------------------------------------------------------------
+
+
+def test_middleware_is_registered():
+    """``JsonStringCoercionMiddleware`` is wired into the MCP server."""
+    from katana_mcp.server import mcp
+
+    coercion = [
+        m for m in mcp.middleware if isinstance(m, JsonStringCoercionMiddleware)
+    ]
+    assert len(coercion) == 1, (
+        f"expected exactly one JsonStringCoercionMiddleware, got {len(coercion)}"
+    )
+
+
+def test_middleware_registered_before_caching():
+    """Coercion must run before ResponseCachingMiddleware so cache keys
+    reflect normalized args, not stringified ones."""
+    from fastmcp.server.middleware.caching import ResponseCachingMiddleware
+    from katana_mcp.server import mcp
+
+    type_names = [type(m).__name__ for m in mcp.middleware]
+    coercion_idx = next(
+        i
+        for i, m in enumerate(mcp.middleware)
+        if isinstance(m, JsonStringCoercionMiddleware)
+    )
+    caching_idx = next(
+        i
+        for i, m in enumerate(mcp.middleware)
+        if isinstance(m, ResponseCachingMiddleware)
+    )
+    assert coercion_idx < caching_idx, (
+        f"JsonStringCoercionMiddleware (idx {coercion_idx}) must come before "
+        f"ResponseCachingMiddleware (idx {caching_idx}); registration order: "
+        f"{type_names}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_modify_purchase_order_schema_classifies_correctly():
+    """PO-881 regression: the exact fields that failed must be schema-classified
+    as "needs decoding" so they get coerced before pydantic validation.
+    """
+    from katana_mcp.server import mcp
+
+    tool = await mcp.get_tool("modify_purchase_order")
+    assert tool is not None, "modify_purchase_order must be registered"
+
+    properties = tool.parameters.get("properties") or {}
+    for field in ("update_rows", "delete_row_ids", "update_header"):
+        assert field in properties, f"{field!r} missing from tool schema"
+        assert _should_decode(properties[field]), (
+            f"{field!r} schema {properties[field]!r} should be classified as "
+            f"needing JSON-string decoding"
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_schema_classifies_correctly():
+    """The other tool the user reported failing earlier in their session."""
+    from katana_mcp.server import mcp
+
+    tool = await mcp.get_tool("get_variant_details")
+    assert tool is not None, "get_variant_details must be registered"
+
+    properties = tool.parameters.get("properties") or {}
+    # ``variant_ids`` already uses CoercedIntListOpt for CSV support; the
+    # middleware adds JSON-string support on top via the schema check.
+    assert "variant_ids" in properties
+    assert _should_decode(properties["variant_ids"]), (
+        f"variant_ids schema {properties['variant_ids']!r} should need decoding"
+    )


### PR DESCRIPTION
## Summary

- Add `JsonStringCoercionMiddleware` — a schema-aware FastMCP `on_call_tool` middleware that pre-decodes JSON-stringified args at the server boundary so harnesses sending `{"update_rows": "[{...}]"}` (instead of native arrays) don't fail strict pydantic validation.
- Registered in `server.py` before `ResponseCachingMiddleware` so cache keys reflect normalized args.
- Zero per-tool changes — covers all 100+ existing tools and any future tool automatically.

## Why

Several MCP harnesses (and some smaller LLMs) JSON-stringify nested argument values before sending `tools/call`. FastMCP follows the MCP/JSON-RPC spec strictly and rejects the string with `Input should be a valid list [type=list_type, input_type=str]`, breaking every write/modify tool (`modify_purchase_order`, `receive_purchase_order`, `verify_order_document`, etc.) before tool logic runs.

The existing per-field `BeforeValidator` aliases in `tools/list_coercion.py` only cover scalar lists on a subset of fields and don't handle list-of-models or bare-model fields at all. The audit found 36 affected fields across 16 request models. A boundary middleware fixes them all in one place.

## Design notes

- **Schema-aware, not blind.** Only decodes strings on fields whose schema declares structured types (`array` / `object` / `$ref`) and never accepts `string`. Ambiguous schemas (`type: ["string", "array"]`) are left to pydantic.
- **Fail-soft.** Unparseable strings are passed through so pydantic produces its normal type-error message rather than masking malformed input.
- **No shared-state mutation.** Coerced args are attached to a copied `MiddlewareContext`; the original message is not modified.
- **Top-level only.** Every tool registers as `Annotated[Model, Unpack()]` which flattens model fields into the tool's input schema as top-level properties; observed harness stringification is also one level deep.
- `tools/list_coercion.py` is left as-is — its CSV fallback (`"a,b,c"` → `["a","b","c"]`) is complementary to the middleware's JSON support.

## Test plan

- [x] 40 new tests in `test_json_string_coercion_middleware.py` (helpers, behavior, integration)
- [x] `uv run poe check` — 2637 existing tests pass, 0 regressions
- [x] End-to-end smoke: PO-881 payload (stringified `update_rows`, `delete_row_ids`, `update_header`) flows through middleware → produces a properly typed `ModifyPurchaseOrderRequest` with `PORowUpdate` model instances and a populated `POHeaderPatch`
- [x] Ruff format/check, pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)