### PR TITLE
fix(mcp): wire feedback handlers on every Confirm-button click (#495)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from prefab_ui.actions import SetState, ShowToast
+from prefab_ui.actions import Action, SetState, ShowToast
 from prefab_ui.actions.mcp import CallTool, SendMessage
 from prefab_ui.app import PrefabApp
 from prefab_ui.components import (
@@ -78,6 +78,8 @@ def call_tool_from_request(
     request: BaseModel,
     *,
     overrides: dict[str, Any] | None = None,
+    on_success: Action | list[Action] | None = None,
+    on_error: Action | list[Action] | None = None,
 ) -> CallTool:
     """Build a CallTool action that re-invokes ``tool_name`` with the
     request's fields **inlined as literal values** (not template strings).
@@ -90,6 +92,11 @@ def call_tool_from_request(
     ``overrides`` (e.g. ``{"preview": False}``) take precedence over the
     inlined values — use them to flip a flag or substitute a literal at
     re-invocation time (typically to switch from preview to apply).
+
+    ``on_success`` and ``on_error`` are passed through to the underlying
+    ``CallTool`` so callers can chain feedback handlers (toast, state
+    update, message) onto the apply call. Without these, the click fires
+    invisibly — see #495 for why every Confirm button needs them.
 
     History: this helper used to emit Mustache-style ``{{ request.<field> }}``
     template strings and rely on the iframe host to substitute them from
@@ -111,7 +118,52 @@ def call_tool_from_request(
                 f"{', '.join(bad)}"
             )
         args.update(overrides)
-    return CallTool(tool_name, arguments=args)
+    return CallTool(
+        tool_name,
+        arguments=args,
+        on_success=on_success,
+        on_error=on_error,
+    )
+
+
+def _build_confirm_action(
+    confirm_tool: str,
+    confirm_request: BaseModel,
+    *,
+    success_message: str,
+    success_chat: str,
+    error_message: str,
+    error_chat: str,
+) -> CallTool:
+    """Construct the standard Confirm-button apply action with feedback
+    handlers attached.
+
+    Centralizes the visible-feedback contract for all preview UIs (#495):
+    every Confirm button must surface a toast on success/error AND push a
+    SendMessage so the apply call shows up in chat history. Without these
+    handlers the click fires invisibly — the tool runs at the API but the
+    user sees nothing. Result data is also captured into iframe state at
+    ``state.result`` so a follow-up iteration can swap the preview content
+    for a submitted/result card without another round-trip.
+
+    All four message strings are baked in at preview-build time (no
+    ``{{ ... }}`` template substitution required); this avoids the host
+    substitution failure mode documented in #491.
+    """
+    return call_tool_from_request(
+        confirm_tool,
+        confirm_request,
+        overrides={"preview": False},
+        on_success=[
+            SetState("result", RESULT),
+            ShowToast(message=success_message, variant="success"),
+            SendMessage(success_chat),
+        ],
+        on_error=[
+            ShowToast(message=error_message, variant="error"),
+            SendMessage(error_chat),
+        ],
+    )
 
 
 # ============================================================================
@@ -454,12 +506,19 @@ def build_order_preview_ui(
     inlined rather than templated from iframe state.
     """
     fields = _extract_order_fields(order)
-    confirm_action = call_tool_from_request(
+    order_number = fields["order_number"]
+    confirm_action = _build_confirm_action(
         confirm_tool,
         confirm_request,
-        overrides={"preview": False},
+        success_message=f"{order_type} {order_number} created",
+        success_chat=f"{order_type} {order_number} was created successfully.",
+        error_message=f"{order_type} creation failed",
+        error_chat=(
+            f"{order_type} {order_number} creation failed — please review "
+            "the error and try again."
+        ),
     )
-    state: dict[str, Any] = {"order": order}
+    state: dict[str, Any] = {"order": order, "result": None}
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
@@ -607,7 +666,10 @@ def build_fulfill_preview_ui(
     order_id = response["order_id"]
     raw_order_type = response["order_type"]
 
-    with PrefabApp(state={"response": response}, css_class="p-4") as app, Card():
+    with (
+        PrefabApp(state={"response": response, "result": None}, css_class="p-4") as app,
+        Card(),
+    ):
         with CardHeader(), Row(gap=2):
             CardTitle(content=f"Fulfill {order_type} Order")
             Badge(label=order_number, variant="outline")
@@ -626,6 +688,12 @@ def build_fulfill_preview_ui(
 
         with CardFooter(), Row(gap=2):
             if not block_warnings:
+                # Same feedback contract as the helper-built confirm
+                # actions (#495): toast + state capture + chat-side
+                # SendMessage so the click produces visible signal
+                # everywhere a user might be looking. Hand-built here
+                # because the args aren't a Pydantic request — they're
+                # echoed from the response dict.
                 Button(
                     label="Confirm Fulfillment",
                     variant="default",
@@ -636,6 +704,27 @@ def build_fulfill_preview_ui(
                             "order_type": raw_order_type,
                             "preview": False,
                         },
+                        on_success=[
+                            SetState("result", RESULT),
+                            ShowToast(
+                                message=f"{order_type} order {order_number} fulfilled",
+                                variant="success",
+                            ),
+                            SendMessage(
+                                f"{order_type} order {order_number} was fulfilled "
+                                "successfully; inventory has been updated."
+                            ),
+                        ],
+                        on_error=[
+                            ShowToast(
+                                message=f"Fulfillment for {order_number} failed",
+                                variant="error",
+                            ),
+                            SendMessage(
+                                f"Fulfilling {order_type.lower()} order {order_number} "
+                                "failed — please review the error and try again."
+                            ),
+                        ],
                     ),
                 )
             Button(
@@ -822,13 +911,21 @@ def build_receipt_ui(
 
     order_number = response.get("order_number", "N/A")
     is_preview = response.get("is_preview", True)
-    state: dict[str, Any] = {"response": response}
+    state: dict[str, Any] = {"response": response, "result": None}
     confirm_action: CallTool | None = None
     if confirm_request is not None and confirm_tool is not None:
-        confirm_action = call_tool_from_request(
+        confirm_action = _build_confirm_action(
             confirm_tool,
             confirm_request,
-            overrides={"preview": False},
+            success_message=f"Receipt for {order_number} recorded",
+            success_chat=(
+                f"Items received for {order_number}; inventory has been updated."
+            ),
+            error_message=f"Receipt for {order_number} failed",
+            error_chat=(
+                f"Receiving items for {order_number} failed — please review "
+                "the error and try again."
+            ),
         )
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
@@ -974,13 +1071,24 @@ def build_batch_recipe_update_ui(
         "is_preview": is_preview,
         "warnings": warnings,
         "groups": list(groups.keys()),
+        "result": None,
     }
     confirm_action: CallTool | None = None
     if confirm_request is not None and confirm_tool is not None:
-        confirm_action = call_tool_from_request(
+        confirm_action = _build_confirm_action(
             confirm_tool,
             confirm_request,
-            overrides={"preview": False},
+            success_message=f"Batch executed: {total} ops",
+            success_chat=(
+                f"Batch recipe update executed: {total} planned operation(s) "
+                "submitted. Review the results card for per-op success / "
+                "failure / skip status."
+            ),
+            error_message="Batch execution failed",
+            error_chat=(
+                "Batch recipe update failed before completing — please "
+                "review the error and re-run."
+            ),
         )
 
     with (

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -766,6 +766,127 @@ class TestConfirmButtonsUseCallTool:
         assert _find_template_strings(args) == []
 
 
+class TestConfirmButtonsHaveFeedbackHandlers:
+    """Regression tests for #495: every Confirm button on every preview
+    builder must wire ``on_success`` and ``on_error`` handlers, otherwise
+    the click fires invisibly. Without these the user has no chat-side
+    or in-iframe signal that the apply tool ran.
+    """
+
+    @staticmethod
+    def _assert_calltool_has_handlers(action: dict, label: str) -> None:
+        """Assert a serialized toolCall action has both lifecycle hooks set.
+
+        We don't pin the *shape* of the hooks (caller wording / variant /
+        component types may evolve) — just that they exist. The point is
+        to make missing handlers fail loudly the moment a future builder
+        forgets to wire them.
+        """
+        on_success = action.get("on_success") or action.get("onSuccess")
+        on_error = action.get("on_error") or action.get("onError")
+        assert on_success, (
+            f"{label}: Confirm button's CallTool has no on_success handler — "
+            f"click would fire invisibly (#495). Action keys: {list(action)}"
+        )
+        assert on_error, (
+            f"{label}: Confirm button's CallTool has no on_error handler — "
+            f"failures would be silent (#495). Action keys: {list(action)}"
+        )
+
+    def test_order_preview_confirm_button_has_feedback_handlers(self):
+        from katana_mcp.tools.foundation.purchase_orders import (
+            CreatePurchaseOrderRequest,
+            PurchaseOrderItem,
+        )
+
+        request = CreatePurchaseOrderRequest(
+            supplier_id=2,
+            location_id=3,
+            order_number="PO-FB-1",
+            items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
+        )
+        app = build_order_preview_ui(
+            {"order_number": "PO-FB-1", "warnings": []},
+            "Purchase Order",
+            confirm_request=request,
+            confirm_tool="create_purchase_order",
+        )
+        envelope = app.to_json()
+        actions = _find_tool_call_actions(envelope)
+        confirm = next(a for a in actions if a.get("tool") == "create_purchase_order")
+        self._assert_calltool_has_handlers(confirm, "build_order_preview_ui")
+
+    def test_receipt_preview_confirm_button_has_feedback_handlers(self):
+        from katana_mcp.tools.foundation.purchase_orders import (
+            ReceiveItemRequest,
+            ReceivePurchaseOrderRequest,
+        )
+
+        request = ReceivePurchaseOrderRequest(
+            order_id=1234,
+            items=[ReceiveItemRequest(purchase_order_row_id=10, quantity=5.0)],
+        )
+        app = build_receipt_ui(
+            {
+                "order_id": 1234,
+                "order_number": "PO-FB-2",
+                "is_preview": True,
+                "items_received": 5,
+                "status": "NOT_RECEIVED",
+                "warnings": [],
+            },
+            confirm_request=request,
+            confirm_tool="receive_purchase_order",
+        )
+        envelope = app.to_json()
+        actions = _find_tool_call_actions(envelope)
+        confirm = next(a for a in actions if a.get("tool") == "receive_purchase_order")
+        self._assert_calltool_has_handlers(confirm, "build_receipt_ui")
+
+    def test_batch_recipe_preview_confirm_button_has_feedback_handlers(self):
+        request = _StubRequest()
+        app = build_batch_recipe_update_ui(
+            {
+                "is_preview": True,
+                "total_ops": 1,
+                "success_count": 0,
+                "failed_count": 0,
+                "skipped_count": 0,
+                "results": [
+                    {
+                        "op_type": "delete",
+                        "manufacturing_order_id": 9999,
+                        "recipe_row_id": 5001,
+                        "status": "pending",
+                    }
+                ],
+                "warnings": [],
+                "message": "Preview",
+            },
+            confirm_request=request,
+            confirm_tool="batch_update_recipes",
+        )
+        envelope = app.to_json()
+        actions = _find_tool_call_actions(envelope)
+        confirm = next(a for a in actions if a.get("tool") == "batch_update_recipes")
+        self._assert_calltool_has_handlers(confirm, "build_batch_recipe_update_ui")
+
+    def test_fulfill_preview_confirm_button_has_feedback_handlers(self):
+        app = build_fulfill_preview_ui(
+            {
+                "order_id": 9999,
+                "order_type": "sales",
+                "order_number": "SO-FB-1",
+                "status": "IN_PROGRESS",
+                "warnings": [],
+            }
+        )
+        envelope = app.to_json()
+        actions = _find_tool_call_actions(envelope)
+        confirm = next(a for a in actions if a.get("tool") == "fulfill_order")
+        self._assert_calltool_has_handlers(confirm, "build_fulfill_preview_ui")
+
+
 def _find_buttons_by_label(tree: object, label: str) -> list[dict]:
     """Walk a Prefab envelope and return every Button node whose label
     matches ``label`` exactly. Used by BLOCK-warning regression tests to


### PR DESCRIPTION
## Summary

Fixes #495 — every Prefab Confirm button now produces visible feedback when clicked. Before this PR, clicks fired the apply tool successfully (after #493) but gave the user no chat-side or in-iframe signal that anything happened. Per #491, that silent-fire behavior was a major contributor to the data-corruption blast radius — users kept re-clicking because they couldn't tell anything had happened.

## What changes

Every Confirm button on every preview UI now wires a three-layer feedback contract on its \`CallTool\` action:

**on_success**
- \`SetState(\"result\", RESULT)\` — captures the apply response into iframe state at \`state.result\`. Forward-compatible with a future iteration that swaps the preview content for a result card; for this PR, just stores the data.
- \`ShowToast(success_message, variant=\"success\")\` — immediate ephemeral visual confirmation.
- \`SendMessage(success_chat)\` — pushes a chat-side message so the apply becomes part of the chat history and the LLM can render naturally.

**on_error**
- \`ShowToast(error_message, variant=\"error\")\`
- \`SendMessage(error_chat)\`

All four message strings are baked in at preview-build time from values already known to the builder (\`order_number\`, \`order_type\`, etc.). **No host-side \`{{ ... }}\` substitution required**, so this doesn't re-introduce the #491 failure mode.

## Implementation

Centralized in a new \`_build_confirm_action\` helper in \`prefab_ui.py\`. The three helper-built builders (\`build_order_preview_ui\`, \`build_receipt_ui\`, \`build_batch_recipe_update_ui\`) delegate to it. \`build_fulfill_preview_ui\` hand-builds its \`CallTool\` (its args come from the response dict not a Pydantic request) but inlines the same handler shape.

\`call_tool_from_request\` gained optional \`on_success\` / \`on_error\` kwargs that pass through to \`CallTool\` — no breaking change to existing callers (defaults to \`None\`, current behavior).

## Tests

New \`TestConfirmButtonsHaveFeedbackHandlers\` class — 4 tests, one per builder. Walks the rendered envelope, finds the Confirm button's \`CallTool\` action, and asserts both \`on_success\` and \`on_error\` are set (without pinning the handler shape — that can evolve, the contract is just \"handlers exist\"). Catches any future builder that forgets to wire feedback.

Test count: 39 → 43 (+4 regression tests).

## Out of scope

- **Iframe-side conditional rendering.** \`SetState(\"result\", RESULT)\` captures the data, but the preview card doesn't yet swap to a \"submitted\" view. Doable as a follow-up — would require Prefab \`Slot\`-based conditional content or rebuilding the card. Toast + SendMessage are sufficient feedback in the short term.
- **Verifying the host actually renders \`SendMessage\` and \`ShowToast\`.** Per #495's asks, we should reproduce on Cowork / Claude Desktop and verify each layer fires visibly. The regression tests pin the contract on our side; field verification is a separate step (covered in the issue's asks list).
- **Architectural \"don't use the button\" path.** Issue #495 lists option 4 (just have the agent re-issue via chat) as the most reliable. That's a bigger architectural call tied to the elicitation-decision in #316; for now we're fixing the in-place pattern.

## Test plan

- [x] \`uv run poe agent-check\` — clean (formatting + lint + ty + tests)
- [x] \`uv run poe test\` — full suite passes (693 tests, +4 new)
- [ ] Manual on Cowork: trigger a preview, click Confirm, verify toast fires + chat-side message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)