### PR TITLE
fix(client): generated _parse_* helpers normalize empty dict to None (#509)

### DIFF
--- a/katana_mcp_server/tests/test_typed_cache.py
+++ b/katana_mcp_server/tests/test_typed_cache.py
@@ -245,15 +245,19 @@ class TestSyncShippingFeeEmpty:
     """
 
     def test_attrs_sales_order_with_empty_shipping_fee_converts(self):
-        """``from_attrs`` must not raise when attrs shipping_fee is ``{}``."""
+        """``from_attrs`` must produce ``shipping_fee=None`` when attrs
+        shipping_fee originated as ``{}`` on the wire."""
         from katana_public_api_client.models import SalesOrder as AttrsSalesOrder
         from katana_public_api_client.models_pydantic._generated import (
             SalesOrder as PydanticSalesOrder,
         )
 
-        # Simulate the wire shape Katana sends for a no-fee order. The attrs
-        # parser can't populate required inner fields from {}, catches the
-        # KeyError, and falls back to storing the raw {} dict.
+        # Simulate the wire shape Katana sends for a no-fee order. As of #509,
+        # the generated ``_parse_shipping_fee`` short-circuits on empty dict
+        # and returns None directly — so the attrs object already has
+        # ``shipping_fee is None`` before from_attrs runs. (The empty-dict
+        # normalization in ``from_attrs._base.py:132-138`` remains as
+        # defense in depth — see #509 for the full story.)
         attrs_so = AttrsSalesOrder.from_dict(
             {
                 "id": 9001,
@@ -264,8 +268,11 @@ class TestSyncShippingFeeEmpty:
                 "shipping_fee": {},
             }
         )
+        # Direct guarantee from the post-processor: attrs side is None,
+        # not a raw dict.
+        assert attrs_so.shipping_fee is None
 
-        # This must not raise pydantic ValidationError.
+        # And the cache-sync path agrees.
         pydantic_so = PydanticSalesOrder.from_attrs(attrs_so)
         assert pydantic_so.shipping_fee is None
 

--- a/katana_mcp_server/tests/test_typed_cache.py
+++ b/katana_mcp_server/tests/test_typed_cache.py
@@ -246,18 +246,12 @@ class TestSyncShippingFeeEmpty:
 
     def test_attrs_sales_order_with_empty_shipping_fee_converts(self):
         """``from_attrs`` must produce ``shipping_fee=None`` when attrs
-        shipping_fee originated as ``{}`` on the wire."""
+        shipping_fee originated as ``{}`` on the wire (#509)."""
         from katana_public_api_client.models import SalesOrder as AttrsSalesOrder
         from katana_public_api_client.models_pydantic._generated import (
             SalesOrder as PydanticSalesOrder,
         )
 
-        # Simulate the wire shape Katana sends for a no-fee order. As of #509,
-        # the generated ``_parse_shipping_fee`` short-circuits on empty dict
-        # and returns None directly — so the attrs object already has
-        # ``shipping_fee is None`` before from_attrs runs. (The empty-dict
-        # normalization in ``from_attrs._base.py:132-138`` remains as
-        # defense in depth — see #509 for the full story.)
         attrs_so = AttrsSalesOrder.from_dict(
             {
                 "id": 9001,
@@ -268,11 +262,7 @@ class TestSyncShippingFeeEmpty:
                 "shipping_fee": {},
             }
         )
-        # Direct guarantee from the post-processor: attrs side is None,
-        # not a raw dict.
         assert attrs_so.shipping_fee is None
-
-        # And the cache-sync path agrees.
         pydantic_so = PydanticSalesOrder.from_attrs(attrs_so)
         assert pydantic_so.shipping_fee is None
 

--- a/katana_public_api_client/models/inventory_item.py
+++ b/katana_public_api_client/models/inventory_item.py
@@ -290,6 +290,9 @@ class InventoryItem:
                 return data
             if isinstance(data, Unset):
                 return data
+            # Empty dict → None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
             try:
                 if not isinstance(data, dict):
                     raise TypeError()

--- a/katana_public_api_client/models/inventory_item.py
+++ b/katana_public_api_client/models/inventory_item.py
@@ -290,7 +290,7 @@ class InventoryItem:
                 return data
             if isinstance(data, Unset):
                 return data
-            # Empty dict → None (Katana wire quirk; see #509).
+            # Empty dict -> None (Katana wire quirk; see #509).
             if isinstance(data, dict) and not data:
                 return None
             try:

--- a/katana_public_api_client/models/material.py
+++ b/katana_public_api_client/models/material.py
@@ -323,6 +323,9 @@ class Material:
                 return data
             if isinstance(data, Unset):
                 return data
+            # Empty dict → None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
             try:
                 if not isinstance(data, dict):
                     raise TypeError()

--- a/katana_public_api_client/models/material.py
+++ b/katana_public_api_client/models/material.py
@@ -323,7 +323,7 @@ class Material:
                 return data
             if isinstance(data, Unset):
                 return data
-            # Empty dict → None (Katana wire quirk; see #509).
+            # Empty dict -> None (Katana wire quirk; see #509).
             if isinstance(data, dict) and not data:
                 return None
             try:

--- a/katana_public_api_client/models/product.py
+++ b/katana_public_api_client/models/product.py
@@ -358,7 +358,7 @@ class Product:
                 return data
             if isinstance(data, Unset):
                 return data
-            # Empty dict → None (Katana wire quirk; see #509).
+            # Empty dict -> None (Katana wire quirk; see #509).
             if isinstance(data, dict) and not data:
                 return None
             try:

--- a/katana_public_api_client/models/product.py
+++ b/katana_public_api_client/models/product.py
@@ -358,6 +358,9 @@ class Product:
                 return data
             if isinstance(data, Unset):
                 return data
+            # Empty dict → None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
             try:
                 if not isinstance(data, dict):
                     raise TypeError()

--- a/katana_public_api_client/models/sales_order.py
+++ b/katana_public_api_client/models/sales_order.py
@@ -772,7 +772,7 @@ class SalesOrder:
                 return data
             if isinstance(data, Unset):
                 return data
-            # Empty dict → None (Katana wire quirk; see #509).
+            # Empty dict -> None (Katana wire quirk; see #509).
             if isinstance(data, dict) and not data:
                 return None
             try:

--- a/katana_public_api_client/models/sales_order.py
+++ b/katana_public_api_client/models/sales_order.py
@@ -772,6 +772,9 @@ class SalesOrder:
                 return data
             if isinstance(data, Unset):
                 return data
+            # Empty dict → None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
             try:
                 if not isinstance(data, dict):
                     raise TypeError()

--- a/scripts/regenerate_client.py
+++ b/scripts/regenerate_client.py
@@ -600,24 +600,36 @@ def fix_specific_generated_issues(workspace_path: Path) -> bool:
     return True
 
 
+# Eligibility for the empty-dict-as-null post-processor (#509). A ``_parse_*``
+# helper is patched only when both ``None`` and ``Unset`` checks are present —
+# that signals ``None`` is a valid return value, so empty-dict-as-null is
+# semantically correct. Multi-variant oneOf parsers (e.g. Material | Product |
+# Unset) lack the ``None`` check and are correctly skipped.
+_PARSE_HEADER_RE = re.compile(
+    r"        def _parse_\w+\(data: object\) -> [^\n]+\n"
+    r"            if data is None:\n"
+    r"                return data\n"
+    r"            if isinstance\(data, Unset\):\n"
+    r"                return data\n",
+)
+_EMPTY_DICT_MARKER = "# Empty dict -> None (Katana wire quirk; see #509)."
+_EMPTY_DICT_EARLY_RETURN = (
+    f"            {_EMPTY_DICT_MARKER}\n"
+    "            if isinstance(data, dict) and not data:\n"
+    "                return None\n"
+)
+
+
 def normalize_parse_helpers_empty_dict(workspace_path: Path) -> None:
     """Insert empty-dict-as-null normalization in generated _parse_* helpers.
 
     Katana sometimes returns ``{}`` instead of ``null`` for absent optional
-    nested objects (known wire quirk; see #509). Without normalization, the
-    generator's silent-fallthrough ``oneOf`` parser returns the raw ``{}``
-    dict cast as the typed union — and downstream consumers crash with
-    ``AttributeError`` on attribute access.
-
-    The cache-sync path already handles this in ``_base.py::from_attrs:132-138``;
-    this post-processor brings the direct-attrs path to parity by inserting
-    the same normalization in every generated typed-object ``_parse_*``
-    helper (those whose return type is ``None | <Class> | Unset`` and which
-    call ``<Class>.from_dict()``).
-
-    Idempotent — detects the marker and skips already-patched helpers.
-    Skips multi-variant ``oneOf`` parsers where ``None`` is not a valid
-    return type.
+    nested objects (#509). Without normalization, the generator's
+    silent-fallthrough ``oneOf`` parser returns the raw ``{}`` dict cast as
+    the typed union — and downstream consumers crash with ``AttributeError``
+    on attribute access. The cache-sync path already handles this in
+    ``_base.py::from_attrs:132-138``; this post-processor brings the
+    direct-attrs path to parity. Idempotent.
     """
     print("🔧 Normalizing empty-dict to None in typed-object _parse_* helpers...")
 
@@ -625,24 +637,6 @@ def normalize_parse_helpers_empty_dict(workspace_path: Path) -> None:
     if not models_dir.exists():
         print(f"   ⚠️  Models directory not found: {models_dir}")
         return
-
-    # Match a ``_parse_*`` header through the standard ``None`` + ``Unset``
-    # checks. Only helpers with both checks are eligible — that signals
-    # ``None`` is a valid return value, so empty-dict-as-null is semantically
-    # correct.
-    parse_header_re = re.compile(
-        r"        def _parse_\w+\(data: object\) -> [^\n]+\n"
-        r"            if data is None:\n"
-        r"                return data\n"
-        r"            if isinstance\(data, Unset\):\n"
-        r"                return data\n",
-    )
-    marker_comment = "# Empty dict → None (Katana wire quirk; see #509)."
-    early_return_block = (
-        f"            {marker_comment}\n"
-        "            if isinstance(data, dict) and not data:\n"
-        "                return None\n"
-    )
 
     file_count = 0
     helper_count = 0
@@ -653,13 +647,10 @@ def normalize_parse_helpers_empty_dict(workspace_path: Path) -> None:
             print(f"   ⚠️  Could not read {model_file.name}: {e}")
             continue
 
-        # Cheap pre-filter: skip files with no typed nested-object parsers.
         if ".from_dict(" not in content:
             continue
 
-        new_content, count = _insert_empty_dict_normalization(
-            content, parse_header_re, early_return_block, marker_comment
-        )
+        new_content, count = _insert_empty_dict_normalization(content)
         if count > 0:
             model_file.write_text(new_content, encoding="utf-8")
             file_count += 1
@@ -671,23 +662,15 @@ def normalize_parse_helpers_empty_dict(workspace_path: Path) -> None:
         print("   (no eligible helpers found — already patched or none exist)")
 
 
-def _insert_empty_dict_normalization(
-    content: str,
-    parse_header_re: "re.Pattern[str]",
-    early_return_block: str,
-    marker_comment: str,
-) -> tuple[str, int]:
-    """Insert ``early_return_block`` after each eligible ``_parse_*`` header.
+def _insert_empty_dict_normalization(content: str) -> tuple[str, int]:
+    """Insert ``_EMPTY_DICT_EARLY_RETURN`` after each eligible ``_parse_*`` header.
 
     Eligibility:
-    - Header matches ``parse_header_re`` (typical ``None``+``Unset`` preamble)
+    - Header matches ``_PARSE_HEADER_RE``
     - Function body contains ``.from_dict(`` (typed-object alternative)
-    - Function body does NOT already contain ``marker_comment`` (idempotency)
-
-    Returns ``(new_content, num_helpers_patched)``. Walks matches in
-    reverse so insertion offsets stay valid.
+    - Function body does not already contain ``_EMPTY_DICT_MARKER`` (idempotency)
     """
-    matches = list(parse_header_re.finditer(content))
+    matches = list(_PARSE_HEADER_RE.finditer(content))
     if not matches:
         return content, 0
 
@@ -700,11 +683,13 @@ def _insert_empty_dict_normalization(
 
         if ".from_dict(" not in body:
             continue
-        if marker_comment in body:
+        if _EMPTY_DICT_MARKER in body:
             continue
 
         new_content = (
-            new_content[:body_start] + early_return_block + new_content[body_start:]
+            new_content[:body_start]
+            + _EMPTY_DICT_EARLY_RETURN
+            + new_content[body_start:]
         )
         patched += 1
 
@@ -714,9 +699,8 @@ def _insert_empty_dict_normalization(
 def _function_body_end(content: str, body_start: int) -> int:
     """End offset of a ``_parse_*`` function body, by indentation.
 
-    The header lives at 8-space indent (inside a classmethod at 4-space
-    indent), so the body is at >=12-space indent. Walk forward; the body
-    ends at the first non-blank line indented less than 12 spaces.
+    Header lives at 8-space indent, so the body is at >=12-space indent.
+    Body ends at the first non-blank line indented less than 12 spaces.
     """
     pos = body_start
     n = len(content)

--- a/scripts/regenerate_client.py
+++ b/scripts/regenerate_client.py
@@ -594,7 +594,143 @@ def fix_specific_generated_issues(workspace_path: Path) -> bool:
     # Fix pagination defaults for auto-pagination
     fix_pagination_defaults(workspace_path)
 
+    # Normalize empty-dict-as-null in typed-object _parse_* helpers (#509)
+    normalize_parse_helpers_empty_dict(workspace_path)
+
     return True
+
+
+def normalize_parse_helpers_empty_dict(workspace_path: Path) -> None:
+    """Insert empty-dict-as-null normalization in generated _parse_* helpers.
+
+    Katana sometimes returns ``{}`` instead of ``null`` for absent optional
+    nested objects (known wire quirk; see #509). Without normalization, the
+    generator's silent-fallthrough ``oneOf`` parser returns the raw ``{}``
+    dict cast as the typed union — and downstream consumers crash with
+    ``AttributeError`` on attribute access.
+
+    The cache-sync path already handles this in ``_base.py::from_attrs:132-138``;
+    this post-processor brings the direct-attrs path to parity by inserting
+    the same normalization in every generated typed-object ``_parse_*``
+    helper (those whose return type is ``None | <Class> | Unset`` and which
+    call ``<Class>.from_dict()``).
+
+    Idempotent — detects the marker and skips already-patched helpers.
+    Skips multi-variant ``oneOf`` parsers where ``None`` is not a valid
+    return type.
+    """
+    print("🔧 Normalizing empty-dict to None in typed-object _parse_* helpers...")
+
+    models_dir = workspace_path / "katana_public_api_client" / "models"
+    if not models_dir.exists():
+        print(f"   ⚠️  Models directory not found: {models_dir}")
+        return
+
+    # Match a ``_parse_*`` header through the standard ``None`` + ``Unset``
+    # checks. Only helpers with both checks are eligible — that signals
+    # ``None`` is a valid return value, so empty-dict-as-null is semantically
+    # correct.
+    parse_header_re = re.compile(
+        r"        def _parse_\w+\(data: object\) -> [^\n]+\n"
+        r"            if data is None:\n"
+        r"                return data\n"
+        r"            if isinstance\(data, Unset\):\n"
+        r"                return data\n",
+    )
+    marker_comment = "# Empty dict → None (Katana wire quirk; see #509)."
+    early_return_block = (
+        f"            {marker_comment}\n"
+        "            if isinstance(data, dict) and not data:\n"
+        "                return None\n"
+    )
+
+    file_count = 0
+    helper_count = 0
+    for model_file in sorted(models_dir.glob("*.py")):
+        try:
+            content = model_file.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"   ⚠️  Could not read {model_file.name}: {e}")
+            continue
+
+        # Cheap pre-filter: skip files with no typed nested-object parsers.
+        if ".from_dict(" not in content:
+            continue
+
+        new_content, count = _insert_empty_dict_normalization(
+            content, parse_header_re, early_return_block, marker_comment
+        )
+        if count > 0:
+            model_file.write_text(new_content, encoding="utf-8")
+            file_count += 1
+            helper_count += count
+
+    if helper_count:
+        print(f"   ✓ Patched {helper_count} helpers across {file_count} files")
+    else:
+        print("   (no eligible helpers found — already patched or none exist)")
+
+
+def _insert_empty_dict_normalization(
+    content: str,
+    parse_header_re: "re.Pattern[str]",
+    early_return_block: str,
+    marker_comment: str,
+) -> tuple[str, int]:
+    """Insert ``early_return_block`` after each eligible ``_parse_*`` header.
+
+    Eligibility:
+    - Header matches ``parse_header_re`` (typical ``None``+``Unset`` preamble)
+    - Function body contains ``.from_dict(`` (typed-object alternative)
+    - Function body does NOT already contain ``marker_comment`` (idempotency)
+
+    Returns ``(new_content, num_helpers_patched)``. Walks matches in
+    reverse so insertion offsets stay valid.
+    """
+    matches = list(parse_header_re.finditer(content))
+    if not matches:
+        return content, 0
+
+    new_content = content
+    patched = 0
+    for m in reversed(matches):
+        body_start = m.end()
+        body_end = _function_body_end(new_content, body_start)
+        body = new_content[body_start:body_end]
+
+        if ".from_dict(" not in body:
+            continue
+        if marker_comment in body:
+            continue
+
+        new_content = (
+            new_content[:body_start] + early_return_block + new_content[body_start:]
+        )
+        patched += 1
+
+    return new_content, patched
+
+
+def _function_body_end(content: str, body_start: int) -> int:
+    """End offset of a ``_parse_*`` function body, by indentation.
+
+    The header lives at 8-space indent (inside a classmethod at 4-space
+    indent), so the body is at >=12-space indent. Walk forward; the body
+    ends at the first non-blank line indented less than 12 spaces.
+    """
+    pos = body_start
+    n = len(content)
+    while pos < n:
+        line_end = content.find("\n", pos)
+        if line_end == -1:
+            line_end = n
+        line = content[pos:line_end]
+        if line.strip():
+            indent = len(line) - len(line.lstrip(" "))
+            if indent < 12:
+                return pos
+        pos = line_end + 1
+    return n
 
 
 def fix_pagination_defaults(workspace_path: Path) -> None:

--- a/tests/test_regenerate_client_postprocess.py
+++ b/tests/test_regenerate_client_postprocess.py
@@ -1,0 +1,202 @@
+"""Regression tests for the regenerate_client.py post-processors.
+
+The post-processors normalize quirks in the openapi-python-client output
+(see #509 for the empty-dict-as-null normalization). These tests pin
+the rewrite behavior so a future codegen tooling change that subtly
+shifts the generated text pattern doesn't silently disable the fix.
+
+Loads ``scripts/regenerate_client.py`` via ``importlib`` so the test
+doesn't need ``sys.path`` manipulation or ``# type: ignore`` markers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent / "scripts" / "regenerate_client.py"
+)
+
+
+def _load_regenerate_client() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "regenerate_client_under_test", _SCRIPT_PATH
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Could not load module from {_SCRIPT_PATH}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def regen() -> ModuleType:
+    return _load_regenerate_client()
+
+
+# A representative typed-object _parse_* helper as openapi-python-client
+# emits it. Used as the input fixture for several tests below.
+_TYPED_PARSER_INPUT = """\
+class SalesOrder:
+    @classmethod
+    def from_dict(cls, src_dict):
+        d = dict(src_dict)
+
+        def _parse_shipping_fee(data: object) -> None | SalesOrderShippingFee | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                shipping_fee_type_0 = SalesOrderShippingFee.from_dict(
+                    cast(Mapping[str, Any], data)
+                )
+
+                return shipping_fee_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | SalesOrderShippingFee | Unset, data)
+
+        shipping_fee = _parse_shipping_fee(d.pop("shipping_fee", UNSET))
+"""
+
+# A nullable-string parser (no nested-object alternative). Should NOT be
+# patched — empty-dict-as-null is meaningless for ``str``.
+_NULLABLE_STRING_PARSER_INPUT = """\
+class SalesOrder:
+    @classmethod
+    def from_dict(cls, src_dict):
+        d = dict(src_dict)
+
+        def _parse_customer_ref(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        customer_ref = _parse_customer_ref(d.pop("customer_ref", UNSET))
+"""
+
+# Multi-variant oneOf where ``None`` is NOT a valid return type. Should
+# NOT be patched — returning ``None`` would violate the declared union.
+_MULTI_VARIANT_ONEOF_INPUT = """\
+class VariantResponse:
+    @classmethod
+    def from_dict(cls, src_dict):
+        d = dict(src_dict)
+
+        def _parse_product_or_material(data: object) -> Material | Product | Unset:
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                product_or_material_type_0 = Product.from_dict(
+                    cast(Mapping[str, Any], data)
+                )
+                return product_or_material_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, dict):
+                raise TypeError()
+            product_or_material_type_1 = Material.from_dict(
+                cast(Mapping[str, Any], data)
+            )
+            return product_or_material_type_1
+
+        product_or_material = _parse_product_or_material(
+            d.pop("product_or_material", UNSET)
+        )
+"""
+
+
+def _patch(regen: Any, content: str) -> tuple[str, int]:
+    """Run the post-processor's core text rewrite on ``content``."""
+    return regen._insert_empty_dict_normalization(
+        content,
+        regen.re.compile(
+            r"        def _parse_\w+\(data: object\) -> [^\n]+\n"
+            r"            if data is None:\n"
+            r"                return data\n"
+            r"            if isinstance\(data, Unset\):\n"
+            r"                return data\n",
+        ),
+        early_return_block=(
+            "            # Empty dict → None (Katana wire quirk; see #509).\n"
+            "            if isinstance(data, dict) and not data:\n"
+            "                return None\n"
+        ),
+        marker_comment="# Empty dict → None (Katana wire quirk; see #509).",
+    )
+
+
+def test_inserts_normalization_into_typed_object_parser(regen: Any) -> None:
+    """Header-matching typed-object helper gets the early-return inserted."""
+    output, count = _patch(regen, _TYPED_PARSER_INPUT)
+    assert count == 1
+    assert "# Empty dict → None (Katana wire quirk; see #509)." in output
+    # The early-return must appear after the Unset check and before the try.
+    unset_idx = output.index("if isinstance(data, Unset):")
+    early_idx = output.index("if isinstance(data, dict) and not data:")
+    try_idx = output.index("try:")
+    assert unset_idx < early_idx < try_idx
+
+
+def test_does_not_patch_nullable_string_parser(regen: Any) -> None:
+    """Helpers without ``<Class>.from_dict()`` shouldn't be patched —
+    empty-dict-as-null is meaningless for ``str``."""
+    output, count = _patch(regen, _NULLABLE_STRING_PARSER_INPUT)
+    assert count == 0
+    assert output == _NULLABLE_STRING_PARSER_INPUT
+
+
+def test_does_not_patch_multi_variant_oneof_without_none(regen: Any) -> None:
+    """Helpers whose return type doesn't include ``None`` shouldn't be
+    patched — returning ``None`` would violate the union (e.g.
+    ``Material | Product | Unset``). The header-match requires a
+    ``if data is None`` check, which these helpers don't have."""
+    output, count = _patch(regen, _MULTI_VARIANT_ONEOF_INPUT)
+    assert count == 0
+    assert output == _MULTI_VARIANT_ONEOF_INPUT
+
+
+def test_idempotent_on_already_patched_input(regen: Any) -> None:
+    """Re-running the post-processor on its own output is a no-op."""
+    once, first_count = _patch(regen, _TYPED_PARSER_INPUT)
+    twice, second_count = _patch(regen, once)
+    assert first_count == 1
+    assert second_count == 0
+    assert twice == once
+
+
+def test_function_body_end_uses_indentation(regen: Any) -> None:
+    """Body-end detection must respect the function's indentation, not
+    look ahead to the next ``def`` keyword anywhere — otherwise it
+    would mistakenly include sibling code at the parent classmethod
+    indent (where ``<Class>.from_dict()`` calls live for list parsers)
+    and produce false-positive matches."""
+    sample = (
+        "            return cast(None | str | Unset, data)\n"
+        "\n"
+        "        customer_ref = _parse_customer_ref(d.pop('customer_ref', UNSET))\n"
+        "\n"
+        "        # Sibling code that calls SalesOrderRow.from_dict — must NOT\n"
+        "        # be considered part of the previous _parse_* body.\n"
+        "        for r in rows:\n"
+        "            row = SalesOrderRow.from_dict(r)\n"
+    )
+    end = regen._function_body_end(sample, 0)
+    body = sample[:end]
+    # Body should stop before the ``customer_ref = ...`` line at 8-space
+    # indent, well before the SalesOrderRow.from_dict call.
+    assert "from_dict" not in body
+    assert "_parse_customer_ref" not in body  # the assignment

--- a/tests/test_regenerate_client_postprocess.py
+++ b/tests/test_regenerate_client_postprocess.py
@@ -40,14 +40,21 @@ def regen() -> ModuleType:
     return _load_regenerate_client()
 
 
-# A representative typed-object _parse_* helper as openapi-python-client
-# emits it. Used as the input fixture for several tests below.
-_TYPED_PARSER_INPUT = """\
-class SalesOrder:
-    @classmethod
-    def from_dict(cls, src_dict):
-        d = dict(src_dict)
+def _wrap_in_class(parser_body: str) -> str:
+    """Wrap a ``_parse_*`` helper body in the surrounding class scaffolding
+    that the openapi-python-client generator emits."""
+    return (
+        "class SalesOrder:\n"
+        "    @classmethod\n"
+        "    def from_dict(cls, src_dict):\n"
+        "        d = dict(src_dict)\n"
+        "\n"
+        f"{parser_body}"
+    )
 
+
+_TYPED_PARSER = _wrap_in_class(
+    """\
         def _parse_shipping_fee(data: object) -> None | SalesOrderShippingFee | Unset:
             if data is None:
                 return data
@@ -67,15 +74,10 @@ class SalesOrder:
 
         shipping_fee = _parse_shipping_fee(d.pop("shipping_fee", UNSET))
 """
+)
 
-# A nullable-string parser (no nested-object alternative). Should NOT be
-# patched — empty-dict-as-null is meaningless for ``str``.
-_NULLABLE_STRING_PARSER_INPUT = """\
-class SalesOrder:
-    @classmethod
-    def from_dict(cls, src_dict):
-        d = dict(src_dict)
-
+_NULLABLE_STRING_PARSER = _wrap_in_class(
+    """\
         def _parse_customer_ref(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -85,15 +87,10 @@ class SalesOrder:
 
         customer_ref = _parse_customer_ref(d.pop("customer_ref", UNSET))
 """
+)
 
-# Multi-variant oneOf where ``None`` is NOT a valid return type. Should
-# NOT be patched — returning ``None`` would violate the declared union.
-_MULTI_VARIANT_ONEOF_INPUT = """\
-class VariantResponse:
-    @classmethod
-    def from_dict(cls, src_dict):
-        d = dict(src_dict)
-
+_MULTI_VARIANT_ONEOF_PARSER = _wrap_in_class(
+    """\
         def _parse_product_or_material(data: object) -> Material | Product | Unset:
             if isinstance(data, Unset):
                 return data
@@ -117,86 +114,58 @@ class VariantResponse:
             d.pop("product_or_material", UNSET)
         )
 """
+)
 
 
-def _patch(regen: Any, content: str) -> tuple[str, int]:
-    """Run the post-processor's core text rewrite on ``content``."""
-    return regen._insert_empty_dict_normalization(
-        content,
-        regen.re.compile(
-            r"        def _parse_\w+\(data: object\) -> [^\n]+\n"
-            r"            if data is None:\n"
-            r"                return data\n"
-            r"            if isinstance\(data, Unset\):\n"
-            r"                return data\n",
-        ),
-        early_return_block=(
-            "            # Empty dict → None (Katana wire quirk; see #509).\n"
-            "            if isinstance(data, dict) and not data:\n"
-            "                return None\n"
-        ),
-        marker_comment="# Empty dict → None (Katana wire quirk; see #509).",
-    )
+@pytest.mark.parametrize(
+    ("label", "source", "expected_count"),
+    [
+        ("typed_object_parser", _TYPED_PARSER, 1),
+        ("nullable_string_parser", _NULLABLE_STRING_PARSER, 0),
+        ("multi_variant_oneof_without_none", _MULTI_VARIANT_ONEOF_PARSER, 0),
+    ],
+)
+def test_eligibility(regen: Any, label: str, source: str, expected_count: int) -> None:
+    """Only typed-object parsers with ``None`` allowed get patched."""
+    output, count = regen._insert_empty_dict_normalization(source)
+    assert count == expected_count, label
+    if expected_count == 0:
+        assert output == source, f"{label} should be unmodified"
+    else:
+        assert regen._EMPTY_DICT_MARKER in output, label
 
 
-def test_inserts_normalization_into_typed_object_parser(regen: Any) -> None:
-    """Header-matching typed-object helper gets the early-return inserted."""
-    output, count = _patch(regen, _TYPED_PARSER_INPUT)
-    assert count == 1
-    assert "# Empty dict → None (Katana wire quirk; see #509)." in output
-    # The early-return must appear after the Unset check and before the try.
+def test_inserts_at_correct_position(regen: Any) -> None:
+    """Early-return lands after the Unset check and before the try block."""
+    output, _ = regen._insert_empty_dict_normalization(_TYPED_PARSER)
     unset_idx = output.index("if isinstance(data, Unset):")
     early_idx = output.index("if isinstance(data, dict) and not data:")
     try_idx = output.index("try:")
     assert unset_idx < early_idx < try_idx
 
 
-def test_does_not_patch_nullable_string_parser(regen: Any) -> None:
-    """Helpers without ``<Class>.from_dict()`` shouldn't be patched —
-    empty-dict-as-null is meaningless for ``str``."""
-    output, count = _patch(regen, _NULLABLE_STRING_PARSER_INPUT)
-    assert count == 0
-    assert output == _NULLABLE_STRING_PARSER_INPUT
-
-
-def test_does_not_patch_multi_variant_oneof_without_none(regen: Any) -> None:
-    """Helpers whose return type doesn't include ``None`` shouldn't be
-    patched — returning ``None`` would violate the union (e.g.
-    ``Material | Product | Unset``). The header-match requires a
-    ``if data is None`` check, which these helpers don't have."""
-    output, count = _patch(regen, _MULTI_VARIANT_ONEOF_INPUT)
-    assert count == 0
-    assert output == _MULTI_VARIANT_ONEOF_INPUT
-
-
 def test_idempotent_on_already_patched_input(regen: Any) -> None:
-    """Re-running the post-processor on its own output is a no-op."""
-    once, first_count = _patch(regen, _TYPED_PARSER_INPUT)
-    twice, second_count = _patch(regen, once)
+    once, first_count = regen._insert_empty_dict_normalization(_TYPED_PARSER)
+    twice, second_count = regen._insert_empty_dict_normalization(once)
     assert first_count == 1
     assert second_count == 0
     assert twice == once
 
 
 def test_function_body_end_uses_indentation(regen: Any) -> None:
-    """Body-end detection must respect the function's indentation, not
-    look ahead to the next ``def`` keyword anywhere — otherwise it
-    would mistakenly include sibling code at the parent classmethod
-    indent (where ``<Class>.from_dict()`` calls live for list parsers)
-    and produce false-positive matches."""
+    # If the body-end walker looked for the next ``def`` keyword anywhere
+    # rather than detecting the parent classmethod's indent, it would
+    # reach into sibling code (``SalesOrderRow.from_dict`` here) and
+    # produce false-positive eligibility matches on nullable-string parsers.
     sample = (
         "            return cast(None | str | Unset, data)\n"
         "\n"
         "        customer_ref = _parse_customer_ref(d.pop('customer_ref', UNSET))\n"
         "\n"
-        "        # Sibling code that calls SalesOrderRow.from_dict — must NOT\n"
-        "        # be considered part of the previous _parse_* body.\n"
         "        for r in rows:\n"
         "            row = SalesOrderRow.from_dict(r)\n"
     )
     end = regen._function_body_end(sample, 0)
     body = sample[:end]
-    # Body should stop before the ``customer_ref = ...`` line at 8-space
-    # indent, well before the SalesOrderRow.from_dict call.
     assert "from_dict" not in body
-    assert "_parse_customer_ref" not in body  # the assignment
+    assert "_parse_customer_ref" not in body

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.53.0"
+version = "0.54.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Fixes #509.

## Summary

Katana's API returns `{}` (empty object) instead of `null` for absent optional nested objects — a known wire quirk. The cache-sync path already handled this in `from_attrs` ([_base.py:132-138](https://github.com/dougborg/katana-openapi-client/blob/main/katana_public_api_client/models_pydantic/_base.py#L132)), but the direct-attrs path didn't: openapi-python-client's silent-fallthrough oneOf parser caught the resulting `KeyError` and returned the raw `{}` dict cast as the typed union, leaving downstream consumers to crash on `.id` access. That's how #501 surfaced.

This PR adds a post-processing pass to `scripts/regenerate_client.py` that brings the direct-attrs path to parity by inserting an empty-dict early-return in every typed-object `_parse_*` helper.

## What changes

### Generator post-processor (`scripts/regenerate_client.py`)

New `normalize_parse_helpers_empty_dict()` function, wired into the existing `fix_specific_generated_issues()`. It walks every model file, finds `_parse_*` helpers matching the standard typed-object preamble (`None` check + `Unset` check + body containing `<Class>.from_dict(`), and inserts:

```python
            # Empty dict → None (Katana wire quirk; see #509).
            if isinstance(data, dict) and not data:
                return None
```

after the `Unset` check, before the existing `try:` block.

### Eligibility — what gets patched, what doesn't

| Helper shape | Patched? | Why |
|--------------|----------|-----|
| `None \| <Class> \| Unset` (typed object, None allowed) | **Yes** | Empty-dict-as-null is semantically valid; matches existing `from_attrs` normalization |
| `None \| str \| Unset` (nullable string, no `from_dict` call) | No | Empty-dict-as-null is meaningless for `str` |
| `Material \| Product \| Unset` (multi-variant oneOf, no `None`) | No | Returning `None` would violate the declared union; no `if data is None` check in the header |

Currently 4 helpers match across 4 files:
- `inventory_item.py::_parse_supplier`
- `material.py::_parse_supplier`
- `product.py::_parse_supplier`
- `sales_order.py::_parse_shipping_fee` ← #501's trigger

### Generated-file changes

The four `models/*.py` files above each get the 3-line early-return inserted. No other changes.

### Tests

5 new tests in `tests/test_regenerate_client_postprocess.py` pin the rewrite behavior:
1. Typed-object helper gets the early-return inserted (correct position: after `Unset` check, before `try:`)
2. Nullable-string parser is **not** patched
3. Multi-variant oneOf without `None` is **not** patched
4. Idempotent on re-run (re-running the post-processor on its own output is a no-op)
5. Body-end detection respects function indentation (doesn't mistakenly extend into sibling `<Class>.from_dict(` calls at the parent classmethod's indent)

The test loads `regenerate_client.py` via `importlib.util.spec_from_file_location` — no `sys.path` manipulation, no `# type: ignore` markers, no addition to ty's exclude list.

Updated `TestSyncShippingFeeEmpty` in `katana_mcp_server/tests/test_typed_cache.py` to assert the attrs side now returns `None` directly (not a raw dict) — making the new direct-attrs guarantee visible in the existing regression suite.

## Defense-in-depth retained

Both the `from_attrs._base.py:132-138` empty-dict normalization and the consumer-side fix in `_shipping_fee_from_attrs` (landed in #508) remain in place. They become redundant for the empty-dict case after this PR, but a future codegen tooling change could silently disable the post-processor — keeping the downstream defenses means the system stays robust during transitions. Cleanup tracked for a later PR after one release cycle of stable behavior.

## Test plan

- [x] `uv run poe check` — 2721 passed, 2 skipped, 0 failures
- [x] `normalize_parse_helpers_empty_dict()` is idempotent (verified by running twice on current files; second run is a no-op)
- [x] Manually verified the 4 patched helpers: `git diff katana_public_api_client/models/sales_order.py` etc.
- [x] `_function_body_end()` correctly bounds each helper's body by indentation (verified by test #5; without this fix the early-return was being inserted into nullable-string parsers via false-positive `from_dict` matches in sibling code)

## Related

- #501 — original bug where `get_sales_order` crashed
- #508 — per-consumer fix that unblocked `get_sales_order`; remains as defense-in-depth
- `TestSyncShippingFeeEmpty` in `katana_mcp_server/tests/test_typed_cache.py` — captures the Katana wire behavior
- `from_attrs._base.py:132-138` — the existing empty-dict normalization on the cache-sync path that this PR brings the direct-attrs path to parity with

🤖 Generated with [Claude Code](https://claude.com/claude-code)
