### PR TITLE
fix(mcp): extend additional_info echo workaround to material/product/MO/stock_adjustment + extract shared helper

### DIFF
--- a/docs/KATANA_API_QUESTIONS.md
+++ b/docs/KATANA_API_QUESTIONS.md
@@ -297,12 +297,67 @@ fact.
 `katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py` (introduced in PR
 #515).
 
+### 6.2 Same wipe-on-PATCH affects every entity with `additional_info`
+
+**Status: CONFIRMED platform-wide via live-API reproduction on 2026-05-05**
+
+We followed up on §6.1 by testing every other Katana entity that exposes
+`additional_info`. The same asymmetric wipe reproduces on every one we could test:
+
+| Entity                 | PATCH endpoint                     | `additional_info` after omitted PATCH |
+| ---------------------- | ---------------------------------- | ------------------------------------- |
+| PurchaseOrder (§6.1)   | `PATCH /purchase_orders/{id}`      | wiped to `""`                         |
+| **Material**           | `PATCH /materials/{id}`            | **wiped to `""`**                     |
+| **Product**            | `PATCH /products/{id}`             | **wiped to `""`**                     |
+| **ManufacturingOrder** | `PATCH /manufacturing_orders/{id}` | **wiped to `""`**                     |
+| **StockAdjustment**    | `PATCH /stock_adjustments/{id}`    | **wiped to `""`**                     |
+
+Each was verified by:
+
+1. Creating a test record with `additional_info` populated.
+1. Issuing a single-field PATCH on a different header field (rename / status change).
+1. Re-fetching and observing `additional_info: ""` post-PATCH.
+1. Cleaning up the test record.
+
+Test records used (all deleted post-verification): Material 17042013, Product 17042018,
+MO 16647058, StockAdjustment 2394711.
+
+Two other candidates couldn't be tested in this round and remain unverified:
+
+- **SalesOrder** — blocked by a separate spec bug (`SalesOrderStatus` enum is missing
+  `PENDING`); newly-created SOs can't be ingested through our cache. Test SO created on
+  Katana but ID unobservable; needs manual cleanup. (Filed as a separate spec issue.)
+- **StockTransfer** — blocked by `create_stock_transfer` returning an opaque 422 on the
+  execute path (preview accepts the same payload). Same shape as `create_purchase_order`
+  requires `status` (#499). Filed as a separate issue.
+
+**Conclusion:** This is a platform-wide PATCH-merge bug, not a one-off on PurchaseOrder.
+Whatever is treating omitted `additional_info` as a null-write is doing so consistently
+across at least 5 distinct PATCH endpoints, strongly suggesting a shared serialization
+or normalization layer at Katana's side.
+
+**Workaround in our MCP wrapper:** Same pattern as §6.1, applied to each affected
+entity:
+
+- `_build_update_header_request` in `katana_mcp_server/.../tools/foundation/items.py`
+  (covers material/product/service)
+- `_build_update_header_request` in
+  `katana_mcp_server/.../tools/foundation/manufacturing_orders.py`
+- `_update_stock_adjustment_impl` in
+  `katana_mcp_server/.../tools/foundation/inventory.py` (pre-fetches the adjustment via
+  `get_all_stock_adjustments(ids=[id])` only when the caller didn't supply
+  `additional_info`)
+
+All four echo the existing value when the caller doesn't change it. Idempotent — if
+Katana fixes the asymmetry, the echo becomes a no-op write.
+
 **Asks:**
 
-1. Confirm whether the wipe is intentional. If yes, document it on the PATCH endpoint
-   (we'd update our spec accordingly).
-1. If unintentional, fix the asymmetry so omitted `additional_info` is treated as a
-   no-op like every other omitted field.
+1. Confirm whether the wipe is intentional across all five entities. If yes, document it
+   on each PATCH endpoint (we'd update our spec accordingly).
+1. If unintentional, fix the asymmetry at the shared layer (we suspect a single
+   normalization step given how uniformly it reproduces) so omitted `additional_info` is
+   treated as a no-op like every other omitted field.
 1. If other entity types (`PATCH /sales_orders/{id}`,
    `PATCH /manufacturing_orders/{id}`, etc.) have the same behavior on their notes /
    free-text fields, please flag them — we haven't audited those yet and would prefer to

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -32,8 +32,36 @@ from fastmcp.tools import ToolResult
 from pydantic import BaseModel, ConfigDict, Field
 
 from katana_mcp.tools.tool_result_utils import BLOCK_WARNING_PREFIX, make_simple_result
-from katana_public_api_client.client_types import UNSET
+from katana_public_api_client.client_types import UNSET, Unset
 from katana_public_api_client.domain.converters import unwrap_unset
+
+
+def patch_additional_info(
+    caller_value: str | None,
+    existing_value: str | None | Unset,
+) -> str | Unset:
+    """Decide ``additional_info`` for a Katana PATCH body.
+
+    Workaround for the platform's wipe-on-omit asymmetry: Katana clears
+    ``additional_info`` to ``""`` whenever the field is omitted from the
+    PATCH body, while every other omitted field is preserved. Confirmed
+    across PO/Material/Product/MO/StockAdjustment — see #505 and
+    ``docs/KATANA_API_QUESTIONS.md`` §6.2.
+
+    Returns:
+        - ``caller_value`` when the caller supplied one (their write wins)
+        - ``existing_value`` (unwrapped) when caller didn't and existing
+          is non-empty (echo to defeat the wipe)
+        - ``UNSET`` otherwise (no echo needed; nothing to preserve)
+
+    The ``UNSET`` return is the same as not setting the field on the
+    attrs request, so callers can unconditionally pass the result via
+    ``additional_info=patch_additional_info(...)``.
+    """
+    if caller_value is not None:
+        return caller_value
+    existing = unwrap_unset(existing_value, None)
+    return existing if existing else UNSET
 
 
 class ConfirmableRequest(BaseModel):

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -1363,13 +1363,18 @@ async def _update_stock_adjustment_impl(
 
     # Pre-fetch only when echo might be needed (caller didn't supply
     # additional_info) so the common-case PATCH stays a single round trip.
-    # See :func:`patch_additional_info` for the workaround story.
+    # ``raise_on_error=False`` keeps the workaround best-effort: if the
+    # pre-fetch fails (transient 5xx, permission gap, etc.) we treat it
+    # as "no existing snapshot" rather than aborting the user's actual
+    # update. Worst case the wipe still fires; the caller's intended
+    # write still lands. See :func:`patch_additional_info` for the
+    # workaround story.
     existing_info_field: str | None | Unset = UNSET
     if request.additional_info is None:
         existing_response = await get_all_stock_adjustments.asyncio_detailed(
             client=services.client, ids=[request.id]
         )
-        existing_rows = unwrap_data(existing_response, default=[])
+        existing_rows = unwrap_data(existing_response, raise_on_error=False, default=[])
         if existing_rows:
             existing_info_field = existing_rows[0].additional_info
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
+from katana_mcp.tools._modification import patch_additional_info
 from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.list_coercion import CoercedIntListOpt, CoercedStrIntList
 from katana_mcp.tools.tool_result_utils import (
@@ -33,7 +34,10 @@ from katana_mcp.tools.tool_result_utils import (
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
+from katana_public_api_client.api.stock_adjustment import get_all_stock_adjustments
+from katana_public_api_client.client_types import UNSET, Unset
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
+from katana_public_api_client.utils import unwrap_data
 
 logger = get_logger(__name__)
 
@@ -1357,35 +1361,26 @@ async def _update_stock_adjustment_impl(
 
     services = get_services(context)
 
-    # Echo existing additional_info when the caller didn't change it. Same
-    # Katana platform asymmetry as ``PATCH /purchase_orders/{id}`` (#505 /
-    # docs/KATANA_API_QUESTIONS.md section 6.1) — the wipe reproduces on
-    # ``PATCH /stock_adjustments/{id}`` too. Verified against stock
-    # adjustment 2394711 on 2026-05-05. Pre-fetch only when the echo
-    # might be needed (caller didn't supply additional_info) so the
-    # common-case PATCH stays a single round trip.
-    additional_info_for_body = to_unset(request.additional_info)
+    # Pre-fetch only when echo might be needed (caller didn't supply
+    # additional_info) so the common-case PATCH stays a single round trip.
+    # See :func:`patch_additional_info` for the workaround story.
+    existing_info_field: str | None | Unset = UNSET
     if request.additional_info is None:
-        from katana_public_api_client.api.stock_adjustment import (
-            get_all_stock_adjustments,
-        )
-        from katana_public_api_client.utils import unwrap_data
-
         existing_response = await get_all_stock_adjustments.asyncio_detailed(
             client=services.client, ids=[request.id]
         )
         existing_rows = unwrap_data(existing_response, default=[])
         if existing_rows:
-            existing_info = unwrap_unset(existing_rows[0].additional_info, None)
-            if existing_info:
-                additional_info_for_body = existing_info
+            existing_info_field = existing_rows[0].additional_info
 
     api_request = APIUpdateStockAdjustmentRequest(
         stock_adjustment_number=to_unset(request.stock_adjustment_number),
         stock_adjustment_date=to_unset(request.stock_adjustment_date),
         location_id=to_unset(request.location_id),
         reason=to_unset(request.reason),
-        additional_info=additional_info_for_body,
+        additional_info=patch_additional_info(
+            request.additional_info, existing_info_field
+        ),
     )
 
     response = await api_update_stock_adjustment.asyncio_detailed(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -1356,12 +1356,36 @@ async def _update_stock_adjustment_impl(
         )
 
     services = get_services(context)
+
+    # Echo existing additional_info when the caller didn't change it. Same
+    # Katana platform asymmetry as ``PATCH /purchase_orders/{id}`` (#505 /
+    # docs/KATANA_API_QUESTIONS.md section 6.1) — the wipe reproduces on
+    # ``PATCH /stock_adjustments/{id}`` too. Verified against stock
+    # adjustment 2394711 on 2026-05-05. Pre-fetch only when the echo
+    # might be needed (caller didn't supply additional_info) so the
+    # common-case PATCH stays a single round trip.
+    additional_info_for_body = to_unset(request.additional_info)
+    if request.additional_info is None:
+        from katana_public_api_client.api.stock_adjustment import (
+            get_all_stock_adjustments,
+        )
+        from katana_public_api_client.utils import unwrap_data
+
+        existing_response = await get_all_stock_adjustments.asyncio_detailed(
+            client=services.client, ids=[request.id]
+        )
+        existing_rows = unwrap_data(existing_response, default=[])
+        if existing_rows:
+            existing_info = unwrap_unset(existing_rows[0].additional_info, None)
+            if existing_info:
+                additional_info_for_body = existing_info
+
     api_request = APIUpdateStockAdjustmentRequest(
         stock_adjustment_number=to_unset(request.stock_adjustment_number),
         stock_adjustment_date=to_unset(request.stock_adjustment_date),
         location_id=to_unset(request.location_id),
         reason=to_unset(request.reason),
-        additional_info=to_unset(request.additional_info),
+        additional_info=additional_info_for_body,
     )
 
     response = await api_update_stock_adjustment.asyncio_detailed(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -22,6 +22,7 @@ from katana_mcp.tools._modification import (
     ModificationResponse,
     compute_field_diff,
     make_response_verifier,
+    patch_additional_info,
     to_tool_result,
 )
 from katana_mcp.tools._modification_dispatch import (
@@ -69,7 +70,8 @@ from katana_public_api_client.api.variant import (
     get_variant as api_get_variant,
     update_variant as api_update_variant,
 )
-from katana_public_api_client.domain.converters import to_unset, unwrap_unset
+from katana_public_api_client.client_types import UNSET
+from katana_public_api_client.domain.converters import to_unset
 from katana_public_api_client.models import (
     CreateMaterialRequest,
     CreateProductRequest,
@@ -886,13 +888,9 @@ def _build_update_header_request(
 
     Each type has a different field set; ``unset_dict`` filters down to
     the actual fields the API accepts after we've validated routing.
-
-    Echoes ``additional_info`` from ``existing_item`` when the caller didn't
-    set it, working around the same Katana platform asymmetry that affects
-    ``PATCH /purchase_orders/{id}`` (see #505 / docs/KATANA_API_QUESTIONS.md
-    section 6.1). The wipe reproduces on PATCH for all item types
-    (product / material / service); without the echo, any header rename
-    silently destroys notes.
+    ``additional_info`` is echoed via :func:`patch_additional_info` so
+    Katana's wipe-on-omit doesn't destroy item notes during a header
+    rename (see its docstring for the full workaround story).
     """
     request_cls = _TYPE_ENDPOINTS[item_type]["update_request"]
     if item_type == ItemType.PRODUCT:
@@ -902,10 +900,10 @@ def _build_update_header_request(
     else:
         exclude = _PRODUCT_ONLY_FIELDS + _PRODUCT_AND_MATERIAL_FIELDS
     kwargs = unset_dict(patch, exclude=exclude)
-    if patch.additional_info is None and existing_item is not None:
-        existing_info = unwrap_unset(existing_item.additional_info, None)
-        if existing_info:
-            kwargs["additional_info"] = existing_info
+    kwargs["additional_info"] = patch_additional_info(
+        patch.additional_info,
+        existing_item.additional_info if existing_item is not None else UNSET,
+    )
     return request_cls(**kwargs)
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -69,7 +69,7 @@ from katana_public_api_client.api.variant import (
     get_variant as api_get_variant,
     update_variant as api_update_variant,
 )
-from katana_public_api_client.domain.converters import to_unset
+from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     CreateMaterialRequest,
     CreateProductRequest,
@@ -879,11 +879,20 @@ def _validate_header_for_type(patch: ItemHeaderPatch, item_type: ItemType) -> No
         )
 
 
-def _build_update_header_request(patch: ItemHeaderPatch, item_type: ItemType) -> Any:
+def _build_update_header_request(
+    patch: ItemHeaderPatch, item_type: ItemType, existing_item: Any | None = None
+) -> Any:
     """Map an ItemHeaderPatch to the right Update*Request attrs class.
 
     Each type has a different field set; ``unset_dict`` filters down to
     the actual fields the API accepts after we've validated routing.
+
+    Echoes ``additional_info`` from ``existing_item`` when the caller didn't
+    set it, working around the same Katana platform asymmetry that affects
+    ``PATCH /purchase_orders/{id}`` (see #505 / docs/KATANA_API_QUESTIONS.md
+    section 6.1). The wipe reproduces on PATCH for all item types
+    (product / material / service); without the echo, any header rename
+    silently destroys notes.
     """
     request_cls = _TYPE_ENDPOINTS[item_type]["update_request"]
     if item_type == ItemType.PRODUCT:
@@ -892,7 +901,12 @@ def _build_update_header_request(patch: ItemHeaderPatch, item_type: ItemType) ->
         exclude = _PRODUCT_ONLY_FIELDS + _SERVICE_ONLY_FIELDS
     else:
         exclude = _PRODUCT_ONLY_FIELDS + _PRODUCT_AND_MATERIAL_FIELDS
-    return request_cls(**unset_dict(patch, exclude=exclude))
+    kwargs = unset_dict(patch, exclude=exclude)
+    if patch.additional_info is None and existing_item is not None:
+        existing_info = unwrap_unset(existing_item.additional_info, None)
+        if existing_info:
+            kwargs["additional_info"] = existing_info
+    return request_cls(**kwargs)
 
 
 def _build_create_variant_request(
@@ -1003,7 +1017,9 @@ async def _modify_item_impl(
                     cfg["update"],
                     services,
                     request.id,
-                    _build_update_header_request(request.update_header, request.type),
+                    _build_update_header_request(
+                        request.update_header, request.type, existing_item
+                    ),
                     return_type=cfg["return_type"],
                 ),
                 verify=make_response_verifier(diff),

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -30,6 +30,7 @@ from katana_mcp.tools._modification import (
     ModificationResponse,
     compute_field_diff,
     make_response_verifier,
+    patch_additional_info,
     to_tool_result,
 )
 from katana_mcp.tools._modification_dispatch import (
@@ -92,6 +93,7 @@ from katana_public_api_client.api.manufacturing_order_recipe import (
     get_manufacturing_order_recipe_row as api_get_mo_recipe_row,
     update_manufacturing_order_recipe_rows as api_update_mo_recipe_row,
 )
+from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     CreateManufacturingOrderOperationRowRequest as APICreateMOOperationRowRequest,
@@ -2714,17 +2716,15 @@ def _build_update_header_request(
 ) -> APIUpdateManufacturingOrderRequest:
     """Build the PATCH body for ``PATCH /manufacturing_orders/{id}``.
 
-    Echoes ``additional_info`` from ``existing_mo`` when the caller didn't
-    set it, working around the same Katana platform asymmetry that affects
-    ``PATCH /purchase_orders/{id}`` (see #505 / docs/KATANA_API_QUESTIONS.md
-    section 6.1). The wipe reproduces on PATCH for MOs too — verified
-    against PO 16647058 on 2026-05-05.
+    ``additional_info`` is echoed via :func:`patch_additional_info` so
+    Katana's wipe-on-omit doesn't destroy MO notes during a header
+    rename (see its docstring for the full workaround story).
     """
     kwargs = unset_dict(patch, transforms={"status": ManufacturingOrderStatus})
-    if patch.additional_info is None and existing_mo is not None:
-        existing_info = unwrap_unset(existing_mo.additional_info, None)
-        if existing_info:
-            kwargs["additional_info"] = existing_info
+    kwargs["additional_info"] = patch_additional_info(
+        patch.additional_info,
+        existing_mo.additional_info if existing_mo is not None else UNSET,
+    )
     return APIUpdateManufacturingOrderRequest(**kwargs)
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -2710,10 +2710,22 @@ class DeleteManufacturingOrderRequest(ConfirmableRequest):
 
 def _build_update_header_request(
     patch: MOHeaderPatch,
+    existing_mo: ManufacturingOrder | None = None,
 ) -> APIUpdateManufacturingOrderRequest:
-    return APIUpdateManufacturingOrderRequest(
-        **unset_dict(patch, transforms={"status": ManufacturingOrderStatus})
-    )
+    """Build the PATCH body for ``PATCH /manufacturing_orders/{id}``.
+
+    Echoes ``additional_info`` from ``existing_mo`` when the caller didn't
+    set it, working around the same Katana platform asymmetry that affects
+    ``PATCH /purchase_orders/{id}`` (see #505 / docs/KATANA_API_QUESTIONS.md
+    section 6.1). The wipe reproduces on PATCH for MOs too — verified
+    against PO 16647058 on 2026-05-05.
+    """
+    kwargs = unset_dict(patch, transforms={"status": ManufacturingOrderStatus})
+    if patch.additional_info is None and existing_mo is not None:
+        existing_info = unwrap_unset(existing_mo.additional_info, None)
+        if existing_info:
+            kwargs["additional_info"] = existing_info
+    return APIUpdateManufacturingOrderRequest(**kwargs)
 
 
 def _build_create_recipe_row_request(
@@ -2811,7 +2823,7 @@ async def _modify_manufacturing_order_impl(
                     api_update_manufacturing_order,
                     services,
                     request.id,
-                    _build_update_header_request(request.update_header),
+                    _build_update_header_request(request.update_header, existing_mo),
                     return_type=ManufacturingOrder,
                 ),
                 verify=make_response_verifier(diff),

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -26,6 +26,7 @@ from katana_mcp.tools._modification import (
     ModificationResponse,
     compute_field_diff,
     make_response_verifier,
+    patch_additional_info,
     to_tool_result,
 )
 from katana_mcp.tools._modification_dispatch import (
@@ -2431,20 +2432,15 @@ def _build_update_header_request(
 ) -> APIUpdatePurchaseOrderRequest:
     """Build the PATCH body for ``PATCH /purchase_orders/{id}``.
 
-    Echoes ``additional_info`` from ``existing_po`` when the caller didn't
-    set it, working around an asymmetric Katana platform behavior: the PATCH
-    endpoint clears ``additional_info`` to ``""`` when the field is omitted
-    from the body, even though every other omitted field is correctly
-    preserved (verified at the wire level — see ``docs/KATANA_API_QUESTIONS.md``
-    section 6.1 for the wire-level reproduction). Without this echo, agents
-    calling ``modify_purchase_order(update_header={'order_no': 'X'})``
-    silently lose any populated PO notes.
+    ``additional_info`` is echoed via :func:`patch_additional_info` so
+    Katana's wipe-on-omit doesn't destroy PO notes during a header
+    rename (see its docstring for the full workaround story).
     """
     kwargs = unset_dict(patch, transforms={"status": PurchaseOrderStatus})
-    if patch.additional_info is None and existing_po is not None:
-        existing_info = unwrap_unset(existing_po.additional_info, None)
-        if existing_info:
-            kwargs["additional_info"] = existing_info
+    kwargs["additional_info"] = patch_additional_info(
+        patch.additional_info,
+        existing_po.additional_info if existing_po is not None else UNSET,
+    )
     return APIUpdatePurchaseOrderRequest(**kwargs)
 
 

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -1423,12 +1423,26 @@ async def test_update_stock_adjustment_confirm_calls_api():
         preview=False,
     )
 
+    # The impl pre-fetches via get_all_stock_adjustments when caller didn't
+    # supply additional_info (echo workaround for the Katana PATCH-wipe bug;
+    # see #505 / KATANA_API_QUESTIONS.md §6.2). Mock it so the test doesn't
+    # try to hit the live API.
+    existing = _make_mock_adjustment(id=42, additional_info=None)
+    list_response = MagicMock()
+    list_response.parsed = MagicMock()
+    list_response.parsed.data = [existing]
+
     with (
+        patch(
+            f"{_SA_GET_ALL}.asyncio_detailed",
+            new=AsyncMock(return_value=list_response),
+        ),
         patch(
             f"{_SA_UPDATE}.asyncio_detailed",
             new=AsyncMock(return_value=MagicMock()),
         ) as mock_api,
         patch(_SA_UNWRAP_AS, return_value=updated),
+        patch("katana_public_api_client.utils.unwrap_data", return_value=[existing]),
     ):
         result = await _update_stock_adjustment_impl(request, context)
 
@@ -2086,3 +2100,121 @@ async def test_list_stock_adjustments_format_json_returns_json():
 
     data = json.loads(_content_text(result))
     assert data["total_count"] == 0
+
+
+# ============================================================================
+# #505 follow-on: PATCH-wipe `additional_info` workaround on StockAdjustment
+# ============================================================================
+#
+# The Katana platform clears `additional_info` to `""` on PATCH whenever the
+# field is omitted from the body. Verified against stock adjustment 2394711
+# on 2026-05-05 (see docs/KATANA_API_QUESTIONS.md §6.2). The impl pre-fetches
+# the adjustment via `get_all_stock_adjustments(ids=[id])` only when the
+# caller didn't supply `additional_info`, then echoes the existing value
+# in the PATCH body so the wipe doesn't fire.
+
+
+@pytest.mark.asyncio
+async def test_update_stock_adjustment_echoes_additional_info_when_unchanged():
+    """Caller updates only `reason`; existing `additional_info` is echoed in
+    the PATCH body so Katana doesn't wipe it. Verified the body includes
+    the echoed value via the captured request kwargs."""
+    context, _ = create_mock_context()
+
+    existing = _make_mock_adjustment(
+        id=42,
+        reason="Cycle count",
+        additional_info="UPS tracking 1Z123 — preserve me",
+    )
+    list_response = MagicMock()
+    list_response.parsed = MagicMock()
+    list_response.parsed.data = [existing]
+
+    updated = _make_mock_adjustment(
+        id=42,
+        reason="Updated reason",
+        additional_info="UPS tracking 1Z123 — preserve me",
+    )
+
+    request = UpdateStockAdjustmentParams(id=42, reason="Updated reason", preview=False)
+
+    update_mock = AsyncMock(return_value=MagicMock())
+    with (
+        patch(
+            f"{_SA_GET_ALL}.asyncio_detailed",
+            new=AsyncMock(return_value=list_response),
+        ),
+        patch(f"{_SA_UPDATE}.asyncio_detailed", new=update_mock),
+        patch(_SA_UNWRAP_AS, return_value=updated),
+        patch(
+            "katana_public_api_client.utils.unwrap_data",
+            return_value=[existing],
+        ),
+    ):
+        result = await _update_stock_adjustment_impl(request, context)
+
+    assert result.is_preview is False
+    body = update_mock.call_args.kwargs["body"]
+    assert body.additional_info == "UPS tracking 1Z123 — preserve me"
+    assert body.reason == "Updated reason"
+
+
+@pytest.mark.asyncio
+async def test_update_stock_adjustment_skips_echo_when_existing_is_empty():
+    """No notes to preserve → wire body keeps `additional_info` as UNSET
+    (no echo, since echoing an empty string would be a wasted write)."""
+    from katana_public_api_client.client_types import UNSET
+
+    context, _ = create_mock_context()
+
+    existing = _make_mock_adjustment(id=42, reason="Cycle count", additional_info=None)
+    list_response = MagicMock()
+    list_response.parsed = MagicMock()
+    list_response.parsed.data = [existing]
+
+    updated = _make_mock_adjustment(id=42, reason="Updated reason")
+
+    request = UpdateStockAdjustmentParams(id=42, reason="Updated reason", preview=False)
+
+    update_mock = AsyncMock(return_value=MagicMock())
+    with (
+        patch(
+            f"{_SA_GET_ALL}.asyncio_detailed",
+            new=AsyncMock(return_value=list_response),
+        ),
+        patch(f"{_SA_UPDATE}.asyncio_detailed", new=update_mock),
+        patch(_SA_UNWRAP_AS, return_value=updated),
+        patch(
+            "katana_public_api_client.utils.unwrap_data",
+            return_value=[existing],
+        ),
+    ):
+        await _update_stock_adjustment_impl(request, context)
+
+    body = update_mock.call_args.kwargs["body"]
+    assert body.additional_info is UNSET
+
+
+@pytest.mark.asyncio
+async def test_update_stock_adjustment_caller_explicit_additional_info_wins():
+    """Caller-supplied additional_info wins; no pre-fetch needed (saves a round trip)."""
+    context, _ = create_mock_context()
+
+    updated = _make_mock_adjustment(id=42, additional_info="new notes")
+
+    request = UpdateStockAdjustmentParams(
+        id=42, additional_info="new notes", preview=False
+    )
+
+    update_mock = AsyncMock(return_value=MagicMock())
+    fetch_mock = AsyncMock()
+    with (
+        patch(f"{_SA_GET_ALL}.asyncio_detailed", new=fetch_mock),
+        patch(f"{_SA_UPDATE}.asyncio_detailed", new=update_mock),
+        patch(_SA_UNWRAP_AS, return_value=updated),
+    ):
+        await _update_stock_adjustment_impl(request, context)
+
+    body = update_mock.call_args.kwargs["body"]
+    assert body.additional_info == "new notes"
+    fetch_mock.assert_not_awaited()  # No pre-fetch when caller supplied the field

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -2218,3 +2218,35 @@ async def test_update_stock_adjustment_caller_explicit_additional_info_wins():
     body = update_mock.call_args.kwargs["body"]
     assert body.additional_info == "new notes"
     fetch_mock.assert_not_awaited()  # No pre-fetch when caller supplied the field
+
+
+@pytest.mark.asyncio
+async def test_update_stock_adjustment_pre_fetch_failure_is_best_effort():
+    """Pre-fetch errors must not abort the user's actual update — the echo
+    is a best-effort workaround. Without ``raise_on_error=False``, a
+    transient 5xx on the pre-fetch would turn this entire PATCH into a
+    hard failure even though the workaround is purely opportunistic."""
+    context, _ = create_mock_context()
+
+    failed_response = MagicMock()
+    failed_response.status_code = 502  # transient gateway error
+    failed_response.parsed = None
+
+    updated = _make_mock_adjustment(id=42, reason="Updated reason")
+
+    request = UpdateStockAdjustmentParams(id=42, reason="Updated reason", preview=False)
+
+    update_mock = AsyncMock(return_value=MagicMock())
+    with (
+        patch(
+            f"{_SA_GET_ALL}.asyncio_detailed",
+            new=AsyncMock(return_value=failed_response),
+        ),
+        patch(f"{_SA_UPDATE}.asyncio_detailed", new=update_mock),
+        patch(_SA_UNWRAP_AS, return_value=updated),
+    ):
+        result = await _update_stock_adjustment_impl(request, context)
+
+    # The user's update lands even though the pre-fetch failed.
+    assert result.is_preview is False
+    update_mock.assert_called_once()

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -822,3 +822,104 @@ async def test_delete_item_dispatches_to_typed_delete_endpoint():
     assert response.actions[0].succeeded is True
     mock_delete.assert_awaited_once()
     mock_product_delete.assert_not_awaited()
+
+
+# ============================================================================
+# #505 follow-on: PATCH-wipe `additional_info` workaround on items
+# ============================================================================
+#
+# The Katana platform clears `additional_info` to `""` on PATCH whenever the
+# field is omitted from the body — verified across PO/Material/Product/MO/
+# StockAdjustment (see docs/KATANA_API_QUESTIONS.md §6.2). To work around it,
+# `_build_update_header_request` echoes the existing value when the caller
+# didn't change it.
+
+
+def test_build_update_header_echoes_additional_info_when_unchanged():
+    """Caller-supplied other field + populated existing notes → notes echoed
+    in the PATCH body so Katana's wipe-on-omit doesn't fire."""
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        _build_update_header_request,
+    )
+
+    existing = MagicMock()
+    existing.additional_info = "important supplier notes"
+
+    req = _build_update_header_request(
+        ItemHeaderPatch(name="RENAMED"), ItemType.MATERIAL, existing
+    )
+
+    assert req.to_dict() == {
+        "name": "RENAMED",
+        "additional_info": "important supplier notes",
+    }
+
+
+def test_build_update_header_does_not_echo_when_existing_is_empty():
+    """No notes to preserve (empty string) → wire body stays minimal."""
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        _build_update_header_request,
+    )
+
+    existing = MagicMock()
+    existing.additional_info = ""
+
+    req = _build_update_header_request(
+        ItemHeaderPatch(name="RENAMED"), ItemType.PRODUCT, existing
+    )
+
+    assert req.to_dict() == {"name": "RENAMED"}
+
+
+def test_build_update_header_does_not_echo_when_existing_is_unset():
+    """No notes to preserve (UNSET sentinel) → wire body stays minimal."""
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        _build_update_header_request,
+    )
+
+    from katana_public_api_client.client_types import UNSET
+
+    existing = MagicMock()
+    existing.additional_info = UNSET
+
+    req = _build_update_header_request(
+        ItemHeaderPatch(name="RENAMED"), ItemType.MATERIAL, existing
+    )
+
+    assert req.to_dict() == {"name": "RENAMED"}
+
+
+def test_build_update_header_caller_explicit_additional_info_wins():
+    """Caller-supplied additional_info beats the echo even if existing differs."""
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        _build_update_header_request,
+    )
+
+    existing = MagicMock()
+    existing.additional_info = "old notes"
+
+    req = _build_update_header_request(
+        ItemHeaderPatch(name="RENAMED", additional_info="new notes"),
+        ItemType.MATERIAL,
+        existing,
+    )
+
+    assert req.to_dict() == {"name": "RENAMED", "additional_info": "new notes"}
+
+
+def test_build_update_header_no_existing_skips_echo():
+    """Without an existing-item snapshot, echo is skipped (best-effort)."""
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        _build_update_header_request,
+    )
+
+    req = _build_update_header_request(
+        ItemHeaderPatch(name="RENAMED"), ItemType.MATERIAL, None
+    )
+
+    assert req.to_dict() == {"name": "RENAMED"}

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -2697,3 +2697,86 @@ async def test_modify_mo_canonical_order_across_all_three_sub_resources():
         "add_operation_row",
         "add_production",
     ]
+
+
+# ============================================================================
+# #505 follow-on: PATCH-wipe `additional_info` workaround on MOs
+# ============================================================================
+#
+# Same Katana platform asymmetry as PO/Material/Product/StockAdjustment
+# (docs/KATANA_API_QUESTIONS.md §6.2). `_build_update_header_request` echoes
+# the existing value when the caller didn't change it.
+
+
+def test_build_update_header_echoes_additional_info_when_unchanged():
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        MOHeaderPatch,
+        _build_update_header_request,
+    )
+
+    existing = MagicMock(spec=ManufacturingOrder)
+    existing.additional_info = "WIP notes"
+
+    req = _build_update_header_request(MOHeaderPatch(order_no="MO-RENAMED"), existing)
+
+    assert req.to_dict() == {
+        "order_no": "MO-RENAMED",
+        "additional_info": "WIP notes",
+    }
+
+
+def test_build_update_header_does_not_echo_when_existing_is_empty():
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        MOHeaderPatch,
+        _build_update_header_request,
+    )
+
+    existing = MagicMock(spec=ManufacturingOrder)
+    existing.additional_info = ""
+
+    req = _build_update_header_request(MOHeaderPatch(order_no="MO-RENAMED"), existing)
+
+    assert req.to_dict() == {"order_no": "MO-RENAMED"}
+
+
+def test_build_update_header_does_not_echo_when_existing_is_unset():
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        MOHeaderPatch,
+        _build_update_header_request,
+    )
+
+    from katana_public_api_client.client_types import UNSET
+
+    existing = MagicMock(spec=ManufacturingOrder)
+    existing.additional_info = UNSET
+
+    req = _build_update_header_request(MOHeaderPatch(order_no="MO-RENAMED"), existing)
+
+    assert req.to_dict() == {"order_no": "MO-RENAMED"}
+
+
+def test_build_update_header_caller_explicit_additional_info_wins():
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        MOHeaderPatch,
+        _build_update_header_request,
+    )
+
+    existing = MagicMock(spec=ManufacturingOrder)
+    existing.additional_info = "old"
+
+    req = _build_update_header_request(
+        MOHeaderPatch(order_no="MO-RENAMED", additional_info="new"), existing
+    )
+
+    assert req.to_dict() == {"order_no": "MO-RENAMED", "additional_info": "new"}
+
+
+def test_build_update_header_no_existing_skips_echo():
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        MOHeaderPatch,
+        _build_update_header_request,
+    )
+
+    req = _build_update_header_request(MOHeaderPatch(order_no="MO-RENAMED"), None)
+
+    assert req.to_dict() == {"order_no": "MO-RENAMED"}

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.54.0"
+version = "0.55.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1306,7 +1306,7 @@ requires-dist = [
 
 [[package]]
 name = "katana-openapi-client"
-version = "0.56.1"
+version = "0.57.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Refs #505. See also #516 (`SalesOrderStatus` PENDING enum), #517 (`create_stock_transfer` 422 details).

## Summary

PR #515 fixed Katana's PATCH wipe-on-omit asymmetry for `PurchaseOrder` (omitting `additional_info` from the body clears it to `""`, while every other omitted field is preserved). I tested every other entity with `additional_info` against the live API on 2026-05-05 — **the same wipe reproduces on every one I could test**:

| Entity | PATCH endpoint | `additional_info` after omitted-field PATCH |
|--------|----------------|---------------------------------------------|
| PurchaseOrder (already fixed in #515) | `PATCH /purchase_orders/{id}` | wiped → `""` |
| **Material** | `PATCH /materials/{id}` | **wiped → `""`** |
| **Product** | `PATCH /products/{id}` | **wiped → `""`** |
| **ManufacturingOrder** | `PATCH /manufacturing_orders/{id}` | **wiped → `""`** |
| **StockAdjustment** | `PATCH /stock_adjustments/{id}` | **wiped → `""`** |

Each verified by create-with-notes → omitted-field PATCH → re-fetch shows `additional_info: ""`. Test records cleaned up post-verification (Material 17042013, Product 17042018, MO 16647058, StockAdjustment 2394711).

This PR replicates the echo workaround for the four newly-confirmed entities and extracts a single `patch_additional_info` helper to centralize the decision logic.

## What changed

### Round 1: per-entity echo (one commit)

Replicate the `_build_update_header_request` echo pattern for material/product/MO/stock_adjustment. The first three are structurally identical to the PO fix (existing entity already fetched for diff context); stock_adjustment has no diff step, so it pre-fetches inline via `get_all_stock_adjustments(ids=[id])` only when the caller didn't supply `additional_info`.

### Round 2: extract shared helper (one commit, /simplify pass)

The four call sites all carried the same caller-explicit-wins / echo-non-empty-existing / else-UNSET decision tree. Extracted `patch_additional_info` into `_modification.py`:

```python
def patch_additional_info(
    caller_value: str | None,
    existing_value: str | None | Unset,
) -> str | Unset:
    """Decide ``additional_info`` for a Katana PATCH body.

    Workaround for the platform's wipe-on-omit asymmetry — see #505 and
    docs/KATANA_API_QUESTIONS.md §6.2 for the full repro.
    """
    if caller_value is not None:
        return caller_value
    existing = unwrap_unset(existing_value, None)
    return existing if existing else UNSET
```

Each `_build_update_*` helper now collapses to one line:

```python
kwargs["additional_info"] = patch_additional_info(
    patch.additional_info,
    existing.additional_info if existing is not None else UNSET,
)
```

When Katana fixes the asymmetry, deleting the workaround is a single helper-removal.

Each caller still owns its own existing-entity fetch (PO/items/MO use the diff-context fetch already in flight; stock_adjustment fetches inline because it has no diff step). Centralizing the I/O would force them all into one fetch shape they don't share.

## Other entities

Two candidates couldn't be tested in this round, blocked by separate spec issues:

- **SalesOrder** — blocked by `SalesOrderStatus` enum missing `PENDING` (filed as #516). Newly-created SOs trigger a parse error in our cache, so I couldn't surface the test SO's ID. There's an orphan `TEST-PATCH-WIPE-SO-2026-05-05` SO on Katana that needs manual cleanup via the web UI.
- **StockTransfer** — blocked by `create_stock_transfer` returning opaque 422 on execute (filed as #517 — same shape as #499). Preview accepts the same payload; execute rejects with details suppressed.

Once #516 and #517 land, the same echo-helper pattern can be applied to those two entities (~10 lines each).

## Documentation

`docs/KATANA_API_QUESTIONS.md` §6.2 added with the platform-wide report (5 confirmed wipe sites, 2 untestable) and broader Asks superseding §6.1's PO-only asks. Worth raising via Katana support.

## Tests

- 5 new for `items.py` (echoes / no-echo-empty / no-echo-unset / caller-explicit-wins / no-existing)
- 5 new for `manufacturing_orders.py` (same pattern)
- 3 new for `inventory.py` (echoes / skip-when-empty / caller-explicit + assert no-prefetch when caller supplied the field)
- 1 existing test updated (`test_update_stock_adjustment_confirm_calls_api` needed the new `get_all_stock_adjustments` mock since the impl now pre-fetches when caller omits `additional_info`)

After Round 2 the existing test files keep their per-entity tests; they're unchanged in shape because they assert against `to_dict()` of the resulting request, which is independent of the helper extraction.

## Test plan

- [x] `uv run poe check` — **2755 passed, 2 skipped, 0 failures**.
- [x] Live-API verification — 4 test records created, modified with omitted-field PATCH, observed wipe, deleted. All cleaned up.
- [x] Manual smoke after extraction: each of the 4 `_build_update_*` callers produces the expected `to_dict()` shape across echo / no-echo / caller-wins / no-existing branches.
- [x] Idempotent — when Katana fixes the asymmetry, the echo becomes a no-op write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
