### PR TITLE
fix(mcp)!: extra="forbid" on every input model — surface silent field drops (#487)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -29,7 +29,7 @@ from enum import Enum
 from typing import Any, ClassVar
 
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.tools.tool_result_utils import BLOCK_WARNING_PREFIX, make_simple_result
 from katana_public_api_client.client_types import UNSET
@@ -41,7 +41,19 @@ class ConfirmableRequest(BaseModel):
     Pydantic models. Carries the primary entity ``id`` and the ``preview``
     field used by every modification tool's preview/apply gate. Subclasses
     add their entity-specific sub-payload slots and override ``id``'s
-    description with an entity-appropriate label."""
+    description with an entity-appropriate label.
+
+    ``extra="forbid"`` is set here so direct Python construction (tests,
+    internal ``_impl`` callers) catches typos like ``previw=False``. MCP
+    protocol traffic is already protected by FastMCP's TypeAdapter against
+    the function signature — this config does not fire there because
+    ``unpack_pydantic_params`` strips unknown top-level kwargs before
+    construction (see ``katana_mcp/unpack.py``). The load-bearing
+    ``extra="forbid"`` for catching wire-level silent drops lives on the
+    nested sub-payload models (``*Patch``, ``*Add``, ``*Update``, ``*Input``).
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Entity ID")
     preview: bool = Field(

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -644,14 +644,16 @@ async def run_modify_plan(
             diff=spec.diff,
         )
 
-    # Reject update-style ActionSpecs with empty diffs. This catches the
-    # case where a caller supplied only unknown or derived field names on
-    # the patch payload — pydantic's ``extra="ignore"`` silently dropped
-    # them, leaving the diff (and the resulting PATCH body) empty. Without
-    # this guard, Katana returns a generic "At least 1 field is required"
-    # 422 that's hard to map back to the original input. Adds and deletes
-    # are exempt: adds carry a non-empty diff by construction (required
-    # fields), and deletes have empty diffs by design.
+    # Reject update-style ActionSpecs with empty diffs. With ``extra="forbid"``
+    # on patch models (#487), unknown fields raise ``ValidationError`` at
+    # construction and never reach this point. The remaining cause for an
+    # empty diff is: the caller supplied only the target ``id`` (and possibly
+    # only derived fields, which the prior ``check_derived_fields`` step
+    # rejects with a clearer error). Without this guard, Katana returns a
+    # generic "At least 1 field is required" 422 that's hard to map back to
+    # the original input. Adds and deletes are exempt: adds carry a non-empty
+    # diff by construction (required fields), and deletes have empty diffs
+    # by design.
     for spec in plan:
         if not spec.operation.startswith("update_"):
             continue
@@ -661,9 +663,8 @@ async def run_modify_plan(
         target = f" (target {spec.target_id})" if spec.target_id is not None else ""
         msg = (
             f"No fields to update for {entity_type} {spec.operation}{target} — "
-            f"the patch payload would be empty. This typically means the "
-            f"caller supplied only field names that aren't on the patch "
-            f"model (pydantic silently drops unknown fields)."
+            f"the patch payload would be empty. Provide at least one patchable "
+            f"field on the sub-payload, or omit this operation."
         )
         if derived_for_op:
             derived_names = ", ".join(sorted(derived_for_op))

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/cache_admin.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/cache_admin.py
@@ -25,7 +25,7 @@ from typing import Annotated, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlmodel import SQLModel, func, select
 
 from katana_mcp.logging import get_logger, observe_tool
@@ -64,6 +64,8 @@ CacheEntityType = Literal[
 
 class RebuildCacheRequest(BaseModel):
     """Request model for ``rebuild_cache``."""
+
+    model_config = ConfigDict(extra="forbid")
 
     entity_types: list[CacheEntityType] = Field(
         ...,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
@@ -11,7 +11,7 @@ from typing import Annotated
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
@@ -35,6 +35,8 @@ logger = get_logger(__name__)
 
 class CreateProductRequest(BaseModel):
     """Request model for creating a product."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str = Field(..., description="Product name")
     sku: str = Field(..., description="SKU for the product variant")
@@ -168,6 +170,8 @@ async def create_product(
 
 class CreateMaterialRequest(BaseModel):
     """Request model for creating a material."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str = Field(..., description="Material name")
     sku: str = Field(..., description="SKU for the material variant")

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
@@ -11,7 +11,7 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools.tool import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import observe_tool
@@ -28,6 +28,8 @@ from katana_mcp.web_urls import katana_web_url
 
 class SearchCustomersRequest(BaseModel):
     """Request model for searching customers."""
+
+    model_config = ConfigDict(extra="forbid")
 
     query: str = Field(..., description="Search query (name or email)")
     limit: int = Field(default=20, description="Maximum results to return")
@@ -136,6 +138,8 @@ async def search_customers(
 
 class GetCustomerRequest(BaseModel):
     """Request model for fetching a customer by ID."""
+
+    model_config = ConfigDict(extra="forbid")
 
     customer_id: int = Field(..., description="Customer ID to look up")
     format: Literal["markdown", "json"] = Field(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -14,7 +14,7 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
@@ -42,6 +42,8 @@ logger = get_logger(__name__)
 
 class CheckInventoryRequest(BaseModel):
     """Request model for checking inventory."""
+
+    model_config = ConfigDict(extra="forbid")
 
     skus_or_variant_ids: CoercedStrIntList = Field(
         ...,
@@ -267,6 +269,8 @@ async def check_inventory(
 class LowStockRequest(BaseModel):
     """Request model for listing low stock items."""
 
+    model_config = ConfigDict(extra="forbid")
+
     threshold: int = Field(default=10, description="Stock threshold level")
     limit: int = Field(default=50, description="Maximum items to return")
     format: Literal["markdown", "json"] = Field(
@@ -280,6 +284,8 @@ class LowStockRequest(BaseModel):
 
 class LowStockItem(BaseModel):
     """Low stock item information."""
+
+    model_config = ConfigDict(extra="forbid")
 
     sku: str
     product_name: str
@@ -412,6 +418,8 @@ async def list_low_stock_items(
 
 class GetInventoryMovementsRequest(BaseModel):
     """Request model for querying inventory movements."""
+
+    model_config = ConfigDict(extra="forbid")
 
     sku: str = Field(..., description="SKU to get movements for")
     limit: int = Field(default=50, description="Maximum movements to return")
@@ -665,6 +673,8 @@ async def get_inventory_movements(
 class StockAdjustmentRow(BaseModel):
     """A single line item in a stock adjustment."""
 
+    model_config = ConfigDict(extra="forbid")
+
     sku: str = Field(..., description="SKU to adjust")
     quantity: float = Field(
         ..., description="Quantity change (positive to add, negative to remove)"
@@ -676,6 +686,8 @@ class StockAdjustmentRow(BaseModel):
 
 class CreateStockAdjustmentRequest(BaseModel):
     """Request to create a stock adjustment."""
+
+    model_config = ConfigDict(extra="forbid")
 
     location_id: int = Field(..., description="Location ID for the adjustment")
     rows: list[StockAdjustmentRow] = Field(..., description="Line items to adjust")
@@ -828,6 +840,8 @@ async def create_stock_adjustment(
 
 class ListStockAdjustmentsRequest(BaseModel):
     """Request to list/filter stock adjustments."""
+
+    model_config = ConfigDict(extra="forbid")
 
     limit: int = Field(
         default=50,
@@ -1201,6 +1215,8 @@ async def list_stock_adjustments(
 class UpdateStockAdjustmentParams(BaseModel):
     """Request to update an existing stock adjustment."""
 
+    model_config = ConfigDict(extra="forbid")
+
     id: int = Field(..., description="Stock adjustment ID to update")
     stock_adjustment_number: str | None = Field(
         default=None, description="New adjustment number (optional)"
@@ -1390,6 +1406,8 @@ async def update_stock_adjustment(
 
 class DeleteStockAdjustmentRequest(BaseModel):
     """Request to delete an existing stock adjustment."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Stock adjustment ID to delete")
     preview: bool = Field(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -285,8 +285,6 @@ class LowStockRequest(BaseModel):
 class LowStockItem(BaseModel):
     """Low stock item information."""
 
-    model_config = ConfigDict(extra="forbid")
-
     sku: str
     product_name: str
     current_stock: int

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
@@ -109,6 +109,8 @@ class ItemType(StrEnum):
 
 class SearchItemsRequest(BaseModel):
     """Request model for searching items."""
+
+    model_config = ConfigDict(extra="forbid")
 
     query: str = Field(..., description="Search query (name, SKU, etc.)")
     limit: int = Field(default=20, description="Maximum results to return")
@@ -223,6 +225,8 @@ class CreateItemRequest(BaseModel):
     For complex items with multiple variants and configurations, use the
     native API models directly.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     type: ItemType = Field(..., description="Type of item to create")
     name: str = Field(..., description="Item name")
@@ -367,6 +371,8 @@ async def create_item(
 
 class GetItemRequest(BaseModel):
     """Request to get an item by ID."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Item ID")
     type: ItemType = Field(..., description="Type of item (product, material, service)")
@@ -742,6 +748,8 @@ class ItemHeaderPatch(BaseModel):
     ``_SERVICE_ONLY_FIELDS``.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     name: str | None = Field(default=None, description="New item name")
     uom: str | None = Field(default=None, description="New unit of measure")
     category_name: str | None = Field(default=None, description="New category")
@@ -780,6 +788,8 @@ class VariantAdd(BaseModel):
     ``material_id`` based on the parent item type.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     sku: str = Field(..., description="Variant SKU")
     sales_price: float | None = Field(default=None)
     purchase_price: float | None = Field(default=None)
@@ -792,6 +802,8 @@ class VariantAdd(BaseModel):
 
 class VariantUpdate(BaseModel):
     """Patch to an existing variant."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Variant ID")
     sku: str | None = Field(default=None)
@@ -1135,6 +1147,8 @@ class GetVariantDetailsRequest(BaseModel):
 
     Accepts a single sku/variant_id OR a list (skus/variant_ids) for batch lookups.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     sku: str | None = Field(
         default=None,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -20,7 +20,7 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
@@ -134,6 +134,8 @@ class CreateManufacturingOrderRequest(BaseModel):
       location_id are inferred from the sales order row; passing them explicitly
       is optional and will be ignored by the API.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     variant_id: int | None = Field(
         default=None,
@@ -506,6 +508,8 @@ _BLOCKING_AVAILABILITY: frozenset[str] = frozenset(
 
 class GetManufacturingOrderRequest(BaseModel):
     """Request to look up a manufacturing order."""
+
+    model_config = ConfigDict(extra="forbid")
 
     order_no: str | None = Field(
         default=None, description="Order number to look up (e.g., '#WEB20082 / 1')"
@@ -1462,6 +1466,8 @@ async def get_manufacturing_order(
 class GetManufacturingOrderRecipeRequest(BaseModel):
     """Request to list ingredient rows for a manufacturing order."""
 
+    model_config = ConfigDict(extra="forbid")
+
     manufacturing_order_id: int = Field(..., description="Manufacturing order ID")
     format: Literal["markdown", "json"] = Field(
         default="markdown",
@@ -1547,6 +1553,8 @@ async def get_manufacturing_order_recipe(
 
 class ListManufacturingOrdersRequest(BaseModel):
     """Request to list/filter manufacturing orders (cache-backed)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     # Paging
     limit: int = Field(
@@ -1939,6 +1947,8 @@ async def list_manufacturing_orders(
 class ListBlockingIngredientsRequest(BaseModel):
     """Request to roll up blocking-ingredient rows across manufacturing orders."""
 
+    model_config = ConfigDict(extra="forbid")
+
     mo_status: CoercedStrListOpt = Field(
         default=None,
         description=(
@@ -2001,6 +2011,8 @@ class ListBlockingIngredientsRequest(BaseModel):
 
 class BlockingRow(BaseModel):
     """One blocking recipe-row entry within a per-MO grouping."""
+
+    model_config = ConfigDict(extra="forbid")
 
     recipe_row_id: int
     variant_id: int | None
@@ -2490,6 +2502,8 @@ class MOHeaderPatch(BaseModel):
     """Header fields to patch on an MO. Status is included here — Katana's
     PATCH /manufacturing_orders/{id} accepts it as a regular field."""
 
+    model_config = ConfigDict(extra="forbid")
+
     order_no: str | None = Field(default=None)
     variant_id: int | None = Field(default=None)
     location_id: int | None = Field(default=None)
@@ -2511,6 +2525,8 @@ class MOHeaderPatch(BaseModel):
 class MORecipeRowAdd(BaseModel):
     """A new recipe row (ingredient) on the MO."""
 
+    model_config = ConfigDict(extra="forbid")
+
     variant_id: int = Field(..., description="Variant ID of the ingredient")
     planned_quantity_per_unit: float = Field(..., description="Quantity per unit", gt=0)
     notes: str | None = Field(default=None)
@@ -2519,6 +2535,8 @@ class MORecipeRowAdd(BaseModel):
 
 class MORecipeRowUpdate(BaseModel):
     """Patch to an existing MO recipe row."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Recipe row ID")
     variant_id: int | None = Field(default=None)
@@ -2529,6 +2547,8 @@ class MORecipeRowUpdate(BaseModel):
 
 class MOOperationRowAdd(BaseModel):
     """A new operation row (production step) on the MO."""
+
+    model_config = ConfigDict(extra="forbid")
 
     status: ManufacturingOperationStatusLiteral = Field(
         ..., description="Initial operation status"
@@ -2549,6 +2569,8 @@ class MOOperationRowAdd(BaseModel):
 class MOOperationRowUpdate(BaseModel):
     """Patch to an existing MO operation row."""
 
+    model_config = ConfigDict(extra="forbid")
+
     id: int = Field(..., description="Operation row ID")
     status: ManufacturingOperationStatusLiteral | None = Field(default=None)
     operation_id: int | None = Field(default=None)
@@ -2566,6 +2588,8 @@ class MOOperationRowUpdate(BaseModel):
 class MOProductionAdd(BaseModel):
     """A new production record on the MO (output completed quantity)."""
 
+    model_config = ConfigDict(extra="forbid")
+
     completed_quantity: float = Field(
         ..., description="Quantity produced in this production record", gt=0
     )
@@ -2581,6 +2605,8 @@ class MOProductionAdd(BaseModel):
 
 class MOProductionUpdate(BaseModel):
     """Patch to an existing MO production record."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Production record ID")
     production_date: datetime | None = Field(default=None)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -2012,8 +2012,6 @@ class ListBlockingIngredientsRequest(BaseModel):
 class BlockingRow(BaseModel):
     """One blocking recipe-row entry within a per-MO grouping."""
 
-    model_config = ConfigDict(extra="forbid")
-
     recipe_row_id: int
     variant_id: int | None
     sku: str | None

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -12,7 +12,7 @@ from typing import Annotated, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
@@ -39,6 +39,8 @@ logger = get_logger(__name__)
 
 class FulfillOrderRequest(BaseModel):
     """Request to fulfill an order."""
+
+    model_config = ConfigDict(extra="forbid")
 
     order_id: int = Field(..., description="Order ID to fulfill")
     order_type: Literal["manufacturing", "sales"] = Field(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -17,7 +17,7 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
@@ -113,6 +113,8 @@ logger = get_logger(__name__)
 class PurchaseOrderItem(BaseModel):
     """Line item for a purchase order."""
 
+    model_config = ConfigDict(extra="forbid")
+
     variant_id: int = Field(..., description="Variant ID to purchase")
     quantity: float = Field(..., description="Quantity to order", gt=0)
     price_per_unit: float = Field(..., description="Unit price")
@@ -126,6 +128,8 @@ class PurchaseOrderItem(BaseModel):
 
 class CreatePurchaseOrderRequest(BaseModel):
     """Request to create a purchase order."""
+
+    model_config = ConfigDict(extra="forbid")
 
     supplier_id: int = Field(..., description="Supplier ID")
     location_id: int = Field(
@@ -362,12 +366,16 @@ async def create_purchase_order(
 class ReceiveItemRequest(BaseModel):
     """Item to receive from purchase order."""
 
+    model_config = ConfigDict(extra="forbid")
+
     purchase_order_row_id: int = Field(..., description="Purchase order row ID")
     quantity: float = Field(..., description="Quantity to receive", gt=0)
 
 
 class ReceivePurchaseOrderRequest(BaseModel):
     """Request to receive items from a purchase order."""
+
+    model_config = ConfigDict(extra="forbid")
 
     order_id: int = Field(..., description="Purchase order ID")
     items: list[ReceiveItemRequest] = Field(
@@ -601,6 +609,8 @@ async def receive_purchase_order(
 
 class GetPurchaseOrderRequest(BaseModel):
     """Request to look up a purchase order by number or ID."""
+
+    model_config = ConfigDict(extra="forbid")
 
     order_no: str | None = Field(
         default=None, description="Purchase order number (e.g., 'PO-1022')"
@@ -1308,6 +1318,8 @@ async def get_purchase_order(
 class DocumentItem(BaseModel):
     """Item from a supplier document to verify."""
 
+    model_config = ConfigDict(extra="forbid")
+
     sku: str = Field(..., description="Item SKU from document")
     quantity: float = Field(..., description="Quantity from document")
     unit_price: float | None = Field(None, description="Price from document")
@@ -1345,6 +1357,8 @@ class Discrepancy(BaseModel):
 
 class VerifyOrderDocumentRequest(BaseModel):
     """Request to verify a document against a purchase order."""
+
+    model_config = ConfigDict(extra="forbid")
 
     order_id: int = Field(..., description="Purchase order ID")
     document_items: list[DocumentItem] = Field(
@@ -1635,6 +1649,8 @@ async def verify_order_document(
 
 class ListPurchaseOrdersRequest(BaseModel):
     """Request to list/filter purchase orders (list-tool pattern v2)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     # Paging
     limit: int = Field(
@@ -2148,6 +2164,8 @@ class POHeaderPatch(BaseModel):
     Katana's PATCH /purchase_orders/{id} accepts it as a regular field, so
     no separate status sub-payload is needed."""
 
+    model_config = ConfigDict(extra="forbid")
+
     order_no: str | None = Field(default=None, description="New PO number")
     supplier_id: int | None = Field(default=None, description="New supplier ID")
     currency: str | None = Field(default=None, description="New currency code")
@@ -2178,6 +2196,8 @@ class POHeaderPatch(BaseModel):
 class PORowAdd(BaseModel):
     """A new line item to add to the PO."""
 
+    model_config = ConfigDict(extra="forbid")
+
     variant_id: int = Field(..., description="Variant ID")
     quantity: float = Field(..., description="Quantity", gt=0)
     price_per_unit: float = Field(..., description="Unit price")
@@ -2196,6 +2216,8 @@ class PORowAdd(BaseModel):
 
 class PORowUpdate(BaseModel):
     """Patch to an existing PO row. Carries the row id plus optional fields."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Row ID to update")
     quantity: float | None = Field(default=None, description="New quantity", gt=0)
@@ -2224,6 +2246,8 @@ class POAdditionalCostAdd(BaseModel):
     resolves the parent PO's ``default_group_id`` automatically.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     additional_cost_id: int = Field(..., description="Additional-cost catalog entry ID")
     tax_rate_id: int = Field(..., description="Tax rate ID")
     price: float = Field(..., description="Cost amount")
@@ -2242,6 +2266,8 @@ class POAdditionalCostAdd(BaseModel):
 
 class POAdditionalCostUpdate(BaseModel):
     """Patch to an existing additional-cost row."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Cost row ID to update")
     additional_cost_id: int | None = Field(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -262,8 +262,6 @@ class TopSellingVariantsRequest(BaseModel):
 class VariantSalesRow(BaseModel):
     """Per-variant sales aggregate row."""
 
-    model_config = ConfigDict(extra="forbid")
-
     sku: str | None
     variant_id: int
     name: str | None
@@ -453,8 +451,6 @@ class SalesSummaryRequest(BaseModel):
 
 class SummaryRow(BaseModel):
     """Grouped sales aggregate row."""
-
-    model_config = ConfigDict(extra="forbid")
 
     group: str
     units: float

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -44,7 +44,7 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
@@ -226,6 +226,8 @@ def _row_revenue(row: Any) -> float:
 class TopSellingVariantsRequest(BaseModel):
     """Request for top-selling variants over a date window."""
 
+    model_config = ConfigDict(extra="forbid")
+
     start_date: date = Field(
         ..., description="Start of the window (inclusive, ISO-8601 date)"
     )
@@ -259,6 +261,8 @@ class TopSellingVariantsRequest(BaseModel):
 
 class VariantSalesRow(BaseModel):
     """Per-variant sales aggregate row."""
+
+    model_config = ConfigDict(extra="forbid")
 
     sku: str | None
     variant_id: int
@@ -430,6 +434,8 @@ SalesGroupBy = Literal["day", "week", "month", "variant", "customer", "category"
 class SalesSummaryRequest(BaseModel):
     """Request for grouped sales summary."""
 
+    model_config = ConfigDict(extra="forbid")
+
     start_date: date = Field(..., description="Start of window (inclusive)")
     end_date: date = Field(..., description="End of window (inclusive)")
     group_by: SalesGroupBy = Field(
@@ -447,6 +453,8 @@ class SalesSummaryRequest(BaseModel):
 
 class SummaryRow(BaseModel):
     """Grouped sales aggregate row."""
+
+    model_config = ConfigDict(extra="forbid")
 
     group: str
     units: float
@@ -640,6 +648,8 @@ class InventoryVelocityRequest(BaseModel):
     Exactly one of ``sku_or_variant_id`` (single-item shape) or
     ``sku_or_variant_ids`` (batch shape) must be provided.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     sku_or_variant_id: str | int | None = Field(
         default=None,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -20,7 +20,7 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
@@ -131,6 +131,8 @@ logger = get_logger(__name__)
 class SalesOrderItem(BaseModel):
     """Line item for a sales order."""
 
+    model_config = ConfigDict(extra="forbid")
+
     variant_id: int = Field(..., description="Variant ID to sell")
     quantity: float = Field(..., description="Quantity to sell", gt=0)
     price_per_unit: float | None = Field(
@@ -148,6 +150,8 @@ class SalesOrderItem(BaseModel):
 
 class SalesOrderAddress(BaseModel):
     """Billing or shipping address for a sales order."""
+
+    model_config = ConfigDict(extra="forbid")
 
     entity_type: Literal["billing", "shipping"] = Field(
         ..., description="Type of address - billing or shipping"
@@ -168,6 +172,8 @@ class SalesOrderAddress(BaseModel):
 
 class CreateSalesOrderRequest(BaseModel):
     """Request to create a sales order."""
+
+    model_config = ConfigDict(extra="forbid")
 
     customer_id: int = Field(..., description="Customer ID placing the order")
     order_number: str = Field(..., description="Unique sales order number")
@@ -417,6 +423,8 @@ async def create_sales_order(
 
 class ListSalesOrdersRequest(BaseModel):
     """Request to list/filter sales orders (list-tool pattern v2)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     # Paging
     limit: int = Field(
@@ -832,6 +840,8 @@ async def list_sales_orders(
 
 class GetSalesOrderRequest(BaseModel):
     """Request to look up a single sales order with line items."""
+
+    model_config = ConfigDict(extra="forbid")
 
     order_no: str | None = Field(default=None, description="Sales order number")
     order_id: int | None = Field(default=None, description="Sales order ID")
@@ -1472,6 +1482,8 @@ class SOHeaderPatch(BaseModel):
     """Header fields to patch on an SO. Status is included here — the Katana
     PATCH endpoint accepts it as a regular field."""
 
+    model_config = ConfigDict(extra="forbid")
+
     order_no: str | None = Field(default=None, description="New SO number")
     customer_id: int | None = Field(default=None, description="New customer ID")
     location_id: int | None = Field(default=None, description="New location ID")
@@ -1504,6 +1516,8 @@ class SOHeaderPatch(BaseModel):
 class SORowAdd(BaseModel):
     """A new line item to add to the SO."""
 
+    model_config = ConfigDict(extra="forbid")
+
     variant_id: int = Field(..., description="Variant ID")
     quantity: float = Field(..., description="Quantity", gt=0)
     price_per_unit: float | None = Field(default=None, description="Unit price")
@@ -1514,6 +1528,8 @@ class SORowAdd(BaseModel):
 
 class SORowUpdate(BaseModel):
     """Patch to an existing SO row."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Row ID to update")
     variant_id: int | None = Field(default=None, description="New variant ID")
@@ -1526,6 +1542,8 @@ class SORowUpdate(BaseModel):
 
 class SOAddressAdd(BaseModel):
     """A new address to attach to the SO."""
+
+    model_config = ConfigDict(extra="forbid")
 
     entity_type: AddressEntityTypeLiteral = Field(
         ..., description="Address kind — billing or shipping"
@@ -1545,6 +1563,8 @@ class SOAddressUpdate(BaseModel):
     the Katana API, so previews show every supplied field as
     ``is_unknown_prior=True`` — we can't read the prior values cheaply."""
 
+    model_config = ConfigDict(extra="forbid")
+
     id: int = Field(..., description="Address ID to update")
     first_name: str | None = Field(default=None)
     last_name: str | None = Field(default=None)
@@ -1559,12 +1579,16 @@ class SOAddressUpdate(BaseModel):
 class SOFulfillmentRowInput(BaseModel):
     """A row inside a fulfillment — references an SO row + a quantity to fulfill."""
 
+    model_config = ConfigDict(extra="forbid")
+
     sales_order_row_id: int = Field(..., description="SO row being fulfilled")
     quantity: float = Field(..., description="Quantity fulfilled", gt=0)
 
 
 class SOFulfillmentAdd(BaseModel):
     """A new fulfillment for the SO."""
+
+    model_config = ConfigDict(extra="forbid")
 
     status: FulfillmentStatusLiteral = Field(
         ..., description="Fulfillment status — DELIVERED or PACKED"
@@ -1584,6 +1608,8 @@ class SOFulfillmentAdd(BaseModel):
 class SOFulfillmentUpdate(BaseModel):
     """Patch to an existing SO fulfillment."""
 
+    model_config = ConfigDict(extra="forbid")
+
     id: int = Field(..., description="Fulfillment ID to update")
     status: FulfillmentStatusLiteral | None = Field(default=None)
     picked_date: datetime | None = Field(default=None)
@@ -1599,6 +1625,8 @@ class SOFulfillmentUpdate(BaseModel):
 class SOShippingFeeAdd(BaseModel):
     """A new shipping fee to attach to the SO."""
 
+    model_config = ConfigDict(extra="forbid")
+
     amount: str = Field(..., description="Fee amount (decimal string)")
     description: str | None = Field(default=None)
     tax_rate_id: int | None = Field(default=None)
@@ -1611,6 +1639,8 @@ class SOShippingFeeUpdate(BaseModel):
     semantic on the fee's amount, not a partial update. The other fields
     are genuinely optional.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Shipping fee ID to update")
     amount: str = Field(..., description="Fee amount (required by API)")

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -20,7 +20,7 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
@@ -134,12 +134,16 @@ class StockTransferSummary(BaseModel):
 class StockTransferBatchTransactionInput(BaseModel):
     """Batch transaction for a batch-tracked variant on a stock transfer row."""
 
+    model_config = ConfigDict(extra="forbid")
+
     batch_id: int = Field(..., description="Batch ID being transferred")
     quantity: float = Field(..., description="Quantity drawn from this batch", gt=0)
 
 
 class StockTransferRowInput(BaseModel):
     """Line item for a stock transfer."""
+
+    model_config = ConfigDict(extra="forbid")
 
     variant_id: int = Field(..., description="Variant ID to transfer")
     quantity: float = Field(..., description="Quantity to transfer", gt=0)
@@ -154,6 +158,8 @@ class StockTransferRowInput(BaseModel):
 
 class CreateStockTransferRequest(BaseModel):
     """Request to create a stock transfer between two locations."""
+
+    model_config = ConfigDict(extra="forbid")
 
     source_location_id: int = Field(..., description="Source location ID")
     destination_location_id: int = Field(
@@ -456,6 +462,8 @@ async def create_stock_transfer(
 
 class ListStockTransfersRequest(BaseModel):
     """Request to list/filter stock transfers (list-tool pattern v2)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     # Paging
     limit: int = Field(
@@ -767,6 +775,8 @@ class StockTransferHeaderPatch(BaseModel):
     ``update_status`` sub-payload.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     stock_transfer_number: str | None = Field(
         default=None, description="New stock transfer number"
     )
@@ -788,6 +798,8 @@ class StockTransferStatusPatch(BaseModel):
     two-endpoint reality discoverable in the schema while still letting one
     ``modify_stock_transfer`` call mutate both header and status.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     new_status: StatusLiteral = Field(
         ...,

--- a/katana_mcp_server/src/katana_mcp/unpack.py
+++ b/katana_mcp_server/src/katana_mcp/unpack.py
@@ -199,7 +199,15 @@ def unpack_pydantic_params(func: Callable) -> Callable:
         reconstructed_kwargs = kwargs.copy()
 
         for original_param_name, (model_class, field_names) in unpack_mapping.items():
-            # Collect fields for this model
+            # Only declared fields make it to ``model_data`` — unknown
+            # top-level kwargs are stripped here, before construction. As a
+            # consequence, ``extra="forbid"`` on the dispatcher request model
+            # does NOT fire on MCP-protocol traffic (FastMCP's TypeAdapter
+            # against the function signature catches top-level typos earlier).
+            # The dispatcher-level ``extra="forbid"`` is defense in depth for
+            # direct Python callers (tests, internal ``_impl`` calls). The
+            # load-bearing ``extra="forbid"`` for catching wire-level silent
+            # drops lives on the nested sub-payload models — see #487.
             model_data = {}
             for field_name in field_names:
                 if field_name in kwargs:
@@ -226,7 +234,15 @@ def unpack_pydantic_params(func: Callable) -> Callable:
         reconstructed_kwargs = kwargs.copy()
 
         for original_param_name, (model_class, field_names) in unpack_mapping.items():
-            # Collect fields for this model
+            # Only declared fields make it to ``model_data`` — unknown
+            # top-level kwargs are stripped here, before construction. As a
+            # consequence, ``extra="forbid"`` on the dispatcher request model
+            # does NOT fire on MCP-protocol traffic (FastMCP's TypeAdapter
+            # against the function signature catches top-level typos earlier).
+            # The dispatcher-level ``extra="forbid"`` is defense in depth for
+            # direct Python callers (tests, internal ``_impl`` calls). The
+            # load-bearing ``extra="forbid"`` for catching wire-level silent
+            # drops lives on the nested sub-payload models — see #487.
             model_data = {}
             for field_name in field_names:
                 if field_name in kwargs:

--- a/katana_mcp_server/tests/test_strict_input_validation.py
+++ b/katana_mcp_server/tests/test_strict_input_validation.py
@@ -47,8 +47,19 @@ _INPUT_SUFFIXES = (
 _OUTPUT_SUFFIXES = ("Response", "Info", "Summary", "Detail", "Stats")
 
 # Class names exempt from the ``extra="forbid"`` requirement. Add with a
-# brief justification — the goal is to keep this list tiny.
-_EXEMPT_CLASSES: frozenset[str] = frozenset()
+# brief justification — the goal is to keep this list tiny. The four below
+# share the ``*Row``/``*Item`` suffix with input shapes (line items in
+# create requests) but are actually nested rows inside ``*Response`` models
+# — constructed by our impl with controlled kwargs from API data, never
+# from untrusted caller input. ``extra="forbid"`` would just add noise.
+_EXEMPT_CLASSES: frozenset[str] = frozenset(
+    {
+        "LowStockItem",  # nested in LowStockResponse
+        "BlockingRow",  # nested in BlockingIngredientByMO/Variant
+        "VariantSalesRow",  # nested in TopSellingVariantsResponse / InventoryVelocityResponse
+        "SummaryRow",  # nested in SalesSummaryResponse
+    }
+)
 
 
 def _is_input_class_name(name: str) -> bool:
@@ -85,11 +96,11 @@ def test_every_foundation_input_model_forbids_extra() -> None:
     classes = _all_foundation_input_classes()
     assert classes, "discovered zero input classes — exploration logic broke"
 
-    missing: list[str] = []
-    for cls in classes:
-        if cls.model_config.get("extra") != "forbid":
-            missing.append(f"{cls.__module__}.{cls.__name__}")
-
+    missing = sorted(
+        f"{cls.__module__}.{cls.__name__}"
+        for cls in classes
+        if cls.model_config.get("extra") != "forbid"
+    )
     assert not missing, (
         f"{len(missing)} input model(s) missing extra='forbid' — add "
         f"`model_config = ConfigDict(extra='forbid')` to each:\n  "
@@ -114,13 +125,22 @@ def test_confirmable_request_forbids_extra() -> None:
 def _assert_forbids(
     model_cls: type[BaseModel], known_kwargs: dict[str, Any], unknown_field: str
 ) -> None:
-    """Construct the model with one extra field; assert ValidationError
-    mentions the extra field name."""
+    """Construct the model with one extra field; assert pydantic emits a
+    structured ``extra_forbidden`` error whose ``loc`` ends with the
+    unknown field name. Reads the structured error rather than the
+    formatted string so the assertion survives pydantic message tweaks."""
     with pytest.raises(ValidationError) as exc:
         model_cls(**known_kwargs, **{unknown_field: 1})
-    assert unknown_field in str(exc.value), (
-        f"ValidationError for {model_cls.__name__} should mention "
-        f"unknown field {unknown_field!r}; got: {exc.value!s}"
+    matching = [
+        err
+        for err in exc.value.errors()
+        if err["type"] == "extra_forbidden"
+        and err["loc"]
+        and err["loc"][-1] == unknown_field
+    ]
+    assert matching, (
+        f"{model_cls.__name__}: expected an `extra_forbidden` error for "
+        f"{unknown_field!r}; got errors: {exc.value.errors()!r}"
     )
 
 

--- a/katana_mcp_server/tests/test_strict_input_validation.py
+++ b/katana_mcp_server/tests/test_strict_input_validation.py
@@ -1,0 +1,185 @@
+"""Tests for ``extra="forbid"`` on every MCP-layer input model (#487).
+
+The bug class: pydantic v2 silently drops unknown fields by default. In this
+codebase that surfaced as silent partial-success failures across multiple
+tools — ``modify_manufacturing_order`` no-op (post-rename of ``confirm`` →
+``preview``), ``modify_item`` configs silently dropped (#503),
+``receive_purchase_order`` per-item ``received_date`` silently dropped (#505).
+
+This module guards against the bug class in two ways:
+
+1. **Introspection test** — walks every input-shape Pydantic class under
+   ``katana_mcp.tools.foundation.*`` and asserts ``model_config["extra"] ==
+   "forbid"``. Catches the next sub-payload added without the config.
+
+2. **Behavior tests** — concrete typo cases that mirror the original bug
+   reports, asserting the resulting ``ValidationError`` names the
+   unknown field so callers can fix the call.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from typing import Any
+
+import pytest
+from katana_mcp.tools import foundation
+from katana_mcp.tools._modification import ConfirmableRequest
+from pydantic import BaseModel, ValidationError
+
+# Class-name suffixes that mark a model as "input shape". Output suffixes are
+# checked first — a class ending in ``Info``/``Response``/``Summary``/etc. is
+# never considered input even if it also matches an input suffix (e.g.
+# ``StockAdjustmentRowInfo`` ends with ``Info``, not ``Row``).
+_INPUT_SUFFIXES = (
+    "Request",
+    "Patch",
+    "Add",
+    "Update",
+    "Input",
+    "Item",
+    "Params",
+    "Row",
+    "Address",
+)
+_OUTPUT_SUFFIXES = ("Response", "Info", "Summary", "Detail", "Stats")
+
+# Class names exempt from the ``extra="forbid"`` requirement. Add with a
+# brief justification — the goal is to keep this list tiny.
+_EXEMPT_CLASSES: frozenset[str] = frozenset()
+
+
+def _is_input_class_name(name: str) -> bool:
+    if any(name.endswith(suf) for suf in _OUTPUT_SUFFIXES):
+        return False
+    return any(name.endswith(suf) for suf in _INPUT_SUFFIXES)
+
+
+def _all_foundation_input_classes() -> list[type[BaseModel]]:
+    """Discover every input-shape ``BaseModel`` subclass across all modules
+    under ``katana_mcp.tools.foundation``."""
+    collected: list[type[BaseModel]] = []
+    for module_info in pkgutil.iter_modules(foundation.__path__):
+        if module_info.name.startswith("_"):
+            continue
+        module = importlib.import_module(f"{foundation.__name__}.{module_info.name}")
+        for _name, obj in inspect.getmembers(module, inspect.isclass):
+            if not issubclass(obj, BaseModel) or obj is BaseModel:
+                continue
+            if obj.__module__ != module.__name__:
+                continue  # imported from elsewhere
+            if obj.__name__ in _EXEMPT_CLASSES:
+                continue
+            if not _is_input_class_name(obj.__name__):
+                continue
+            collected.append(obj)
+    return collected
+
+
+def test_every_foundation_input_model_forbids_extra() -> None:
+    """Every input-shape Pydantic model in ``foundation/`` must reject
+    unknown fields. Adding a new patch/sub-payload model without
+    ``extra="forbid"`` will fail this test — that's the point."""
+    classes = _all_foundation_input_classes()
+    assert classes, "discovered zero input classes — exploration logic broke"
+
+    missing: list[str] = []
+    for cls in classes:
+        if cls.model_config.get("extra") != "forbid":
+            missing.append(f"{cls.__module__}.{cls.__name__}")
+
+    assert not missing, (
+        f"{len(missing)} input model(s) missing extra='forbid' — add "
+        f"`model_config = ConfigDict(extra='forbid')` to each:\n  "
+        + "\n  ".join(missing)
+    )
+
+
+def test_confirmable_request_forbids_extra() -> None:
+    """The base class for every ``Modify*Request`` and ``Delete*Request``
+    inherits ``extra="forbid"`` so dispatcher-level typos are caught when
+    callers go through direct Python (tests, internal ``_impl`` calls)."""
+    assert ConfirmableRequest.model_config.get("extra") == "forbid"
+
+
+# ============================================================================
+# Behavior tests — one per foundation file's flagship sub-payload, plus the
+# original bug-report cases. Each asserts ValidationError names the unknown
+# field so the caller can fix the call.
+# ============================================================================
+
+
+def _assert_forbids(
+    model_cls: type[BaseModel], known_kwargs: dict[str, Any], unknown_field: str
+) -> None:
+    """Construct the model with one extra field; assert ValidationError
+    mentions the extra field name."""
+    with pytest.raises(ValidationError) as exc:
+        model_cls(**known_kwargs, **{unknown_field: 1})
+    assert unknown_field in str(exc.value), (
+        f"ValidationError for {model_cls.__name__} should mention "
+        f"unknown field {unknown_field!r}; got: {exc.value!s}"
+    )
+
+
+def test_po_row_add_rejects_unknown_field() -> None:
+    from katana_mcp.tools.foundation.purchase_orders import PORowAdd
+
+    _assert_forbids(
+        PORowAdd,
+        known_kwargs={"variant_id": 1, "quantity": 1, "price_per_unit": 1.0},
+        unknown_field="landed_cost",
+    )
+
+
+def test_so_header_patch_rejects_unknown_field() -> None:
+    from katana_mcp.tools.foundation.sales_orders import SOHeaderPatch
+
+    _assert_forbids(SOHeaderPatch, known_kwargs={}, unknown_field="unknown_field")
+
+
+def test_mo_recipe_row_update_rejects_unknown_field() -> None:
+    from katana_mcp.tools.foundation.manufacturing_orders import MORecipeRowUpdate
+
+    _assert_forbids(MORecipeRowUpdate, known_kwargs={"id": 1}, unknown_field="bogus")
+
+
+def test_item_header_patch_rejects_unknown_field() -> None:
+    from katana_mcp.tools.foundation.items import ItemHeaderPatch
+
+    _assert_forbids(ItemHeaderPatch, known_kwargs={}, unknown_field="config_attributes")
+
+
+def test_stock_transfer_header_patch_rejects_unknown_field() -> None:
+    from katana_mcp.tools.foundation.stock_transfers import StockTransferHeaderPatch
+
+    _assert_forbids(
+        StockTransferHeaderPatch, known_kwargs={}, unknown_field="ghost_field"
+    )
+
+
+def test_receive_item_request_rejects_received_date_505() -> None:
+    """#505: the original bug — ``received_date`` silently dropped on
+    ``ReceiveItemRequest``. Now surfaces loudly so the caller knows the
+    field isn't supported and to use ``modify_purchase_order`` for back-dating."""
+    from katana_mcp.tools.foundation.purchase_orders import ReceiveItemRequest
+
+    _assert_forbids(
+        ReceiveItemRequest,
+        known_kwargs={"purchase_order_row_id": 1, "quantity": 1},
+        unknown_field="received_date",
+    )
+
+
+def test_modify_po_request_rejects_dispatcher_typo() -> None:
+    """``ConfirmableRequest`` base — typos like ``previw=False`` (instead of
+    ``preview``) on direct Python callers must be loud, not silent. (MCP
+    protocol traffic is already protected by FastMCP's TypeAdapter against
+    the function signature.)"""
+    from katana_mcp.tools.foundation.purchase_orders import ModifyPurchaseOrderRequest
+
+    _assert_forbids(
+        ModifyPurchaseOrderRequest, known_kwargs={"id": 1}, unknown_field="previw"
+    )


### PR DESCRIPTION
Fixes #487. Closes the silent-field-drop bug class that motivated #503 and #505.

## Summary

Pydantic v2 silently drops unknown field names by default. This codebase has had three documented user-visible bugs caused by exactly that:

| Bug | What was sent | What pydantic dropped | What happened |
|-----|---------------|----------------------|----------------|
| `modify_manufacturing_order` no-op | `confirm=True` | `confirm` (renamed to `preview` in #492) | Returns `is_preview=True, succeeded=None`. User believes call executed. |
| `modify_item` configs (#503) | `config_attributes=[…]` | `config_attributes` (never on patch model) | Variant created without configs; diff returned shows other fields. |
| `receive_purchase_order` (#505) | per-item `received_date` | `received_date` (not on `ReceiveItemRequest`) | Receive completes against "now"; only discoverable via follow-up `get_purchase_order`. |

All three: call **succeeded**, customization **silently lost**.

This PR sets `model_config = ConfigDict(extra="forbid")` on every input-shape Pydantic model under `katana_mcp_server/src/katana_mcp/tools/foundation/`, plus the shared `ConfirmableRequest` base. Pydantic now raises `ValidationError: Extra inputs are not permitted: <field>` immediately on construction, surfacing the bug to the LLM.

## Scope (74 input models + 1 base)

Eligibility: classes with names ending in `Request|Patch|Add|Update|Input|Item|Params|Row|Address` that inherit directly from `BaseModel`. Output models (`*Response`, `*Info`, `*Summary`, `*Detail`, `*Stats`) excluded — strict input validation shouldn't constrain response-shape evolution.

| File | Patched | Notable |
|------|---------|---------|
| `_modification.py` | 1 (`ConfirmableRequest`) | Covers all 11 `Modify*Request`/`Delete*Request` dispatchers via inheritance |
| `cache_admin.py` | 1 | |
| `catalog.py` | 2 | |
| `customers.py` | 2 | |
| `inventory.py` | 9 | including `DeleteStockAdjustmentRequest` (direct `BaseModel`, not `ConfirmableRequest`) |
| `items.py` | 7 | including `ItemHeaderPatch`, `VariantAdd`, `VariantUpdate` |
| `manufacturing_orders.py` | 13 | including `MOHeaderPatch`, `MORecipeRowAdd/Update`, `MOOperationRowAdd/Update`, `MOProductionAdd/Update` |
| `orders.py` | 1 | |
| `purchase_orders.py` | 13 | including `ReceiveItemRequest` (#505 motivation), `POHeaderPatch`, `PORowAdd/Update`, `POAdditionalCostAdd/Update` |
| `reporting.py` | 5 | |
| `sales_orders.py` | 15 | including `SOHeaderPatch`, `SORowAdd/Update`, `SOAddressAdd/Update`, `SOFulfillmentRowInput`, `SOFulfillmentAdd/Update`, `SOShippingFeeAdd/Update` |
| `stock_transfers.py` | 6 | including `StockTransferBatchTransactionInput`, `StockTransferRowInput`, `StockTransferHeaderPatch`, `StockTransferStatusPatch` |

## Two layers, two reasons

Per Plan-agent review:

| Layer | Where it fires | What it catches |
|-------|---------------|------------------|
| **Sub-payload `model_config`** (load-bearing) | Nested dicts in tool args, e.g. `update_rows=[{"id":5,"qty":99}]` (typo) | The actual silent-drop bug class |
| **Top-level `*Request` `model_config`** (defense in depth) | Direct Python construction (tests, internal `_impl`) | Top-level typos in non-MCP code paths |
| FastMCP TypeAdapter (already exists) | Top-level MCP-protocol kwargs, e.g. `previw=False` | Already rejected today; this PR doesn't touch the path |

`unpack.py` got an explanatory comment at the relevant line: `unpack_pydantic_params` strips unknown top-level kwargs *before* construction (line 205), so dispatcher-level `extra="forbid"` doesn't fire on MCP-protocol traffic. Without the comment, a future refactor could quietly remove the protection.

## Companion changes

- **`_modification_dispatch.py`** — empty-diff guard message updated. The previous message blamed pydantic's silent drop, which is no longer accurate (that path now raises `ValidationError` *before* the guard). Guard still fires for the legitimate "caller passed only `id`, no patchable fields" case.

- **New `katana_mcp_server/tests/test_strict_input_validation.py`**:
  - **Introspection test** — walks every input-shape `BaseModel` subclass under `katana_mcp.tools.foundation.*` and asserts `model_config["extra"] == "forbid"`. Catches the next sub-payload added without the config.
  - **7 behavior tests** — one per foundation file's flagship sub-payload, plus `ReceiveItemRequest` (the #505 motivating bug surfaces as a loud `ValidationError`) and `ConfirmableRequest` (dispatcher typo).

## Trade-offs

1. **Forward-compat**: callers can no longer pre-emptively send fields that exist in Katana's API but not yet in our MCP layer. Mitigated: we regen on every spec audit, generated attrs models still have `additional_properties` for forward-compat at the wire layer; this only constrains the MCP layer.
2. **JSON schema impact**: generated tool schemas for nested models gain `additionalProperties: false`. Pre-validating MCP clients may start rejecting calls earlier — net positive.
3. **Picking only `extra="forbid"`** (not also `frozen=True`/`validate_assignment=True`): deliberate. Other configs would expand the change beyond bug prevention. Revisit as a separate PR.

## Breaking change marker

Tagged `feat!:` despite the additive-only nature because adding `additionalProperties: false` to the JSON schema is a wire-visible contract change for MCP clients. Callers that have been getting away with extras (typo-tolerance) will start seeing `ValidationError`.

## Test plan

- [x] `uv run poe check` — **2731 passed, 2 skipped, 0 failures**. Zero existing tests broke (no test depended on silent-drop behavior).
- [x] Introspection test covers every current and future input model.
- [x] Behavior tests assert error messages name the unknown field.
- [x] Manual smoke test: the original #505 bug now raises:
  ```python
  >>> ReceiveItemRequest(purchase_order_row_id=1, quantity=1, received_date="2026-05-01T17:48:00Z")
  ValidationError: 1 validation error for ReceiveItemRequest
  ```

## Related

- #487 — original issue (this PR fully resolves it)
- #503 — `modify_item` configs silently dropped (motivating bug)
- #505 — `receive_purchase_order` `received_date` silently dropped (motivating bug, now raises loudly)
- #492 — the rename that produced the `confirm` vs `preview` no-op pattern this PR catches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
