### PR TITLE
refactor(mcp)!: collapse confirm builder kwargs and rename confirm → preview

### DIFF
--- a/katana_mcp_server/src/katana_mcp/prompts/workflows.py
+++ b/katana_mcp_server/src/katana_mcp/prompts/workflows.py
@@ -21,11 +21,11 @@ Check inventory for items below {threshold} units and create purchase orders to 
    - The variant_id (needed for purchase order line items)
    - Supplier item codes and pricing info
 3. Group items by supplier
-4. For each supplier group, call **create_purchase_order** with confirm=false to preview:
+4. For each supplier group, call **create_purchase_order** with preview=true (default) to preview:
    - Set supplier_id, location_id, order_number
    - Include line items with variant_id, quantity, price_per_unit
 5. Review the preview totals with the user
-6. Call **create_purchase_order** with confirm=true to create each order
+6. Call **create_purchase_order** with preview=false to create each order
 """
 
 
@@ -44,9 +44,9 @@ Verify and receive delivery for purchase order {order_id}:
    - If "match": all items verified, safe to receive
    - If "partial_match": review discrepancies with user before proceeding
    - If "no_match": investigate before receiving
-3. Call **receive_purchase_order** with confirm=false to preview the receipt
+3. Call **receive_purchase_order** with preview=true (default) to preview the receipt
 4. Review the preview with the user
-5. Call **receive_purchase_order** with confirm=true to receive items and update inventory
+5. Call **receive_purchase_order** with preview=false to receive items and update inventory
 """
 
 
@@ -59,12 +59,12 @@ async def fulfill_sales_order(order_id: int) -> str:
     return f"""\
 Fulfill sales order {order_id}:
 
-1. Call **fulfill_order** with order_id={order_id}, order_type="sales", confirm=false
-   to preview the fulfillment and check current order status
+1. Call **fulfill_order** with order_id={order_id}, order_type="sales", preview=true
+   (default) to preview the fulfillment and check current order status
 2. If the order has items that need stock verification, call **check_inventory**
    for each SKU to confirm availability
 3. Review the fulfillment preview and stock levels with the user
-4. Call **fulfill_order** with order_id={order_id}, order_type="sales", confirm=true
+4. Call **fulfill_order** with order_id={order_id}, order_type="sales", preview=false
    to create the fulfillment, reduce inventory, and mark items as shipped
 """
 

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -46,38 +46,38 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **create_stock_adjustment / list_stock_adjustments / update_stock_adjustment / delete_stock_adjustment** - Full CRUD for manual inventory adjustments
 
 ### Purchase Orders
-- **create_purchase_order** - Create PO with preview/confirm pattern
+- **create_purchase_order** - Create PO with preview/apply pattern
 - **list_purchase_orders** - List POs with supplier/status/date filters
 - **receive_purchase_order** - Receive items and update inventory
 - **verify_order_document** - Verify supplier documents against POs (returns the full PO alongside match/discrepancy details)
 - **get_purchase_order** - Look up a PO by number or ID — exhaustive detail (every PO/row field, additional cost rows, accounting metadata)
-- **modify_purchase_order** - Unified modify: header, rows, additional-cost rows in one call (typed sub-payload slots, multi-action, preview/confirm)
+- **modify_purchase_order** - Unified modify: header, rows, additional-cost rows in one call (typed sub-payload slots, multi-action, preview/apply)
 - **delete_purchase_order** - Delete a PO (Katana cascades child rows)
 
 ### Manufacturing & Sales
 - **create_manufacturing_order** - Create production work orders
 - **list_manufacturing_orders** - List MOs with status/location/date filters
 - **get_manufacturing_order** - Look up an MO with full details
-- **modify_manufacturing_order** - Unified modify: header, recipe rows, operation rows, production records (multi-action, preview/confirm)
+- **modify_manufacturing_order** - Unified modify: header, recipe rows, operation rows, production records (multi-action, preview/apply)
 - **delete_manufacturing_order** - Delete an MO (Katana cascades child rows)
 - **fulfill_order** - Complete manufacturing or sales orders
-- **create_sales_order** - Create sales orders with preview/confirm
+- **create_sales_order** - Create sales orders with preview/apply
 - **list_sales_orders** - List SOs with customer/status/date filters
 - **get_sales_order** - Look up an SO with full details
-- **modify_sales_order** - Unified modify: header, rows, addresses, fulfillments, shipping fees (multi-action, preview/confirm)
+- **modify_sales_order** - Unified modify: header, rows, addresses, fulfillments, shipping fees (multi-action, preview/apply)
 - **delete_sales_order** - Delete an SO (Katana cascades child rows)
 
 ### Stock Transfers
-- **create_stock_transfer** - Move inventory between locations (preview/confirm)
+- **create_stock_transfer** - Move inventory between locations (preview/apply)
 - **list_stock_transfers** - List transfers with status / location / date filters
-- **modify_stock_transfer** - Unified modify: header body fields and/or status transition in one call (preview/confirm). Hides Katana's two-endpoint split.
+- **modify_stock_transfer** - Unified modify: header body fields and/or status transition in one call (preview/apply). Hides Katana's two-endpoint split.
 - **delete_stock_transfer** - Delete a transfer
 
 ## Safety Pattern
 
-All create/modify operations use a **two-step confirm pattern**:
-1. Call with `confirm=false` to preview (no changes made)
-2. Call with `confirm=true` to execute
+All create/modify operations use a **two-step preview/apply pattern**:
+1. Call with `preview=true` (default) to preview (no changes made)
+2. Call with `preview=false` to execute
 
 Destructive tools advertise this via the standard MCP `destructiveHint`
 tool annotation; hosts that respect the annotation prompt the user before
@@ -93,11 +93,11 @@ the same shape:
 - **Typed sub-payload slots** — one optional field per kind of action
   the entity supports (e.g. `update_header`, `add_rows`, `update_rows`,
   `delete_row_ids`). Set any subset; combinations are valid.
-- **Multi-action confirm** — actions execute in canonical order
+- **Multi-action apply** — actions execute in canonical order
   (header → adds → updates → deletes → status). The Katana API is not
   transactional across endpoints; the dispatcher fail-fasts on the
   first error, leaving earlier successful actions applied.
-- **Prior-state snapshot** — on a confirmed call, the response carries
+- **Prior-state snapshot** — on an applied call, the response carries
   a `prior_state` snapshot of the pre-modification entity (best-effort:
   `prior_state` is `null` when the entity has no GET-by-id endpoint,
   e.g. stock transfer, or the diff-context fetch failed). Callers can
@@ -145,7 +145,7 @@ Patterns (base: `factory.katanamrp.com`, override via `KATANA_WEB_BASE_URL`):
 | Stock adjustments | `/stockadjustment/{id}` |
 
 `katana_url` is `None` when the entity id isn't available — typically
-create-tool previews (no id assigned until confirm=true). Update-tool
+create-tool previews (no id assigned until preview=false). Update-tool
 previews already know the id and return a populated `katana_url`.
 
 ## Common Workflows
@@ -160,7 +160,7 @@ Use `katana://help/workflows` for detailed step-by-step guides.
 ## Reporting & Analytics
 
 Aggregation tools compute rollups in one MCP call instead of paginating
-through hundreds of sales orders client-side. All read-only, no `confirm`.
+through hundreds of sales orders client-side. All read-only, no `preview` flag.
 
 - **top_selling_variants** — top-N variants by units or revenue over a
   date window. Filters: category, location.
@@ -206,7 +206,7 @@ Detailed step-by-step guides for common manufacturing ERP workflows.
      "location_id": 1,
      "order_number": "PO-2025-001",
      "items": [{"variant_id": 501, "quantity": 100, "price_per_unit": 0.15}],
-     "confirm": false
+     "preview": true
    }
    ```
    Returns preview with total cost - no order created yet.
@@ -214,9 +214,9 @@ Detailed step-by-step guides for common manufacturing ERP workflows.
 4. **Confirm and create order**
    ```json
    Tool: create_purchase_order
-   Request: {...same as above..., "confirm": true}
+   Request: {...same as above..., "preview": false}
    ```
-   Creates actual PO once invoked with confirm=true.
+   Creates actual PO once invoked with preview=false.
 
 ---
 
@@ -244,7 +244,7 @@ Detailed step-by-step guides for common manufacturing ERP workflows.
    Request: {
      "order_id": 1234,
      "items": [{"purchase_order_row_id": 501, "quantity": 100}],
-     "confirm": false
+     "preview": true
    }
    ```
    Shows what will be received.
@@ -252,9 +252,9 @@ Detailed step-by-step guides for common manufacturing ERP workflows.
 3. **Confirm receipt**
    ```json
    Tool: receive_purchase_order
-   Request: {...same as above..., "confirm": true}
+   Request: {...same as above..., "preview": false}
    ```
-   Updates inventory once invoked with confirm=true.
+   Updates inventory once invoked with preview=false.
 
 ---
 
@@ -279,7 +279,7 @@ Detailed step-by-step guides for common manufacturing ERP workflows.
    Request: {
      "order_id": 345,
      "order_type": "manufacturing",
-     "confirm": true
+     "preview": false
    }
    ```
    Marks order complete and updates finished goods inventory.
@@ -307,7 +307,7 @@ Detailed step-by-step guides for common manufacturing ERP workflows.
    Request: {
      "order_id": 789,
      "order_type": "sales",
-     "confirm": true
+     "preview": false
    }
    ```
    Updates inventory and marks order as shipped.
@@ -507,7 +507,7 @@ Create a stock adjustment to correct inventory levels.
 - `location_id` (required): Location ID for the adjustment
 - `rows` (required): List of `{sku, quantity, cost_per_unit?}` — positive to add, negative to remove
 - `reason` (optional): Reason for adjustment
-- `confirm` (optional, default false): Set false to preview, true to create
+- `preview` (optional, default true): Set true to preview, false to create
 
 **Returns:** Adjustment ID and summary of changes.
 
@@ -548,7 +548,7 @@ Update header fields on an existing stock adjustment.
 - `location_id` (optional): New location
 - `reason` (optional): New reason
 - `additional_info` (optional): New additional_info
-- `confirm` (optional, default false): false = preview, true = apply (prompts)
+- `preview` (optional, default true): true = preview, false = apply (prompts)
 
 **Safety:** At least one updatable field is required. Row-level edits are not supported
 via this tool — create a new adjustment for that.
@@ -562,11 +562,11 @@ Delete an existing stock adjustment by ID.
 
 **Parameters:**
 - `id` (required): Stock adjustment ID
-- `confirm` (optional, default false): false = preview, true = delete (prompts)
+- `preview` (optional, default true): true = preview, false = delete (prompts)
 
 **Safety:** Deletion reverses the associated inventory movements; the preview returns
 the adjustment number, location, and row count so the change is inspectable before
-confirming.
+applying.
 
 ---
 
@@ -741,7 +741,7 @@ endpoint; variant sub-payloads route to the shared `/variant` family.
 - `id` (required): Item ID
 - `type` (required): "product" | "material" | "service"
 - Any subset of the sub-payloads above
-- `confirm` (optional, default false): false=preview, true=execute
+- `preview` (optional, default true): true=preview, false=execute
 
 ---
 
@@ -751,23 +751,23 @@ Delete an item. Destructive — Katana cascades child variants server-side.
 **Parameters:**
 - `id` (required): Item ID
 - `type` (required): "product" | "material" | "service"
-- `confirm` (optional, default false): false=preview, true=delete
+- `preview` (optional, default true): true=preview, false=delete
 
 ---
 
 ## Purchase Order Tools
 
 ### create_purchase_order
-Create a purchase order with preview/confirm pattern.
+Create a purchase order with preview/apply pattern.
 
 **Parameters:**
 - `supplier_id` (required): Supplier ID
 - `location_id` (required): Warehouse location for receipt
 - `order_number` (required): PO number (e.g., "PO-2025-001")
 - `items` (required): Array of line items with variant_id, quantity, price_per_unit
-- `confirm` (optional, default false): false=preview, true=create
+- `preview` (optional, default true): true=preview, false=create
 
-**Safety:** When confirm=true, prompts user for confirmation before creating.
+**Safety:** When preview=false, prompts user for confirmation before creating.
 
 ---
 
@@ -777,9 +777,9 @@ Receive items from a purchase order.
 **Parameters:**
 - `order_id` (required): Purchase order ID
 - `items` (required): Array of items with purchase_order_row_id and quantity
-- `confirm` (optional, default false): false=preview, true=receive
+- `preview` (optional, default true): true=preview, false=receive
 
-**Safety:** When confirm=true, prompts user for confirmation.
+**Safety:** When preview=false, prompts user for confirmation.
 
 ---
 
@@ -923,8 +923,8 @@ recomputes per-row `landed_cost` automatically.
 **Parameters:**
 - `id` (required): Purchase order ID
 - Any subset of the sub-payloads above
-- `confirm` (optional, default false): false=preview with per-action diff,
-  true=execute the action plan in canonical order (header → row adds →
+- `preview` (optional, default true): true=preview with per-action diff,
+  false=execute the action plan in canonical order (header → row adds →
   row updates → row deletes → cost adds → cost updates → cost deletes);
   fail-fast on first error
 
@@ -940,7 +940,7 @@ Delete a purchase order. Destructive — Katana cascades child rows server-side.
 
 **Parameters:**
 - `id` (required): Purchase order ID
-- `confirm` (optional, default false): false=preview, true=delete
+- `preview` (optional, default true): true=preview, false=delete
 
 ---
 
@@ -955,7 +955,7 @@ Create a manufacturing work order.
 - `location_id` (required): Production location ID
 - `production_deadline_date` (optional): Production deadline
 - `additional_info` (optional): Notes
-- `confirm` (optional, default false): false=preview, true=create
+- `preview` (optional, default true): true=preview, false=create
 
 ---
 
@@ -1021,7 +1021,7 @@ Unified modification surface for an MO — header, recipe rows
 **Parameters:**
 - `id` (required): Manufacturing order ID
 - Any subset of the sub-payloads above
-- `confirm` (optional, default false): false=preview, true=execute the
+- `preview` (optional, default true): true=preview, false=execute the
   action plan in canonical order; fail-fast on first error
 
 **Returns:** A `ModificationResponse` carrying per-action results and a
@@ -1037,7 +1037,7 @@ rows / operation rows / production records server-side.
 
 **Parameters:**
 - `id` (required): Manufacturing order ID
-- `confirm` (optional, default false): false=preview, true=delete
+- `preview` (optional, default true): true=preview, false=delete
 
 ---
 
@@ -1048,7 +1048,7 @@ Create a sales order.
 - `customer_id` (required): Customer ID (use `search_customers` to find)
 - `order_number` (required): Unique sales order number
 - `items` (required): Array of items with variant_id, quantity, and optional price_per_unit
-- `confirm` (optional, default false): false=preview, true=create
+- `preview` (optional, default true): true=preview, false=create
 
 ---
 
@@ -1146,7 +1146,7 @@ fulfillments, and shipping fees in one call.
 **Parameters:**
 - `id` (required): Sales order ID
 - Any subset of the sub-payloads above
-- `confirm` (optional, default false): false=preview, true=execute
+- `preview` (optional, default true): true=preview, false=execute
 
 ---
 
@@ -1156,7 +1156,7 @@ addresses / fulfillments / shipping fees server-side.
 
 **Parameters:**
 - `id` (required): Sales order ID
-- `confirm` (optional, default false): false=preview, true=delete
+- `preview` (optional, default true): true=preview, false=delete
 
 ---
 
@@ -1171,7 +1171,7 @@ Complete a manufacturing or sales order.
 **Parameters:**
 - `order_id` (required): Order ID to fulfill
 - `order_type` (required): "manufacturing" or "sales"
-- `confirm` (optional, default false): false=preview, true=fulfill
+- `preview` (optional, default true): true=preview, false=fulfill
 
 ---
 
@@ -1188,9 +1188,9 @@ Create a stock transfer moving inventory between two locations.
   `batch_transactions` is `[{batch_id, quantity}]` for batch-tracked variants
 - `order_no` (optional): Stock transfer number. When omitted, the tool generates a `ST-<unix-ts>` default before sending — Katana's API requires the field.
 - `additional_info` (optional): Notes
-- `confirm` (optional, default false): false=preview, true=create
+- `preview` (optional, default true): true=preview, false=create
 
-**Safety:** When confirm=true, prompts user for confirmation before creating.
+**Safety:** When preview=false, prompts user for confirmation before creating.
 
 ---
 
@@ -1237,7 +1237,7 @@ these as two separate PATCH endpoints
 **Parameters:**
 - `id` (required): Stock transfer ID
 - Any subset of the sub-payloads above
-- `confirm` (optional, default false): false=preview, true=execute the
+- `preview` (optional, default true): true=preview, false=execute the
   action plan in canonical order (header first, then status); fail-fast
   on first error
 
@@ -1253,7 +1253,7 @@ Delete a stock transfer. Destructive — the transfer record is removed.
 
 **Parameters:**
 - `id` (required): Stock transfer ID
-- `confirm` (optional, default false): false=preview, true=delete
+- `preview` (optional, default true): true=preview, false=delete
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/server.py
+++ b/katana_mcp_server/src/katana_mcp/server.py
@@ -242,9 +242,9 @@ Katana MCP Server — Manufacturing ERP tools for inventory, orders, and product
 
 ## Safety Pattern
 
-All create/modify/delete operations use a two-step confirm pattern:
-1. Call with confirm=false — returns a preview (no changes made)
-2. Call with confirm=true — executes the operation
+All create/modify/delete operations use a two-step preview/apply pattern:
+1. Call with preview=true (default) — returns a preview (no changes made)
+2. Call with preview=false — executes the operation
 
 Destructive tools advertise this via the standard MCP ``destructiveHint``
 tool annotation, which the host uses to confirm with the user before

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -1,17 +1,17 @@
 """Shared infrastructure for entity-modification MCP tools.
 
 Provides a uniform Pydantic response model + helpers for consistent
-preview/confirm UX across modification tools (PO, SO, MO, ...).
+preview/apply UX across modification tools (PO, SO, MO, ...).
 
 A modification tool follows this shape:
 
-1. Build a request Pydantic model with ``confirm: bool = False`` and the
+1. Build a request Pydantic model with ``preview: bool = True`` and the
    fields to modify (all ``Optional`` for PATCH-style operations).
 2. In the impl, optionally fetch the existing entity for diff context, then
    compute a list of :class:`FieldChange` via :func:`compute_field_diff`.
-3. If ``confirm=False`` return :class:`ModificationResponse` with
+3. If ``preview=True`` return :class:`ModificationResponse` with
    ``is_preview=True``.
-4. If ``confirm=True`` call the API, then return
+4. If ``preview=False`` call the API, then return
    :class:`ModificationResponse` with ``is_preview=False``.
 
 Use :func:`render_modification_md` (or :func:`to_tool_result`) to produce the
@@ -38,17 +38,17 @@ from katana_public_api_client.domain.converters import unwrap_unset
 
 class ConfirmableRequest(BaseModel):
     """Base for top-level ``Modify<Entity>Request`` and ``Delete<Entity>Request``
-    Pydantic models. Carries the primary entity ``id`` and the ``confirm``
+    Pydantic models. Carries the primary entity ``id`` and the ``preview``
     field used by every modification tool's preview/apply gate. Subclasses
     add their entity-specific sub-payload slots and override ``id``'s
     description with an entity-appropriate label."""
 
     id: int = Field(..., description="Entity ID")
-    confirm: bool = Field(
-        default=False,
+    preview: bool = Field(
+        default=True,
         description=(
-            "If false, returns a preview with planned actions. "
-            "If true, executes the action plan."
+            "If true (default), returns a preview with planned actions. "
+            "If false, executes the action plan."
         ),
     )
 
@@ -95,7 +95,7 @@ class ActionResult(BaseModel):
 
     Three states:
 
-    - **Preview** (``confirm=False`` on the parent request): ``succeeded``
+    - **Preview** (``preview=True`` on the parent request): ``succeeded``
       and ``verified`` are both ``None`` — the action hasn't been executed,
       only planned. ``changes`` carries the diff that *would* be applied.
     - **Confirmed success**: ``succeeded=True``. ``verified`` may be
@@ -126,7 +126,7 @@ class ModificationResponse(BaseModel):
       are populated; ``actions`` is empty.
     - **Multi-action** (the unified ``modify_<entity>`` tools): ``actions``
       is a list of :class:`ActionResult` and ``operation``/``changes`` are
-      left at their defaults. ``prior_state`` is populated on the confirm
+      left at their defaults. ``prior_state`` is populated on the apply
       branch so the caller can manually revert if needed.
 
     The renderer (:func:`render_modification_md`) checks which shape is in
@@ -147,7 +147,7 @@ class ModificationResponse(BaseModel):
     katana_url: str | None = None
     message: str
 
-    DEFAULT_EXCLUDED: ClassVar[tuple[str, ...]] = ("id", "confirm")
+    DEFAULT_EXCLUDED: ClassVar[tuple[str, ...]] = ("id", "preview")
 
 
 def _normalize(value: Any) -> Any:
@@ -190,7 +190,7 @@ def compute_field_diff(
         field_map: Optional ``request_field -> entity_attr`` rename map for
             fields that don't share names across the layers.
         exclude: Field names on the request to skip (defaults to ``id`` and
-            ``confirm``).
+            ``preview``).
         unknown_prior: When True, ``existing`` being ``None`` represents a
             failed best-effort fetch (the entity exists, we just couldn't
             read it). Each change is then marked ``is_unknown_prior`` so
@@ -349,7 +349,7 @@ def render_modification_md(response: ModificationResponse) -> str:
             lines.append("### Current State (preview snapshot)")
             lines.append(
                 "Snapshot of the entity in its current state — verify this is "
-                "the right target before setting `confirm=true`."
+                "the right target before setting `preview=false` to apply."
             )
         else:
             lines.append("### Prior State (for manual revert)")

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -15,10 +15,10 @@ Every ``modify_<entity>`` tool follows this shape:
 3. Build a ``list[ActionSpec]`` translating sub-payloads into planned API
    calls — each ActionSpec carries the operation name, target id, diff
    metadata, and async closures for ``apply`` and (optional) ``verify``.
-4. **Preview branch** (``confirm=False``): wrap the plan in
+4. **Preview branch** (``preview=True``): wrap the plan in
    :class:`ActionResult` entries with ``succeeded=None`` (planned, not run)
    and return the :class:`ModificationResponse`.
-5. **Confirm branch** (``confirm=True``): call :func:`execute_plan` to run
+5. **Apply branch** (``preview=False``): call :func:`execute_plan` to run
    the actions in order, fail-fast on the first error. Capture
    ``prior_state`` before invoking. Return the same response shape with
    ``actions`` populated.
@@ -184,7 +184,7 @@ async def execute_plan(plan: list[ActionSpec]) -> list[ActionResult]:
 def plan_to_preview_results(plan: list[ActionSpec]) -> list[ActionResult]:
     """Convert a plan to preview-shaped :class:`ActionResult` entries.
 
-    Used by the preview branch (``confirm=False``) where no API calls run.
+    Used by the preview branch (``preview=True``) where no API calls run.
     Each ActionResult carries the operation/target/diff but
     ``succeeded=None`` to signal "planned, not yet executed".
     """
@@ -240,7 +240,7 @@ def has_any_subpayload(
     """True if the request has any sub-payload set (any field outside ``exclude``).
 
     Generic across every ``modify_<entity>`` tool — each has a top-level
-    request with a primary id, ``confirm``, and a set of optional
+    request with a primary id, ``preview``, and a set of optional
     sub-payload slots. This checks whether the caller asked for at least
     one action.
     """
@@ -258,7 +258,7 @@ def make_create_action(
     payload: BaseModel,
     apply: ApplyCallable,
     *,
-    exclude: tuple[str, ...] = ("confirm",),
+    exclude: tuple[str, ...] = ("preview",),
 ) -> ActionSpec:
     """Build an ActionSpec for a create-style operation (POST).
 
@@ -283,7 +283,7 @@ async def make_update_action(
     fetcher: Callable[[int], Awaitable[Any | None]],
     apply: ApplyCallable,
     *,
-    exclude: tuple[str, ...] = ("id", "confirm"),
+    exclude: tuple[str, ...] = ("id", "preview"),
 ) -> ActionSpec:
     """Build an ActionSpec for an update-style operation (PATCH).
 
@@ -579,7 +579,7 @@ def summarize_delete_outcome(
 
 
 # ============================================================================
-# Drivers — wrap the preview/confirm scaffolding so per-entity impls are
+# Drivers — wrap the preview/apply scaffolding so per-entity impls are
 # left with just ``build the plan`` plus a couple of identifying strings.
 # ============================================================================
 
@@ -604,7 +604,7 @@ async def run_modify_plan(
     here, identically across PO/SO/MO/etc.
 
     Args:
-        request: The Pydantic request — must have ``id`` and ``confirm`` fields.
+        request: The Pydantic request — must have ``id`` and ``preview`` fields.
         entity_type: Stable machine-readable type tag (e.g. ``"purchase_order"``).
         entity_label: Human-readable label including the id (e.g. ``"purchase
             order 42"``). Used in messages and warnings.
@@ -633,7 +633,7 @@ async def run_modify_plan(
     )
 
     # Reject server-computed (derived) fields before plan execution. Fires
-    # for both preview and confirm paths so the caller sees the error
+    # for both preview and apply paths so the caller sees the error
     # immediately, not after a partial plan applies. See
     # ``katana_mcp.tools._derived_fields`` for registry semantics.
     for spec in plan:
@@ -673,7 +673,7 @@ async def run_modify_plan(
             )
         raise ValueError(msg)
 
-    if not request.confirm:
+    if request.preview:
         return ModificationResponse(
             entity_type=entity_type,
             entity_id=request.id,
@@ -682,7 +682,7 @@ async def run_modify_plan(
             warnings=warnings,
             next_actions=[
                 f"Review {len(plan)} planned action(s)",
-                "Set confirm=true to execute the plan",
+                "Set preview=false to execute the plan",
             ],
             katana_url=katana_url,
             message=f"Preview: {len(plan)} action(s) planned for {entity_label}",
@@ -724,7 +724,7 @@ async def run_delete_plan(
     ModificationResponse. Katana cascades child deletes server-side.
 
     Args:
-        request: The Pydantic request — needs ``id`` and ``confirm``.
+        request: The Pydantic request — needs ``id`` and ``preview``.
         services: Result of ``get_services(context)``.
         entity_type: Machine tag (e.g. ``"purchase_order"``). The
             human-readable noun ("purchase order") is derived by replacing
@@ -749,11 +749,11 @@ async def run_delete_plan(
     )
     katana_url = katana_web_url(web_url_kind, request.id) if web_url_kind else None
 
-    if not request.confirm:
+    if request.preview:
         # Populate prior_state on the preview path so the rendered markdown
         # shows callers a snapshot of what they're about to delete — gives
         # them a chance to verify they targeted the right entity before
-        # confirming. The fetch is already best-effort: per-entity fetchers
+        # applying. The fetch is already best-effort: per-entity fetchers
         # wrap ``safe_fetch_for_diff`` which swallows errors to ``None``,
         # so a failed fetch leaves prior_state=None and the preview still
         # renders without raising.
@@ -765,7 +765,7 @@ async def run_delete_plan(
             prior_state=prior_state,
             next_actions=[
                 "Review the deletion",
-                f"Set confirm=true to delete the {entity_type.replace('_', ' ')}",
+                f"Set preview=false to delete the {entity_type.replace('_', ' ')}",
             ],
             katana_url=katana_url,
             message=f"Preview: delete {entity_label}",

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -683,9 +683,9 @@ class CreateStockAdjustmentRequest(BaseModel):
         default=None, description="Reason for adjustment (e.g., 'Sample received')"
     )
     additional_info: str | None = Field(default=None, description="Additional notes")
-    confirm: bool = Field(
-        default=False,
-        description="Set false to preview, true to create",
+    preview: bool = Field(
+        default=True,
+        description="Set true (default) to preview, false to create",
     )
 
 
@@ -739,11 +739,11 @@ async def _create_stock_adjustment_impl(
     rows_summary = "\n".join(rows_summary_parts)
 
     # Preview mode
-    if not request.confirm:
+    if request.preview:
         return StockAdjustmentResponse(
             id=None,
             is_preview=True,
-            message="Preview — call again with confirm=true to create",
+            message="Preview — call again with preview=false to create",
             rows_summary=rows_summary,
         )
 
@@ -795,8 +795,8 @@ async def create_stock_adjustment(
 ) -> ToolResult:
     """Create a stock adjustment to correct inventory levels.
 
-    Two-step flow: confirm=false to preview, confirm=true to create (prompts
-    for confirmation). Resolves SKUs to variant IDs automatically.
+    Two-step flow: preview=true (default) to preview, preview=false to create
+    (prompts for confirmation). Resolves SKUs to variant IDs automatically.
 
     Use positive quantities to add stock, negative to remove.
     """
@@ -1215,9 +1215,9 @@ class UpdateStockAdjustmentParams(BaseModel):
     additional_info: str | None = Field(
         default=None, description="New additional_info (optional)"
     )
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns a preview. If true, applies the update.",
+    preview: bool = Field(
+        default=True,
+        description="If true (default), returns a preview. If false, applies the update.",
     )
 
 
@@ -1259,7 +1259,7 @@ def _format_changes_summary(request: UpdateStockAdjustmentParams) -> str:
 async def _update_stock_adjustment_impl(
     request: UpdateStockAdjustmentParams, context: Context
 ) -> UpdateStockAdjustmentResponse:
-    """Update a stock adjustment with preview/confirm safety pattern."""
+    """Update a stock adjustment with preview/apply safety pattern."""
     from katana_public_api_client.api.stock_adjustment import (
         update_stock_adjustment as api_update_stock_adjustment,
     )
@@ -1289,7 +1289,7 @@ async def _update_stock_adjustment_impl(
         )
 
     # Preview mode — no API call.
-    if not request.confirm:
+    if request.preview:
         logger.info(
             "stock_adjustment_update_preview",
             id=request.id,
@@ -1306,7 +1306,7 @@ async def _update_stock_adjustment_impl(
             additional_info=request.additional_info,
             changes_summary=changes_summary,
             message=(
-                f"Preview — call again with confirm=true to update stock "
+                f"Preview — call again with preview=false to update stock "
                 f"adjustment {request.id}"
             ),
             katana_url=katana_web_url("stock_adjustment", request.id),
@@ -1366,11 +1366,12 @@ async def update_stock_adjustment(
 ) -> ToolResult:
     """Update an existing stock adjustment's header fields.
 
-    Two-step flow: `confirm=false` returns a preview of the changes, `confirm=true`
-    prompts the user for confirmation and applies the update via PATCH. At least
-    one updatable field must be supplied (stock_adjustment_number,
-    stock_adjustment_date, location_id, reason, additional_info). Row-level
-    changes are not supported — create a new adjustment for that.
+    Two-step flow: `preview=true` (default) returns a preview of the changes,
+    `preview=false` prompts the user for confirmation and applies the update
+    via PATCH. At least one updatable field must be supplied
+    (stock_adjustment_number, stock_adjustment_date, location_id, reason,
+    additional_info). Row-level changes are not supported — create a new
+    adjustment for that.
     """
     response = await _update_stock_adjustment_impl(request, context)
     status = "PREVIEW" if response.is_preview else "UPDATED"
@@ -1391,9 +1392,9 @@ class DeleteStockAdjustmentRequest(BaseModel):
     """Request to delete an existing stock adjustment."""
 
     id: int = Field(..., description="Stock adjustment ID to delete")
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns a preview. If true, deletes the adjustment.",
+    preview: bool = Field(
+        default=True,
+        description="If true (default), returns a preview. If false, deletes the adjustment.",
     )
 
 
@@ -1411,11 +1412,11 @@ class DeleteStockAdjustmentResponse(BaseModel):
 async def _delete_stock_adjustment_impl(
     request: DeleteStockAdjustmentRequest, context: Context
 ) -> DeleteStockAdjustmentResponse:
-    """Delete a stock adjustment with preview/confirm safety pattern.
+    """Delete a stock adjustment with preview/apply safety pattern.
 
     Preview mode fetches the adjustment (via the list endpoint filter) so the
-    caller can see what will be removed before confirming. Confirm mode calls
-    the API's DELETE endpoint, which reverses the associated inventory changes.
+    caller can see what will be removed before applying. Apply mode calls the
+    API's DELETE endpoint, which reverses the associated inventory changes.
     """
     from katana_public_api_client.api.stock_adjustment import (
         delete_stock_adjustment as api_delete_stock_adjustment,
@@ -1445,7 +1446,7 @@ async def _delete_stock_adjustment_impl(
     stock_adjustment_number = existing.stock_adjustment_number
     location_id = existing.location_id
 
-    if not request.confirm:
+    if request.preview:
         logger.info(
             "stock_adjustment_delete_preview",
             id=request.id,
@@ -1458,7 +1459,7 @@ async def _delete_stock_adjustment_impl(
             location_id=location_id,
             row_count=row_count,
             message=(
-                f"Preview — call again with confirm=true to delete stock "
+                f"Preview — call again with preview=false to delete stock "
                 f"adjustment {stock_adjustment_number} "
                 f"({row_count} row{'s' if row_count != 1 else ''})"
             ),
@@ -1498,10 +1499,10 @@ async def delete_stock_adjustment(
 ) -> ToolResult:
     """Delete a stock adjustment by ID.
 
-    Two-step flow: `confirm=false` returns a preview (including the adjustment
-    number, location, and row count that would be affected); `confirm=true`
-    prompts the user for confirmation, then calls DELETE. Deleting a stock
-    adjustment reverses the associated inventory movements.
+    Two-step flow: `preview=true` (default) returns a preview (including the
+    adjustment number, location, and row count that would be affected);
+    `preview=false` prompts the user for confirmation, then calls DELETE.
+    Deleting a stock adjustment reverses the associated inventory movements.
     """
     response = await _delete_stock_adjustment_impl(request, context)
     status = "PREVIEW" if response.is_preview else "DELETED"

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -930,7 +930,7 @@ async def _invalidate_item_cache(services: Any, item_type: ItemType) -> None:
     """Mark the per-type entity row and the variants table dirty.
 
     The typed cache stores variants and per-type entities (products /
-    materials / services) separately. After a confirmed modify or delete
+    materials / services) separately. After an applied modify or delete
     we invalidate both so the next read sees fresh data. Other modify_*
     tools don't need this because their entity types aren't cache-backed.
     """
@@ -955,7 +955,7 @@ async def _modify_item_impl(
     # ``type`` is a routing discriminator, not a sub-payload — exclude it from
     # the "is anything set?" check so a request with only ``type`` set is
     # still rejected.
-    if not has_any_subpayload(request, exclude=("id", "type", "confirm")):
+    if not has_any_subpayload(request, exclude=("id", "type", "preview")):
         raise ValueError(
             "At least one sub-payload must be set: update_header, "
             "add_variants, update_variants, or delete_variant_ids. "
@@ -1039,7 +1039,7 @@ async def _modify_item_impl(
         plan=plan,
     )
 
-    if request.confirm:
+    if not request.preview:
         await _invalidate_item_cache(services, request.type)
 
     return response
@@ -1072,8 +1072,8 @@ async def modify_item(
 
     To remove an item entirely, use the sibling ``delete_item`` tool.
 
-    Two-step flow: ``confirm=false`` returns a per-action preview;
-    ``confirm=true`` executes the plan in canonical order. Fail-fast on
+    Two-step flow: ``preview=true`` (default) returns a per-action preview;
+    ``preview=false`` executes the plan in canonical order. Fail-fast on
     error.
     """
     response = await _modify_item_impl(request, context)
@@ -1103,7 +1103,7 @@ async def _delete_item_impl(
         operation=ItemOperation.DELETE,
     )
 
-    if request.confirm:
+    if not request.preview:
         await _invalidate_item_cache(services, request.type)
 
     return response

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -174,9 +174,9 @@ class CreateManufacturingOrderRequest(BaseModel):
             "(``MO-<unix-ts>``) is generated client-side."
         ),
     )
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, creates order.",
+    preview: bool = Field(
+        default=True,
+        description="If true (default), returns preview. If false, creates order.",
     )
 
 
@@ -229,12 +229,12 @@ async def _create_manufacturing_order_impl(
             )
 
     mode = "make-to-order" if is_make_to_order else "standalone"
-    action = "Previewing" if not request.confirm else "Starting"
+    action = "Previewing" if request.preview else "Starting"
     logger.info(f"{action} manufacturing order ({mode})")
 
     # Make-to-order: fetch the sales_order_row upfront so both preview and
-    # confirm see the same backing data. The duplicate-create guard runs
-    # in the confirm path too — programmatic callers skipping the preview
+    # apply paths see the same backing data. The duplicate-create guard runs
+    # on the apply path too — programmatic callers skipping the preview
     # UI get the same protection as the iframe (defense in depth).
     sor_variant_id: int | None = None
     sor_quantity: float | None = None
@@ -261,11 +261,11 @@ async def _create_manufacturing_order_impl(
         # the user to recognize what's being made.
         linked_mo = unwrap_unset(sor.linked_manufacturing_order_id, None)
 
-    if not request.confirm:
+    if request.preview:
         warnings: list[str] = []
         next_actions = [
             "Review the order details",
-            "Set confirm=true to create the manufacturing order",
+            "Set preview=false to create the manufacturing order",
         ]
 
         if is_make_to_order:
@@ -454,7 +454,7 @@ async def create_manufacturing_order(
     to also create MOs for subassemblies. This is what you want when processing
     a new sales order that needs production.
 
-    Two-step flow: confirm=false to preview, confirm=true to create.
+    Two-step flow: preview=true (default) to preview, preview=false to create.
     """
     from katana_mcp.tools.prefab_ui import (
         build_order_created_ui,
@@ -2938,8 +2938,8 @@ async def modify_manufacturing_order(
     To remove an MO entirely, use the sibling ``delete_manufacturing_order``
     tool.
 
-    Two-step flow: ``confirm=false`` returns a per-action preview;
-    ``confirm=true`` executes the plan in canonical order. Fail-fast on
+    Two-step flow: ``preview=true`` (default) returns a per-action preview;
+    ``preview=false`` executes the plan in canonical order. Fail-fast on
     error; the response carries a ``prior_state`` snapshot for manual
     revert.
     """

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -459,7 +459,6 @@ async def create_manufacturing_order(
     from katana_mcp.tools.prefab_ui import (
         build_order_created_ui,
         build_order_preview_ui,
-        call_tool_from_request,
     )
 
     response = await _create_manufacturing_order_impl(request, context)
@@ -469,12 +468,8 @@ async def create_manufacturing_order(
         ui = build_order_preview_ui(
             order_dict,
             "Manufacturing Order",
-            request=request.model_dump(),
-            confirm_action=call_tool_from_request(
-                "create_manufacturing_order",
-                CreateManufacturingOrderRequest,
-                overrides={"confirm": True},
-            ),
+            confirm_request=request,
+            confirm_tool="create_manufacturing_order",
         )
     else:
         ui = build_order_created_ui(order_dict, "Manufacturing Order")

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -44,8 +44,9 @@ class FulfillOrderRequest(BaseModel):
     order_type: Literal["manufacturing", "sales"] = Field(
         ..., description="Type of order (manufacturing or sales)"
     )
-    confirm: bool = Field(
-        False, description="If false, returns preview. If true, fulfills order."
+    preview: bool = Field(
+        True,
+        description="If true (default), returns preview. If false, fulfills order.",
     )
 
 
@@ -116,14 +117,14 @@ async def _fulfill_manufacturing_order(
             f"Manufacturing order {order_number} is blocked - review before completing"
         )
 
-    if not request.confirm:
+    if request.preview:
         next_actions = (
             ["Order is already completed - no action needed"]
             if current_status == "DONE"
             else [
                 "Review the manufacturing order details",
                 "Verify all production steps are complete",
-                "Set confirm=true to mark order as DONE",
+                "Set preview=false to mark order as DONE",
             ]
         )
         return FulfillOrderResponse(
@@ -235,14 +236,14 @@ async def _fulfill_sales_order(
             f"{BLOCK_WARNING_PREFIX} Sales order {order_number} has no rows to fulfill."
         )
 
-    if not request.confirm:
+    if request.preview:
         has_block = any(w.startswith(BLOCK_WARNING_PREFIX) for w in warnings)
         next_actions = (
             ["Resolve the issue above (cancel and inspect via the Katana UI)"]
             if has_block
             else [
                 "Review the row list above",
-                "Set confirm=true to create a DELIVERED fulfillment for the full order",
+                "Set preview=false to create a DELIVERED fulfillment for the full order",
             ]
         )
         return FulfillOrderResponse(
@@ -260,7 +261,7 @@ async def _fulfill_sales_order(
             ),
         )
 
-    # Refuse on confirm if the order is already in a delivered state — the
+    # Refuse on apply if the order is already in a delivered state — the
     # preview's BLOCK warning would have suppressed the Confirm button in
     # the iframe, but we re-check here so direct/programmatic callers
     # (skipping the UI) get the same protection.
@@ -352,7 +353,7 @@ async def _fulfill_order_impl(
 ) -> FulfillOrderResponse:
     """Dispatch to the appropriate fulfillment handler."""
     logger.info(
-        f"{'Previewing' if not request.confirm else 'Fulfilling'} {request.order_type} order {request.order_id}"
+        f"{'Previewing' if request.preview else 'Fulfilling'} {request.order_type} order {request.order_id}"
     )
     try:
         if request.order_type == "manufacturing":
@@ -370,8 +371,8 @@ async def fulfill_order(
 ) -> ToolResult:
     """Complete a manufacturing order (mark DONE) or fulfill a sales order (ship items).
 
-    Destructive operation that updates inventory. Two-step flow: confirm=false to
-    preview what would happen, confirm=true to execute.
+    Destructive operation that updates inventory. Two-step flow: preview=true
+    (default) to preview what would happen, preview=false to execute.
 
     Manufacturing: marks order DONE, adds finished goods, consumes raw materials.
     Sales: creates a fulfillment record, reduces available inventory.

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -3,7 +3,7 @@
 Foundation tools for creating, receiving, and verifying purchase orders.
 
 These tools provide:
-- create_purchase_order: Create regular purchase orders with preview/confirm pattern
+- create_purchase_order: Create regular purchase orders with preview/apply pattern
 - receive_purchase_order: Receive items from purchase orders with inventory updates
 - verify_order_document: Verify supplier documents against POs
 """
@@ -139,8 +139,9 @@ class CreatePurchaseOrderRequest(BaseModel):
         None,
         description="Initial status — 'DRAFT' or 'NOT_RECEIVED' (default: NOT_RECEIVED)",
     )
-    confirm: bool = Field(
-        False, description="If false, returns preview. If true, creates order."
+    preview: bool = Field(
+        True,
+        description="If true (default), returns preview. If false, creates order.",
     )
 
 
@@ -173,7 +174,7 @@ def _po_response_to_tool_result(
 
     On the preview branch, the rendered UI's "Confirm & Create" button
     invokes ``create_purchase_order`` directly via ``CallTool`` with the
-    original args + ``confirm=True``.
+    original args + ``preview=False``.
     """
     from katana_mcp.tools.prefab_ui import (
         build_order_created_ui,
@@ -211,13 +212,13 @@ async def _create_purchase_order_impl(
         Exception: If API call fails
     """
     logger.info(
-        f"{'Previewing' if not request.confirm else 'Creating'} purchase order {request.order_number}"
+        f"{'Previewing' if request.preview else 'Creating'} purchase order {request.order_number}"
     )
 
     # Calculate preview total
     total_cost = sum(item.price_per_unit * item.quantity for item in request.items)
 
-    if not request.confirm:
+    if request.preview:
         logger.info(
             f"Preview mode: PO {request.order_number} would have {len(request.items)} items"
         )
@@ -256,7 +257,7 @@ async def _create_purchase_order_impl(
             warnings=warnings,
             next_actions=[
                 "Review the order details",
-                "Set confirm=true to create the purchase order",
+                "Set preview=false to create the purchase order",
             ],
             message=f"Preview: Purchase order {request.order_number} with {len(request.items)} items totaling {total_cost:.2f}",
         )
@@ -344,8 +345,8 @@ async def create_purchase_order(
 ) -> ToolResult:
     """Create a purchase order to buy items from a supplier.
 
-    Two-step flow: set confirm=false to preview totals without creating, then
-    confirm=true to create. Requires supplier_id,
+    Two-step flow: preview=true (default) to preview totals without creating,
+    then preview=false to create. Requires supplier_id,
     location_id, order_number, and at least one line item with variant_id,
     quantity, and price_per_unit. Use get_variant_details to look up variant IDs.
     """
@@ -372,8 +373,9 @@ class ReceivePurchaseOrderRequest(BaseModel):
     items: list[ReceiveItemRequest] = Field(
         ..., description="Items to receive", min_length=1
     )
-    confirm: bool = Field(
-        False, description="If false, returns preview. If true, receives items."
+    preview: bool = Field(
+        True,
+        description="If true (default), returns preview. If false, receives items.",
     )
 
 
@@ -402,7 +404,7 @@ def _receive_response_to_tool_result(
 
     On the preview branch, ``request`` is plumbed into the UI so the
     "Confirm Receipt" button can re-invoke ``receive_purchase_order``
-    directly with ``confirm=True`` and the original items[].
+    directly with ``preview=False`` and the original items[].
     """
     from katana_mcp.tools.prefab_ui import build_receipt_ui
 
@@ -437,7 +439,7 @@ async def _receive_purchase_order_impl(
         Exception: If API call fails
     """
     logger.info(
-        f"{'Previewing' if not request.confirm else 'Receiving'} items for PO {request.order_id}"
+        f"{'Previewing' if request.preview else 'Receiving'} items for PO {request.order_id}"
     )
 
     try:
@@ -461,7 +463,7 @@ async def _receive_purchase_order_impl(
         currency = unwrap_unset(po.currency, None)
         total_cost = unwrap_unset(po.total, None)
 
-        if not request.confirm:
+        if request.preview:
             logger.info(
                 f"Preview mode: Would receive {len(request.items)} items for PO {order_no}"
             )
@@ -482,7 +484,7 @@ async def _receive_purchase_order_impl(
 
             next_actions = [
                 "Review the items to receive",
-                "Set confirm=true to receive the items and update inventory",
+                "Set preview=false to receive the items and update inventory",
             ]
             if po_status == "RECEIVED":
                 warnings.append(
@@ -580,8 +582,8 @@ async def receive_purchase_order(
 ) -> ToolResult:
     """Receive delivered items from a purchase order and update inventory.
 
-    Two-step flow: confirm=false to preview, confirm=true to receive. Use
-    verify_order_document first to validate a supplier document against the
+    Two-step flow: preview=true (default) to preview, preview=false to receive.
+    Use verify_order_document first to validate a supplier document against the
     PO before receiving. Requires the PO ID and row IDs.
     """
     response = await _receive_purchase_order_impl(request, context)
@@ -2395,7 +2397,7 @@ async def _modify_purchase_order_impl(
     request: ModifyPurchaseOrderRequest, context: Context
 ) -> ModificationResponse:
     """Build the action plan from the request's sub-payloads and either
-    preview or execute based on ``confirm``."""
+    preview or execute based on ``preview``."""
     services = get_services(context)
 
     if not has_any_subpayload(request):
@@ -2547,9 +2549,9 @@ async def modify_purchase_order(
 
     To remove a PO entirely, use the sibling ``delete_purchase_order`` tool.
 
-    Two-step flow: ``confirm=false`` returns a per-action preview with diffs;
-    ``confirm=true`` executes the plan in canonical order (header → row adds
-    → row updates → row deletes → cost adds → cost updates → cost deletes).
+    Two-step flow: ``preview=true`` (default) returns a per-action preview with
+    diffs; ``preview=false`` executes the plan in canonical order (header → row
+    adds → row updates → row deletes → cost adds → cost updates → cost deletes).
 
     **Caveats** (Katana's API is not transactional):
 
@@ -2594,9 +2596,9 @@ async def delete_purchase_order(
 ) -> ToolResult:
     """Delete a purchase order. Destructive — the order record is removed.
 
-    Two-step flow: ``confirm=false`` returns a preview, ``confirm=true``
-    deletes the PO. The response carries a ``prior_state`` snapshot of the
-    pre-delete PO so callers can recreate it manually if needed.
+    Two-step flow: ``preview=true`` (default) returns a preview,
+    ``preview=false`` deletes the PO. The response carries a ``prior_state``
+    snapshot of the pre-delete PO so callers can recreate it manually if needed.
     """
     response = await _delete_purchase_order_impl(request, context)
     return to_tool_result(response)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -178,7 +178,6 @@ def _po_response_to_tool_result(
     from katana_mcp.tools.prefab_ui import (
         build_order_created_ui,
         build_order_preview_ui,
-        call_tool_from_request,
     )
 
     order_dict = response.model_dump()
@@ -186,12 +185,8 @@ def _po_response_to_tool_result(
         ui = build_order_preview_ui(
             order_dict,
             "Purchase Order",
-            request=request.model_dump(),
-            confirm_action=call_tool_from_request(
-                "create_purchase_order",
-                CreatePurchaseOrderRequest,
-                overrides={"confirm": True},
-            ),
+            confirm_request=request,
+            confirm_tool="create_purchase_order",
         )
     else:
         ui = build_order_created_ui(order_dict, "Purchase Order")
@@ -409,29 +404,19 @@ def _receive_response_to_tool_result(
     "Confirm Receipt" button can re-invoke ``receive_purchase_order``
     directly with ``confirm=True`` and the original items[].
     """
-    from katana_mcp.tools.prefab_ui import build_receipt_ui, call_tool_from_request
+    from katana_mcp.tools.prefab_ui import build_receipt_ui
 
-    # request and confirm_action are only used by the preview-mode Confirm
-    # Receipt button. Skip seeding them on the non-preview render to keep
+    # confirm_request/confirm_tool are only used by the preview-mode
+    # Confirm Receipt button. Skip them on the non-preview render to keep
     # the structured UI payload trim.
-    seed_request = response.is_preview and request is not None
-    ui = build_receipt_ui(
-        response.model_dump(),
-        request=(
-            request.model_dump()
-            if response.is_preview and request is not None
-            else None
-        ),
-        confirm_action=(
-            call_tool_from_request(
-                "receive_purchase_order",
-                ReceivePurchaseOrderRequest,
-                overrides={"confirm": True},
-            )
-            if seed_request
-            else None
-        ),
-    )
+    if response.is_preview and request is not None:
+        ui = build_receipt_ui(
+            response.model_dump(),
+            confirm_request=request,
+            confirm_tool="receive_purchase_order",
+        )
+    else:
+        ui = build_receipt_ui(response.model_dump())
     return make_tool_result(response, ui=ui)
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -392,7 +392,6 @@ async def create_sales_order(
     from katana_mcp.tools.prefab_ui import (
         build_order_created_ui,
         build_order_preview_ui,
-        call_tool_from_request,
     )
 
     response = await _create_sales_order_impl(request, context)
@@ -402,12 +401,8 @@ async def create_sales_order(
         ui = build_order_preview_ui(
             order_dict,
             "Sales Order",
-            request=request.model_dump(),
-            confirm_action=call_tool_from_request(
-                "create_sales_order",
-                CreateSalesOrderRequest,
-                overrides={"confirm": True},
-            ),
+            confirm_request=request,
+            confirm_tool="create_sales_order",
         )
     else:
         ui = build_order_created_ui(order_dict, "Sales Order")

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -4,7 +4,7 @@ Foundation tools covering the sales-order lifecycle: create, list, get
 (read-mostly tools), plus the unified modify/delete pair.
 
 Tools:
-- create_sales_order: Create sales orders with preview/confirm pattern
+- create_sales_order: Create sales orders with preview/apply pattern
 - list_sales_orders / get_sales_order: discovery + exhaustive read
 - modify_sales_order: header + row CRUD + addresses + fulfillments +
   shipping-fee CRUD via typed sub-payload slots
@@ -189,9 +189,9 @@ class CreateSalesOrderRequest(BaseModel):
     customer_ref: str | None = Field(
         default=None, description="Customer's reference number (optional)"
     )
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, creates order.",
+    preview: bool = Field(
+        default=True,
+        description="If true (default), returns preview. If false, creates order.",
     )
 
 
@@ -232,7 +232,7 @@ async def _create_sales_order_impl(
         Exception: If API call fails
     """
     logger.info(
-        f"{'Previewing' if not request.confirm else 'Creating'} sales order {request.order_number}"
+        f"{'Previewing' if request.preview else 'Creating'} sales order {request.order_number}"
     )
 
     # Calculate preview total (estimate based on items with prices)
@@ -241,7 +241,7 @@ async def _create_sales_order_impl(
         for item in request.items
     )
 
-    if not request.confirm:
+    if request.preview:
         logger.info(
             f"Preview mode: SO {request.order_number} would have {len(request.items)} items"
         )
@@ -279,7 +279,7 @@ async def _create_sales_order_impl(
             warnings=warnings,
             next_actions=[
                 "Review the order details",
-                "Set confirm=true to create the sales order",
+                "Set preview=false to create the sales order",
             ],
             message=f"Preview: Sales order {request.order_number} with {len(request.items)} items"
             + (f" totaling {total_estimate:.2f}" if total_estimate > 0 else ""),
@@ -384,7 +384,7 @@ async def create_sales_order(
 ) -> ToolResult:
     """Create a sales order for a customer purchase.
 
-    Two-step flow: confirm=false to preview totals, confirm=true to create.
+    Two-step flow: preview=true (default) to preview totals, preview=false to create.
     Requires customer_id, order_number, and at least one line item with
     variant_id and quantity. Supports optional pricing overrides, discounts,
     delivery dates, and billing/shipping addresses.
@@ -1808,7 +1808,7 @@ async def _modify_sales_order_impl(
     request: ModifySalesOrderRequest, context: Context
 ) -> ModificationResponse:
     """Build the action plan from the request's sub-payloads and either
-    preview or execute based on ``confirm``."""
+    preview or execute based on ``preview``."""
     services = get_services(context)
 
     if not has_any_subpayload(request):
@@ -2018,8 +2018,8 @@ async def modify_sales_order(
 
     To remove an SO entirely, use the sibling ``delete_sales_order`` tool.
 
-    Two-step flow: ``confirm=false`` returns a per-action preview;
-    ``confirm=true`` executes the plan in canonical order. Fail-fast on
+    Two-step flow: ``preview=true`` (default) returns a per-action preview;
+    ``preview=false`` executes the plan in canonical order. Fail-fast on
     error; per-action ``verified`` reflects post-execution re-fetch
     confirmation (when supported by the resource).
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -2,7 +2,7 @@
 
 Foundation tools covering the full stock-transfer lifecycle:
 
-- create_stock_transfer: Create a transfer with preview/confirm pattern
+- create_stock_transfer: Create a transfer with preview/apply pattern
 - list_stock_transfers: List transfers with paging, date, status filters
 - modify_stock_transfer: Unified modification — header (body fields) and/or
   status transition in a single call. Hides the fact that Katana exposes
@@ -176,9 +176,9 @@ class CreateStockTransferRequest(BaseModel):
     additional_info: str | None = Field(
         default=None, description="Additional notes (optional)"
     )
-    confirm: bool = Field(
-        default=False,
-        description="If false, returns preview. If true, creates the transfer.",
+    preview: bool = Field(
+        default=True,
+        description="If true (default), returns preview. If false, creates the transfer.",
     )
 
 
@@ -258,7 +258,7 @@ async def _create_stock_transfer_impl(
 ) -> StockTransferResponse:
     """Implementation of create_stock_transfer tool."""
     logger.info(
-        f"{'Previewing' if not request.confirm else 'Creating'} stock transfer "
+        f"{'Previewing' if request.preview else 'Creating'} stock transfer "
         f"{request.order_no or '(auto)'} "
         f"({request.source_location_id} -> {request.destination_location_id})"
     )
@@ -266,9 +266,9 @@ async def _create_stock_transfer_impl(
     item_count = len(request.rows)
 
     # Resolve source/destination names + compute warnings up-front; both
-    # the preview and confirm paths use them. Source==destination is a
-    # hard BLOCK enforced on confirm too — defense in depth for callers
-    # that skip the preview UI.
+    # the preview and apply paths use them. Source==destination is a
+    # hard BLOCK enforced on the apply path too — defense in depth for
+    # callers that skip the preview UI.
     from katana_mcp.cache import EntityType
 
     services = get_services(context)
@@ -306,7 +306,7 @@ async def _create_stock_transfer_impl(
         else f"location id={request.destination_location_id}"
     )
 
-    if not request.confirm:
+    if request.preview:
         preview_message = (
             f"Preview: Stock transfer with {item_count} row(s) from "
             f"{src_label} to {dst_label}"
@@ -325,7 +325,7 @@ async def _create_stock_transfer_impl(
             warnings=warnings,
             next_actions=[
                 "Review the transfer details",
-                "Set confirm=true to create the stock transfer",
+                "Set preview=false to create the stock transfer",
             ],
             message=preview_message,
         )
@@ -395,10 +395,11 @@ async def create_stock_transfer(
 ) -> ToolResult:
     """Create a stock transfer moving inventory between two locations.
 
-    Two-step flow: confirm=false to preview, confirm=true to create (prompts for
-    confirmation). Requires source_location_id, destination_location_id,
-    expected_arrival_date, and at least one row with variant_id + quantity.
-    For batch-tracked variants, supply `batch_transactions` on the row.
+    Two-step flow: preview=true (default) to preview, preview=false to create
+    (prompts for confirmation). Requires source_location_id,
+    destination_location_id, expected_arrival_date, and at least one row with
+    variant_id + quantity. For batch-tracked variants, supply
+    `batch_transactions` on the row.
     """
     response = await _create_stock_transfer_impl(request, context)
 
@@ -925,8 +926,8 @@ async def modify_stock_transfer(
     not expose row-CRUD endpoints. To remove a transfer entirely, use the
     sibling ``delete_stock_transfer`` tool.
 
-    Two-step flow: ``confirm=false`` returns a per-action preview;
-    ``confirm=true`` executes the plan in canonical order (header before
+    Two-step flow: ``preview=true`` (default) returns a per-action preview;
+    ``preview=false`` executes the plan in canonical order (header before
     status). Fail-fast on error.
 
     Note: Katana doesn't expose a GET-by-id endpoint for stock transfers,

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from prefab_ui.actions import Action, SetState, ShowToast
+from prefab_ui.actions import SetState, ShowToast
 from prefab_ui.actions.mcp import CallTool, SendMessage
 from prefab_ui.app import PrefabApp
 from prefab_ui.components import (
@@ -88,9 +88,10 @@ def call_tool_from_request(
     over the templated values — use them to flip a flag or substitute a literal.
 
     The caller must seed the iframe state with the original request under
-    ``state_key`` (default ``"request"``); the matching builder
-    (``build_order_preview_ui`` and friends) accepts a ``request=`` kwarg
-    that does this.
+    ``state_key`` (default ``"request"``). Most callers don't invoke this
+    helper directly — the order/receipt/batch builders accept a
+    ``confirm_request`` Pydantic model and handle both the seeding and the
+    ``CallTool`` construction internally.
     """
     valid_fields = set(request_model.model_fields)
     args: dict[str, Any] = {
@@ -426,20 +427,24 @@ def build_order_preview_ui(
     order: dict[str, Any],
     order_type: OrderType,
     *,
-    confirm_action: Action,
-    request: dict[str, Any],
+    confirm_request: BaseModel,
+    confirm_tool: str,
 ) -> PrefabApp:
     """Build an order preview card with confirm/cancel buttons.
 
-    Caller supplies ``confirm_action`` (typically a ``CallTool`` built via
-    ``call_tool_from_request``) so each tool (sales/PO/MO) wires its own
-    direct re-invocation with ``confirm=True``. ``request`` is the original
-    input dict (``request.model_dump()``); it's seeded into iframe state at
-    ``state.request`` so ``CallTool``'s ``{{ request.* }}`` templates
-    resolve.
+    Pass ``confirm_request`` (the original Pydantic input) and
+    ``confirm_tool`` (the matching tool name); the builder seeds iframe
+    state at ``state.request`` and constructs the ``CallTool`` action with
+    ``confirm=True`` internally so the Confirm button re-invokes the tool
+    directly without an LLM round-trip.
     """
     fields = _extract_order_fields(order)
-    state: dict[str, Any] = {"order": order, "request": request}
+    confirm_action = call_tool_from_request(
+        confirm_tool,
+        type(confirm_request),
+        overrides={"confirm": True},
+    )
+    state: dict[str, Any] = {"order": order, "request": confirm_request.model_dump()}
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
@@ -774,23 +779,34 @@ def build_item_mutation_ui(
 def build_receipt_ui(
     response: dict[str, Any],
     *,
-    request: dict[str, Any] | None = None,
-    confirm_action: Action | None = None,
+    confirm_request: BaseModel | None = None,
+    confirm_tool: str | None = None,
 ) -> PrefabApp:
     """Build a receipt card for received purchase order items.
 
-    On the preview branch the caller must supply both ``request`` (seeded
-    into iframe state at ``state.request``) and ``confirm_action`` (a
-    ``CallTool`` built via ``call_tool_from_request``) so the "Confirm
-    Receipt" button can re-invoke ``receive_purchase_order`` directly with
-    ``confirm=True``. Both kwargs are optional because the same builder is
-    reused for the non-preview render where no confirm button is shown.
+    On the preview branch, pass ``confirm_request`` (the original Pydantic
+    input) and ``confirm_tool`` (the matching tool name) so the "Confirm
+    Receipt" button can re-invoke the tool directly with ``confirm=True``.
+    Both kwargs are optional because the same builder is reused for the
+    non-preview render where no confirm button is shown — but they must be
+    set together.
     """
+    if (confirm_request is None) != (confirm_tool is None):
+        raise ValueError(
+            "confirm_request and confirm_tool must be set together (or both None)"
+        )
+
     order_number = response.get("order_number", "N/A")
     is_preview = response.get("is_preview", True)
     state: dict[str, Any] = {"response": response}
-    if request is not None:
-        state["request"] = request
+    confirm_action: CallTool | None = None
+    if confirm_request is not None and confirm_tool is not None:
+        state["request"] = confirm_request.model_dump()
+        confirm_action = call_tool_from_request(
+            confirm_tool,
+            type(confirm_request),
+            overrides={"confirm": True},
+        )
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
@@ -864,20 +880,24 @@ def build_receipt_ui(
 def build_batch_recipe_update_ui(
     response: dict[str, Any],
     *,
-    request: dict[str, Any] | None = None,
-    confirm_action: Action | None = None,
+    confirm_request: BaseModel | None = None,
+    confirm_tool: str | None = None,
 ) -> PrefabApp:
     """Build a batch recipe update card with per-group tables and summary metrics.
 
     Shows one row per planned sub-op grouped by replacement group_label.
     Preview mode shows all ops as PENDING; executed mode shows SUCCESS/FAILED/SKIPPED.
 
-    On the preview branch, the "Execute batch" button uses ``confirm_action``
-    (typically a ``CallTool`` built from the original request via
-    ``call_tool_from_request``) for direct re-invocation with ``confirm=True``.
-    Pass ``request=request.model_dump()`` from the caller so the iframe state
-    has the original input under ``state.request``.
+    On the preview branch, pass ``confirm_request`` (the original Pydantic
+    input) and ``confirm_tool`` (the matching tool name) so the "Execute
+    batch" button can re-invoke the tool directly with ``confirm=True``.
+    Both kwargs are optional because the same builder is reused for the
+    non-preview render — but they must be set together.
     """
+    if (confirm_request is None) != (confirm_tool is None):
+        raise ValueError(
+            "confirm_request and confirm_tool must be set together (or both None)"
+        )
     is_preview = response.get("is_preview", True)
     results = response.get("results", [])
     warnings = response.get("warnings", [])
@@ -931,8 +951,14 @@ def build_batch_recipe_update_ui(
         "warnings": warnings,
         "groups": list(groups.keys()),
     }
-    if request is not None:
-        state["request"] = request
+    confirm_action: CallTool | None = None
+    if confirm_request is not None and confirm_tool is not None:
+        state["request"] = confirm_request.model_dump()
+        confirm_action = call_tool_from_request(
+            confirm_tool,
+            type(confirm_request),
+            overrides={"confirm": True},
+        )
 
     with (
         PrefabApp(

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -84,7 +84,7 @@ def call_tool_from_request(
     of ``request_model`` templated from iframe state.
 
     Each field on the Pydantic request model maps to a ``{{ <state_key>.field }}``
-    template string. ``overrides`` (e.g. ``{"confirm": True}``) take precedence
+    template string. ``overrides`` (e.g. ``{"preview": False}``) take precedence
     over the templated values — use them to flip a flag or substitute a literal.
 
     The caller must seed the iframe state with the original request under
@@ -435,14 +435,14 @@ def build_order_preview_ui(
     Pass ``confirm_request`` (the original Pydantic input) and
     ``confirm_tool`` (the matching tool name); the builder seeds iframe
     state at ``state.request`` and constructs the ``CallTool`` action with
-    ``confirm=True`` internally so the Confirm button re-invokes the tool
+    ``preview=False`` internally so the Confirm button re-invokes the tool
     directly without an LLM round-trip.
     """
     fields = _extract_order_fields(order)
     confirm_action = call_tool_from_request(
         confirm_tool,
         type(confirm_request),
-        overrides={"confirm": True},
+        overrides={"preview": False},
     )
     state: dict[str, Any] = {"order": order, "request": confirm_request.model_dump()}
 
@@ -578,7 +578,7 @@ def build_fulfill_preview_ui(
     """Build a fulfillment preview card.
 
     The "Confirm Fulfillment" button invokes ``fulfill_order`` directly via
-    ``CallTool`` with ``confirm=True`` and the original order_id/order_type
+    ``CallTool`` with ``preview=False`` and the original order_id/order_type
     sourced from the response (where they're echoed). No LLM round-trip.
     """
     order_type, order_number, status = _extract_fulfill_fields(response)
@@ -610,7 +610,7 @@ def build_fulfill_preview_ui(
                         arguments={
                             "order_id": "{{ response.order_id }}",
                             "order_type": "{{ response.order_type }}",
-                            "confirm": True,
+                            "preview": False,
                         },
                     ),
                 )
@@ -786,7 +786,7 @@ def build_receipt_ui(
 
     On the preview branch, pass ``confirm_request`` (the original Pydantic
     input) and ``confirm_tool`` (the matching tool name) so the "Confirm
-    Receipt" button can re-invoke the tool directly with ``confirm=True``.
+    Receipt" button can re-invoke the tool directly with ``preview=False``.
     Both kwargs are optional because the same builder is reused for the
     non-preview render where no confirm button is shown — but they must be
     set together.
@@ -805,7 +805,7 @@ def build_receipt_ui(
         confirm_action = call_tool_from_request(
             confirm_tool,
             type(confirm_request),
-            overrides={"confirm": True},
+            overrides={"preview": False},
         )
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
@@ -890,7 +890,7 @@ def build_batch_recipe_update_ui(
 
     On the preview branch, pass ``confirm_request`` (the original Pydantic
     input) and ``confirm_tool`` (the matching tool name) so the "Execute
-    batch" button can re-invoke the tool directly with ``confirm=True``.
+    batch" button can re-invoke the tool directly with ``preview=False``.
     Both kwargs are optional because the same builder is reused for the
     non-preview render — but they must be set together.
     """
@@ -957,7 +957,7 @@ def build_batch_recipe_update_ui(
         confirm_action = call_tool_from_request(
             confirm_tool,
             type(confirm_request),
-            overrides={"confirm": True},
+            overrides={"preview": False},
         )
 
     with (

--- a/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
+++ b/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
@@ -69,7 +69,7 @@ async def resolve_entity_name(
         warning = (
             f"{entity_label} with id={entity_id} was not found in the cache "
             f"(possible cache lag); the {entity_label.lower()} will be "
-            "validated by the live API on confirm."
+            "validated by the live API on apply."
         )
         return None, warning
     return d.get("name") or None, None

--- a/katana_mcp_server/tests/integration/test_manufacturing_workflow.py
+++ b/katana_mcp_server/tests/integration/test_manufacturing_workflow.py
@@ -40,7 +40,7 @@ class TestManufacturingOrderPreviewWorkflow:
             planned_quantity=50,
             location_id=1,  # Test location ID
             additional_info="Integration test - preview only",
-            confirm=False,  # Preview mode
+            preview=True,  # Preview mode
         )
 
         result = await _create_manufacturing_order_impl(request, integration_context)
@@ -69,7 +69,7 @@ class TestManufacturingOrderPreviewWorkflow:
             order_created_date=datetime.now(UTC),
             production_deadline_date=deadline,
             additional_info="Full fields test",
-            confirm=False,
+            preview=True,
         )
 
         result = await _create_manufacturing_order_impl(request, integration_context)
@@ -112,7 +112,7 @@ class TestManufacturingOrderPreviewWorkflow:
             planned_quantity=25,
             location_id=1,
             additional_info=f"Test MO for {first_item.sku}",
-            confirm=False,
+            preview=True,
         )
 
         result = await _create_manufacturing_order_impl(mo_request, integration_context)
@@ -138,7 +138,7 @@ class TestManufacturingOrderValidation:
                 variant_id=1,
                 planned_quantity=0,  # Zero should fail
                 location_id=1,
-                confirm=False,
+                preview=True,
             )
 
         with pytest.raises(ValueError):
@@ -146,7 +146,7 @@ class TestManufacturingOrderValidation:
                 variant_id=1,
                 planned_quantity=-10,  # Negative should fail
                 location_id=1,
-                confirm=False,
+                preview=True,
             )
 
     async def test_mo_preview_vs_confirm_behavior(self, integration_context):
@@ -160,7 +160,7 @@ class TestManufacturingOrderValidation:
         # Preview mode - should not create
         preview_request = CreateManufacturingOrderRequest(
             **base_request_data,
-            confirm=False,
+            preview=True,
         )
         preview_result = await _create_manufacturing_order_impl(
             preview_request, integration_context
@@ -169,7 +169,7 @@ class TestManufacturingOrderValidation:
         assert preview_result.is_preview is True
         assert preview_result.id is None  # No ID in preview
 
-        # Note: We don't test confirm=True here as it would create real data
+        # Note: We don't test preview=False here as it would create real data
 
 
 @pytest.mark.integration
@@ -184,7 +184,7 @@ class TestManufacturingWorkflowEdgeCases:
             planned_quantity=100000,
             location_id=1,
             additional_info="Large batch test",
-            confirm=False,
+            preview=True,
         )
 
         result = await _create_manufacturing_order_impl(request, integration_context)
@@ -198,7 +198,7 @@ class TestManufacturingWorkflowEdgeCases:
             variant_id=1,
             planned_quantity=12.5,
             location_id=1,
-            confirm=False,
+            preview=True,
         )
 
         result = await _create_manufacturing_order_impl(request, integration_context)
@@ -215,7 +215,7 @@ class TestManufacturingWorkflowEdgeCases:
             planned_quantity=10,
             location_id=1,
             production_deadline_date=past_deadline,
-            confirm=False,
+            preview=True,
         )
 
         result = await _create_manufacturing_order_impl(request, integration_context)
@@ -232,7 +232,7 @@ class TestManufacturingWorkflowEdgeCases:
             planned_quantity=10,
             location_id=1,
             additional_info=long_info,
-            confirm=False,
+            preview=True,
         )
 
         result = await _create_manufacturing_order_impl(request, integration_context)
@@ -276,7 +276,7 @@ class TestManufacturingSearchIntegration:
                 planned_quantity=10,
                 location_id=1,
                 additional_info=f"Batch test for {item.sku}",
-                confirm=False,
+                preview=True,
             )
 
             result = await _create_manufacturing_order_impl(

--- a/katana_mcp_server/tests/integration/test_purchase_order_workflow.py
+++ b/katana_mcp_server/tests/integration/test_purchase_order_workflow.py
@@ -59,7 +59,7 @@ class TestPurchaseOrderPreviewWorkflow:
                 ),
             ],
             notes="Integration test order - preview only",
-            confirm=False,  # Preview mode
+            preview=True,  # Preview mode
         )
 
         result = await _create_purchase_order_impl(request, integration_context)
@@ -120,7 +120,7 @@ class TestPurchaseOrderPreviewWorkflow:
             order_number=order_number,
             items=po_items,
             notes="Test PO created from search results",
-            confirm=False,  # Preview only
+            preview=True,  # Preview only
         )
 
         result = await _create_purchase_order_impl(po_request, integration_context)
@@ -152,7 +152,7 @@ class TestPurchaseOrderPreviewWorkflow:
             notes="Full options test",
             currency="USD",
             status="NOT_RECEIVED",
-            confirm=False,
+            preview=True,
         )
 
         result = await _create_purchase_order_impl(request, integration_context)
@@ -180,7 +180,7 @@ class TestPurchaseOrderValidation:
                 location_id=1,
                 order_number="TEST-EMPTY",
                 items=[],  # Empty items should fail
-                confirm=False,
+                preview=True,
             )
 
     async def test_po_item_requires_positive_quantity(self):
@@ -223,7 +223,7 @@ class TestPurchaseOrderValidation:
         # Preview mode
         preview_request = CreatePurchaseOrderRequest(
             **base_request_data,
-            confirm=False,
+            preview=True,
         )
         preview_result = await _create_purchase_order_impl(
             preview_request, integration_context
@@ -232,7 +232,7 @@ class TestPurchaseOrderValidation:
         assert preview_result.is_preview is True
         assert preview_result.id is None  # No ID in preview
 
-        # Note: We don't test confirm=True here as it would create real data
+        # Note: We don't test preview=False here as it would create real data
         # That's tested in a separate test marked with @pytest.mark.creates_data
 
 
@@ -256,7 +256,7 @@ class TestPurchaseOrderWorkflowEdgeCases:
                     price_per_unit=0.01,  # Small unit price
                 ),
             ],
-            confirm=False,
+            preview=True,
         )
 
         result = await _create_purchase_order_impl(request, integration_context)
@@ -282,7 +282,7 @@ class TestPurchaseOrderWorkflowEdgeCases:
             location_id=1,
             order_number=unique_order_number,
             items=items,
-            confirm=False,
+            preview=True,
         )
 
         result = await _create_purchase_order_impl(request, integration_context)
@@ -311,7 +311,7 @@ class TestPurchaseOrderWorkflowEdgeCases:
                     price_per_unit=100.00,
                 ),
             ],
-            confirm=False,
+            preview=True,
         )
 
         result = await _create_purchase_order_impl(request, integration_context)

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -24,6 +24,16 @@ from katana_mcp.tools.prefab_ui import (
     build_verification_ui,
 )
 from prefab_ui.app import PrefabApp
+from pydantic import BaseModel
+
+
+class _StubRequest(BaseModel):
+    """Minimal Pydantic stub used by builder tests that don't care about the
+    real request shape — only that the builder accepts a BaseModel and emits
+    a valid envelope.
+    """
+
+    confirm: bool = False
 
 
 def _assert_valid_prefab(app: PrefabApp) -> None:
@@ -146,11 +156,6 @@ class TestBuildLowStockUI:
 
 
 class TestBuildOrderPreviewUI:
-    def _stub_action(self):
-        from prefab_ui.actions.mcp import SendMessage
-
-        return SendMessage("stub")
-
     def test_purchase_order(self):
         order = {
             "order_number": "PO-001",
@@ -163,8 +168,8 @@ class TestBuildOrderPreviewUI:
         app = build_order_preview_ui(
             order,
             "Purchase Order",
-            request={},
-            confirm_action=self._stub_action(),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_purchase_order",
         )
         _assert_valid_prefab(app)
 
@@ -179,8 +184,8 @@ class TestBuildOrderPreviewUI:
         app = build_order_preview_ui(
             order,
             "Sales Order",
-            request={},
-            confirm_action=self._stub_action(),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_sales_order",
         )
         _assert_valid_prefab(app)
 
@@ -478,8 +483,8 @@ class TestConfirmButtonsUseCallTool:
     def test_order_preview_confirm_action_emits_calltool(self):
         from katana_mcp.tools.foundation.purchase_orders import (
             CreatePurchaseOrderRequest,
+            PurchaseOrderItem,
         )
-        from katana_mcp.tools.prefab_ui import call_tool_from_request
 
         order_dict = {
             "id": 1,
@@ -493,27 +498,17 @@ class TestConfirmButtonsUseCallTool:
             "next_actions": [],
             "message": "Preview",
         }
-        request_dict = {
-            "supplier_id": 2,
-            "location_id": 3,
-            "order_number": "PO-1",
-            "items": [],
-            "currency": "USD",
-            "expected_arrival_date": None,
-            "additional_info": None,
-            "status": "NOT_RECEIVED",
-            "confirm": False,
-        }
-        confirm_action = call_tool_from_request(
-            "create_purchase_order",
-            CreatePurchaseOrderRequest,
-            overrides={"confirm": True},
+        request = CreatePurchaseOrderRequest(
+            supplier_id=2,
+            location_id=3,
+            order_number="PO-1",
+            items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
         )
         app = build_order_preview_ui(
             order_dict,
             "Purchase Order",
-            request=request_dict,
-            confirm_action=confirm_action,
+            confirm_request=request,
+            confirm_tool="create_purchase_order",
         )
         envelope = app.to_json()
 
@@ -558,12 +553,6 @@ class TestBlockWarningSuppressesConfirm:
     the server has flagged as unsafe (e.g. duplicate-create, already-done).
     """
 
-    @staticmethod
-    def _stub_action():
-        from prefab_ui.actions.mcp import SendMessage
-
-        return SendMessage("stub")
-
     def test_order_preview_with_block_warning_omits_confirm_button(self):
         order = {
             "order_number": "MO-1",
@@ -577,8 +566,8 @@ class TestBlockWarningSuppressesConfirm:
         app = build_order_preview_ui(
             order,
             "Manufacturing Order",
-            request={},
-            confirm_action=self._stub_action(),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_manufacturing_order",
         )
         envelope = app.to_json()
 
@@ -603,8 +592,8 @@ class TestBlockWarningSuppressesConfirm:
         app = build_order_preview_ui(
             order,
             "Manufacturing Order",
-            request={},
-            confirm_action=self._stub_action(),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_manufacturing_order",
         )
         envelope = app.to_json()
 
@@ -633,9 +622,9 @@ class TestBlockWarningSuppressesConfirm:
 
     def test_receipt_ui_with_block_warning_omits_confirm_button(self):
         from katana_mcp.tools.foundation.purchase_orders import (
+            ReceiveItemRequest,
             ReceivePurchaseOrderRequest,
         )
-        from katana_mcp.tools.prefab_ui import call_tool_from_request
 
         response = {
             "order_number": "PO-1",
@@ -647,15 +636,14 @@ class TestBlockWarningSuppressesConfirm:
                 "BLOCK: Purchase order PO-1 is already RECEIVED.",
             ],
         }
-        confirm_action = call_tool_from_request(
-            "receive_purchase_order",
-            ReceivePurchaseOrderRequest,
-            overrides={"confirm": True},
+        request = ReceivePurchaseOrderRequest(
+            order_id=1,
+            items=[ReceiveItemRequest(purchase_order_row_id=10, quantity=1.0)],
         )
         app = build_receipt_ui(
             response,
-            request={"order_id": 1, "items": [], "confirm": False},
-            confirm_action=confirm_action,
+            confirm_request=request,
+            confirm_tool="receive_purchase_order",
         )
         envelope = app.to_json()
 
@@ -679,8 +667,8 @@ class TestBlockWarningSuppressesConfirm:
         app = build_order_preview_ui(
             order,
             "Manufacturing Order",
-            request={},
-            confirm_action=self._stub_action(),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_manufacturing_order",
         )
 
         def collect_badge_labels(tree: object, out: list[str]) -> None:

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -33,7 +33,7 @@ class _StubRequest(BaseModel):
     a valid envelope.
     """
 
-    confirm: bool = False
+    preview: bool = True
 
 
 def _assert_valid_prefab(app: PrefabApp) -> None:
@@ -421,7 +421,7 @@ class TestCallToolFromRequest:
     The helper introspects a Pydantic request model and emits a CallTool
     action whose ``arguments`` template every field from iframe state.
     Used to wire the Confirm buttons in preview UIs back to their tool with
-    ``confirm=True``, without an LLM round-trip.
+    ``preview=False``, without an LLM round-trip.
     """
 
     def test_args_template_each_field(self):
@@ -433,17 +433,17 @@ class TestCallToolFromRequest:
         action = call_tool_from_request(
             "create_purchase_order",
             CreatePurchaseOrderRequest,
-            overrides={"confirm": True},
+            overrides={"preview": False},
         )
         # Tool name is set
         assert action.tool == "create_purchase_order"
         # Every non-overridden field is templated from state.request
         for fname in CreatePurchaseOrderRequest.model_fields:
-            if fname == "confirm":
+            if fname == "preview":
                 continue  # overridden — verified separately
             assert action.arguments[fname] == f"{{{{ request.{fname} }}}}"
         # Override wins over the templated value
-        assert action.arguments["confirm"] is True
+        assert action.arguments["preview"] is False
 
     def test_state_key_override(self):
         from katana_mcp.tools.foundation.orders import FulfillOrderRequest
@@ -477,7 +477,7 @@ def _find_tool_call_actions(tree: object) -> list[dict]:
 class TestConfirmButtonsUseCallTool:
     """Tests asserting the Prefab confirm buttons emit CallTool actions
     (not SendMessage) so the iframe re-invokes the tool directly with
-    ``confirm=True``, instead of round-tripping through the LLM.
+    ``preview=False``, instead of round-tripping through the LLM.
     """
 
     def test_order_preview_confirm_action_emits_calltool(self):
@@ -513,18 +513,18 @@ class TestConfirmButtonsUseCallTool:
         envelope = app.to_json()
 
         # Walk the envelope's view tree looking for a toolCall action that
-        # invokes create_purchase_order with confirm=True. If absent, the
+        # invokes create_purchase_order with preview=False. If absent, the
         # migration regressed — the button reverted to SendMessage.
         actions = _find_tool_call_actions(envelope)
         matching = [
             a
             for a in actions
             if a.get("tool") == "create_purchase_order"
-            and a.get("arguments", {}).get("confirm") is True
+            and a.get("arguments", {}).get("preview") is False
         ]
         assert len(matching) == 1, (
             f"Expected exactly one create_purchase_order toolCall with "
-            f"confirm=True; found {len(matching)}. Total toolCall actions "
+            f"preview=False; found {len(matching)}. Total toolCall actions "
             f"in envelope: {len(actions)}."
         )
 

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -567,7 +567,7 @@ async def test_create_stock_adjustment_preview():
         location_id=1,
         rows=[StockAdjustmentRow(sku="WIDGET-001", quantity=5)],
         reason="Test adjustment",
-        confirm=False,
+        preview=True,
     )
     result = await _create_stock_adjustment_impl(request, context)
 
@@ -585,7 +585,7 @@ async def test_create_stock_adjustment_sku_not_found():
     request = CreateStockAdjustmentRequest(
         location_id=1,
         rows=[StockAdjustmentRow(sku="BAD-SKU", quantity=1)],
-        confirm=False,
+        preview=True,
     )
     with pytest.raises(ValueError, match="SKU 'BAD-SKU' not found"):
         await _create_stock_adjustment_impl(request, context)
@@ -599,7 +599,7 @@ async def test_create_stock_adjustment_empty_rows():
     request = CreateStockAdjustmentRequest(
         location_id=1,
         rows=[],
-        confirm=False,
+        preview=True,
     )
     with pytest.raises(ValueError, match="At least one adjustment row"):
         await _create_stock_adjustment_impl(request, context)
@@ -1281,10 +1281,10 @@ async def test_list_stock_adjustments_pagination_meta_none_without_page(
 
 @pytest.mark.asyncio
 async def test_update_stock_adjustment_preview_returns_is_preview_true():
-    """confirm=False returns preview without calling the API."""
+    """preview=True returns preview without calling the API."""
     context, _ = create_mock_context()
 
-    request = UpdateStockAdjustmentParams(id=42, reason="Updated reason", confirm=False)
+    request = UpdateStockAdjustmentParams(id=42, reason="Updated reason", preview=True)
 
     with patch(f"{_SA_UPDATE}.asyncio_detailed", new=AsyncMock()) as mock_api:
         result = await _update_stock_adjustment_impl(request, context)
@@ -1297,7 +1297,7 @@ async def test_update_stock_adjustment_preview_returns_is_preview_true():
 
 @pytest.mark.asyncio
 async def test_update_stock_adjustment_confirm_calls_api():
-    """confirm=True calls the PATCH endpoint directly (host already confirmed)."""
+    """preview=False calls the PATCH endpoint directly (host already confirmed)."""
     context, _ = create_mock_context()
 
     # The API returns an updated StockAdjustment. `_update_stock_adjustment_impl`
@@ -1311,7 +1311,7 @@ async def test_update_stock_adjustment_confirm_calls_api():
         id=42,
         reason="Updated reason",
         stock_adjustment_number="SA-UPDATED",
-        confirm=True,
+        preview=False,
     )
 
     with (
@@ -1334,7 +1334,7 @@ async def test_update_stock_adjustment_rejects_empty_change_set():
     """Missing all updatable fields raises ValueError."""
     context, _ = create_mock_context()
 
-    request = UpdateStockAdjustmentParams(id=42, confirm=False)
+    request = UpdateStockAdjustmentParams(id=42, preview=True)
 
     with pytest.raises(ValueError, match="At least one updatable field"):
         await _update_stock_adjustment_impl(request, context)
@@ -1347,7 +1347,7 @@ async def test_update_stock_adjustment_rejects_empty_change_set():
 
 @pytest.mark.asyncio
 async def test_delete_stock_adjustment_preview_returns_what_would_be_deleted():
-    """confirm=False fetches the adjustment and returns it in preview.
+    """preview=True fetches the adjustment and returns it in preview.
 
     Also asserts the lookup passes page=1 so auto-pagination doesn't chase
     extra pages for a single-record fetch.
@@ -1370,7 +1370,7 @@ async def test_delete_stock_adjustment_preview_returns_what_would_be_deleted():
         patch(f"{_SA_DELETE}.asyncio_detailed", new=AsyncMock()) as mock_delete,
     ):
         result = await _delete_stock_adjustment_impl(
-            DeleteStockAdjustmentRequest(id=99, confirm=False), context
+            DeleteStockAdjustmentRequest(id=99, preview=True), context
         )
 
     assert result.is_preview is True
@@ -1385,7 +1385,7 @@ async def test_delete_stock_adjustment_preview_returns_what_would_be_deleted():
 
 @pytest.mark.asyncio
 async def test_delete_stock_adjustment_confirm_calls_api():
-    """confirm=True calls DELETE directly (host already confirmed)."""
+    """preview=False calls DELETE directly (host already confirmed)."""
     context, _ = create_mock_context()
 
     adj = _make_mock_adjustment(
@@ -1407,7 +1407,7 @@ async def test_delete_stock_adjustment_confirm_calls_api():
         ) as mock_delete,
     ):
         result = await _delete_stock_adjustment_impl(
-            DeleteStockAdjustmentRequest(id=99, confirm=True), context
+            DeleteStockAdjustmentRequest(id=99, preview=False), context
         )
 
     assert result.is_preview is False
@@ -1427,7 +1427,7 @@ async def test_delete_stock_adjustment_not_found_raises():
         pytest.raises(ValueError, match="not found"),
     ):
         await _delete_stock_adjustment_impl(
-            DeleteStockAdjustmentRequest(id=12345, confirm=False), context
+            DeleteStockAdjustmentRequest(id=12345, preview=True), context
         )
 
 

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -570,7 +570,7 @@ async def test_modify_item_requires_at_least_one_subpayload():
     context, _ = create_mock_context()
     with pytest.raises(ValueError, match="At least one sub-payload"):
         await _modify_item_impl(
-            ModifyItemRequest(id=42, type=ItemType.PRODUCT, confirm=False), context
+            ModifyItemRequest(id=42, type=ItemType.PRODUCT, preview=True), context
         )
 
 
@@ -589,7 +589,7 @@ async def test_modify_item_rejects_misrouted_header_field():
         id=42,
         type=ItemType.SERVICE,
         update_header=ItemHeaderPatch(name="Renamed", is_producible=True),
-        confirm=False,
+        preview=True,
     )
     with pytest.raises(ValueError, match="not valid for type=service"):
         await _modify_item_impl(request, context)
@@ -608,7 +608,7 @@ async def test_modify_item_rejects_variant_crud_for_services():
         id=42,
         type=ItemType.SERVICE,
         add_variants=[VariantAdd(sku="V-1")],
-        confirm=False,
+        preview=True,
     )
     with pytest.raises(ValueError, match="not supported for SERVICE"):
         await _modify_item_impl(request, context)
@@ -651,7 +651,7 @@ async def test_modify_item_product_header_dispatches_to_products_endpoint():
             id=42,
             type=ItemType.PRODUCT,
             update_header=ItemHeaderPatch(name="Renamed Product", is_producible=True),
-            confirm=True,
+            preview=False,
         )
         response = await _modify_item_impl(request, context)
 
@@ -694,7 +694,7 @@ async def test_modify_item_material_header_dispatches_to_materials_endpoint():
             id=99,
             type=ItemType.MATERIAL,
             update_header=ItemHeaderPatch(name="Renamed Material"),
-            confirm=True,
+            preview=False,
         )
         response = await _modify_item_impl(request, context)
 
@@ -740,7 +740,7 @@ async def test_modify_item_service_header_dispatches_to_services_endpoint():
             id=7,
             type=ItemType.SERVICE,
             update_header=ItemHeaderPatch(name="Renamed Service", sales_price=12.50),
-            confirm=True,
+            preview=False,
         )
         response = await _modify_item_impl(request, context)
 
@@ -776,7 +776,7 @@ async def test_modify_item_add_variant_injects_parent_id_for_product():
             id=42,
             type=ItemType.PRODUCT,
             add_variants=[VariantAdd(sku="NEW-SKU-1", sales_price=99.99)],
-            confirm=True,
+            preview=False,
         )
         response = await _modify_item_impl(request, context)
 
@@ -815,7 +815,7 @@ async def test_delete_item_dispatches_to_typed_delete_endpoint():
         ),
         patch(_MODIFY_ITEM_IS_SUCCESS, return_value=True),
     ):
-        request = DeleteItemRequest(id=99, type=ItemType.MATERIAL, confirm=True)
+        request = DeleteItemRequest(id=99, type=ItemType.MATERIAL, preview=False)
         response = await _delete_item_impl(request, context)
 
     assert response.is_preview is False

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -52,7 +52,7 @@ async def test_create_manufacturing_order_preview():
         location_id=1,
         production_deadline_date=datetime(2024, 1, 25, 17, 0, 0, tzinfo=UTC),
         additional_info="Priority order",
-        confirm=False,
+        preview=True,
     )
     result = await _create_manufacturing_order_impl(request, context)
 
@@ -72,7 +72,7 @@ async def test_create_manufacturing_order_preview():
 
 @pytest.mark.asyncio
 async def test_create_manufacturing_order_confirm_success():
-    """Test create_manufacturing_order with confirm=True succeeds."""
+    """Test create_manufacturing_order with preview=False succeeds."""
     context, _lifespan_ctx = create_mock_context()
 
     # Mock successful API response
@@ -108,7 +108,7 @@ async def test_create_manufacturing_order_confirm_success():
             location_id=1,
             production_deadline_date=datetime(2024, 1, 25, 17, 0, 0, tzinfo=UTC),
             additional_info="Priority order",
-            confirm=True,
+            preview=False,
         )
         result = await _create_manufacturing_order_impl(request, context)
 
@@ -160,7 +160,7 @@ async def test_create_manufacturing_order_make_to_order_preview_populates_fields
     try:
         request = CreateManufacturingOrderRequest(
             sales_order_row_id=99001,
-            confirm=False,
+            preview=True,
         )
         result = await _create_manufacturing_order_impl(request, context)
 
@@ -178,7 +178,7 @@ async def test_create_manufacturing_order_make_to_order_preview_populates_fields
 
 @pytest.mark.asyncio
 async def test_create_manufacturing_order_make_to_order_confirm_refuses_when_already_linked():
-    """confirm=True against a sales_order_row that's already linked to an MO
+    """preview=False against a sales_order_row that's already linked to an MO
     must refuse — the preview UI's BLOCK warning suppresses the Confirm
     button in the iframe, but a programmatic caller skipping the UI gets
     the same defense-in-depth protection here.
@@ -211,7 +211,7 @@ async def test_create_manufacturing_order_make_to_order_confirm_refuses_when_alr
     try:
         request = CreateManufacturingOrderRequest(
             sales_order_row_id=99003,
-            confirm=True,
+            preview=False,
         )
         result = await _create_manufacturing_order_impl(request, context)
 
@@ -257,7 +257,7 @@ async def test_create_manufacturing_order_make_to_order_blocks_when_already_link
     try:
         request = CreateManufacturingOrderRequest(
             sales_order_row_id=99002,
-            confirm=False,
+            preview=True,
         )
         result = await _create_manufacturing_order_impl(request, context)
 
@@ -282,7 +282,7 @@ async def test_create_manufacturing_order_missing_optional_fields():
         variant_id=2101,
         planned_quantity=50.0,
         location_id=1,
-        confirm=False,
+        preview=True,
     )
     result = await _create_manufacturing_order_impl(request, context)
 
@@ -335,7 +335,7 @@ async def test_create_manufacturing_order_confirm_with_minimal_fields():
             variant_id=2102,
             planned_quantity=25.0,
             location_id=2,
-            confirm=True,
+            preview=False,
         )
         result = await _create_manufacturing_order_impl(request, context)
 
@@ -376,7 +376,7 @@ async def test_create_manufacturing_order_api_error():
             variant_id=2101,
             planned_quantity=50.0,
             location_id=1,
-            confirm=True,
+            preview=False,
         )
 
         with pytest.raises(APIError):
@@ -405,7 +405,7 @@ async def test_create_manufacturing_order_api_exception():
             variant_id=2101,
             planned_quantity=50.0,
             location_id=1,
-            confirm=True,
+            preview=False,
         )
 
         with pytest.raises(Exception, match="Network error"):
@@ -426,7 +426,7 @@ async def test_create_manufacturing_order_with_order_created_date():
         planned_quantity=50.0,
         location_id=1,
         order_created_date=order_date,
-        confirm=False,
+        preview=True,
     )
     result = await _create_manufacturing_order_impl(request, context)
 
@@ -450,7 +450,7 @@ async def test_create_manufacturing_order_invalid_quantity():
             variant_id=2101,
             planned_quantity=0.0,  # Invalid: must be > 0
             location_id=1,
-            confirm=False,
+            preview=True,
         )
 
 
@@ -465,7 +465,7 @@ async def test_create_manufacturing_order_negative_quantity():
             variant_id=2101,
             planned_quantity=-10.0,  # Invalid: must be > 0
             location_id=1,
-            confirm=False,
+            preview=True,
         )
 
 
@@ -488,7 +488,7 @@ async def test_create_manufacturing_order_preview_integration(katana_context):
         location_id=1,
         production_deadline_date=datetime(2024, 12, 31, 17, 0, 0, tzinfo=UTC),
         additional_info="Integration test preview",
-        confirm=False,
+        preview=True,
     )
 
     try:
@@ -527,7 +527,7 @@ async def test_create_manufacturing_order_confirm_integration(katana_context):
         location_id=1,
         production_deadline_date=datetime(2024, 12, 31, 17, 0, 0, tzinfo=UTC),
         additional_info="Integration test - can be deleted",
-        confirm=True,
+        preview=False,
     )
 
     try:
@@ -574,7 +574,7 @@ async def test_create_manufacturing_order_minimal_fields_integration(katana_cont
         variant_id=2101,
         planned_quantity=1.0,
         location_id=1,
-        confirm=True,
+        preview=False,
     )
 
     try:
@@ -702,7 +702,7 @@ async def test_create_manufacturing_order_make_to_order_preview():
     try:
         request = CreateManufacturingOrderRequest(
             sales_order_row_id=105664660,
-            confirm=False,
+            preview=True,
         )
         result = await _create_manufacturing_order_impl(request, context)
 
@@ -718,7 +718,7 @@ async def test_create_manufacturing_order_standalone_requires_fields():
     """Standalone mode without required fields raises ValueError."""
     context, _ = create_mock_context()
 
-    request = CreateManufacturingOrderRequest(confirm=False)
+    request = CreateManufacturingOrderRequest(preview=True)
     with pytest.raises(ValueError, match="variant_id"):
         await _create_manufacturing_order_impl(request, context)
 
@@ -743,7 +743,7 @@ async def test_create_manufacturing_order_make_to_order_with_subassemblies():
         request = CreateManufacturingOrderRequest(
             sales_order_row_id=105664660,
             create_subassemblies=True,
-            confirm=False,
+            preview=True,
         )
         result = await _create_manufacturing_order_impl(request, context)
 
@@ -2344,7 +2344,7 @@ async def test_modify_mo_requires_at_least_one_subpayload():
     context, _ = create_mock_context()
     with pytest.raises(ValueError, match="At least one sub-payload"):
         await _modify_manufacturing_order_impl(
-            ModifyManufacturingOrderRequest(id=42, confirm=False), context
+            ModifyManufacturingOrderRequest(id=42, preview=True), context
         )
 
 
@@ -2364,7 +2364,7 @@ async def test_modify_mo_preview_emits_planned_actions():
             add_recipe_rows=[
                 MORecipeRowAdd(variant_id=100, planned_quantity_per_unit=2.0)
             ],
-            confirm=False,
+            preview=True,
         )
         response = await _modify_manufacturing_order_impl(request, context)
 
@@ -2418,7 +2418,7 @@ async def test_modify_mo_confirm_executes_in_canonical_order():
             add_recipe_rows=[
                 MORecipeRowAdd(variant_id=100, planned_quantity_per_unit=2.0)
             ],
-            confirm=True,
+            preview=False,
         )
         response = await _modify_manufacturing_order_impl(request, context)
 
@@ -2445,7 +2445,7 @@ async def test_delete_mo_preview_returns_planned_action():
         return_value=existing,
     ):
         response = await _delete_manufacturing_order_impl(
-            DeleteManufacturingOrderRequest(id=42, confirm=False), context
+            DeleteManufacturingOrderRequest(id=42, preview=True), context
         )
 
     assert response.is_preview is True
@@ -2478,7 +2478,7 @@ async def test_delete_mo_confirm_calls_api_and_records_prior_state():
     ):
         mock_api.return_value = api_response
         response = await _delete_manufacturing_order_impl(
-            DeleteManufacturingOrderRequest(id=42, confirm=True), context
+            DeleteManufacturingOrderRequest(id=42, preview=False), context
         )
 
     assert response.is_preview is False
@@ -2541,7 +2541,7 @@ async def test_modify_mo_operation_row_add_translates_status_and_type_enums():
                     planned_time_per_unit=2.5,
                 ),
             ],
-            confirm=True,
+            preview=False,
         )
         response = await _modify_manufacturing_order_impl(request, context)
 
@@ -2599,7 +2599,7 @@ async def test_modify_mo_production_record_add_passes_through_to_api():
                     serial_numbers=["SN-001", "SN-002"],
                 ),
             ],
-            confirm=True,
+            preview=False,
         )
         response = await _modify_manufacturing_order_impl(request, context)
 
@@ -2683,7 +2683,7 @@ async def test_modify_mo_canonical_order_across_all_three_sub_resources():
                 MOOperationRowAdd(status="NOT_STARTED", operation_name="Assembly")
             ],
             add_productions=[MOProductionAdd(completed_quantity=5.0)],
-            confirm=True,
+            preview=False,
         )
         response = await _modify_manufacturing_order_impl(request, context)
 

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -43,11 +43,11 @@ class _SampleRequest(BaseModel):
     qty: int | None = None
     when: datetime | None = None
     state: _SampleEnum | None = None
-    confirm: bool = False
+    preview: bool = True
 
 
-def test_compute_field_diff_skips_id_and_confirm_by_default():
-    request = _SampleRequest(id=1, name="x", confirm=True)
+def test_compute_field_diff_skips_id_and_preview_by_default():
+    request = _SampleRequest(id=1, name="x", preview=False)
     diff = compute_field_diff(None, request)
     assert {c.field for c in diff} == {"name"}
 
@@ -158,13 +158,13 @@ def test_render_modification_md_preview_label():
         is_preview=True,
         message="Preview: update",
         changes=[FieldChange(field="qty", old=1, new=2)],
-        next_actions=["Set confirm=true"],
+        next_actions=["Set preview=false"],
     )
     md = render_modification_md(response)
     assert "## Purchase Order Update (PREVIEW)" in md
     assert "**ID**: 42" in md
     assert "`qty`: 1 → 2" in md
-    assert "Set confirm=true" in md
+    assert "Set preview=false" in md
 
 
 def test_render_modification_md_confirmed_label_uses_operation():

--- a/katana_mcp_server/tests/tools/test_orders.py
+++ b/katana_mcp_server/tests/tools/test_orders.py
@@ -44,7 +44,7 @@ async def test_fulfill_manufacturing_order_preview():
     get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
 
     request = FulfillOrderRequest(
-        order_id=1234, order_type="manufacturing", confirm=False
+        order_id=1234, order_type="manufacturing", preview=True
     )
     result = await _fulfill_order_impl(request, context)
 
@@ -55,7 +55,7 @@ async def test_fulfill_manufacturing_order_preview():
     assert result.is_preview is True
     assert len(result.inventory_updates) > 0
     assert any("finished goods" in msg.lower() for msg in result.inventory_updates)
-    assert "Set confirm=true" in result.next_actions[2]
+    assert "Set preview=false" in result.next_actions[2]
 
 
 @pytest.mark.asyncio
@@ -93,7 +93,7 @@ async def test_fulfill_manufacturing_order_confirm():
     )
 
     request = FulfillOrderRequest(
-        order_id=1234, order_type="manufacturing", confirm=True
+        order_id=1234, order_type="manufacturing", preview=False
     )
     result = await _fulfill_order_impl(request, context)
 
@@ -131,7 +131,7 @@ async def test_fulfill_manufacturing_order_already_done():
 
     # Preview mode
     request = FulfillOrderRequest(
-        order_id=1234, order_type="manufacturing", confirm=False
+        order_id=1234, order_type="manufacturing", preview=True
     )
     result = await _fulfill_order_impl(request, context)
 
@@ -141,7 +141,7 @@ async def test_fulfill_manufacturing_order_already_done():
 
     # Confirm mode - should not try to update
     request = FulfillOrderRequest(
-        order_id=1234, order_type="manufacturing", confirm=True
+        order_id=1234, order_type="manufacturing", preview=False
     )
     result = await _fulfill_order_impl(request, context)
 
@@ -171,7 +171,7 @@ async def test_fulfill_manufacturing_order_blocked():
     get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
 
     request = FulfillOrderRequest(
-        order_id=1234, order_type="manufacturing", confirm=False
+        order_id=1234, order_type="manufacturing", preview=True
     )
     result = await _fulfill_order_impl(request, context)
 
@@ -196,7 +196,7 @@ async def test_fulfill_manufacturing_order_not_found():
     get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
 
     request = FulfillOrderRequest(
-        order_id=9999, order_type="manufacturing", confirm=False
+        order_id=9999, order_type="manufacturing", preview=True
     )
 
     with pytest.raises(APIError):
@@ -238,7 +238,7 @@ async def test_fulfill_sales_order_preview():
 
     get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
 
-    request = FulfillOrderRequest(order_id=5678, order_type="sales", confirm=False)
+    request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=True)
     result = await _fulfill_order_impl(request, context)
 
     assert result.order_id == 5678
@@ -250,8 +250,8 @@ async def test_fulfill_sales_order_preview():
     assert len(result.inventory_updates) == 2
     assert any("variant 100" in u for u in result.inventory_updates)
     assert any("variant 200" in u for u in result.inventory_updates)
-    # Last next_action should mention confirm=true.
-    assert any("confirm=true" in a for a in result.next_actions)
+    # Last next_action should mention preview=false.
+    assert any("preview=false" in a for a in result.next_actions)
 
 
 @pytest.mark.asyncio
@@ -281,7 +281,7 @@ async def test_fulfill_sales_order_confirm_creates_fulfillment():
     create_mock = AsyncMock(return_value=mock_create_response)
     create_sales_order_fulfillment.asyncio_detailed = create_mock
 
-    request = FulfillOrderRequest(order_id=5678, order_type="sales", confirm=True)
+    request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=False)
     result = await _fulfill_order_impl(request, context)
 
     assert result.is_preview is False
@@ -292,7 +292,7 @@ async def test_fulfill_sales_order_confirm_creates_fulfillment():
 
 @pytest.mark.asyncio
 async def test_fulfill_sales_order_confirm_refuses_when_no_rows():
-    """confirm=True against a sales order with no rows must refuse cleanly
+    """preview=False against a sales order with no rows must refuse cleanly
     (no-op response with BLOCK warning + Refused message), not raise. Matches
     the defense-in-depth pattern of the other BLOCK guards.
     """
@@ -314,7 +314,7 @@ async def test_fulfill_sales_order_confirm_refuses_when_no_rows():
     create_mock = AsyncMock()
     create_sales_order_fulfillment.asyncio_detailed = create_mock
 
-    request = FulfillOrderRequest(order_id=5678, order_type="sales", confirm=True)
+    request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=False)
     result = await _fulfill_order_impl(request, context)
 
     assert result.is_preview is False
@@ -343,7 +343,7 @@ async def test_fulfill_sales_order_blocks_when_already_delivered():
     get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
 
     # Preview path: BLOCK warning present.
-    request = FulfillOrderRequest(order_id=5678, order_type="sales", confirm=False)
+    request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=True)
     result = await _fulfill_order_impl(request, context)
     assert result.is_preview is True
     block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
@@ -351,7 +351,7 @@ async def test_fulfill_sales_order_blocks_when_already_delivered():
     assert "DELIVERED" in block_warnings[0]
 
     # Confirm path: refuses without raising — returns a no-op response.
-    request = FulfillOrderRequest(order_id=5678, order_type="sales", confirm=True)
+    request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=False)
     result = await _fulfill_order_impl(request, context)
     assert result.is_preview is False
     assert result.status == "DELIVERED"
@@ -372,7 +372,7 @@ async def test_fulfill_sales_order_not_found():
 
     get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
 
-    request = FulfillOrderRequest(order_id=9999, order_type="sales", confirm=False)
+    request = FulfillOrderRequest(order_id=9999, order_type="sales", preview=True)
 
     with pytest.raises(APIError):
         await _fulfill_order_impl(request, context)
@@ -390,7 +390,7 @@ async def test_fulfill_order_invalid_type():
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
-        FulfillOrderRequest(order_id=1234, order_type="invalid", confirm=False)  # type: ignore
+        FulfillOrderRequest(order_id=1234, order_type="invalid", preview=True)  # type: ignore
 
 
 # ============================================================================
@@ -428,7 +428,7 @@ async def test_fulfill_manufacturing_order_api_error():
     )
 
     request = FulfillOrderRequest(
-        order_id=1234, order_type="manufacturing", confirm=True
+        order_id=1234, order_type="manufacturing", preview=False
     )
 
     with pytest.raises(APIError):

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -738,7 +738,7 @@ async def test_verify_order_document_no_match():
 
 @pytest.mark.asyncio
 async def test_receive_purchase_order_preview():
-    """Test receive_purchase_order in preview mode (confirm=false)."""
+    """Test receive_purchase_order in preview mode (preview=true)."""
     context, lifespan_ctx = create_mock_context()
 
     # Mock the get_purchase_order API response
@@ -767,14 +767,14 @@ async def test_receive_purchase_order_preview():
 
     api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
 
-    # Create request with confirm=false (preview mode)
+    # Create request with preview=true (preview mode)
     request = ReceivePurchaseOrderRequest(
         order_id=1234,
         items=[
             ReceiveItemRequest(purchase_order_row_id=501, quantity=100.0),
             ReceiveItemRequest(purchase_order_row_id=502, quantity=50.0),
         ],
-        confirm=False,
+        preview=True,
     )
 
     result = await _receive_purchase_order_impl(request, context)
@@ -786,7 +786,7 @@ async def test_receive_purchase_order_preview():
     assert result.items_received == 2
     assert result.is_preview is True
     assert "Review the items to receive" in result.next_actions
-    assert "confirm=true" in result.next_actions[1]
+    assert "preview=false" in result.next_actions[1]
     assert "Preview" in result.message
 
 
@@ -823,14 +823,14 @@ async def test_receive_purchase_order_confirm_success():
         return_value=mock_receive_response
     )
 
-    # Create request with confirm=true
+    # Create request with preview=false
     request = ReceivePurchaseOrderRequest(
         order_id=1234,
         items=[
             ReceiveItemRequest(purchase_order_row_id=501, quantity=100.0),
             ReceiveItemRequest(purchase_order_row_id=502, quantity=50.0),
         ],
-        confirm=True,
+        preview=False,
     )
 
     result = await _receive_purchase_order_impl(request, context)
@@ -894,7 +894,7 @@ async def test_receive_purchase_order_single_item():
     request = ReceivePurchaseOrderRequest(
         order_id=5678,
         items=[ReceiveItemRequest(purchase_order_row_id=601, quantity=25.5)],
-        confirm=True,
+        preview=False,
     )
 
     result = await _receive_purchase_order_impl(request, context)
@@ -925,7 +925,7 @@ async def test_receive_purchase_order_get_po_fails():
     request = ReceivePurchaseOrderRequest(
         order_id=9999,
         items=[ReceiveItemRequest(purchase_order_row_id=701, quantity=10.0)],
-        confirm=False,
+        preview=True,
     )
 
     # Should raise an APIError (404 with parsed=None)
@@ -975,7 +975,7 @@ async def test_receive_purchase_order_receive_api_fails():
     request = ReceivePurchaseOrderRequest(
         order_id=1234,
         items=[ReceiveItemRequest(purchase_order_row_id=501, quantity=100.0)],
-        confirm=True,
+        preview=False,
     )
 
     # Should raise a ValidationError (422 is validation error)
@@ -1015,7 +1015,7 @@ async def test_receive_purchase_order_order_no_unset():
     request = ReceivePurchaseOrderRequest(
         order_id=1234,
         items=[ReceiveItemRequest(purchase_order_row_id=501, quantity=100.0)],
-        confirm=False,
+        preview=True,
     )
 
     result = await _receive_purchase_order_impl(request, context)
@@ -1065,7 +1065,7 @@ async def test_receive_purchase_order_received_date_set():
     request = ReceivePurchaseOrderRequest(
         order_id=1234,
         items=[ReceiveItemRequest(purchase_order_row_id=501, quantity=100.0)],
-        confirm=True,
+        preview=False,
     )
 
     # Record time before call
@@ -1106,7 +1106,7 @@ async def test_receive_purchase_order_integration_preview(katana_context):
     request = ReceivePurchaseOrderRequest(
         order_id=int(test_po_id),
         items=[ReceiveItemRequest(purchase_order_row_id=1, quantity=1.0)],
-        confirm=False,
+        preview=True,
     )
 
     # This should not fail even if the row ID doesn't exist
@@ -1157,7 +1157,7 @@ async def test_receive_purchase_order_wrapper():
     request = ReceivePurchaseOrderRequest(
         order_id=1234,
         items=[ReceiveItemRequest(purchase_order_row_id=501, quantity=100.0)],
-        confirm=False,
+        preview=True,
     )
 
     # Call the implementation function directly (wrapper expects unpacked args from FastMCP)
@@ -1209,7 +1209,7 @@ async def test_receive_purchase_order_multiple_items_various_quantities():
             ReceiveItemRequest(purchase_order_row_id=503, quantity=0.75),
             ReceiveItemRequest(purchase_order_row_id=504, quantity=1000.0),
         ],
-        confirm=True,
+        preview=False,
     )
 
     result = await _receive_purchase_order_impl(request, context)
@@ -1247,7 +1247,7 @@ async def test_receive_purchase_order_validates_min_items():
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
-        ReceivePurchaseOrderRequest(order_id=1234, items=[], confirm=False)
+        ReceivePurchaseOrderRequest(order_id=1234, items=[], preview=True)
 
 
 @pytest.mark.asyncio
@@ -1269,7 +1269,7 @@ async def test_receive_purchase_order_exception_handling():
     request = ReceivePurchaseOrderRequest(
         order_id=1234,
         items=[ReceiveItemRequest(purchase_order_row_id=501, quantity=100.0)],
-        confirm=False,
+        preview=True,
     )
 
     # Should raise and propagate the exception
@@ -1317,7 +1317,7 @@ async def test_receive_purchase_order_builds_correct_api_payload():
             ReceiveItemRequest(purchase_order_row_id=501, quantity=100.0),
             ReceiveItemRequest(purchase_order_row_id=502, quantity=50.5),
         ],
-        confirm=True,
+        preview=False,
     )
 
     await _receive_purchase_order_impl(request, context)
@@ -1350,7 +1350,7 @@ async def test_receive_purchase_order_builds_correct_api_payload():
 
 @pytest.mark.asyncio
 async def test_receive_purchase_order_confirm_refuses_when_already_received():
-    """confirm=True against a PO already at status=RECEIVED must refuse —
+    """preview=False against a PO already at status=RECEIVED must refuse —
     defense-in-depth: the preview UI suppresses Confirm via BLOCK warning,
     but programmatic callers skipping the UI need the same protection so
     they can't create duplicate inventory.
@@ -1384,7 +1384,7 @@ async def test_receive_purchase_order_confirm_refuses_when_already_received():
     request = ReceivePurchaseOrderRequest(
         order_id=8888,
         items=[ReceiveItemRequest(purchase_order_row_id=999, quantity=10.0)],
-        confirm=True,
+        preview=False,
     )
 
     result = await _receive_purchase_order_impl(request, context)
@@ -1438,7 +1438,7 @@ async def test_receive_purchase_order_response_structure():
     request = ReceivePurchaseOrderRequest(
         order_id=9999,
         items=[ReceiveItemRequest(purchase_order_row_id=701, quantity=25.0)],
-        confirm=True,
+        preview=False,
     )
 
     result = await _receive_purchase_order_impl(request, context)
@@ -2529,7 +2529,7 @@ async def test_modify_po_requires_at_least_one_subpayload():
     context, _ = create_mock_context()
     with pytest.raises(ValueError, match="At least one sub-payload"):
         await _modify_purchase_order_impl(
-            ModifyPurchaseOrderRequest(id=42, confirm=False), context
+            ModifyPurchaseOrderRequest(id=42, preview=True), context
         )
 
 
@@ -2548,7 +2548,7 @@ async def test_modify_po_preview_emits_planned_actions(patch_fetch_po):
                 expected_arrival_date=datetime(2026, 2, 15, tzinfo=UTC)
             ),
             add_rows=[PORowAdd(variant_id=100, quantity=10, price_per_unit=5.0)],
-            confirm=False,
+            preview=True,
         )
         # Stub the row prefetch so update_rows doesn't error here (no update_rows in this case)
         response = await _modify_purchase_order_impl(request, context)
@@ -2599,7 +2599,7 @@ async def test_modify_po_confirm_executes_plan_in_canonical_order(patch_fetch_po
                 expected_arrival_date=datetime(2026, 2, 15, tzinfo=UTC)
             ),
             add_rows=[PORowAdd(variant_id=100, quantity=10, price_per_unit=5.0)],
-            confirm=True,
+            preview=False,
         )
         response = await _modify_purchase_order_impl(request, context)
 
@@ -2635,7 +2635,7 @@ async def test_modify_po_fail_fast_halts_on_first_error(patch_fetch_po):
             id=42,
             update_header=POHeaderPatch(order_no="PO-NEW"),
             add_rows=[PORowAdd(variant_id=100, quantity=10, price_per_unit=5.0)],
-            confirm=True,
+            preview=False,
         )
         response = await _modify_purchase_order_impl(request, context)
 
@@ -2659,7 +2659,7 @@ async def test_modify_po_preview_when_fetch_fails_marks_unknown_prior():
         request = ModifyPurchaseOrderRequest(
             id=42,
             update_header=POHeaderPatch(order_no="PO-NEW"),
-            confirm=False,
+            preview=True,
         )
         response = await _modify_purchase_order_impl(request, context)
 
@@ -2691,7 +2691,7 @@ async def test_modify_po_row_update_fetches_row_for_diff(patch_fetch_po):
         request = ModifyPurchaseOrderRequest(
             id=42,
             update_rows=[PORowUpdate(id=555, quantity=15)],
-            confirm=False,
+            preview=True,
         )
         response = await _modify_purchase_order_impl(request, context)
 
@@ -2735,7 +2735,7 @@ async def test_modify_po_add_additional_costs_preview_lists_each_cost_row(
                     group_id=99,
                 ),
             ],
-            confirm=False,
+            preview=True,
         )
         response = await _modify_purchase_order_impl(request, context)
 
@@ -2795,7 +2795,7 @@ async def test_modify_po_add_additional_costs_confirm_calls_create_endpoint(
                     distribution_method="BY_VALUE",
                 )
             ],
-            confirm=True,
+            preview=False,
         )
         response = await _modify_purchase_order_impl(request, context)
 
@@ -2824,7 +2824,7 @@ async def test_modify_po_add_additional_costs_without_default_group_id_errors(
             add_additional_costs=[
                 POAdditionalCostAdd(additional_cost_id=1, tax_rate_id=2, price=10.0)
             ],
-            confirm=False,
+            preview=True,
         )
         with pytest.raises(ValueError, match="group_id"):
             await _modify_purchase_order_impl(request, context)
@@ -2851,7 +2851,7 @@ async def test_modify_po_empty_update_row_payload_raises(patch_fetch_po):
         request = ModifyPurchaseOrderRequest(
             id=42,
             update_rows=[PORowUpdate(id=555)],
-            confirm=False,
+            preview=True,
         )
         with pytest.raises(
             ValueError,
@@ -2873,7 +2873,7 @@ async def test_modify_po_empty_update_row_payload_raises(patch_fetch_po):
 async def test_delete_po_preview_returns_planned_action():
     context, _ = create_mock_context()
     existing = create_mock_po(order_id=42, order_no="PO-1", rows=[])
-    request = DeletePurchaseOrderRequest(id=42, confirm=False)
+    request = DeletePurchaseOrderRequest(id=42, preview=True)
 
     with patch(
         "katana_mcp.tools.foundation.purchase_orders._fetch_purchase_order_attrs",
@@ -2910,7 +2910,7 @@ async def test_delete_po_confirm_calls_api_and_records_prior_state():
     ):
         mock_api.return_value = api_response
         response = await _delete_purchase_order_impl(
-            DeletePurchaseOrderRequest(id=42, confirm=True), context
+            DeletePurchaseOrderRequest(id=42, preview=False), context
         )
 
     assert response.is_preview is False

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -62,7 +62,7 @@ async def test_create_sales_order_preview():
         currency="USD",
         notes="Test order",
         customer_ref="CUST-REF-001",
-        confirm=False,
+        preview=True,
     )
     result = await _create_sales_order_impl(request, context)
 
@@ -93,7 +93,7 @@ async def test_create_sales_order_preview_minimal_fields():
         items=[
             SalesOrderItem(variant_id=2101, quantity=1),
         ],
-        confirm=False,
+        preview=True,
     )
     result = await _create_sales_order_impl(request, context)
 
@@ -131,7 +131,7 @@ async def test_create_sales_order_preview_warns_advisorily_on_customer_cache_mis
         items=[SalesOrderItem(variant_id=1, quantity=1)],
         location_id=1,
         delivery_date=datetime(2024, 1, 22, 14, 0, 0, tzinfo=UTC),
-        confirm=False,
+        preview=True,
     )
     result = await _create_sales_order_impl(request, context)
 
@@ -148,7 +148,7 @@ async def test_create_sales_order_preview_warns_advisorily_on_customer_cache_mis
 
 @pytest.mark.asyncio
 async def test_create_sales_order_confirm_success():
-    """Test create_sales_order with confirm=True succeeds."""
+    """Test create_sales_order with preview=False succeeds."""
     context, _lifespan_ctx = create_mock_context()
 
     # Mock successful API response
@@ -185,7 +185,7 @@ async def test_create_sales_order_confirm_success():
             ],
             location_id=1,
             currency="USD",
-            confirm=True,
+            preview=False,
         )
         result = await _create_sales_order_impl(request, context)
 
@@ -263,7 +263,7 @@ async def test_create_sales_order_with_addresses():
                     country="US",
                 ),
             ],
-            confirm=True,
+            preview=False,
         )
         result = await _create_sales_order_impl(request, context)
 
@@ -296,7 +296,7 @@ async def test_create_sales_order_with_discount():
                 total_discount=50.0,
             ),
         ],
-        confirm=False,
+        preview=True,
     )
     result = await _create_sales_order_impl(request, context)
 
@@ -329,7 +329,7 @@ async def test_create_sales_order_api_error():
             items=[
                 SalesOrderItem(variant_id=2101, quantity=1),
             ],
-            confirm=True,
+            preview=False,
         )
 
         with pytest.raises(APIError):
@@ -358,7 +358,7 @@ async def test_create_sales_order_api_exception():
             items=[
                 SalesOrderItem(variant_id=2101, quantity=1),
             ],
-            confirm=True,
+            preview=False,
         )
 
         with pytest.raises(Exception, match="Network error"):
@@ -401,7 +401,7 @@ async def test_create_sales_order_confirm_with_minimal_fields():
             items=[
                 SalesOrderItem(variant_id=2101, quantity=1),
             ],
-            confirm=True,
+            preview=False,
         )
         result = await _create_sales_order_impl(request, context)
 
@@ -432,7 +432,7 @@ async def test_create_sales_order_invalid_quantity():
             items=[
                 SalesOrderItem(variant_id=2101, quantity=0.0),  # Invalid: must be > 0
             ],
-            confirm=False,
+            preview=True,
         )
 
 
@@ -448,7 +448,7 @@ async def test_create_sales_order_negative_quantity():
             items=[
                 SalesOrderItem(variant_id=2101, quantity=-5.0),  # Invalid: must be > 0
             ],
-            confirm=False,
+            preview=True,
         )
 
 
@@ -462,7 +462,7 @@ async def test_create_sales_order_empty_items():
             customer_id=1501,
             order_number="SO-2024-010",
             items=[],  # Invalid: min_length=1
-            confirm=False,
+            preview=True,
         )
 
 
@@ -488,7 +488,7 @@ async def test_create_sales_order_preview_integration(katana_context):
         location_id=1,
         delivery_date=datetime(2024, 12, 31, 17, 0, 0, tzinfo=UTC),
         notes="Integration test preview",
-        confirm=False,
+        preview=True,
     )
 
     try:
@@ -529,7 +529,7 @@ async def test_create_sales_order_confirm_integration(katana_context):
         ],
         location_id=1,
         notes="Integration test - can be deleted",
-        confirm=True,
+        preview=False,
     )
 
     try:
@@ -1577,7 +1577,7 @@ async def test_modify_so_requires_at_least_one_subpayload():
     context, _ = create_mock_context()
     with pytest.raises(ValueError, match="At least one sub-payload"):
         await _modify_sales_order_impl(
-            ModifySalesOrderRequest(id=42, confirm=False), context
+            ModifySalesOrderRequest(id=42, preview=True), context
         )
 
 
@@ -1596,7 +1596,7 @@ async def test_modify_so_preview_emits_planned_actions():
             id=42,
             update_header=SOHeaderPatch(status="PACKED"),
             add_rows=[SORowAdd(variant_id=100, quantity=2)],
-            confirm=False,
+            preview=True,
         )
         response = await _modify_sales_order_impl(request, context)
 
@@ -1645,7 +1645,7 @@ async def test_modify_so_confirm_executes_in_canonical_order():
             id=42,
             update_header=SOHeaderPatch(status="PACKED"),
             add_rows=[SORowAdd(variant_id=100, quantity=2)],
-            confirm=True,
+            preview=False,
         )
         response = await _modify_sales_order_impl(request, context)
 
@@ -1675,7 +1675,7 @@ async def test_modify_so_address_update_marks_unknown_prior():
             update_addresses=[
                 SOAddressUpdate(id=99, city="Springfield", zip="12345"),
             ],
-            confirm=False,
+            preview=True,
         )
         response = await _modify_sales_order_impl(request, context)
 
@@ -1710,7 +1710,7 @@ async def test_modify_so_fail_fast_halts_on_first_error():
             id=42,
             update_header=SOHeaderPatch(status="PACKED"),
             add_rows=[SORowAdd(variant_id=100, quantity=2)],
-            confirm=True,
+            preview=False,
         )
         response = await _modify_sales_order_impl(request, context)
 
@@ -1736,7 +1736,7 @@ async def test_delete_so_preview_returns_planned_action():
         return_value=existing,
     ):
         response = await _delete_sales_order_impl(
-            DeleteSalesOrderRequest(id=42, confirm=False), context
+            DeleteSalesOrderRequest(id=42, preview=True), context
         )
 
     assert response.is_preview is True
@@ -1769,7 +1769,7 @@ async def test_delete_so_confirm_calls_api_and_records_prior_state():
     ):
         mock_api.return_value = api_response
         response = await _delete_sales_order_impl(
-            DeleteSalesOrderRequest(id=42, confirm=True), context
+            DeleteSalesOrderRequest(id=42, preview=False), context
         )
 
     assert response.is_preview is False

--- a/katana_mcp_server/tests/tools/test_stock_transfers.py
+++ b/katana_mcp_server/tests/tools/test_stock_transfers.py
@@ -1,10 +1,10 @@
 """Tests for stock transfer MCP tools.
 
 Covers the unified four-tool surface:
-- create_stock_transfer (preview + confirm)
+- create_stock_transfer (preview + apply)
 - list_stock_transfers (list-tool pattern v2 — limit, page, dates, filters)
-- modify_stock_transfer (header + status, preview + confirm + multi-action)
-- delete_stock_transfer (preview + confirm)
+- modify_stock_transfer (header + status, preview + apply + multi-action)
+- delete_stock_transfer (preview + apply)
 """
 
 from __future__ import annotations
@@ -106,7 +106,7 @@ async def test_create_stock_transfer_preview():
         expected_arrival_date=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
         rows=[StockTransferRowInput(variant_id=100, quantity=5)],
         order_no="ST-PREVIEW-1",
-        confirm=False,
+        preview=True,
     )
     result = await _create_stock_transfer_impl(request, context)
 
@@ -121,7 +121,7 @@ async def test_create_stock_transfer_preview():
 
 @pytest.mark.asyncio
 async def test_create_stock_transfer_confirm_success():
-    """confirm=True builds the request and returns the created transfer."""
+    """preview=False builds the request and returns the created transfer."""
     context, _ = create_mock_context()
 
     mock_transfer = _make_mock_transfer(
@@ -150,7 +150,7 @@ async def test_create_stock_transfer_confirm_success():
                     ],
                 )
             ],
-            confirm=True,
+            preview=False,
         )
         result = await _create_stock_transfer_impl(request, context)
 
@@ -203,7 +203,7 @@ async def test_create_stock_transfer_auto_generates_number_when_order_no_omitted
                 )
             ],
             # order_no intentionally omitted
-            confirm=True,
+            preview=False,
         )
         await _create_stock_transfer_impl(request, context)
 
@@ -247,7 +247,7 @@ async def test_create_stock_transfer_passes_through_provided_order_no():
                     ],
                 )
             ],
-            confirm=True,
+            preview=False,
         )
         await _create_stock_transfer_impl(request, context)
 
@@ -257,7 +257,7 @@ async def test_create_stock_transfer_passes_through_provided_order_no():
 
 @pytest.mark.asyncio
 async def test_create_stock_transfer_confirm_refuses_when_source_equals_destination():
-    """confirm=True with source==destination must refuse — defense in depth.
+    """preview=False with source==destination must refuse — defense in depth.
     The preview UI's BLOCK warning suppresses Confirm, but a programmatic
     caller skipping the UI would otherwise create a no-op transfer.
     """
@@ -269,7 +269,7 @@ async def test_create_stock_transfer_confirm_refuses_when_source_equals_destinat
             destination_location_id=42,  # same!
             expected_arrival_date=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
             rows=[StockTransferRowInput(variant_id=100, quantity=5)],
-            confirm=True,
+            preview=False,
         )
         result = await _create_stock_transfer_impl(request, context)
 
@@ -292,7 +292,7 @@ async def test_create_stock_transfer_rejects_empty_rows():
             destination_location_id=2,
             expected_arrival_date=datetime(2026, 5, 1, tzinfo=UTC),
             rows=[],
-            confirm=False,
+            preview=True,
         )
 
 
@@ -510,7 +510,7 @@ async def test_modify_st_requires_at_least_one_subpayload():
     context, _ = create_mock_context()
     with pytest.raises(ValueError, match="At least one sub-payload"):
         await _modify_stock_transfer_impl(
-            ModifyStockTransferRequest(id=42, confirm=False), context
+            ModifyStockTransferRequest(id=42, preview=True), context
         )
 
 
@@ -523,7 +523,7 @@ async def test_modify_st_header_preview_emits_planned_action():
             stock_transfer_number="ST-42-revised",
             additional_info="Updated notes",
         ),
-        confirm=False,
+        preview=True,
     )
     response = await _modify_stock_transfer_impl(request, context)
 
@@ -551,7 +551,7 @@ async def test_modify_st_header_confirm_dispatches_to_update_endpoint():
             update_header=StockTransferHeaderPatch(
                 stock_transfer_number="ST-42-revised"
             ),
-            confirm=True,
+            preview=False,
         )
         response = await _modify_stock_transfer_impl(request, context)
 
@@ -579,7 +579,7 @@ async def test_modify_st_status_confirm_dispatches_to_status_endpoint():
         request = ModifyStockTransferRequest(
             id=42,
             update_status=StockTransferStatusPatch(new_status="IN_TRANSIT"),
-            confirm=True,
+            preview=False,
         )
         response = await _modify_stock_transfer_impl(request, context)
 
@@ -617,7 +617,7 @@ async def test_modify_st_canonical_order_header_then_status():
                 stock_transfer_number="ST-42-revised"
             ),
             update_status=StockTransferStatusPatch(new_status="IN_TRANSIT"),
-            confirm=True,
+            preview=False,
         )
         response = await _modify_stock_transfer_impl(request, context)
 
@@ -646,7 +646,7 @@ async def test_modify_st_status_failfast_halts_remaining_actions():
                 stock_transfer_number="ST-42-revised"
             ),
             update_status=StockTransferStatusPatch(new_status="IN_TRANSIT"),
-            confirm=True,
+            preview=False,
         )
         response = await _modify_stock_transfer_impl(request, context)
 
@@ -668,7 +668,7 @@ async def test_modify_st_status_failfast_halts_remaining_actions():
 @pytest.mark.asyncio
 async def test_delete_stock_transfer_preview():
     context, _ = create_mock_context()
-    request = DeleteStockTransferRequest(id=42, confirm=False)
+    request = DeleteStockTransferRequest(id=42, preview=True)
     response = await _delete_stock_transfer_impl(request, context)
 
     assert response.is_preview is True
@@ -689,7 +689,7 @@ async def test_delete_stock_transfer_confirm_success():
         ) as mock_delete,
         patch(_MODIFY_ST_IS_SUCCESS, return_value=True),
     ):
-        request = DeleteStockTransferRequest(id=42, confirm=True)
+        request = DeleteStockTransferRequest(id=42, preview=False)
         response = await _delete_stock_transfer_impl(request, context)
 
     assert response.is_preview is False

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.51.0"
+version = "0.51.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bundles two MCP-side cleanups:

## Summary

### #438 — Collapse prefab builder `confirm_action`+`request` kwargs (refactor, no behavior change)
`build_order_preview_ui`, `build_receipt_ui`, and `build_batch_recipe_update_ui` previously took `request: dict[str, Any]` *and* `confirm_action: Action` — two parameters that were always passed together and always derived from the same Pydantic request model. Replaced with a single coupled pair: `confirm_request: BaseModel` and `confirm_tool: str`. The builder now owns the `model_dump()` and the `call_tool_from_request(...)` construction internally.

- 5 call sites simplified, `call_tool_from_request` is no longer imported at any call site (only inside the builder module)
- ~50 LoC removed at call sites; ~30 added inside builders; net negative
- The pair is now visibly coupled: type checker catches passing one without the other
- `build_receipt_ui` and `build_batch_recipe_update_ui` keep optional kwargs for the non-preview render path; runtime check enforces "both set together or both `None`"

### #312 — Rename `confirm` → `preview` (BREAKING)
`confirm: bool = False` → `preview: bool = True` (with inverted semantics) on every write tool's request model. The default behavior (no flag → preview, no API call) is unchanged; the flag value that triggers it is now the truthy one. Naming now matches what the parameter does — \`confirm=true\` always meant "ready to be asked," not "confirmed."

Tools touched: \`create_purchase_order\`, \`receive_purchase_order\`, \`create_sales_order\`, \`create_manufacturing_order\`, \`fulfill_order\`, \`create/update/delete_stock_adjustment\`, \`create_stock_transfer\`, the \`modify_<entity>\` family (PO/SO/MO/stock-transfer/item via the \`ConfirmableRequest\` base), and the \`delete_<entity>\` family.

Also updated: prefab builder overrides (\`{\"confirm\": True}\` → \`{\"preview\": False}\`), help-resource docs, server-instructions, prompt workflows, every test file under \`katana_mcp_server/tests\`.

## Why bundle

Both touch the same MCP surface and share reviewers. Splitting would mean two passes through the same files; bundling lets reviewers see the rename in context with the builder API change that makes the rename's call sites cleaner.

## Test plan

- [ ] CI: \`uv run poe check\` (passing locally — 2660 passed, 2 skipped)
- [ ] Manual smoke: open Claude Desktop, exercise \`create_purchase_order\` / \`create_sales_order\` / \`create_manufacturing_order\` previews. Buttons render. (Note: a separate bug — #491 — affects what happens *after* the button click; this PR doesn't fix or worsen it.)
- [ ] No \`confirm=*\` in committed source (\`grep -r 'confirm=True\\|confirm=False' katana_mcp_server\` → no hits)

## Migration

For external callers passing \`confirm=true/false\`:

\`\`\`text
confirm=true  →  preview=false
confirm=false →  preview=true   (or omit it — preview=True is the new default)
\`\`\`

Closes #438
Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)