### PR TITLE
feat(mcp): surface archived items in search and document archive lifecycle

### DIFF
--- a/katana_mcp_server/src/katana_mcp/cache.py
+++ b/katana_mcp_server/src/katana_mcp/cache.py
@@ -43,7 +43,7 @@ _DEFAULT_CACHE_DIR = Path(user_cache_dir("katana-mcp"))
 _DEFAULT_DB_PATH = _DEFAULT_CACHE_DIR / "cache.db"
 
 # Schema version — bump to force a rebuild
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 
 _SCHEMA_SQL = """\
 -- Schema version tracking
@@ -60,7 +60,9 @@ CREATE TABLE IF NOT EXISTS entities (
     PRIMARY KEY (entity_type, id)
 );
 
--- Searchable index fields extracted from entities
+-- Searchable index fields extracted from entities. ``is_archived`` is
+-- denormalized so search can filter without decoding the JSON ``data``
+-- column. For variants it mirrors the parent product/material's state.
 CREATE TABLE IF NOT EXISTS entity_index (
     rowid       INTEGER PRIMARY KEY AUTOINCREMENT,
     entity_type TEXT NOT NULL,
@@ -68,6 +70,7 @@ CREATE TABLE IF NOT EXISTS entity_index (
     sku         TEXT,
     name        TEXT,
     name2       TEXT,
+    is_archived INTEGER NOT NULL DEFAULT 0,
     UNIQUE (entity_type, id)
 );
 
@@ -132,20 +135,37 @@ class IndexFields:
         sku_key: Dict key for SKU field (variants only), or None.
         name_key: Dict key for the primary name field.
         name2_key: Dict key for the secondary name field (category, parent name, code).
+        archived_key: Dict key whose value, if not ``None``, marks the entity
+            as archived (``is_archived = 1``). Most types use ``"archived_at"``
+            (a timestamp; any non-``None`` value = archived). Variants use
+            ``"parent_archived_at"`` (synthesized in ``_variant_to_cache_dict``
+            from the extended ``product_or_material`` payload). When this
+            field itself is ``None`` (the default), the entity has no archive
+            concept and the index column stays 0.
     """
 
     sku_key: str | None = None
     name_key: str | None = None
     name2_key: str | None = None
+    archived_key: str | None = None
 
 
-# Pre-defined index field mappings for each entity type
+# Pre-defined index field mappings for each entity type.
 VARIANT_INDEX = IndexFields(
-    sku_key="sku", name_key="display_name", name2_key="parent_name"
+    sku_key="sku",
+    name_key="display_name",
+    name2_key="parent_name",
+    archived_key="parent_archived_at",
 )
-PRODUCT_INDEX = IndexFields(name_key="name", name2_key="category_name")
-MATERIAL_INDEX = IndexFields(name_key="name", name2_key="category_name")
-SERVICE_INDEX = IndexFields(name_key="name", name2_key="category_name")
+PRODUCT_INDEX = IndexFields(
+    name_key="name", name2_key="category_name", archived_key="archived_at"
+)
+MATERIAL_INDEX = IndexFields(
+    name_key="name", name2_key="category_name", archived_key="archived_at"
+)
+SERVICE_INDEX = IndexFields(
+    name_key="name", name2_key="category_name", archived_key="archived_at"
+)
 SUPPLIER_INDEX = IndexFields(name_key="name", name2_key="code")
 CUSTOMER_INDEX = IndexFields(name_key="name", name2_key="email")
 # No FTS for small/stable entity types
@@ -285,6 +305,12 @@ class CatalogCache:
                     e.get(index_fields.sku_key) if index_fields.sku_key else None,
                     e.get(index_fields.name_key) if index_fields.name_key else None,
                     e.get(index_fields.name2_key) if index_fields.name2_key else None,
+                    1
+                    if (
+                        index_fields.archived_key
+                        and e.get(index_fields.archived_key) is not None
+                    )
+                    else 0,
                 )
                 for e in entities
             ]
@@ -295,8 +321,9 @@ class CatalogCache:
                 index_ids,
             )
             await db.executemany(
-                "INSERT INTO entity_index (entity_type, id, sku, name, name2) "
-                "VALUES (?, ?, ?, ?, ?)",
+                "INSERT INTO entity_index "
+                "(entity_type, id, sku, name, name2, is_archived) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
                 index_rows,
             )
 
@@ -348,6 +375,7 @@ class CatalogCache:
         entity_type: str,
         query: str,
         limit: int = 50,
+        include_archived: bool = False,
     ) -> list[dict[str, Any]]:
         """Search entities using FTS5 with BM25 ranking.
 
@@ -357,6 +385,10 @@ class CatalogCache:
             entity_type: Entity type to search within.
             query: Search query string.
             limit: Maximum results to return.
+            include_archived: When False (default), archived rows are filtered
+                out via ``entity_index.is_archived``. Pass True to surface them
+                — primarily so callers can find an archived item to unarchive
+                via ``modify_item``.
 
         Returns:
             List of entity dicts, ranked by relevance.
@@ -374,14 +406,15 @@ class CatalogCache:
         # FTS5 query: each token as a prefix match, ANDed together
         fts_query = " AND ".join(f'"{t}"*' for t in escaped_tokens)
 
+        archived_clause = "" if include_archived else " AND idx.is_archived = 0"
         try:
             async with db.execute(
-                """
+                f"""
                 SELECT e.data
                 FROM entity_fts fts
                 JOIN entity_index idx ON fts.rowid = idx.rowid
                 JOIN entities e ON e.entity_type = idx.entity_type AND e.id = idx.id
-                WHERE entity_fts MATCH ? AND idx.entity_type = ?
+                WHERE entity_fts MATCH ? AND idx.entity_type = ?{archived_clause}
                 ORDER BY bm25(entity_fts)
                 LIMIT ?
                 """,
@@ -399,6 +432,7 @@ class CatalogCache:
         entity_type: str,
         query: str,
         limit: int = 50,
+        include_archived: bool = False,
     ) -> list[dict[str, Any]]:
         """Fuzzy search fallback using difflib on cached entity index fields.
 
@@ -408,6 +442,8 @@ class CatalogCache:
             entity_type: Entity type to search within.
             query: Search query string.
             limit: Maximum results to return.
+            include_archived: When False (default), archived rows are filtered
+                out before scoring. See :meth:`search` for the rationale.
 
         Returns:
             List of entity dicts, ranked by fuzzy relevance.
@@ -421,11 +457,12 @@ class CatalogCache:
         db = self._conn()
 
         # Load all index entries for this entity type
+        archived_clause = "" if include_archived else " AND idx.is_archived = 0"
         async with db.execute(
-            "SELECT idx.id, idx.sku, idx.name, idx.name2, e.data "
-            "FROM entity_index idx "
-            "JOIN entities e ON e.entity_type = idx.entity_type AND e.id = idx.id "
-            "WHERE idx.entity_type = ?",
+            f"SELECT idx.id, idx.sku, idx.name, idx.name2, e.data "
+            f"FROM entity_index idx "
+            f"JOIN entities e ON e.entity_type = idx.entity_type AND e.id = idx.id "
+            f"WHERE idx.entity_type = ?{archived_clause}",
             (entity_type,),
         ) as cursor:
             rows = await cursor.fetchall()
@@ -580,6 +617,7 @@ class CatalogCache:
         entity_type: str,
         query: str,
         limit: int = 50,
+        include_archived: bool = False,
     ) -> list[dict[str, Any]]:
         """Search with FTS5 primary and difflib fuzzy fallback.
 
@@ -590,17 +628,23 @@ class CatalogCache:
             entity_type: Entity type to search within.
             query: Search query string.
             limit: Maximum results to return.
+            include_archived: When False (default), archived rows are filtered
+                out. Threaded through to both FTS5 and fuzzy paths.
 
         Returns:
             List of entity dicts, ranked by relevance.
         """
         # Try FTS5 first
-        results = await self.search(entity_type, query, limit=limit)
+        results = await self.search(
+            entity_type, query, limit=limit, include_archived=include_archived
+        )
         if results:
             return results
 
         # Fuzzy fallback for typos
-        return await self.search_fuzzy(entity_type, query, limit=limit)
+        return await self.search_fuzzy(
+            entity_type, query, limit=limit, include_archived=include_archived
+        )
 
     # ── Internal ─────────────────────────────────────────────────────
 

--- a/katana_mcp_server/src/katana_mcp/cache_sync.py
+++ b/katana_mcp_server/src/katana_mcp/cache_sync.py
@@ -67,22 +67,33 @@ def _attrs_to_dicts(attrs_list: list[Any]) -> list[dict[str, Any]]:
 
 
 def _variant_to_cache_dict(attrs_obj: Any) -> dict[str, Any]:
-    """Convert a variant attrs model to a cache-friendly dict with display fields."""
+    """Convert a variant attrs model to a cache-friendly dict with display fields.
+
+    Variants don't carry their own archived state — Katana archives at the
+    parent (Product/Material) level and cascades. We pull
+    ``parent_archived_at`` off the extended ``product_or_material`` payload so
+    ``cache.sync`` can populate ``entity_index.is_archived`` for variants;
+    without it, archived variants would always look "active" in search.
+    """
     d = attrs_obj.to_dict() if hasattr(attrs_obj, "to_dict") else vars(attrs_obj)
 
     # Extract product_or_material info for indexing
     pom = d.get("product_or_material")
     parent_name = ""
     variant_type = ""
+    parent_archived_at: Any = None
     if isinstance(pom, dict):
         parent_name = pom.get("name", "")
         variant_type = pom.get("type", "")
+        parent_archived_at = pom.get("archived_at")
     elif pom and hasattr(pom, "name"):
         parent_name = getattr(pom, "name", "")
         variant_type = getattr(pom, "type_", "")
+        parent_archived_at = getattr(pom, "archived_at", None)
 
     d["parent_name"] = parent_name
     d["type"] = variant_type
+    d["parent_archived_at"] = parent_archived_at
 
     # Build display name for FTS indexing
     sku = d.get("sku", "")
@@ -266,9 +277,13 @@ async def _ensure_synced(
 async def _fetch_variants(
     client: Any, updated_at_min: datetime | None = None
 ) -> list[dict]:
+    # ``include_archived=True`` so the cache mirrors Katana's full catalog,
+    # not just active rows. Search filters archived out by default via the
+    # ``is_archived`` index column; callers opt in to surface them.
     kwargs: dict[str, Any] = {
         "client": client,
         "extend": [GetAllVariantsExtendItem.PRODUCT_OR_MATERIAL],
+        "include_archived": True,
     }
     if updated_at_min:
         kwargs["updated_at_min"] = updated_at_min
@@ -283,10 +298,13 @@ async def _fetch_generic(
     client: Any,
     updated_at_min: datetime | None = None,
     supports_incremental: bool = True,
+    include_archived: bool = False,
     extra_kwargs: dict[str, Any] | None = None,
 ) -> list[dict]:
     """Generic fetch: build kwargs, call asyncio_detailed, convert to dicts."""
     kwargs: dict[str, Any] = {"client": client}
+    if include_archived:
+        kwargs["include_archived"] = True
     if extra_kwargs:
         kwargs.update(extra_kwargs)
     if updated_at_min and supports_incremental:
@@ -298,19 +316,25 @@ async def _fetch_generic(
 async def _fetch_products(
     client: Any, updated_at_min: datetime | None = None
 ) -> list[dict]:
-    return await _fetch_generic(get_all_products, client, updated_at_min)
+    return await _fetch_generic(
+        get_all_products, client, updated_at_min, include_archived=True
+    )
 
 
 async def _fetch_materials(
     client: Any, updated_at_min: datetime | None = None
 ) -> list[dict]:
-    return await _fetch_generic(get_all_materials, client, updated_at_min)
+    return await _fetch_generic(
+        get_all_materials, client, updated_at_min, include_archived=True
+    )
 
 
 async def _fetch_services(
     client: Any, updated_at_min: datetime | None = None
 ) -> list[dict]:
-    return await _fetch_generic(get_all_services, client, updated_at_min)
+    return await _fetch_generic(
+        get_all_services, client, updated_at_min, include_archived=True
+    )
 
 
 async def _fetch_suppliers(

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -403,17 +403,47 @@ Detailed guide for all available MCP tools.
 ### search_items
 Find products, materials, and services by name or SKU.
 
+By default, archived items are filtered out. To find an archived item (so
+you can unarchive it via `modify_item`), pass `include_archived=true`.
+
 **Parameters:**
 - `query` (required): Search term to match against name or SKU
 - `limit` (optional): Maximum results (default: 20)
+- `include_archived` (optional, default false): When true, archived items
+  are included in results. Each row carries an `is_archived` flag so the
+  UI / caller can distinguish active vs archived rows.
 - `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
-**Example:**
+**Examples:**
+
+Active-only search:
 ```json
 {"query": "bolt", "limit": 10}
 ```
 
-**Returns:** List of matching items with ID, SKU, name, and sellable status.
+Include archived rows:
+```json
+{"query": "old style", "include_archived": true}
+```
+
+**Returns:** List of matching items with ID, SKU, name, sellable status,
+and archived state.
+
+**Archive workflow:** Katana doesn't expose dedicated archive/unarchive
+endpoints. Instead, archive state is a writable boolean on the item header
+that you toggle via `modify_item`. Send this body to archive:
+
+```json
+{"update_header": {"is_archived": true}}
+```
+
+Or to unarchive:
+
+```json
+{"update_header": {"is_archived": false}}
+```
+
+See `modify_item` below for the full request shape.
 
 ---
 
@@ -732,8 +762,9 @@ endpoint; variant sub-payloads route to the shared `/variant` family.
   `serial_tracked` / `operations_in_sequence` are PRODUCT-only;
   `default_supplier_id` / `batch_tracked` / `purchase_uom` /
   `purchase_uom_conversion_rate` are PRODUCT/MATERIAL only;
-  `sales_price` / `default_cost` / `sku` are SERVICE-only. Misrouted
-  fields fail fast with a clear error.
+  `sales_price` / `default_cost` / `sku` are SERVICE-only.
+  `is_archived` is shared across all three types — set true to archive,
+  false to unarchive. Misrouted fields fail fast with a clear error.
 - `add_variants` — POST `/variant`. Parent `product_id` / `material_id`
   is injected automatically from the request's `type`. Not supported
   for SERVICE (services carry pricing on the header, not on variants).
@@ -745,6 +776,26 @@ endpoint; variant sub-payloads route to the shared `/variant` family.
 - `type` (required): "product" | "material" | "service"
 - Any subset of the sub-payloads above
 - `preview` (optional, default true): true=preview, false=execute
+
+**Archive / unarchive examples:**
+
+Archive a product (preview):
+```json
+{"id": 12345, "type": "product", "update_header": {"is_archived": true}}
+```
+
+Unarchive a material (apply):
+```json
+{
+  "id": 67890,
+  "type": "material",
+  "update_header": {"is_archived": false},
+  "preview": false
+}
+```
+
+To find an archived item before unarchiving it, call `search_items` with
+`include_archived=true`.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -116,6 +116,15 @@ class SearchItemsRequest(BaseModel):
 
     query: str = Field(..., description="Search query (name, SKU, etc.)")
     limit: int = Field(default=20, description="Maximum results to return")
+    include_archived: bool = Field(
+        default=False,
+        description=(
+            "Include archived items in results. Defaults to false so normal "
+            "searches only see active items. Pass true to find an archived "
+            "item — typically as a precursor to unarchiving it via modify_item "
+            'with {"update_header": {"is_archived": false}}.'
+        ),
+    )
     format: Literal["markdown", "json"] = Field(
         default="markdown",
         description=(
@@ -134,6 +143,7 @@ class ItemInfo(BaseModel):
     item_type: str = "unknown"
     is_sellable: bool
     stock_level: int | None = None
+    is_archived: bool = False
 
 
 class SearchItemsResponse(BaseModel):
@@ -175,9 +185,14 @@ async def _search_items_impl(
 
     services = get_services(context)
     variant_dicts = await services.cache.smart_search(
-        "variant", request.query, limit=request.limit
+        "variant",
+        request.query,
+        limit=request.limit,
+        include_archived=request.include_archived,
     )
 
+    # Variants inherit archived state from their parent product/material;
+    # ``parent_archived_at`` is set during sync (see cache_sync._variant_to_cache_dict).
     items_info = [
         ItemInfo(
             id=v["id"],
@@ -186,6 +201,7 @@ async def _search_items_impl(
             item_type=v.get("type") or "unknown",
             is_sellable=v.get("type") == "product",
             stock_level=None,
+            is_archived=v.get("parent_archived_at") is not None,
         )
         for v in variant_dicts
     ]
@@ -203,6 +219,11 @@ async def search_items(
     Use this as the starting point when you need to find items. Returns item IDs
     and SKUs needed by other tools like create_purchase_order or check_inventory.
     For full details on a specific item, follow up with get_variant_details.
+
+    By default, archived items are excluded. Pass ``include_archived=true`` to
+    surface them (each row carries an ``is_archived`` flag). To unarchive an
+    item once you've found it, call ``modify_item`` with the request body
+    ``{"update_header": {"is_archived": false}}``.
 
     Query must not be empty. Default limit is 20 results.
     """
@@ -450,6 +471,12 @@ class ItemDetailsResponse(BaseModel):
     archived_at: str | None = None
     deleted_at: str | None = None
 
+    # Convenience boolean derived from ``archived_at`` — saves callers from
+    # having to know the timestamp/null convention. Pair with
+    # ``modify_item`` and ``{"update_header": {"is_archived": ...}}`` to
+    # toggle the state.
+    is_archived: bool = False
+
     # Product / Material only
     default_supplier_id: int | None = None
     batch_tracked: bool | None = None
@@ -592,6 +619,11 @@ async def _get_item_impl(
     supplier = _supplier_to_info(d.get("supplier"))
 
     item_id = d.get("id", request.id)
+    # Katana represents archive state as ``archived_at: timestamp | null`` on
+    # read; non-null = archived. The boolean ``is_archived`` is a convenience
+    # field that mirrors Katana's own update-request convention so callers
+    # can pair it with ``modify_item`` and
+    # ``{"update_header": {"is_archived": ...}}``.
     return ItemDetailsResponse(
         id=item_id,
         name=d.get("name") or "",
@@ -606,6 +638,7 @@ async def _get_item_impl(
         updated_at=_iso_or_none(d.get("updated_at")),
         archived_at=_iso_or_none(d.get("archived_at")),
         deleted_at=_iso_or_none(d.get("deleted_at")),
+        is_archived=d.get("archived_at") is not None,
         # Product / Material only (remain None on Service)
         default_supplier_id=d.get("default_supplier_id"),
         batch_tracked=d.get("batch_tracked"),
@@ -1090,11 +1123,18 @@ async def modify_item(
     - ``update_header`` — patch header fields. Field set is type-specific:
       ``is_producible`` etc. are PRODUCT-only, ``default_supplier_id``
       etc. are PRODUCT/MATERIAL, ``sales_price`` etc. are SERVICE-only.
+      ``is_archived`` is shared across all three types and is the
+      archive/unarchive lever (Katana has no dedicated archive endpoint).
       Misrouted fields fail fast with a clear error.
     - ``add_variants`` — POST /variant. Parent ``product_id`` /
       ``material_id`` is injected from the request's ``type``.
     - ``update_variants`` — PATCH /variant/{id}.
     - ``delete_variant_ids`` — DELETE /variant/{id}.
+
+    Archive / unarchive: send ``{"update_header": {"is_archived": true}}`` to
+    archive, ``{"update_header": {"is_archived": false}}`` to unarchive.
+    Archived items are hidden from ``search_items`` by default; pass
+    ``include_archived=true`` on that call to find them.
 
     To remove an item entirely, use the sibling ``delete_item`` tool.
 

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -192,6 +192,11 @@ def build_search_results_ui(
                     header="Sellable",
                     sortable=True,
                 ),
+                DataTableColumn(
+                    key="is_archived",
+                    header="Archived",
+                    sortable=True,
+                ),
             ],
             rows="items",
             search=True,
@@ -319,6 +324,8 @@ def build_item_detail_ui(
                         else "Not Producible",
                         variant="default" if item["is_producible"] else "secondary",
                     )
+                if item.get("is_archived"):
+                    Badge(label="Archived", variant="secondary")
 
         with CardFooter(), Row(gap=2):
             if item.get("sku"):

--- a/katana_mcp_server/tests/test_cache.py
+++ b/katana_mcp_server/tests/test_cache.py
@@ -212,6 +212,55 @@ class TestFTS5Search:
         assert len(product_results) == 1
 
 
+class TestArchivedFiltering:
+    """Search must hide archived items by default and surface them on opt-in."""
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def _populate(self, cache):
+        # Mix of active and archived variants under the same parent name so
+        # FTS5 returns multiple hits and we can verify the filter actually
+        # narrows the set rather than coincidentally matching one.
+        active = {
+            "id": 1,
+            "sku": "ACTIVE-001",
+            "display_name": "Active Widget",
+            "parent_name": "Widget Parent",
+            "parent_archived_at": None,
+            "updated_at": time.time(),
+        }
+        archived = {
+            "id": 2,
+            "sku": "ARCHIVED-001",
+            "display_name": "Archived Widget",
+            "parent_name": "Widget Parent",
+            "parent_archived_at": "2024-01-01T00:00:00+00:00",
+            "updated_at": time.time(),
+        }
+        await cache.sync("variant", [active, archived], VARIANT_INDEX)
+
+    @pytest.mark.asyncio
+    async def test_search_excludes_archived_by_default(self, cache):
+        results = await cache.search("variant", "widget")
+        assert {r["sku"] for r in results} == {"ACTIVE-001"}
+
+    @pytest.mark.asyncio
+    async def test_search_includes_archived_when_opted_in(self, cache):
+        results = await cache.search("variant", "widget", include_archived=True)
+        assert {r["sku"] for r in results} == {"ACTIVE-001", "ARCHIVED-001"}
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_excludes_archived_by_default(self, cache):
+        # "widgt" is a deletion typo — FTS5 prefix won't catch it, so this
+        # exercises search_fuzzy specifically.
+        results = await cache.search_fuzzy("variant", "widgt")
+        assert {r["sku"] for r in results} == {"ACTIVE-001"}
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_includes_archived_when_opted_in(self, cache):
+        results = await cache.search_fuzzy("variant", "widgt", include_archived=True)
+        assert {r["sku"] for r in results} == {"ACTIVE-001", "ARCHIVED-001"}
+
+
 class TestFuzzySearch:
     """Tests for the difflib fuzzy fallback."""
 

--- a/katana_mcp_server/tests/test_cache_sync.py
+++ b/katana_mcp_server/tests/test_cache_sync.py
@@ -86,6 +86,44 @@ class TestVariantToCacheDict:
         }
         result = _variant_to_cache_dict(attrs_obj)
         assert result["display_name"] == "SKU-003"
+        # No parent → no archived state to inherit.
+        assert result["parent_archived_at"] is None
+
+    def test_parent_archived_at_propagates_from_dict_parent(self):
+        """Variants don't carry archived state directly — the cache reads it
+        off the extended ``product_or_material`` payload so the search index
+        can filter archived variants."""
+        attrs_obj = MagicMock()
+        attrs_obj.to_dict.return_value = {
+            "id": 4,
+            "sku": "SKU-004",
+            "product_or_material": {
+                "name": "Old Widget",
+                "type": "product",
+                "archived_at": "2024-01-01T00:00:00+00:00",
+            },
+            "config_attributes": [],
+        }
+        result = _variant_to_cache_dict(attrs_obj)
+        assert result["parent_archived_at"] == "2024-01-01T00:00:00+00:00"
+
+    def test_parent_archived_at_propagates_from_attrs_parent(self):
+        # When the upstream client returns nested attrs (not a dict), the
+        # helper must use getattr — same data, different shape.
+        parent_obj = MagicMock(spec=["name", "type_", "archived_at"])
+        parent_obj.name = "Old Widget"
+        parent_obj.type_ = "product"
+        parent_obj.archived_at = "2024-01-01T00:00:00+00:00"
+
+        attrs_obj = MagicMock()
+        attrs_obj.to_dict.return_value = {
+            "id": 5,
+            "sku": "SKU-005",
+            "product_or_material": parent_obj,
+            "config_attributes": [],
+        }
+        result = _variant_to_cache_dict(attrs_obj)
+        assert result["parent_archived_at"] == "2024-01-01T00:00:00+00:00"
 
     def test_supplier_item_codes_preserved_verbatim(self):
         """supplier_item_codes flow through cache-sync unchanged.

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -413,7 +413,48 @@ async def test_search_items_default_limit():
     await _search_items_impl(request, context)
 
     assert request.limit == 20  # Default
-    lifespan_ctx.cache.smart_search.assert_called_once_with("variant", "test", limit=20)
+    lifespan_ctx.cache.smart_search.assert_called_once_with(
+        "variant", "test", limit=20, include_archived=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_items_surfaces_archived_state_from_parent():
+    """Variants inherit archived state from their parent — assert it surfaces."""
+    context, lifespan_ctx = create_mock_context()
+
+    # Two variants: one with an archived parent, one without. The
+    # ``parent_archived_at`` field is synthesized in cache_sync from the
+    # extended ``product_or_material`` payload, so the dict shape here
+    # mirrors what _variant_to_cache_dict actually writes.
+    cached_variants = [
+        {
+            "id": 1,
+            "sku": "ACTIVE-1",
+            "type": "product",
+            "display_name": "Active Item",
+            "parent_archived_at": None,
+        },
+        {
+            "id": 2,
+            "sku": "ARCHIVED-1",
+            "type": "material",
+            "display_name": "Archived Item",
+            "parent_archived_at": "2024-01-01T00:00:00+00:00",
+        },
+    ]
+    lifespan_ctx.cache.smart_search = AsyncMock(return_value=cached_variants)
+
+    request = SearchItemsRequest(query="item", include_archived=True)
+    result = await _search_items_impl(request, context)
+
+    by_sku = {item.sku: item for item in result.items}
+    assert by_sku["ACTIVE-1"].is_archived is False
+    assert by_sku["ARCHIVED-1"].is_archived is True
+    # Cache call must thread the flag through, otherwise the filter is moot.
+    lifespan_ctx.cache.smart_search.assert_called_once_with(
+        "variant", "item", limit=20, include_archived=True
+    )
 
 
 @pytest.mark.asyncio

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -315,6 +315,8 @@ async def test_get_item_product_surfaces_every_field():
     assert result.updated_at == "2024-08-20T14:45:00+00:00"
     assert result.archived_at is None
     assert result.deleted_at is None
+    # Convenience boolean derived from archived_at
+    assert result.is_archived is False
     # Tracking & purchase
     assert result.batch_tracked is True
     assert result.serial_tracked is False
@@ -401,6 +403,8 @@ async def test_get_item_service_surfaces_every_field():
     assert result.updated_at == "2024-04-15T14:30:00+00:00"
     assert result.archived_at == "2024-06-15T00:00:00+00:00"
     assert result.deleted_at is None
+    # Convenience boolean — non-null archived_at means archived
+    assert result.is_archived is True
     # Product/Material-only fields are None on Service
     assert result.batch_tracked is None
     assert result.default_supplier_id is None

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.56.1"
+version = "0.56.2"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Closes the gap where MCP `search_items` couldn't see archived items, so users had no way to find an archived row to unarchive it without going out-of-band to Katana's web UI.

- **Cache the full catalog**: variants / products / materials / services now sync with `include_archived=true`. The cache mirrors Katana's full state instead of just active rows.
- **Filter at search time**: `entity_index` gets a denormalized `is_archived` column. `cache.search` / `search_fuzzy` / `smart_search` and `search_items` all accept `include_archived` (default `false`). Archived variants inherit state from their parent product/material (`parent_archived_at`).
- **Surface state to callers**: `ItemInfo` and `ItemDetailsResponse` get an `is_archived` convenience boolean — mirrors Katana's own *write* convention (`update_header.is_archived`) so callers can pair the round-trip with `modify_item`. UI gets an Archived column in search results and a badge on item detail cards.
- **Document the workflow**: `help.py` + `modify_item` docstring now spell out that Katana has no dedicated archive endpoint — toggle `update_header.is_archived` instead. Examples included.

No new tools — archive/unarchive was already supported via `modify_item`'s existing `is_archived` field on `ItemHeaderPatch`. The visibility gap was the only real bug.

## Schema migration

`_SCHEMA_VERSION` bumped 1 → 2. The existing `_ensure_schema` migration path drops and recreates `entities` / `entity_index` / `entity_fts` / `sync_metadata` on version mismatch. **First cache open after this lands re-fetches the full catalog from Katana** — proportional to catalog size, one-time cost. No data loss (cache is a derived store).

## Test plan

- [x] `uv run poe check` — all 2763 tests pass
- [x] New tests:
  - `TestArchivedFiltering` (test_cache.py) — search and fuzzy each have an excluded-by-default + included-on-opt-in case
  - `test_parent_archived_at_propagates_from_dict_parent` / `_attrs_parent` (test_cache_sync.py) — variants inherit parent state across both response shapes
  - `test_search_items_surfaces_archived_state_from_parent` (test_inventory.py) — end-to-end through `_search_items_impl`, asserts cache call threads the flag
  - `is_archived` assertions added to existing `test_get_item_*_surfaces_every_field` tests
- [ ] Manual: after merge, run an MCP `search_items` with `include_archived=true` against an account with archived items; confirm rows appear with `is_archived: true`. Then `modify_item` with `update_header={is_archived: false}` to unarchive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)