### PR TITLE
fix(mcp): close landed-cost UX gap (row shape + cost catalog + derived-field rejection)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/cache.py
+++ b/katana_mcp_server/src/katana_mcp/cache.py
@@ -121,6 +121,7 @@ class EntityType(StrEnum):
     TAX_RATE = "tax_rate"
     OPERATOR = "operator"
     FACTORY = "factory"
+    ADDITIONAL_COST = "additional_cost"
 
 
 @dataclass(frozen=True)
@@ -151,6 +152,7 @@ CUSTOMER_INDEX = IndexFields(name_key="name", name2_key="email")
 LOCATION_INDEX = IndexFields(name_key="name")
 TAX_RATE_INDEX = IndexFields(name_key="name")
 OPERATOR_INDEX = IndexFields(name_key="name")
+ADDITIONAL_COST_INDEX = IndexFields(name_key="name")
 
 
 class CatalogCache:

--- a/katana_mcp_server/src/katana_mcp/cache_sync.py
+++ b/katana_mcp_server/src/katana_mcp/cache_sync.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from katana_mcp.cache import (
+    ADDITIONAL_COST_INDEX,
     CUSTOMER_INDEX,
     LOCATION_INDEX,
     MATERIAL_INDEX,
@@ -28,6 +29,7 @@ from katana_mcp.cache import (
     VARIANT_INDEX,
     IndexFields,
 )
+from katana_public_api_client.api.additional_costs import get_additional_costs
 from katana_public_api_client.api.customer import get_all_customers
 from katana_public_api_client.api.factory import get_factory
 from katana_public_api_client.api.location import get_all_locations
@@ -194,6 +196,17 @@ async def ensure_operators_synced(services: Services) -> None:
     )
 
 
+async def ensure_additional_costs_synced(services: Services) -> None:
+    """Ensure the additional-cost catalog cache is fresh."""
+    await _ensure_synced(
+        services=services,
+        entity_type="additional_cost",
+        index_fields=ADDITIONAL_COST_INDEX,
+        fetch_fn=_fetch_additional_costs,
+        supports_incremental=True,
+    )
+
+
 async def ensure_factory_synced(services: Services) -> None:
     """Ensure the factory cache is fresh."""
     await _ensure_synced(
@@ -332,6 +345,12 @@ async def _fetch_operators(
     return await _fetch_generic(
         get_all_operators, client, updated_at_min, supports_incremental=False
     )
+
+
+async def _fetch_additional_costs(
+    client: Any, updated_at_min: datetime | None = None
+) -> list[dict]:
+    return await _fetch_generic(get_additional_costs, client, updated_at_min)
 
 
 async def _fetch_factory(

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -878,18 +878,45 @@ additional-cost rows in one call. Replaces the prior 8 separate
   `expected_arrival_date`, `order_created_date`, `additional_info`,
   `status`). Status uses the PATCH endpoint; to flip to RECEIVED with
   inventory updates use `receive_purchase_order` instead.
-- `add_rows` / `update_rows` / `delete_row_ids` — line item CRUD.
-  `update_rows` entries each carry their own row id + patch.
-- `add_additional_costs` / `update_additional_costs` /
-  `delete_additional_cost_ids` — freight / duty / handling cost rows.
-  The tool resolves the PO's `default_group_id` automatically.
+- `add_rows` — list of new line items. Each row:
+  `variant_id` (int, required), `quantity` (float, required, >0),
+  `price_per_unit` (float, required), `tax_rate_id` (int — see
+  `katana://tax-rates`), `tax_name`, `tax_rate`, `currency`,
+  `purchase_uom`, `purchase_uom_conversion_rate`, `arrival_date`.
+- `update_rows` — list of patches. Each entry: `id` (int, required) +
+  any subset of `quantity`, `variant_id`, `tax_rate_id`, `tax_name`,
+  `tax_rate`, `price_per_unit`, `purchase_uom`,
+  `purchase_uom_conversion_rate`, `received_date`, `arrival_date`.
+- `delete_row_ids` — list of row IDs to delete.
+- `add_additional_costs` — list of new freight / duty / handling rows.
+  Each row: `additional_cost_id` (int, required — see
+  `katana://additional-costs` for catalog IDs), `tax_rate_id` (int,
+  required — see `katana://tax-rates`), `price` (float, required),
+  `distribution_method` (`BY_VALUE` | `NON_DISTRIBUTED` — controls how
+  the cost spreads across line items; `BY_VALUE` is what produces
+  `landed_cost` on each row), `group_id` (int, optional — defaults to
+  the PO's `default_group_id`).
+- `update_additional_costs` — list of patches to existing cost rows.
+  Each entry: `id` (int, required) + any subset of `additional_cost_id`,
+  `tax_rate_id`, `price`, `distribution_method`.
+- `delete_additional_cost_ids` — list of cost row IDs to delete.
+
+**Derived fields (rejected on update):** `landed_cost`,
+`total_in_base_currency`, `total`, `conversion_rate`, and
+`conversion_date` on PO rows are computed by Katana from supplier price,
+exchange rates, and distributed additional costs. Trying to set them via
+`update_rows` returns "At least 1 field is required" because every other
+patched field is also derived. To distribute landed cost across rows,
+use `add_additional_costs` with `distribution_method=BY_VALUE` — Katana
+recomputes per-row `landed_cost` automatically.
 
 **Parameters:**
 - `id` (required): Purchase order ID
 - Any subset of the sub-payloads above
 - `confirm` (optional, default false): false=preview with per-action diff,
-  true=execute the action plan in canonical order (header → adds → updates
-  → deletes); fail-fast on first error
+  true=execute the action plan in canonical order (header → row adds →
+  row updates → row deletes → cost adds → cost updates → cost deletes);
+  fail-fast on first error
 
 **Returns:** A `ModificationResponse` with `is_preview`, an `actions` list
 (one entry per planned API call with `operation`, `target_id`, `changes`,
@@ -1344,6 +1371,20 @@ All manufacturing operators.
 - Summary count
 
 **Use when:** Assigning operators to manufacturing order operations.
+
+---
+
+### katana://additional-costs
+Configured additional-cost catalog (freight, duties, handling fees) for
+purchase orders.
+
+**Contains:**
+- id, name
+- Summary count
+
+**Use when:** Looking up `additional_cost_id` for
+`modify_purchase_order(add_additional_costs=[...])`. Pair with
+`katana://tax-rates` for the matching `tax_rate_id`.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/resources/reference.py
+++ b/katana_mcp_server/src/katana_mcp/resources/reference.py
@@ -20,6 +20,7 @@ from fastmcp import Context, FastMCP
 
 from katana_mcp.cache import EntityType
 from katana_mcp.cache_sync import (
+    ensure_additional_costs_synced,
     ensure_locations_synced,
     ensure_operators_synced,
     ensure_suppliers_synced,
@@ -175,6 +176,52 @@ async def get_tax_rates(context: Context) -> str:
 
 
 # ============================================================================
+# Resource: katana://additional-costs
+# ============================================================================
+
+
+async def get_additional_costs(context: Context) -> str:
+    """Browse all configured additional-cost types (freight, duties,
+    handling fees) for purchase orders.
+
+    **Resource URI:** `katana://additional-costs`
+
+    **Purpose:** Reference data for additional-cost catalog lookup — use
+    to find ``additional_cost_id`` when calling
+    ``modify_purchase_order(add_additional_costs=[...])``. Pair with
+    ``katana://tax-rates`` for the matching ``tax_rate_id``.
+    """
+    start = time.monotonic()
+    services = get_services(context)
+    await ensure_additional_costs_synced(services)
+    raw = await services.cache.get_all(EntityType.ADDITIONAL_COST)
+    additional_costs = _filter_deleted(raw)
+
+    items = [
+        {
+            "id": ac.get("id"),
+            "name": ac.get("name"),
+        }
+        for ac in additional_costs
+    ]
+
+    duration_ms = round((time.monotonic() - start) * 1000, 2)
+    logger.info("additional_costs_resource", count=len(items), duration_ms=duration_ms)
+
+    return json.dumps(
+        {
+            "generated_at": datetime.now(UTC).isoformat(),
+            "summary": {"total_additional_costs": len(items)},
+            "additional_costs": items,
+            "next_actions": [
+                "Reference additional_cost_id when calling "
+                "modify_purchase_order(add_additional_costs=[...])",
+            ],
+        }
+    )
+
+
+# ============================================================================
 # Resource: katana://operators
 # ============================================================================
 
@@ -250,6 +297,16 @@ def register_resources(mcp: FastMCP) -> None:
         description="Manufacturing operators — for operation assignments",
         mime_type="application/json",
     )(get_operators)
+
+    mcp.resource(
+        uri="katana://additional-costs",
+        name="Additional Costs",
+        description=(
+            "Configured additional-cost catalog (freight, duties, handling) "
+            "— for modify_purchase_order(add_additional_costs=...)"
+        ),
+        mime_type="application/json",
+    )(get_additional_costs)
 
 
 __all__ = ["register_resources"]

--- a/katana_mcp_server/src/katana_mcp/server.py
+++ b/katana_mcp_server/src/katana_mcp/server.py
@@ -275,6 +275,8 @@ Browse cached reference data:
 - katana://locations — warehouses/facilities for orders and inventory
 - katana://tax-rates — configured tax rates for sales orders
 - katana://operators — manufacturing operators for operation assignments
+- katana://additional-costs — additional-cost catalog (freight, duties,
+  handling) for modify_purchase_order add_additional_costs
 - katana://help — detailed workflow guides and tool reference
 
 For transactional data (orders, stock movements), use the corresponding tools.

--- a/katana_mcp_server/src/katana_mcp/tools/_derived_fields.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_derived_fields.py
@@ -1,0 +1,147 @@
+"""Registry of server-computed (derived) fields per entity-operation.
+
+Katana computes some fields server-side from other inputs and rejects them
+on update — for example, ``landed_cost`` on a purchase-order row is
+distributed from PO-level additional costs and cannot be patched directly.
+Trying to set such a field via ``modify_<entity>`` produces a generic 422
+"At least 1 field is required" because every other patched field was also
+derived (the request body collapsed to empty). This registry replaces that
+generic failure with a named, actionable error before the API round-trip.
+
+## Layered defense
+
+The primary defense is **the MCP-layer patch models** (``PORowUpdate`` etc.)
+not exposing derived fields at all — so callers literally cannot pass them.
+Pydantic's default ``extra="ignore"`` silently drops unknown fields at
+validation time, which means a caller who tries to set ``landed_cost`` on
+``PORowUpdate`` won't even reach this check; their field gets dropped on
+construction. That's intentional and good — it's the cleanest UX.
+
+This registry is **defense-in-depth** for the case where a derived field
+sneaks onto the MCP-layer patch model — either via a future code change
+that widens the model, or via direct construction (in tests, alternate
+tool entry points). The dispatch-layer check fires before
+``execute_plan`` so the caller sees a named "this field is derived" error
+instead of a partial-apply failure mid-plan.
+
+## Adding entries
+
+Keep entries narrow and verified. Each entry records a real rejection
+observed against the live Katana API. The PR B audit (driven by
+``spec-auditor``) will broaden the registry by sweeping the OpenAPI spec
+for fields present on response schemas but absent from
+``Update*Request`` schemas.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from katana_mcp.tools._modification import FieldChange
+
+# ----------------------------------------------------------------------------
+# Registry
+# ----------------------------------------------------------------------------
+
+# Each entry: derived field name → short workaround hint (or None for "no
+# workaround, the field is just not settable"). The hint is appended to the
+# error message so the caller sees the canonical alternative.
+_DerivedFieldMap = dict[str, str | None]
+
+# Outer key: ``entity_type`` (matches the value passed to ``run_modify_plan``).
+# Inner key: ``operation`` string (matches ``ActionSpec.operation`` — the value
+# of the per-entity ``*Operation`` enum, e.g. ``"update_row"``).
+DERIVED_FIELDS: dict[str, dict[str, _DerivedFieldMap]] = {
+    "purchase_order": {
+        # PORowUpdate-level derived fields. Currently the MCP-layer
+        # PORowUpdate model does NOT expose any of these — pydantic
+        # silently drops them at construction. The entries here are
+        # registered against future drift: if any of these get added to
+        # PORowUpdate, the dispatch check fires before the API call.
+        "update_row": {
+            "landed_cost": (
+                "use modify_purchase_order(add_additional_costs=[...]) with "
+                "distribution_method=BY_VALUE — Katana recomputes per-row "
+                "landed_cost from distributed additional costs"
+            ),
+            "total": "computed from quantity * price_per_unit + tax",
+            "total_in_base_currency": (
+                "computed from total * conversion_rate at the PO header level"
+            ),
+            "conversion_rate": "set via the PO header (update_header.currency)",
+            "conversion_date": "set via the PO header",
+        },
+    },
+}
+
+
+# ----------------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------------
+
+
+class DerivedFieldError(ValueError):
+    """Raised when a planned action sets a server-derived field.
+
+    Subclasses :class:`ValueError` so it surfaces through the standard
+    MCP tool error path without special handling — the message carries
+    the field name and workaround hint.
+    """
+
+
+def _lookup(entity_type: str, operation: str) -> _DerivedFieldMap:
+    """Look up the derived-field map for ``(entity_type, operation)``.
+
+    Returns an empty dict when no entries exist — callers can iterate
+    without a None check.
+    """
+    return DERIVED_FIELDS.get(entity_type, {}).get(operation, {})
+
+
+def check_derived_fields(
+    *,
+    entity_type: str,
+    operation: str,
+    target_id: int | None,
+    diff: Iterable[FieldChange],
+) -> None:
+    """Raise :class:`DerivedFieldError` if ``diff`` references derived fields.
+
+    Called from the modification dispatcher before plan execution. Walks
+    the diff once and raises on the first hit (fail-fast — no partial
+    enumeration). The error message names the field, identifies it as
+    derived, and includes the registered workaround hint when available.
+
+    Args:
+        entity_type: Stable entity-type tag passed to ``run_modify_plan``
+            (e.g. ``"purchase_order"``).
+        operation: ``ActionSpec.operation`` string for the planned action
+            (e.g. ``"update_row"``).
+        target_id: Optional id of the action target — used to make the
+            error message specific. ``None`` for create-style actions.
+        diff: Iterable of :class:`FieldChange` from the action plan.
+    """
+    derived = _lookup(entity_type, operation)
+    if not derived:
+        return
+
+    for change in diff:
+        if change.field not in derived:
+            continue
+        hint = derived[change.field]
+        target = f" (target {target_id})" if target_id is not None else ""
+        msg = (
+            f"Field {change.field!r} on {entity_type} {operation}{target} "
+            f"is derived — Katana computes it server-side and rejects it "
+            f"on update."
+        )
+        if hint:
+            msg = f"{msg} To set this value: {hint}."
+        raise DerivedFieldError(msg)
+
+
+__all__ = [
+    "DERIVED_FIELDS",
+    "DerivedFieldError",
+    "check_derived_fields",
+]

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -58,6 +58,10 @@ from typing import Any, cast
 from pydantic import BaseModel
 
 from katana_mcp.logging import get_logger
+from katana_mcp.tools._derived_fields import (
+    DERIVED_FIELDS,
+    check_derived_fields,
+)
 from katana_mcp.tools._modification import (
     ActionResult,
     ConfirmableRequest,
@@ -627,6 +631,47 @@ async def run_modify_plan(
         if existing is None and has_get_endpoint
         else []
     )
+
+    # Reject server-computed (derived) fields before plan execution. Fires
+    # for both preview and confirm paths so the caller sees the error
+    # immediately, not after a partial plan applies. See
+    # ``katana_mcp.tools._derived_fields`` for registry semantics.
+    for spec in plan:
+        check_derived_fields(
+            entity_type=entity_type,
+            operation=spec.operation,
+            target_id=spec.target_id,
+            diff=spec.diff,
+        )
+
+    # Reject update-style ActionSpecs with empty diffs. This catches the
+    # case where a caller supplied only unknown or derived field names on
+    # the patch payload — pydantic's ``extra="ignore"`` silently dropped
+    # them, leaving the diff (and the resulting PATCH body) empty. Without
+    # this guard, Katana returns a generic "At least 1 field is required"
+    # 422 that's hard to map back to the original input. Adds and deletes
+    # are exempt: adds carry a non-empty diff by construction (required
+    # fields), and deletes have empty diffs by design.
+    for spec in plan:
+        if not spec.operation.startswith("update_"):
+            continue
+        if spec.diff:
+            continue
+        derived_for_op = DERIVED_FIELDS.get(entity_type, {}).get(spec.operation, {})
+        target = f" (target {spec.target_id})" if spec.target_id is not None else ""
+        msg = (
+            f"No fields to update for {entity_type} {spec.operation}{target} — "
+            f"the patch payload would be empty. This typically means the "
+            f"caller supplied only field names that aren't on the patch "
+            f"model (pydantic silently drops unknown fields)."
+        )
+        if derived_for_op:
+            derived_names = ", ".join(sorted(derived_for_op))
+            msg = (
+                f"{msg} Derived fields registered on this operation "
+                f"(rejected by the API on update): {derived_names}."
+            )
+        raise ValueError(msg)
 
     if not request.confirm:
         return ModificationResponse(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -2558,16 +2558,79 @@ class ModifyManufacturingOrderRequest(ConfirmableRequest):
     """
 
     id: int = Field(..., description="Manufacturing order ID")
-    update_header: MOHeaderPatch | None = Field(default=None)
-    add_recipe_rows: list[MORecipeRowAdd] | None = Field(default=None)
-    update_recipe_rows: list[MORecipeRowUpdate] | None = Field(default=None)
-    delete_recipe_row_ids: list[int] | None = Field(default=None)
-    add_operation_rows: list[MOOperationRowAdd] | None = Field(default=None)
-    update_operation_rows: list[MOOperationRowUpdate] | None = Field(default=None)
-    delete_operation_row_ids: list[int] | None = Field(default=None)
-    add_productions: list[MOProductionAdd] | None = Field(default=None)
-    update_productions: list[MOProductionUpdate] | None = Field(default=None)
-    delete_production_ids: list[int] | None = Field(default=None)
+    update_header: MOHeaderPatch | None = Field(
+        default=None,
+        description=(
+            "Header-level patch. Fields: order_no, variant_id, location_id, "
+            "status (NOT_STARTED/IN_PROGRESS/DONE/BLOCKED/PARTIALLY_COMPLETED "
+            "— transitions validated server-side), planned_quantity (>0), "
+            "actual_quantity (>=0), order_created_date, "
+            "production_deadline_date, done_date, additional_info."
+        ),
+    )
+    add_recipe_rows: list[MORecipeRowAdd] | None = Field(
+        default=None,
+        description=(
+            "New recipe rows (ingredients). Each: variant_id (int, required), "
+            "planned_quantity_per_unit (float, required, >0), notes, "
+            "total_actual_quantity (>=0)."
+        ),
+    )
+    update_recipe_rows: list[MORecipeRowUpdate] | None = Field(
+        default=None,
+        description=(
+            "Patches to existing recipe rows. Each entry: id (int, required) "
+            "+ any subset of variant_id, planned_quantity_per_unit, notes, "
+            "total_actual_quantity."
+        ),
+    )
+    delete_recipe_row_ids: list[int] | None = Field(
+        default=None,
+        description="Recipe row IDs to delete from the MO.",
+    )
+    add_operation_rows: list[MOOperationRowAdd] | None = Field(
+        default=None,
+        description=(
+            "New operation rows (production steps). Each: status (required), "
+            "operation_id, type (LINKED template | STANDARD), operation_name, "
+            "resource_id, resource_name, planned_time_parameter, "
+            "planned_time_per_unit, cost_parameter, cost_per_hour."
+        ),
+    )
+    update_operation_rows: list[MOOperationRowUpdate] | None = Field(
+        default=None,
+        description=(
+            "Patches to existing operation rows. Each entry: id (int, "
+            "required) + any subset of status, operation_id, type, "
+            "operation_name, resource_id, resource_name, "
+            "planned_time_parameter, planned_time_per_unit, "
+            "total_actual_time, cost_parameter, cost_per_hour."
+        ),
+    )
+    delete_operation_row_ids: list[int] | None = Field(
+        default=None,
+        description="Operation row IDs to delete from the MO.",
+    )
+    add_productions: list[MOProductionAdd] | None = Field(
+        default=None,
+        description=(
+            "New production records (completion logs). Each: "
+            "completed_quantity (float, required, >0), completed_date, "
+            "is_final (bool — marks as final production record), "
+            "serial_numbers (list[str] — for serial-tracked variants)."
+        ),
+    )
+    update_productions: list[MOProductionUpdate] | None = Field(
+        default=None,
+        description=(
+            "Patches to existing production records. Each entry: id (int, "
+            "required), production_date."
+        ),
+    )
+    delete_production_ids: list[int] | None = Field(
+        default=None,
+        description="Production record IDs to delete from the MO.",
+    )
 
 
 class DeleteManufacturingOrderRequest(ConfirmableRequest):

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -2277,17 +2277,75 @@ class ModifyPurchaseOrderRequest(ConfirmableRequest):
     Fail-fast on first error; the response carries per-action result blocks
     plus a ``prior_state`` snapshot for manual revert.
 
+    Some fields on PO rows are derived (e.g. ``landed_cost``,
+    ``total_in_base_currency``) — Katana computes them server-side and
+    rejects them on update. Set those values indirectly via
+    ``add_additional_costs`` (group-level distribution with ``BY_VALUE``).
+    See ``katana://help/tools`` for the full list of derived fields.
+
     To remove a PO entirely, use the sibling ``delete_purchase_order`` tool.
     """
 
     id: int = Field(..., description="Purchase order ID")
-    update_header: POHeaderPatch | None = Field(default=None)
-    add_rows: list[PORowAdd] | None = Field(default=None)
-    update_rows: list[PORowUpdate] | None = Field(default=None)
-    delete_row_ids: list[int] | None = Field(default=None)
-    add_additional_costs: list[POAdditionalCostAdd] | None = Field(default=None)
-    update_additional_costs: list[POAdditionalCostUpdate] | None = Field(default=None)
-    delete_additional_cost_ids: list[int] | None = Field(default=None)
+    update_header: POHeaderPatch | None = Field(
+        default=None,
+        description=(
+            "Header-level patch. Fields: order_no, supplier_id, currency, "
+            "location_id, tracking_location_id, status (DRAFT/NOT_RECEIVED/"
+            "PARTIALLY_RECEIVED/RECEIVED), expected_arrival_date, "
+            "order_created_date, additional_info. To flip status to RECEIVED "
+            "with inventory updates, use the receive_purchase_order tool."
+        ),
+    )
+    add_rows: list[PORowAdd] | None = Field(
+        default=None,
+        description=(
+            "New line items. Each row: variant_id (int, required), quantity "
+            "(float, required, >0), price_per_unit (float, required), "
+            "tax_rate_id (int — see katana://tax-rates), tax_name, tax_rate, "
+            "currency, purchase_uom, purchase_uom_conversion_rate, "
+            "arrival_date."
+        ),
+    )
+    update_rows: list[PORowUpdate] | None = Field(
+        default=None,
+        description=(
+            "Patches to existing line items. Each entry: id (int, required) + "
+            "any subset of quantity, variant_id, tax_rate_id, tax_name, "
+            "tax_rate, price_per_unit, purchase_uom, "
+            "purchase_uom_conversion_rate, received_date, arrival_date. "
+            "Derived fields (landed_cost, total_in_base_currency, etc.) are "
+            "rejected — distribute landed cost via add_additional_costs."
+        ),
+    )
+    delete_row_ids: list[int] | None = Field(
+        default=None,
+        description="Row IDs to delete from the PO.",
+    )
+    add_additional_costs: list[POAdditionalCostAdd] | None = Field(
+        default=None,
+        description=(
+            "New additional-cost rows (freight, duties, handling). Each row: "
+            "additional_cost_id (int, required — see katana://additional-costs), "
+            "tax_rate_id (int, required — see katana://tax-rates), price "
+            "(float, required), distribution_method (BY_VALUE | "
+            "NON_DISTRIBUTED — controls how the cost spreads across line "
+            "items), group_id (int, optional — defaults to the PO's "
+            "default_group_id)."
+        ),
+    )
+    update_additional_costs: list[POAdditionalCostUpdate] | None = Field(
+        default=None,
+        description=(
+            "Patches to existing additional-cost rows. Each entry: id (int, "
+            "required) + any subset of additional_cost_id, tax_rate_id, "
+            "price, distribution_method."
+        ),
+    )
+    delete_additional_cost_ids: list[int] | None = Field(
+        default=None,
+        description="Additional-cost row IDs to delete from the PO.",
+    )
 
 
 class DeletePurchaseOrderRequest(ConfirmableRequest):

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -1617,19 +1617,99 @@ class ModifySalesOrderRequest(ConfirmableRequest):
     """
 
     id: int = Field(..., description="Sales order ID")
-    update_header: SOHeaderPatch | None = Field(default=None)
-    add_rows: list[SORowAdd] | None = Field(default=None)
-    update_rows: list[SORowUpdate] | None = Field(default=None)
-    delete_row_ids: list[int] | None = Field(default=None)
-    add_addresses: list[SOAddressAdd] | None = Field(default=None)
-    update_addresses: list[SOAddressUpdate] | None = Field(default=None)
-    delete_address_ids: list[int] | None = Field(default=None)
-    add_fulfillments: list[SOFulfillmentAdd] | None = Field(default=None)
-    update_fulfillments: list[SOFulfillmentUpdate] | None = Field(default=None)
-    delete_fulfillment_ids: list[int] | None = Field(default=None)
-    add_shipping_fees: list[SOShippingFeeAdd] | None = Field(default=None)
-    update_shipping_fees: list[SOShippingFeeUpdate] | None = Field(default=None)
-    delete_shipping_fee_ids: list[int] | None = Field(default=None)
+    update_header: SOHeaderPatch | None = Field(
+        default=None,
+        description=(
+            "Header-level patch. Fields: order_no, customer_id, location_id, "
+            "status (NOT_SHIPPED/PENDING/PACKED/DELIVERED), currency, "
+            "conversion_rate, conversion_date, order_created_date, "
+            "delivery_date, picked_date, additional_info, customer_ref, "
+            "tracking_number, tracking_number_url."
+        ),
+    )
+    add_rows: list[SORowAdd] | None = Field(
+        default=None,
+        description=(
+            "New line items. Each row: variant_id (int, required), quantity "
+            "(float, required, >0), price_per_unit, tax_rate_id (see "
+            "katana://tax-rates), location_id, total_discount."
+        ),
+    )
+    update_rows: list[SORowUpdate] | None = Field(
+        default=None,
+        description=(
+            "Patches to existing line items. Each entry: id (int, required) + "
+            "any subset of variant_id, quantity, price_per_unit, tax_rate_id, "
+            "location_id, total_discount."
+        ),
+    )
+    delete_row_ids: list[int] | None = Field(
+        default=None,
+        description="Row IDs to delete from the SO.",
+    )
+    add_addresses: list[SOAddressAdd] | None = Field(
+        default=None,
+        description=(
+            "New addresses. Each: entity_type (billing | shipping, required), "
+            "first_name, last_name, company, city, state, zip, country, phone."
+        ),
+    )
+    update_addresses: list[SOAddressUpdate] | None = Field(
+        default=None,
+        description=(
+            "Patches to existing addresses. Each entry: id (int, required) + "
+            "any subset of first_name, last_name, company, city, state, zip, "
+            "country, phone. Katana doesn't expose address get-by-id, so "
+            "previews mark every supplied field as is_unknown_prior=True."
+        ),
+    )
+    delete_address_ids: list[int] | None = Field(
+        default=None,
+        description="Address IDs to delete from the SO.",
+    )
+    add_fulfillments: list[SOFulfillmentAdd] | None = Field(
+        default=None,
+        description=(
+            "New fulfillments. Each: status (DELIVERED | PACKED, required), "
+            "sales_order_fulfillment_rows (list of {sales_order_row_id, "
+            "quantity}, required, min_length=1), picked_date, "
+            "conversion_rate, conversion_date, tracking_number, tracking_url, "
+            "tracking_carrier, tracking_method."
+        ),
+    )
+    update_fulfillments: list[SOFulfillmentUpdate] | None = Field(
+        default=None,
+        description=(
+            "Patches to existing fulfillments. Each entry: id (int, "
+            "required) + any subset of status, picked_date, packer_id "
+            "(operator — see katana://operators), conversion_rate, "
+            "conversion_date, tracking_number, tracking_url, "
+            "tracking_carrier, tracking_method."
+        ),
+    )
+    delete_fulfillment_ids: list[int] | None = Field(
+        default=None,
+        description="Fulfillment IDs to delete from the SO.",
+    )
+    add_shipping_fees: list[SOShippingFeeAdd] | None = Field(
+        default=None,
+        description=(
+            "New shipping fees. Each: amount (decimal string, required), "
+            "description, tax_rate_id (see katana://tax-rates)."
+        ),
+    )
+    update_shipping_fees: list[SOShippingFeeUpdate] | None = Field(
+        default=None,
+        description=(
+            "Patches to existing shipping fees. Each entry: id (int, "
+            "required), amount (decimal string, required — Katana semantics "
+            "are replace, not partial), description, tax_rate_id."
+        ),
+    )
+    delete_shipping_fee_ids: list[int] | None = Field(
+        default=None,
+        description="Shipping fee IDs to delete from the SO.",
+    )
 
 
 class DeleteSalesOrderRequest(ConfirmableRequest):

--- a/katana_mcp_server/tests/resources/test_reference.py
+++ b/katana_mcp_server/tests/resources/test_reference.py
@@ -1,10 +1,12 @@
-"""Tests for reference data resources (suppliers, locations, tax-rates, operators)."""
+"""Tests for reference data resources (suppliers, locations, tax-rates,
+operators, additional-costs)."""
 
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from katana_mcp.resources.reference import (
+    get_additional_costs,
     get_locations,
     get_operators,
     get_suppliers,
@@ -205,25 +207,85 @@ class TestOperatorsResource:
 
 
 # ============================================================================
+# Additional Costs resource
+# ============================================================================
+
+
+class TestAdditionalCostsResource:
+    @pytest.mark.asyncio
+    async def test_returns_expected_shape(self):
+        context = _make_context_with_cache(
+            [
+                {"id": 1, "name": "Shipping Cost"},
+                {"id": 2, "name": "Import Duty"},
+            ]
+        )
+        with patch(
+            "katana_mcp.resources.reference.ensure_additional_costs_synced",
+            new_callable=AsyncMock,
+        ):
+            result = await _call_and_parse(get_additional_costs, context)
+
+        assert result["summary"]["total_additional_costs"] == 2
+        assert {ac["name"] for ac in result["additional_costs"]} == {
+            "Shipping Cost",
+            "Import Duty",
+        }
+        # next_actions points callers at the consuming tool/parameter
+        assert any(
+            "additional_cost_id" in action and "modify_purchase_order" in action
+            for action in result["next_actions"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_filters_deleted(self):
+        context = _make_context_with_cache(
+            [
+                {"id": 1, "name": "Active"},
+                {"id": 2, "name": "Retired", "deleted_at": "2026-01-01T00:00:00Z"},
+            ]
+        )
+        with patch(
+            "katana_mcp.resources.reference.ensure_additional_costs_synced",
+            new_callable=AsyncMock,
+        ):
+            result = await _call_and_parse(get_additional_costs, context)
+
+        assert result["summary"]["total_additional_costs"] == 1
+        assert result["additional_costs"][0]["name"] == "Active"
+
+    @pytest.mark.asyncio
+    async def test_calls_ensure_synced_before_get_all(self):
+        context = _make_context_with_cache([])
+        with patch(
+            "katana_mcp.resources.reference.ensure_additional_costs_synced",
+            new_callable=AsyncMock,
+        ) as mock_sync:
+            await get_additional_costs(context)
+            mock_sync.assert_awaited_once()
+
+
+# ============================================================================
 # Registration
 # ============================================================================
 
 
 class TestRegistration:
-    def test_registers_four_resources(self):
+    def test_registers_five_resources(self):
         mcp = MagicMock()
         resource_decorator = MagicMock(return_value=lambda fn: fn)
         mcp.resource = MagicMock(return_value=resource_decorator)
 
         register_resources(mcp)
 
-        # Four resource decorators should have been created
-        assert mcp.resource.call_count == 4
+        # Five resource decorators should have been created
+        assert mcp.resource.call_count == 5
         uris = [call.kwargs["uri"] for call in mcp.resource.call_args_list]
         assert "katana://suppliers" in uris
         assert "katana://locations" in uris
         assert "katana://tax-rates" in uris
         assert "katana://operators" in uris
+        assert "katana://additional-costs" in uris
 
     def test_order_resources_not_registered(self):
         """Verify no order resources are registered by the reference module."""

--- a/katana_mcp_server/tests/tools/test_derived_fields.py
+++ b/katana_mcp_server/tests/tools/test_derived_fields.py
@@ -1,0 +1,136 @@
+"""Tests for the derived-field registry and dispatch-layer check."""
+
+import pytest
+from katana_mcp.tools._derived_fields import (
+    DERIVED_FIELDS,
+    DerivedFieldError,
+    check_derived_fields,
+)
+from katana_mcp.tools._modification import FieldChange
+
+
+def _change(field: str, *, new=None, is_added: bool = False) -> FieldChange:
+    """Build a minimal FieldChange for tests."""
+    return FieldChange(field=field, new=new, is_added=is_added)
+
+
+class TestRegistryShape:
+    def test_purchase_order_update_row_includes_landed_cost(self):
+        """Regression: ``landed_cost`` is the field that triggered this work."""
+        po_map = DERIVED_FIELDS["purchase_order"]["update_row"]
+        assert "landed_cost" in po_map
+        # A workaround hint must be set so the user gets a path forward
+        assert po_map["landed_cost"] is not None
+        assert "add_additional_costs" in po_map["landed_cost"]
+
+    def test_workaround_hints_are_strings_or_none(self):
+        for entity_map in DERIVED_FIELDS.values():
+            for op_map in entity_map.values():
+                for hint in op_map.values():
+                    assert hint is None or isinstance(hint, str)
+
+
+class TestCheckDerivedFields:
+    def test_raises_for_landed_cost_on_po_update_row(self):
+        with pytest.raises(DerivedFieldError, match="landed_cost"):
+            check_derived_fields(
+                entity_type="purchase_order",
+                operation="update_row",
+                target_id=555,
+                diff=[_change("landed_cost", new=100.0)],
+            )
+
+    def test_error_message_names_target_id(self):
+        with pytest.raises(DerivedFieldError, match=r"\(target 555\)"):
+            check_derived_fields(
+                entity_type="purchase_order",
+                operation="update_row",
+                target_id=555,
+                diff=[_change("landed_cost", new=100.0)],
+            )
+
+    def test_error_message_includes_workaround_hint(self):
+        with pytest.raises(DerivedFieldError, match="add_additional_costs"):
+            check_derived_fields(
+                entity_type="purchase_order",
+                operation="update_row",
+                target_id=1,
+                diff=[_change("landed_cost", new=50.0)],
+            )
+
+    def test_does_not_raise_for_legitimate_po_row_update(self):
+        check_derived_fields(
+            entity_type="purchase_order",
+            operation="update_row",
+            target_id=555,
+            diff=[
+                _change("quantity", new=15),
+                _change("price_per_unit", new=12.50),
+            ],
+        )
+
+    def test_does_not_raise_for_unknown_entity_type(self):
+        # Unknown entity types pass through — registry is opt-in per entity
+        check_derived_fields(
+            entity_type="unknown_entity",
+            operation="update_row",
+            target_id=1,
+            diff=[_change("landed_cost", new=100)],
+        )
+
+    def test_does_not_raise_for_unknown_operation(self):
+        # Unknown operations pass through — registry is opt-in per operation
+        check_derived_fields(
+            entity_type="purchase_order",
+            operation="some_other_op",
+            target_id=1,
+            diff=[_change("landed_cost", new=100)],
+        )
+
+    def test_does_not_raise_on_empty_diff(self):
+        check_derived_fields(
+            entity_type="purchase_order",
+            operation="update_row",
+            target_id=1,
+            diff=[],
+        )
+
+    def test_fails_fast_on_first_match(self):
+        """Two derived fields in the same diff — only the first surfaces."""
+        with pytest.raises(DerivedFieldError, match="landed_cost"):
+            check_derived_fields(
+                entity_type="purchase_order",
+                operation="update_row",
+                target_id=1,
+                diff=[
+                    _change("landed_cost", new=100.0),
+                    _change("total", new=999.0),
+                ],
+            )
+
+    def test_handles_target_id_none(self):
+        """Create-style actions have target_id=None; the message omits the
+        target suffix rather than rendering ``(target None)``."""
+        with pytest.raises(DerivedFieldError) as exc_info:
+            check_derived_fields(
+                entity_type="purchase_order",
+                operation="update_row",
+                target_id=None,
+                diff=[_change("landed_cost", new=100.0)],
+            )
+        assert "(target" not in str(exc_info.value)
+
+    def test_derived_field_error_subclasses_value_error(self):
+        """Raising ``DerivedFieldError`` surfaces through the standard
+        ``except ValueError`` handler used by tool wrappers."""
+        try:
+            check_derived_fields(
+                entity_type="purchase_order",
+                operation="update_row",
+                target_id=1,
+                diff=[_change("landed_cost", new=10.0)],
+            )
+        except ValueError as exc:
+            assert isinstance(exc, DerivedFieldError)
+        else:
+            pytest.fail("Expected DerivedFieldError to be raised")

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -12,6 +12,7 @@ from katana_mcp.tools.foundation.purchase_orders import (
     DocumentItem,
     GetPurchaseOrderRequest,
     ModifyPurchaseOrderRequest,
+    POAdditionalCostAdd,
     POHeaderPatch,
     PORowAdd,
     PORowUpdate,
@@ -2497,6 +2498,10 @@ _PO_ROW_UPDATE = (
 _PO_ROW_DELETE = (
     "katana_public_api_client.api.purchase_order_row.delete_purchase_order_row"
 )
+_PO_COST_CREATE = (
+    "katana_public_api_client.api.purchase_order_additional_cost_row"
+    ".create_po_additional_cost_row"
+)
 # The modify/delete dispatcher pipes through ``_modification_dispatch.unwrap_as``
 # (apply factories + safe_fetch_for_diff use the dispatcher's binding).
 _PO_UNWRAP_AS = "katana_mcp.tools._modification_dispatch.unwrap_as"
@@ -2697,6 +2702,166 @@ async def test_modify_po_row_update_fetches_row_for_diff(patch_fetch_po):
     diff_by_field = {c.field: c for c in response.actions[0].changes}
     assert diff_by_field["quantity"].old == 10
     assert diff_by_field["quantity"].new == 15
+
+
+@pytest.mark.asyncio
+async def test_modify_po_add_additional_costs_preview_lists_each_cost_row(
+    patch_fetch_po,
+):
+    """Each POAdditionalCostAdd produces its own planned ``add_additional_cost``
+    action with field-level diff entries. Verifies the row schema documented
+    on ``ModifyPurchaseOrderRequest.add_additional_costs`` round-trips through
+    the dispatcher without per-call boilerplate.
+    """
+    context, _ = create_mock_context()
+    existing = create_mock_po(order_id=880, order_no="PO-880", rows=[])
+    existing.default_group_id = 7
+
+    with patch_fetch_po(existing):
+        request = ModifyPurchaseOrderRequest(
+            id=880,
+            add_additional_costs=[
+                POAdditionalCostAdd(
+                    additional_cost_id=1,
+                    tax_rate_id=2,
+                    price=125.0,
+                    distribution_method="BY_VALUE",
+                ),
+                POAdditionalCostAdd(
+                    additional_cost_id=3,
+                    tax_rate_id=2,
+                    price=85.0,
+                    distribution_method="BY_VALUE",
+                    group_id=99,
+                ),
+            ],
+            confirm=False,
+        )
+        response = await _modify_purchase_order_impl(request, context)
+
+    assert response.is_preview is True
+    assert len(response.actions) == 2
+    assert {a.operation for a in response.actions} == {"add_additional_cost"}
+    # Diffs reflect user-supplied fields. Row 0 omitted group_id (resolved from
+    # the PO's default_group_id at dispatch time, not part of the user's input
+    # diff); row 1 supplied group_id=99 explicitly.
+    fields_action_0 = {c.field for c in response.actions[0].changes}
+    assert {
+        "additional_cost_id",
+        "tax_rate_id",
+        "price",
+        "distribution_method",
+    }.issubset(fields_action_0)
+    assert "group_id" not in fields_action_0
+    diff1 = {c.field: c.new for c in response.actions[1].changes}
+    assert diff1["group_id"] == 99
+
+
+@pytest.mark.asyncio
+async def test_modify_po_add_additional_costs_confirm_calls_create_endpoint(
+    patch_fetch_po,
+):
+    """Confirm path POSTs each row to /po_additional_cost_rows."""
+    context, _ = create_mock_context()
+    existing = create_mock_po(order_id=880, order_no="PO-880", rows=[])
+    existing.default_group_id = 7
+    new_cost = MagicMock()
+    new_cost.id = 201
+
+    call_count = 0
+
+    async def fake_create_cost(*, client, body):
+        nonlocal call_count
+        call_count += 1
+        resp = MagicMock()
+        resp.parsed = new_cost
+        return resp
+
+    with (
+        patch_fetch_po(existing),
+        patch(
+            f"{_PO_COST_CREATE}.asyncio_detailed",
+            side_effect=fake_create_cost,
+        ),
+        patch(_PO_UNWRAP_AS, return_value=new_cost),
+    ):
+        request = ModifyPurchaseOrderRequest(
+            id=880,
+            add_additional_costs=[
+                POAdditionalCostAdd(
+                    additional_cost_id=1,
+                    tax_rate_id=2,
+                    price=125.0,
+                    distribution_method="BY_VALUE",
+                )
+            ],
+            confirm=True,
+        )
+        response = await _modify_purchase_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert call_count == 1
+    assert len(response.actions) == 1
+    assert response.actions[0].succeeded is True
+    assert response.actions[0].operation == "add_additional_cost"
+
+
+@pytest.mark.asyncio
+async def test_modify_po_add_additional_costs_without_default_group_id_errors(
+    patch_fetch_po,
+):
+    """When PO has no default_group_id and the row omits group_id, the
+    pre-flight enrichment surfaces a ``ValueError`` (rather than letting the
+    API reject a malformed request).
+    """
+    context, _ = create_mock_context()
+    existing = create_mock_po(order_id=880, order_no="PO-880", rows=[])
+    existing.default_group_id = UNSET
+
+    with patch_fetch_po(existing):
+        request = ModifyPurchaseOrderRequest(
+            id=880,
+            add_additional_costs=[
+                POAdditionalCostAdd(additional_cost_id=1, tax_rate_id=2, price=10.0)
+            ],
+            confirm=False,
+        )
+        with pytest.raises(ValueError, match="group_id"):
+            await _modify_purchase_order_impl(request, context)
+
+
+@pytest.mark.asyncio
+async def test_modify_po_empty_update_row_payload_raises(patch_fetch_po):
+    """A ``PORowUpdate`` carrying only ``id`` (no patch fields) produces an
+    empty diff — the resulting PATCH body would be empty and Katana would
+    return a generic 422. The empty-diff guard surfaces the issue at
+    plan-build time with a named error.
+    """
+    context, _ = create_mock_context()
+    existing_po = create_mock_po(order_id=42, order_no="PO-1", rows=[])
+    existing_row = MagicMock()
+    existing_row.purchase_order_id = 42
+    existing_row.quantity = 10
+
+    with (
+        patch_fetch_po(existing_po),
+        patch(f"{_PO_ROW_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_PO_UNWRAP_AS, return_value=existing_row),
+    ):
+        request = ModifyPurchaseOrderRequest(
+            id=42,
+            update_rows=[PORowUpdate(id=555)],
+            confirm=False,
+        )
+        with pytest.raises(
+            ValueError,
+            match=r"No fields to update.*update_row.*target 555",
+        ) as exc_info:
+            await _modify_purchase_order_impl(request, context)
+
+    # Registered derived fields are mentioned so the caller sees the
+    # likely cause (e.g. tried to set ``landed_cost`` and pydantic dropped it).
+    assert "landed_cost" in str(exc_info.value)
 
 
 # ============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.48.0"
+version = "0.49.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Three intertwined fixes that close the UX gap encountered when distributing landed cost across purchase-order rows. Each is small on its own; in combination they make the workflow self-serve.

**The bug:** trying to set `landed_cost` via `update_rows` returns `UnprocessableEntityError: At least 1 field is required` because every other patched field is also derived and gets stripped from the body. The actual lever is `add_additional_costs` with `distribution_method=BY_VALUE` — but the row shape was undiscoverable in the MCP schema, the `additional_cost_id` catalog had no resource exposure, and the "this field is derived" guidance was buried.

### Changes

1. **Inline row-shape descriptions on `modify_*_order` requests** — Pydantic nests `list[POAdditionalCostAdd]` schemas inside `$defs`; many MCP clients render only the parameter's own description and don't drill in. Each list-of-rows slot now carries a `Field(description=...)` that inline-enumerates the row fields. Applied across PO, SO, and MO for consistency. PO help-resource section gets an explicit "derived fields" call-out pointing at `add_additional_costs` as the landed-cost workaround.

2. **`katana://additional-costs` MCP resource** — mirrors the `katana://tax-rates` pattern. Cache-backed with incremental sync, exposes `{id, name}` per cost type. Lets callers discover `additional_cost_id` rather than guess.

3. **Derived-field registry + preview-time validation** — `katana_mcp/tools/_derived_fields.py` registers entity-operation → derived-field maps with workaround hints. `run_modify_plan` walks each action's diff before execution and raises `DerivedFieldError` (subclasses `ValueError`, surfaces through the standard tool-error path) with a named field + workaround hint. Narrow seed for PO rows: `landed_cost`, `total`, `total_in_base_currency`, `conversion_rate`, `conversion_date`. Defense-in-depth — pydantic's `extra="ignore"` is the primary line of defense; the registry catches future drift if a derived field sneaks onto a hand-rolled patch model.

### Follow-up (separate PR)

A spec-wide audit (PR B, driven by `spec-auditor`) will sweep `docs/katana-openapi.yaml` for fields present on response schemas but absent from `Update*Request` schemas, mark them `readOnly: true`, and expand the registry. Out of scope here to keep this branch reviewable.

### File highlights

- `katana_mcp_server/src/katana_mcp/tools/foundation/{purchase,sales,manufacturing}_orders.py` — `Modify*Request` field descriptions
- `katana_mcp_server/src/katana_mcp/cache.py` + `cache_sync.py` — `EntityType.ADDITIONAL_COST` + sync helpers
- `katana_mcp_server/src/katana_mcp/resources/reference.py` — `get_additional_costs` + registration
- `katana_mcp_server/src/katana_mcp/tools/_derived_fields.py` — new registry module
- `katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py` — preview-time check hook
- `katana_mcp_server/tests/tools/test_derived_fields.py` — 12 unit tests
- `katana_mcp_server/tests/tools/test_purchase_orders.py` — `add_additional_costs` preview/confirm/group_id coverage
- `katana_mcp_server/tests/resources/test_reference.py` — `get_additional_costs` resource tests

Bundles a `uv.lock` workspace-version bump (mcp v0.48.0 → v0.49.0) that landed on main between branch creation and commit.

## Test plan

- [x] `uv run poe check` — full validation (format, lint, typecheck, 2656 tests)
- [x] New tests pass: 12 derived-field, 3 PO additional-cost, 3 additional-costs resource, registration count update
- [x] No regressions in adjacent suites (PO/SO/MO modify, cache, resources, modification dispatch)
- [ ] Manual verification: invoke `modify_purchase_order` with `add_additional_costs` against a sandbox PO; confirm preview surfaces row fields without trial-and-error
- [ ] Manual verification: read `katana://additional-costs` resource; confirm cost catalog returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)