### PR TITLE
refactor(mcp): apply #521 batch-transactions helper pattern to receive + stock_transfer (consistency)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -94,6 +94,8 @@ from katana_public_api_client.models import (
     FindPurchaseOrdersStatus,
     PurchaseOrderAdditionalCostRow,
     PurchaseOrderEntityType,
+    PurchaseOrderReceiveRow,
+    PurchaseOrderReceiveRowBatchTransactionsItem,
     PurchaseOrderRow,
     PurchaseOrderRowRequest,
     PurchaseOrderStatus,
@@ -405,6 +407,24 @@ class ReceiveItemRequest(BaseModel):
     )
 
 
+def _convert_receive_batch_transactions(
+    items: list[ReceiveBatchTransaction] | None,
+) -> list[PurchaseOrderReceiveRowBatchTransactionsItem] | Unset:
+    """Map MCP ``ReceiveBatchTransaction`` payloads to the attrs API model.
+
+    Returns ``UNSET`` when the caller didn't supply any transactions, so
+    the wire body skips the key (Katana treats absent as 'no batch
+    tracking required for this row')."""
+    if not items:
+        return UNSET
+    return [
+        PurchaseOrderReceiveRowBatchTransactionsItem(
+            batch_id=bt.batch_id, quantity=bt.quantity
+        )
+        for bt in items
+    ]
+
+
 class ReceivePurchaseOrderRequest(BaseModel):
     """Request to receive items from a purchase order."""
 
@@ -576,35 +596,23 @@ async def _receive_purchase_order_impl(
         from katana_public_api_client.api.purchase_order import (
             receive_purchase_order as api_receive_purchase_order,
         )
-        from katana_public_api_client.models import (
-            PurchaseOrderReceiveRow,
-            PurchaseOrderReceiveRowBatchTransactionsItem,
-        )
 
         # Caller-supplied received_date wins; fall back to "now" so callers
         # who don't care still get a sensible timestamp. Without this branch
         # back-dated re-receives (variant fixes, late paperwork) silently
         # land on the call time — see #505.
         default_received_date = datetime.now(UTC)
-        receive_rows = []
-        for item in request.items:
-            api_batch_transactions: (
-                list[PurchaseOrderReceiveRowBatchTransactionsItem] | Unset
-            ) = UNSET
-            if item.batch_transactions:
-                api_batch_transactions = [
-                    PurchaseOrderReceiveRowBatchTransactionsItem(
-                        batch_id=bt.batch_id, quantity=bt.quantity
-                    )
-                    for bt in item.batch_transactions
-                ]
-            row = PurchaseOrderReceiveRow(
+        receive_rows = [
+            PurchaseOrderReceiveRow(
                 purchase_order_row_id=item.purchase_order_row_id,
                 quantity=item.quantity,
                 received_date=item.received_date or default_received_date,
-                batch_transactions=api_batch_transactions,
+                batch_transactions=_convert_receive_batch_transactions(
+                    item.batch_transactions
+                ),
             )
-            receive_rows.append(row)
+            for item in request.items
+        ]
 
         response = await api_receive_purchase_order.asyncio_detailed(
             client=services.client, body=receive_rows

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -228,17 +228,28 @@ def _transfer_to_response(
     )
 
 
+def _convert_stock_transfer_batch_transactions(
+    items: list[StockTransferBatchTransactionInput],
+) -> list[dict[str, Any]]:
+    """Map MCP ``StockTransferBatchTransactionInput`` payloads to the wire
+    shape Katana expects on a transfer row's ``batch_transactions``.
+
+    Returns dicts (not attrs models) because ``StockTransferRowRequest``
+    doesn't expose ``batch_transactions`` as a declared attrs field —
+    we stash them through ``additional_properties`` so they flow into the
+    serialized JSON body."""
+    return [
+        StockTransferRowBatchTransactionsItem(
+            batch_id=bt.batch_id, quantity=bt.quantity
+        ).to_dict()
+        for bt in items
+    ]
+
+
 def _build_row_requests(
     rows: list[StockTransferRowInput],
 ) -> list[StockTransferRowRequest]:
-    """Convert pydantic row inputs to attrs request rows.
-
-    The generated `StockTransferRowRequest` model exposes only `variant_id` and
-    `quantity` as declared attrs fields, but Katana's API accepts
-    `batch_transactions` on transfer rows (see `StockTransferRow` response).
-    We stash batch transactions through the row's `additional_properties` bag
-    so they flow into the serialized JSON body.
-    """
+    """Convert pydantic row inputs to attrs request rows."""
     out: list[StockTransferRowRequest] = []
     for row in rows:
         api_row = StockTransferRowRequest(
@@ -246,14 +257,10 @@ def _build_row_requests(
             quantity=row.quantity,
         )
         if row.batch_transactions:
-            batch_items = [
-                StockTransferRowBatchTransactionsItem(
-                    batch_id=bt.batch_id, quantity=bt.quantity
-                )
-                for bt in row.batch_transactions
-            ]
             api_row.additional_properties = {
-                "batch_transactions": [bi.to_dict() for bi in batch_items]
+                "batch_transactions": _convert_stock_transfer_batch_transactions(
+                    row.batch_transactions
+                )
             }
         out.append(api_row)
     return out

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.55.0"
+version = "0.56.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Follow-on to #521 (`MORecipeRowAdd/Update.batch_transactions`). Applies the same `_convert_*_batch_transactions` helper-extraction shape to the two other batch-transaction call sites so all three flow look the same.

## Changes

| File | Helper extracted | Call site |
|------|------------------|-----------|
| `purchase_orders.py` | `_convert_receive_batch_transactions(items) -> list[T] \| UNSET` | `_receive_purchase_order_impl`'s 14-line per-item loop collapses to a 1-line list comprehension over `request.items` |
| `stock_transfers.py` | `_convert_stock_transfer_batch_transactions(items) -> list[dict[str, Any]]` | `_build_row_requests` keeps the `additional_properties` stash but the conversion logic moves out of the row-builder loop |

Also moves `PurchaseOrderReceiveRow` / `PurchaseOrderReceiveRowBatchTransactionsItem` imports from `_receive_purchase_order_impl`'s inline scope to module-top.

The two helpers have slightly different return types because:
- Receive uses the attrs API model directly (`PurchaseOrderReceiveRowBatchTransactionsItem`).
- Stock transfers stash through `StockTransferRowRequest.additional_properties` which expects dicts (the underlying API attrs model doesn't expose `batch_transactions` as a declared field).

## Survey: what other unification could happen

The user asked whether this opens up further refactors. Findings:

**Three near-identical input models exist, plus the helper functions:**

| Module | MCP input class | Description differs only by entity context |
|--------|-----------------|-------------------------------------------|
| `purchase_orders.py` | `ReceiveBatchTransaction` | "land on the right batch record" |
| `manufacturing_orders.py` | `RecipeRowBatchTransaction` | "draw from the right batch" |
| `stock_transfers.py` | `StockTransferBatchTransactionInput` | "transfer from the right batch" |

All three have identical structural shape: `{batch_id: int, quantity: float}` with `extra="forbid"`. The descriptions differ minimally. They could collapse to one shared `BatchTransaction` Pydantic model + a single generic `_convert_batch_transactions[T](items, target_cls)` helper.

**Pros of unification:**
- 3 → 1 input class
- 3 → 1 helper (with `target_cls` parameter)
- Mirrors that the upstream attrs models are also structurally identical (just per-entity due to openapi-python-client codegen)
- Future batch-transaction sites get the same machinery for free

**Cons:**
- Breaking change on the per-entity Pydantic class names (3 classes removed). Internal-only — no external callers I'm aware of, but it would change the JSON schema's `title` field exposed to MCP clients (the actual field shape stays the same).
- Slight loss of per-entity description context in the JSON schema docstrings.
- Stock-transfer's call site currently outputs dicts (additional_properties), the others output attrs models — the generic helper would need to handle both, OR we'd need to keep two helpers.

**My read:** Unification is worth doing if/when a 4th batch-transaction site appears. With three sites and three slightly-different output shapes, the cost of the abstraction barely beats the cost of the duplication. Filing the option for the user to weigh in but not bundling into this PR.

## Test plan

- [x] `uv run poe check` — **2756 passed, 2 skipped, 0 failures**
- [x] No behavior change — pure refactor
- [x] Tests against existing receive/stock-transfer paths still pass without modification

## Related

- #521 — established the helper-extraction shape this PR mirrors
- #515 — original receive-side batch_transactions plumbing
- #505 — bug class context

🤖 Generated with [Claude Code](https://claude.com/claude-code)
