### PR TITLE
feat(client)!: remove broken Inventory.check_stock helper (closes #315)

### DIFF
--- a/katana_mcp_server/docs/development.md
+++ b/katana_mcp_server/docs/development.md
@@ -185,27 +185,26 @@ uv run mcp-hmr katana_mcp.server:mcp
 Hot reload makes debugging much faster:
 
 ```python
-# Before (in src/katana_mcp/tools/inventory.py)
-async def _check_inventory_impl(request: CheckInventoryRequest, context: Context) -> StockInfo:
-    server_context = context.request_context.lifespan_context
-    client = server_context.client
-    product = await client.inventory.check_stock(request.sku)
-    # ... rest of function
+# Before (in src/katana_mcp/tools/foundation/inventory.py)
+async def _check_inventory_impl(
+    request: CheckInventoryRequest, context: Context
+) -> list[StockInfo]:
+    services = get_services(context)
+    # ... fetch variants from cache, look up stock per variant ...
 
 # After (add logging - save file - test immediately!)
-import logging
-logger = logging.getLogger(__name__)
+from katana_mcp.logging import get_logger
+logger = get_logger(__name__)
 
-async def _check_inventory_impl(request: CheckInventoryRequest, context: Context) -> StockInfo:
-    logger.debug(f"Context structure: {dir(context)}")  # See what's available
-    logger.debug(f"Request context: {dir(context.request_context)}")  # Debug paths
-
-    server_context = context.request_context.lifespan_context
-    client = server_context.client
-
-    logger.info(f"Checking stock for SKU: {request.sku}")  # Track calls
-    product = await client.inventory.check_stock(request.sku)
-    logger.info(f"Found product: {product.name if product else 'Not found'}")
+async def _check_inventory_impl(
+    request: CheckInventoryRequest, context: Context
+) -> list[StockInfo]:
+    logger.info(
+        "inventory_check_started",
+        sku_count=sum(1 for x in request.skus_or_variant_ids if isinstance(x, str)),
+        variant_id_count=sum(1 for x in request.skus_or_variant_ids if isinstance(x, int)),
+    )
+    services = get_services(context)
     # ... rest of function
 ```
 

--- a/katana_public_api_client/helpers/__init__.py
+++ b/katana_public_api_client/helpers/__init__.py
@@ -11,7 +11,6 @@ Example:
     ...     results = await client.products.search("widget")
     ...
     ...     # Inventory and stock operations
-    ...     stock = await client.inventory.check_stock("WIDGET-001")
     ...     low_stock = await client.inventory.list_low_stock(threshold=10)
 """
 

--- a/katana_public_api_client/helpers/inventory.py
+++ b/katana_public_api_client/helpers/inventory.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from katana_public_api_client.api.product import get_all_products
-from katana_public_api_client.domain.converters import unwrap_unset
 from katana_public_api_client.helpers.base import Base
 from katana_public_api_client.models.product import Product
 from katana_public_api_client.utils import unwrap_data
@@ -12,54 +11,28 @@ from katana_public_api_client.utils import unwrap_data
 class Inventory(Base):
     """Inventory and stock operations.
 
-    Provides methods for checking stock levels (used by MCP tools).
-    For product catalog CRUD, use client.products instead.
+    For per-SKU stock lookups, call
+    ``katana_public_api_client.api.inventory.get_inventory.asyncio_detailed``
+    directly with a ``sku`` filter — the inventory endpoint provides the
+    canonical stock view (on-hand, allocations, incoming) without the
+    per-page pagination guess that the legacy ``check_stock`` helper
+    had to make.
+
+    For product catalog CRUD, use ``client.products`` instead.
+
+    .. warning::
+       ``list_low_stock`` reads ``product.stock_information`` which is
+       not a typed field on the generated ``Product`` attrs model. The
+       helper currently returns ``[]`` against live API data regardless
+       of inventory state. Migration to the inventory endpoint is
+       tracked in #510; until then prefer that endpoint directly.
 
     Example:
         >>> async with KatanaClient() as client:
-        ...     stock = await client.inventory.check_stock("WIDGET-001")
         ...     low_stock = await client.inventory.list_low_stock(threshold=10)
     """
 
     # === MCP Tool Support Methods ===
-
-    async def check_stock(self, sku: str) -> Product | None:
-        """Check stock levels for a specific SKU.
-
-        Used by: MCP tool check_inventory
-
-        Args:
-            sku: The SKU to check stock for.
-
-        Returns:
-            Product model with stock information, or None if SKU not found.
-
-        Example:
-            >>> product = await client.inventory.check_stock("WIDGET-001")
-            >>> if product:
-            ...     stock = product.stock_information
-            ...     print(f"Available: {stock.available}, In Stock: {stock.in_stock}")
-        """
-        # Note: The API doesn't support direct SKU filtering yet
-        # We need to fetch products and filter client-side
-        # TODO: When API adds SKU parameter, use that instead
-        response = await get_all_products.asyncio_detailed(
-            client=self._client,
-            limit=100,
-        )
-        products = unwrap_data(response)
-
-        # Find product by SKU - check variants for matching SKU
-        # Note: Product attrs model doesn't have 'sku' directly - SKU is on Variant
-        for product in products:
-            # Check variants for matching SKU (variants is an attrs field that may be UNSET)
-            variants = unwrap_unset(product.variants, [])
-            for variant in variants or []:
-                # Variant.sku is a required field, always present
-                if variant.sku == sku:
-                    return product
-
-        return None
 
     async def list_low_stock(self, threshold: int | None = None) -> list[Product]:
         """Find products below their reorder point.

--- a/katana_public_api_client/katana_client.py
+++ b/katana_public_api_client/katana_client.py
@@ -1437,15 +1437,16 @@ class KatanaClient(AuthenticatedClient):
 
     @property
     def inventory(self) -> Inventory:
-        """Access inventory and stock operations.
+        """Access inventory helpers.
 
         Returns:
-            Inventory instance for stock levels, movements, and adjustments.
+            Inventory instance providing low-stock reporting. For per-SKU
+            stock lookups, stock movements, and stock adjustments, call
+            the corresponding endpoint via ``client.api.*`` directly —
+            those are not exposed on this helper class.
 
         Example:
             >>> async with KatanaClient() as client:
-            ...     # Check stock levels
-            ...     stock = await client.inventory.check_stock("WIDGET-001")
             ...     low_stock = await client.inventory.list_low_stock(threshold=10)
         """
         if self._inventory is None:


### PR DESCRIPTION
Closes #315. Removes the broken \`Inventory.check_stock\` helper from the published client package. **Major version bump** for the client.

## Why it was broken

\`Inventory.check_stock(sku)\` had three structural problems:

1. **Pagination guess.** Fetched the first 100 products and filtered client-side. Catalogs with >100 products silently returned \`None\` for items that genuinely existed.
2. **Wrong shape.** Scanned \`product.variants\` for a matching SKU. Variants only populate when fetched with the right \`extend=\` parameter; without that, the helper returned \`None\` even for products it loaded.
3. **Wrong axis.** Returned a \`Product\`, not stock info. Callers wanting current on-hand / available / committed had to re-derive them from \`product.stock_information\`, which doesn't even exist on the live API response in many cases.

## Why now

The MCP \`check_inventory\` tool was rewritten in #309 to use the typed cache + the inventory endpoint directly, bypassing this helper. **Nothing else in the codebase calls it** (verified by grep across \`katana_*\`, \`tests/\`, and the integration suite). Only docstring examples referenced it; both updated to drop the call.

## Migration

For external callers using \`client.inventory.check_stock(sku)\`:

\`\`\`python
# Before
product = await client.inventory.check_stock(\"WIDGET-001\")

# After
from katana_public_api_client.api.inventory import get_inventory
from katana_public_api_client.utils import unwrap_data

response = await get_inventory.asyncio_detailed(
    client=client,
    sku=[\"WIDGET-001\"],
)
inventory_rows = unwrap_data(response, default=[])
\`\`\`

The inventory endpoint provides the canonical stock view (on-hand, allocations, incoming) without the per-page guess.

## What stays

\`Inventory.list_low_stock(threshold)\` is **not** removed — still used by the MCP \`list_low_stock_items\` tool. Its own \`limit=100\` truncation (same blast radius as \`check_stock\`'s) is a separate concern, tracked in #469's roadmap for tool surface parity.

## Files changed

| File | What |
|---|---|
| \`katana_public_api_client/helpers/inventory.py\` | Remove \`check_stock\` method; update class docstring to point callers at the inventory API; drop now-unused \`unwrap_unset\` import. |
| \`katana_public_api_client/helpers/__init__.py\` | Drop \`check_stock\` from the docstring example. |
| \`katana_public_api_client/katana_client.py\` | Drop \`check_stock\` from the \`inventory\` property docstring example. |
| \`katana_mcp_server/docs/development.md\` | Replace stale debug-logging example (referenced both \`check_stock\` and a pre-#309 \`_check_inventory_impl\` shape) with one that matches the current cache-backed implementation. |

## Test plan

- [x] \`uv run poe agent-check\` — clean
- [x] \`uv run poe test\` — full suite (2682 passed)
- [x] \`grep -rn check_stock\` — no remaining references in code or docs
- [x] Verified \`Inventory.list_low_stock\` is still in place and the only remaining live caller (\`katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py:328\`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)