### PR TITLE
fix(mcp): handle dict shipping_fee from oneOf parser fallthrough in get_sales_order

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -985,9 +985,24 @@ def _shipping_fee_from_attrs(fee: Any) -> SalesOrderShippingFeeInfo | None:
     Callers must pre-unwrap the attrs field (via ``unwrap_unset(obj.shipping_fee,
     None)``) so this helper only receives ``None`` or a populated object —
     passing the raw UNSET sentinel would AttributeError on ``.id``.
+
+    Accepts both attrs ``SalesOrderShippingFee`` and a raw dict: the
+    generated ``SalesOrder._parse_shipping_fee`` silently falls through to
+    a raw dict cast as the union type when ``SalesOrderShippingFee.from_dict``
+    raises (a quirk of openapi-python-client's oneOf codegen). When that
+    happens, parse the dict via ``from_dict`` here; if even that fails
+    (malformed payload), return ``None`` so the SO assembly completes
+    rather than crashing with an opaque ``AttributeError`` (#501).
     """
     if fee is None:
         return None
+    if isinstance(fee, dict):
+        from katana_public_api_client.models import SalesOrderShippingFee
+
+        try:
+            fee = SalesOrderShippingFee.from_dict(fee)
+        except (TypeError, ValueError, KeyError, AttributeError):
+            return None
     return SalesOrderShippingFeeInfo(
         id=fee.id,
         sales_order_id=fee.sales_order_id,

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -20,6 +20,7 @@ from katana_mcp.tools.foundation.sales_orders import (
     _get_sales_order_impl,
     _list_sales_orders_impl,
     _modify_sales_order_impl,
+    _shipping_fee_from_attrs,
     get_sales_order,
     list_sales_orders,
 )
@@ -1549,6 +1550,113 @@ async def test_get_sales_order_format_json_returns_json():
     data = json.loads(_content_text(result))
     assert data["id"] == 9
     assert data["order_no"] == "SO-9"
+
+
+# ============================================================================
+# Regression: #501 — get_sales_order raises "'dict' object has no attribute 'id'"
+# ============================================================================
+#
+# Root cause: the generated SalesOrder._parse_shipping_fee swallows
+# TypeError/ValueError/AttributeError/KeyError from
+# SalesOrderShippingFee.from_dict() and silently returns the raw dict
+# typed as the union — so what the type system says is a SalesOrderShippingFee
+# attrs object is at runtime a dict for any payload that doesn't match the
+# expected schema. The downstream consumer (_shipping_fee_from_attrs) then
+# accesses .id and crashes.
+
+
+def test_shipping_fee_from_attrs_handles_typed_input():
+    """Sanity: typed SalesOrderShippingFee input still works after the fix."""
+    from katana_public_api_client.models import SalesOrderShippingFee
+
+    fee = SalesOrderShippingFee(
+        id=901, sales_order_id=44372778, amount="12.99", tax_rate_id=7
+    )
+    result = _shipping_fee_from_attrs(fee)
+    assert result is not None
+    assert result.id == 901
+    assert result.sales_order_id == 44372778
+    assert result.amount == "12.99"
+    assert result.tax_rate_id == 7
+
+
+def test_shipping_fee_from_attrs_handles_dict_input_from_silent_fallthrough():
+    """Regression for #501: when SalesOrder._parse_shipping_fee falls
+    through to the raw dict cast, the consumer must accept dict input
+    instead of AttributeError on `.id`."""
+    fee_dict = {
+        "id": 901,
+        "sales_order_id": 44372778,
+        "amount": "12.99",
+        "tax_rate_id": 7,
+    }
+    result = _shipping_fee_from_attrs(fee_dict)
+    assert result is not None
+    assert result.id == 901
+    assert result.sales_order_id == 44372778
+    assert result.amount == "12.99"
+    assert result.tax_rate_id == 7
+
+
+def test_shipping_fee_from_attrs_degrades_malformed_dict_to_none():
+    """Regression for #501: a dict missing required fields is the symptom
+    of a spec/wire mismatch upstream. Degrade to None so the SO assembly
+    completes — surfacing the rest of the SO is more useful than crashing
+    the entire lookup with an opaque AttributeError."""
+    assert _shipping_fee_from_attrs({}) is None
+    assert _shipping_fee_from_attrs({"sales_order_id": 100}) is None
+    assert _shipping_fee_from_attrs({"id": 1}) is None  # missing amount
+
+
+@pytest.mark.asyncio
+async def test_get_sales_order_handles_shipping_fee_returned_as_dict():
+    """Regression for #501: end-to-end repro — `so.shipping_fee` arrives as
+    a dict (silent fallthrough from the generated parser) and the SO
+    assembly must complete without raising 'dict has no attribute id'."""
+    context, _ = create_mock_context()
+    mock_so = _make_mock_so(id=44372778, order_no="#WEB20495")
+    # Simulate the silent-fallthrough output: type system says
+    # SalesOrderShippingFee, runtime says raw dict.
+    mock_so.shipping_fee = {
+        "id": 901,
+        "sales_order_id": 44372778,
+        "amount": "12.99",
+    }
+
+    with (
+        patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
+    ):
+        request = GetSalesOrderRequest(order_id=44372778)
+        result = await _get_sales_order_impl(request, context)
+
+    assert result.id == 44372778
+    assert result.shipping_fee is not None
+    assert result.shipping_fee.id == 901
+    assert result.shipping_fee.amount == "12.99"
+
+
+@pytest.mark.asyncio
+async def test_get_sales_order_handles_malformed_shipping_fee_dict():
+    """Regression for #501: even a malformed shipping_fee dict (the worst
+    case of the silent fallthrough — the dict is missing the required
+    fields that caused from_dict to bail in the first place) shouldn't
+    crash the SO lookup."""
+    context, _ = create_mock_context()
+    mock_so = _make_mock_so(id=44372778)
+    mock_so.shipping_fee = {}  # malformed — would have made from_dict raise
+
+    with (
+        patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
+    ):
+        request = GetSalesOrderRequest(order_id=44372778)
+        result = await _get_sales_order_impl(request, context)
+
+    assert result.id == 44372778
+    assert result.shipping_fee is None
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes #501. `get_sales_order` raised `'dict' object has no attribute 'id'` on every call, on both `order_no` and `order_id` paths. Tool was 100% unusable; agents had to fall back to `list_sales_orders(ids=[...])`.

## Root cause

Both lookup paths converged on the SO assembly, which calls:

```python
shipping_fee=_shipping_fee_from_attrs(unwrap_unset(so.shipping_fee, None))
```

That helper accessed `fee.id` directly. At runtime, `fee` could be a raw dict typed as `SalesOrderShippingFee` — a silent-fallthrough quirk in the generated [`SalesOrder._parse_shipping_fee`](https://github.com/dougborg/katana-openapi-client/blob/main/katana_public_api_client/models/sales_order.py#L770) (openapi-python-client's standard codegen for oneOf schemas):

```python
def _parse_shipping_fee(data: object) -> None | SalesOrderShippingFee | Unset:
    ...
    try:
        if not isinstance(data, dict):
            raise TypeError()
        return SalesOrderShippingFee.from_dict(cast(Mapping[str, Any], data))
    except (TypeError, ValueError, AttributeError, KeyError):
        pass
    return cast(None | SalesOrderShippingFee | Unset, data)  # ← raw dict, lying type
```

Any malformed payload (missing required field, wire-format drift, etc.) hits the `except` and returns the raw dict cast as the typed union — bypassing the type system entirely. The downstream `.id` access then crashes with the exact error from the bug report.

## Fix

`_shipping_fee_from_attrs` now accepts both shapes:
- typed `SalesOrderShippingFee` → existing path (unchanged)
- raw dict → re-parse via `SalesOrderShippingFee.from_dict`; if that fails too (truly malformed payload), degrade to `None` so the SO assembly completes rather than crashing the entire lookup with an opaque `AttributeError`

Surfacing the rest of the SO is more useful to the user than refusing to return anything because the optional shipping_fee field couldn't be parsed.

## Tests

5 new regression tests in `katana_mcp_server/tests/tools/test_sales_orders.py`:

| Test | What it covers |
|------|----------------|
| `test_shipping_fee_from_attrs_handles_typed_input` | Sanity — typed input still works after the fix |
| `test_shipping_fee_from_attrs_handles_dict_input_from_silent_fallthrough` | Direct repro of the bug — well-formed dict |
| `test_shipping_fee_from_attrs_degrades_malformed_dict_to_none` | Degrades to None on dict missing required fields |
| `test_get_sales_order_handles_shipping_fee_returned_as_dict` | End-to-end via `_get_sales_order_impl` with well-formed dict |
| `test_get_sales_order_handles_malformed_shipping_fee_dict` | End-to-end with empty `{}` (worst-case malformed) |

The bug-repro test fails before this PR with the exact error from #501:

```
AttributeError: 'dict' object has no attribute 'id'
katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py:992
```

## Out of scope (follow-up)

The silent fallthrough exists in **11 other generator-emitted `_parse_*` helpers** across the client (`SalesOrderShippingFee`, `Supplier` ×3, `LocationType0` ×2, `DeletableEntity` ×2, `Product`, `Material`, `CustomFieldDefinitionOptionsType0`). Any of those can produce the same dict-vs-typed surprise in different code paths. That's a generator-level fix — either patching openapi-python-client or post-processing in `scripts/regenerate_client.py` — and should be a separate PR. Filing as a follow-up issue.

## Test plan

- [x] `uv run poe check` — 2665 passed, 2 skipped, 0 failures
- [x] New regression tests fail before the fix (verified)
- [x] New regression tests pass after the fix
- [x] Existing `test_sales_orders.py` suite stays green (52 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
