### PR TITLE
fix(mcp): expose batch_transactions on MORecipeRowAdd/Update (#518)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1028,7 +1028,10 @@ Unified modification surface for an MO — header, recipe rows
   (NOT_STARTED / IN_PROGRESS / DONE / BLOCKED / PARTIALLY_COMPLETED).
 - `add_recipe_rows` / `update_recipe_rows` / `delete_recipe_row_ids` —
   ingredient CRUD. Each `add_recipe_rows` entry carries `variant_id` +
-  `planned_quantity_per_unit` + optional notes.
+  `planned_quantity_per_unit` + optional notes. Both add and update
+  accept `batch_transactions` (list of `{batch_id, quantity}`) for
+  batch-tracked ingredients — required so the MO consumes from the
+  right batch records.
 - `add_operation_rows` / `update_operation_rows` /
   `delete_operation_row_ids` — production step CRUD. Operation rows
   carry status (NOT_STARTED / IN_PROGRESS / PAUSED / BLOCKED /

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -106,6 +106,7 @@ from katana_public_api_client.models import (
     ManufacturingOrderOperationRow,
     ManufacturingOrderProduction,
     ManufacturingOrderRecipeRow,
+    ManufacturingOrderRecipeRowBatchTransactionsItem,
     ManufacturingOrderStatus,
     UpdateManufacturingOrderOperationRowRequest as APIUpdateMOOperationRowRequest,
     UpdateManufacturingOrderProductionRequest as APIUpdateMOProductionRequest,
@@ -2522,6 +2523,21 @@ class MOHeaderPatch(BaseModel):
     additional_info: str | None = Field(default=None)
 
 
+class RecipeRowBatchTransaction(BaseModel):
+    """Allocate a portion of a recipe row's quantity to a specific batch.
+
+    Required for batch-tracked materials so the MO consumes from the right
+    batch record. The summed ``quantity`` across an item's
+    ``batch_transactions`` should equal the row-level quantity being
+    consumed (Katana validates this server-side).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    batch_id: int = Field(..., description="Batch ID to allocate quantity to")
+    quantity: float = Field(..., description="Quantity to allocate to this batch", gt=0)
+
+
 class MORecipeRowAdd(BaseModel):
     """A new recipe row (ingredient) on the MO."""
 
@@ -2531,6 +2547,15 @@ class MORecipeRowAdd(BaseModel):
     planned_quantity_per_unit: float = Field(..., description="Quantity per unit", gt=0)
     notes: str | None = Field(default=None)
     total_actual_quantity: float | None = Field(default=None, ge=0)
+    batch_transactions: list[RecipeRowBatchTransaction] | None = Field(
+        default=None,
+        description=(
+            "Optional batch allocations for this recipe row. Required when "
+            "the underlying ingredient is batch-tracked — without it the row "
+            "either fails to land or assigns to a default batch. Each entry "
+            "pairs a batch_id with the quantity to draw from that batch."
+        ),
+    )
 
 
 class MORecipeRowUpdate(BaseModel):
@@ -2543,6 +2568,15 @@ class MORecipeRowUpdate(BaseModel):
     planned_quantity_per_unit: float | None = Field(default=None, gt=0)
     notes: str | None = Field(default=None)
     total_actual_quantity: float | None = Field(default=None, ge=0)
+    batch_transactions: list[RecipeRowBatchTransaction] | None = Field(
+        default=None,
+        description=(
+            "Replace the row's batch allocations. Required when the "
+            "underlying ingredient is batch-tracked. Each entry pairs a "
+            "batch_id with the quantity to draw from that batch; Katana "
+            "replaces the existing allocations with this list."
+        ),
+    )
 
 
 class MOOperationRowAdd(BaseModel):
@@ -2728,16 +2762,42 @@ def _build_update_header_request(
     return APIUpdateManufacturingOrderRequest(**kwargs)
 
 
+def _convert_recipe_batch_transactions(
+    items: list[dict[str, Any]],
+) -> list[ManufacturingOrderRecipeRowBatchTransactionsItem]:
+    """Convert Pydantic ``RecipeRowBatchTransaction`` payloads (already
+    serialized to dicts via ``unset_dict``'s ``model_dump``) into the
+    attrs API model. Used as a transform for ``unset_dict`` so the field
+    flows through the standard plumbing."""
+    return [
+        ManufacturingOrderRecipeRowBatchTransactionsItem(
+            batch_id=bt["batch_id"], quantity=bt["quantity"]
+        )
+        for bt in items
+    ]
+
+
 def _build_create_recipe_row_request(
     mo_id: int, row: MORecipeRowAdd
 ) -> APICreateMORecipeRowRequest:
-    return APICreateMORecipeRowRequest(manufacturing_order_id=mo_id, **unset_dict(row))
+    return APICreateMORecipeRowRequest(
+        manufacturing_order_id=mo_id,
+        **unset_dict(
+            row, transforms={"batch_transactions": _convert_recipe_batch_transactions}
+        ),
+    )
 
 
 def _build_update_recipe_row_request(
     patch: MORecipeRowUpdate,
 ) -> APIUpdateMORecipeRowRequest:
-    return APIUpdateMORecipeRowRequest(**unset_dict(patch, exclude=("id",)))
+    return APIUpdateMORecipeRowRequest(
+        **unset_dict(
+            patch,
+            exclude=("id",),
+            transforms={"batch_transactions": _convert_recipe_batch_transactions},
+        )
+    )
 
 
 def _build_create_operation_row_request(

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -2780,3 +2780,89 @@ def test_build_update_header_no_existing_skips_echo():
     req = _build_update_header_request(MOHeaderPatch(order_no="MO-RENAMED"), None)
 
     assert req.to_dict() == {"order_no": "MO-RENAMED"}
+
+
+# ============================================================================
+# #518: batch_transactions on MORecipeRowAdd / MORecipeRowUpdate
+# ============================================================================
+#
+# Same under-modeled-MCP-request bug class as #505 (receive_purchase_order)
+# and #503 (modify_item.configs). Caller-supplied batch_transactions are
+# now first-class on both add and update; without them, batch-tracked
+# materials on MOs can't be allocated to specific batches via MCP.
+
+
+def test_build_create_recipe_row_request_passes_batch_transactions():
+    """Caller-supplied batch_transactions on add are converted to the
+    attrs API model and forwarded verbatim."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        MORecipeRowAdd,
+        RecipeRowBatchTransaction,
+        _build_create_recipe_row_request,
+    )
+
+    row = MORecipeRowAdd(
+        variant_id=100,
+        planned_quantity_per_unit=2.0,
+        batch_transactions=[
+            RecipeRowBatchTransaction(batch_id=501, quantity=1.0),
+            RecipeRowBatchTransaction(batch_id=502, quantity=1.0),
+        ],
+    )
+    req = _build_create_recipe_row_request(42, row)
+    body = req.to_dict()
+    assert body["batch_transactions"] == [
+        {"batch_id": 501, "quantity": 1.0},
+        {"batch_id": 502, "quantity": 1.0},
+    ]
+    assert body["variant_id"] == 100
+    assert body["manufacturing_order_id"] == 42
+
+
+def test_build_create_recipe_row_request_omits_batch_transactions_when_unset():
+    """Omitted batch_transactions doesn't appear in the wire body — Katana
+    treats absent as 'no batch tracking required for this row'."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        MORecipeRowAdd,
+        _build_create_recipe_row_request,
+    )
+
+    row = MORecipeRowAdd(variant_id=100, planned_quantity_per_unit=2.0)
+    body = _build_create_recipe_row_request(42, row).to_dict()
+    assert "batch_transactions" not in body
+
+
+def test_build_update_recipe_row_request_passes_batch_transactions():
+    """Caller-supplied batch_transactions on update are converted to the
+    attrs API model and forwarded verbatim. Katana replaces the row's
+    existing allocations with this list."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        MORecipeRowUpdate,
+        RecipeRowBatchTransaction,
+        _build_update_recipe_row_request,
+    )
+
+    patch = MORecipeRowUpdate(
+        id=999,
+        batch_transactions=[
+            RecipeRowBatchTransaction(batch_id=503, quantity=3.5),
+        ],
+    )
+    body = _build_update_recipe_row_request(patch).to_dict()
+    assert body["batch_transactions"] == [{"batch_id": 503, "quantity": 3.5}]
+    # ``id`` is excluded — it's the URL path param, not a body field.
+    assert "id" not in body
+
+
+def test_build_update_recipe_row_request_omits_batch_transactions_when_unset():
+    """Update without batch_transactions doesn't replace the row's existing
+    allocations — Katana keeps them."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        MORecipeRowUpdate,
+        _build_update_recipe_row_request,
+    )
+
+    patch = MORecipeRowUpdate(id=999, planned_quantity_per_unit=5.0)
+    body = _build_update_recipe_row_request(patch).to_dict()
+    assert "batch_transactions" not in body
+    assert body["planned_quantity_per_unit"] == 5.0

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.55.0"
+version = "0.56.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Closes #518.

## Summary

`MORecipeRowAdd` and `MORecipeRowUpdate` (used by `modify_manufacturing_order`'s `add_recipe_rows` / `update_recipe_rows` sub-payloads) didn't expose `batch_transactions`, even though the underlying API attrs models accept it. That blocked **batch-allocation workflows for batch-tracked materials on MOs**: callers had to either fall back to the Katana web UI or chain a separate API call after creating/modifying the row.

Same under-modeled-MCP-request bug class as #505 (receive side) and #503 (modify_item.configs). This was the only audit-finding from PR #515 still standing.

## Changes

| Piece | What |
|-------|------|
| New `RecipeRowBatchTransaction` input model | `{batch_id: int, quantity: float}` with `extra="forbid"` — same shape as `ReceiveBatchTransaction` from PR #515 |
| `MORecipeRowAdd.batch_transactions` | New optional field, list of `RecipeRowBatchTransaction` |
| `MORecipeRowUpdate.batch_transactions` | Same — Katana replaces existing allocations with the supplied list |
| `_convert_recipe_batch_transactions` | Transform fn that maps Pydantic dicts → attrs `ManufacturingOrderRecipeRowBatchTransactionsItem` |
| `_build_create_recipe_row_request` | Wires the transform via `unset_dict(transforms=...)` |
| `_build_update_recipe_row_request` | Same |
| `help.py` block for `modify_manufacturing_order` | Mentions the new field on add and update |

The `unset_dict` transforms infrastructure (already used for status enum conversion) handles the Pydantic→attrs conversion cleanly without inlining loops at the call sites — slightly cleaner than the receive-side pattern in PR #515.

## Tests

4 new tests:
- `test_build_create_recipe_row_request_passes_batch_transactions` — caller-supplied list of 2 batch transactions are converted and forwarded; `manufacturing_order_id` is correctly injected by the builder.
- `test_build_create_recipe_row_request_omits_batch_transactions_when_unset` — wire body skips the key.
- `test_build_update_recipe_row_request_passes_batch_transactions` — same as create; also verifies `id` is correctly excluded from the body (URL path param).
- `test_build_update_recipe_row_request_omits_batch_transactions_when_unset` — wire body skips the key, other fields still flow through.

## Test plan

- [x] `uv run poe check` — **2760 passed, 2 skipped, 0 failures**.
- [x] `extra="forbid"` from #514 ensures any future caller passing extra fields to `RecipeRowBatchTransaction` gets a loud error.

## Out of scope

- Validation of summed batch_transactions quantity vs row-level planned_quantity_per_unit — Katana validates server-side; we'd just be duplicating.
- Existing recipe rows with no batch tracking — no behavior change for those (passthrough only fires when caller supplies the field).

## Related

- #505 — same bug class on `receive_purchase_order` (PR #515)
- #503 — same bug class on `modify_item.configs`
- #515 — found this via field-set audit; the only standing item from that audit's punch list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
