### PR TITLE
feat(mcp): add correct_manufacturing_order and correct_sales_order for closed-record edits

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -60,12 +60,14 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **get_manufacturing_order** - Look up an MO with full details
 - **modify_manufacturing_order** - Unified modify: header, recipe rows, operation rows, production records (multi-action, preview/apply)
 - **delete_manufacturing_order** - Delete an MO (Katana cascades child rows)
+- **correct_manufacturing_order** - Edit a closed (DONE / PARTIALLY_COMPLETED) MO without losing its `done_date` / per-production timestamps. Reopens, swaps ingredients keyed by current variant, then re-closes preserving close-state. See "Closed-Record Corrections" below.
 - **fulfill_order** - Complete manufacturing or sales orders
 - **create_sales_order** - Create sales orders with preview/apply
 - **list_sales_orders** - List SOs with customer/status/date filters
 - **get_sales_order** - Look up an SO with full details
 - **modify_sales_order** - Unified modify: header, rows, addresses, fulfillments, shipping fees (multi-action, preview/apply)
 - **delete_sales_order** - Delete an SO (Katana cascades child rows)
+- **correct_sales_order** - Edit a closed (DELIVERED) SO without losing its `picked_date` / fulfillment metadata. Reopens, edits lines keyed by current variant, then re-closes preserving close-state. See "Closed-Record Corrections" below.
 
 ### Stock Transfers
 - **create_stock_transfer** - Move inventory between locations (preview/apply)
@@ -114,6 +116,40 @@ the same shape:
 
 Destructive `delete_<entity>` tools are siblings of the modify tools —
 keeping them separate makes the destructiveHint annotation honest.
+
+## Closed-Record Corrections
+
+Two specialized tools — `correct_manufacturing_order` and
+`correct_sales_order` — exist for the case where you need to edit a record
+that has *already* reached a terminal status (DONE for an MO, DELIVERED for
+an SO) without losing the original close-state metadata.
+
+The standard `modify_<entity>` tool can technically do this, but the
+operator has to discover and sequence several mechanical quirks each time:
+
+- `done_date` can only be set once an MO is `DONE`; combined `status:
+  DONE + done_date` PATCH calls fail because validation runs *before* the
+  status change applies.
+- Reverting a DONE MO auto-reverses its productions, so the original
+  per-production `quantity`, `production_date`, and serial numbers must be
+  re-played on the way back.
+- Re-fulfilling a DELIVERED SO requires deleting fulfillments first
+  (the delete returns an empty 200 body — `unwrap()` correctly flags it
+  as `APIError`; callers should use `is_success`), then patching the
+  status, editing lines, and re-creating fulfillments with the original
+  `picked_date` / tracking metadata.
+
+The correction tools encode the proven sequence once. Each takes the edits
+keyed by the *current* variant on the row (not the row ID), so the operator
+expresses intent at the level they think about it ("swap SP73000 for
+SP73001 on this MO"). Both follow the standard preview/apply pattern.
+
+Use the regular `modify_<entity>` tool when:
+- The record is still open (no close-state to preserve).
+- The edits don't fit the variant-keyed shape — e.g. you need to add a row,
+  delete a row, or change something other than variant/quantity.
+- The same variant appears on multiple rows and you want to disambiguate
+  with the explicit row ID.
 
 ## Output Format
 
@@ -1062,6 +1098,47 @@ rows / operation rows / production records server-side.
 
 ---
 
+### correct_manufacturing_order
+Edit a closed MO (status DONE or PARTIALLY_COMPLETED) without losing its
+original close-state. Reopens the MO, swaps recipe-row ingredients keyed
+by current variant, then re-closes preserving the original status,
+`done_date`, and per-production `quantity` / `production_date` / serial
+numbers.
+
+For an MO that hasn't shipped yet, use `modify_manufacturing_order`
+directly — there's no close-state to preserve.
+
+**Parameters:**
+- `id` (required): Manufacturing order ID
+- `ingredient_changes` (required, min_length=1): list of recipe-row edits.
+  Each entry: `old_variant_id` (variant currently on the row, required),
+  `new_variant_id` (optional — None to keep variant), and/or
+  `planned_quantity_per_unit` (optional, >0 — None to keep quantity). At
+  least one of `new_variant_id` / `planned_quantity_per_unit` must be set.
+- `preview` (optional, default true): true=preview, false=execute
+
+**Sequence executed (in order):**
+1. PATCH MO status → IN_PROGRESS (Katana auto-reverses productions)
+2. PATCH each recipe row per `ingredient_changes`
+3. POST one production per snapshot (replays `completed_quantity` and
+   `serial_numbers`)
+4. PATCH each new production's `production_date` to its snapshot value
+5. PATCH MO status → DONE
+
+**Errors when:**
+- The MO isn't in DONE / PARTIALLY_COMPLETED status (use `modify_manufacturing_order`).
+- An `old_variant_id` doesn't match any current recipe row, or matches
+  multiple rows (use `modify_manufacturing_order` with the explicit row ID).
+- An `ingredient_changes` entry has neither `new_variant_id` nor
+  `planned_quantity_per_unit` set.
+
+**Returns:** A `ModificationResponse` with one `ActionResult` per phase
+step. Fail-fast halt at any phase boundary leaves the MO in an
+intermediate (open) state with the captured close-state in `prior_state`
+for manual recovery.
+
+---
+
 ### create_sales_order
 Create a sales order.
 
@@ -1178,6 +1255,52 @@ addresses / fulfillments / shipping fees server-side.
 **Parameters:**
 - `id` (required): Sales order ID
 - `preview` (optional, default true): true=preview, false=delete
+
+---
+
+### correct_sales_order
+Edit a closed SO (status DELIVERED) without losing its original
+close-state. Reopens the SO, edits line items keyed by current variant,
+then re-closes preserving the original status, `picked_date`, and per-
+fulfillment metadata (status / `picked_date` / tracking_*).
+
+For an SO that hasn't shipped yet, use `modify_sales_order` directly —
+there's no close-state to preserve.
+
+**Parameters:**
+- `id` (required): Sales order ID
+- `line_changes` (required, min_length=1): list of line-item edits. Each
+  entry: `old_variant_id` (variant currently on the row, required),
+  `new_variant_id` (optional), `quantity` (optional, >0), `price_per_unit`
+  (optional). At least one of the latter three must be set.
+- `preview` (optional, default true): true=preview, false=execute
+
+**Sequence executed (in order):**
+1. DELETE each existing fulfillment (Katana returns empty 200 — handled)
+2. PATCH SO status → PENDING
+3. PATCH each row per `line_changes`
+4. POST one fulfillment per snapshot (replays status + `picked_date` +
+   tracking_* + row references)
+5. PATCH SO status → DELIVERED
+
+**Errors when:**
+- The SO isn't in DELIVERED status.
+- An `old_variant_id` doesn't match any current row, or matches multiple
+  rows on this SO.
+- A `line_changes` entry sets none of `new_variant_id` / `quantity` /
+  `price_per_unit`.
+
+**Constraints:**
+- Only updates rows in place; doesn't add or delete rows. Row IDs must stay
+  stable so the re-created fulfillments can reference them by the original
+  `sales_order_row_id`. If you need to add or remove a line, use
+  `modify_sales_order`.
+- A new `quantity` must be >= the original fulfillment quantity for that
+  row, or Katana will reject the re-fulfillment step.
+
+**Returns:** A `ModificationResponse` with one `ActionResult` per phase
+step. Fail-fast halt leaves the SO in an intermediate (open) state with
+the captured close-state in `prior_state`.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/_reopen.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_reopen.py
@@ -1,0 +1,248 @@
+"""Close-state snapshots for the reopen → modify → restore pattern.
+
+The composite ``correct_<entity>`` tools (``correct_manufacturing_order``,
+``correct_sales_order``) edit records that have already reached a terminal
+status (DONE / DELIVERED) without losing the original close-state metadata.
+
+This module owns the **what to capture and replay** — it doesn't run any
+API calls. The composite tools in ``foundation/corrections.py`` consume
+these snapshots, build ``ActionSpec`` lists, and execute them via the
+existing ``_modification_dispatch`` machinery.
+
+State-machine quirks the snapshots paper over:
+
+- **MO**: ``done_date`` can only be set once status is ``DONE``; combined
+  status+date PATCH calls fail because validation runs *before* the status
+  change is applied. After reverting, productions are auto-reversed by
+  Katana, so re-creating them is part of the restore. ``MOProductionAdd``
+  takes ``completed_quantity`` (singular create body field) but the
+  persisted entity stores it as ``quantity``.
+- **SO**: a DELIVERED SO can't be edited; reopening means deleting the
+  fulfillments (which empties the 200 body — callers must use
+  ``is_success`` instead of ``unwrap``) and patching status back to PENDING.
+  Restore means re-creating each fulfillment with its original
+  ``picked_date``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from katana_public_api_client.client_types import UNSET
+from katana_public_api_client.domain.converters import unwrap_unset
+from katana_public_api_client.models import (
+    ManufacturingOrder,
+    ManufacturingOrderProduction,
+    ManufacturingOrderStatus,
+    SalesOrder,
+    SalesOrderFulfillment,
+    SalesOrderStatus,
+    UpdateSalesOrderStatus,
+)
+
+# ============================================================================
+# Manufacturing order snapshots
+# ============================================================================
+
+
+# MO statuses where the record is treated as "closed" — entry conditions for
+# ``correct_manufacturing_order``. PARTIALLY_COMPLETED is included because
+# Katana can land an MO there when productions don't carry ``is_final=True``;
+# the operator-perceived state is still "shipped, fix me".
+MO_CLOSED_STATUSES: frozenset[str] = frozenset(
+    {
+        ManufacturingOrderStatus.DONE.value,
+        ManufacturingOrderStatus.PARTIALLY_COMPLETED.value,
+    }
+)
+
+# Status to revert to when reopening — clears the close-state and lets
+# Katana auto-reverse the productions.
+MO_REOPEN_STATUS: str = ManufacturingOrderStatus.IN_PROGRESS.value
+
+# Status to restore to once edits and re-productions land.
+MO_RESTORE_STATUS: str = ManufacturingOrderStatus.DONE.value
+
+
+@dataclass(frozen=True)
+class MOProductionSnapshot:
+    """Restorable shape of a single production record on an MO.
+
+    Captured by reading the persisted entity (``ManufacturingOrderProduction``);
+    replayed via the create-production POST body (``completed_quantity``,
+    ``completed_date``, ``serial_numbers``) plus a follow-up PATCH that sets
+    ``production_date`` exactly. Two-step replay matches the operator-proven
+    sequence in the original Shopify SP73000→SP73001 correction: Katana
+    stamps the create with server-time, so the explicit PATCH is what
+    actually backdates the production.
+    """
+
+    completed_quantity: float
+    production_date: datetime | None
+    serial_numbers: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class MOCloseState:
+    """Snapshot of an MO's close-state metadata, captured before reopen."""
+
+    status: str
+    done_date: datetime | None
+    productions: list[MOProductionSnapshot]
+
+
+def _serial_numbers_to_strs(value: Any) -> list[str]:
+    """Extract serial-number strings from an attrs ``list[SerialNumber]``.
+
+    The persisted entity carries ``SerialNumber`` objects; the create-body
+    field accepts a flat ``list[str]``. UNSET / None / missing
+    ``serial_number`` field on an item all fall through to "skip".
+    """
+    items = unwrap_unset(value, None)
+    if not items:
+        return []
+    out: list[str] = []
+    for item in items:
+        sn = unwrap_unset(getattr(item, "serial_number", UNSET), None)
+        if isinstance(sn, str) and sn:
+            out.append(sn)
+    return out
+
+
+def snapshot_mo_close_state(
+    mo: ManufacturingOrder,
+    productions: list[ManufacturingOrderProduction],
+) -> MOCloseState:
+    """Build an :class:`MOCloseState` from a fetched MO + its productions."""
+    status_enum = unwrap_unset(mo.status, None)
+    status = status_enum.value if status_enum is not None else ""
+    done_date = unwrap_unset(mo.done_date, None)
+
+    snapshots: list[MOProductionSnapshot] = []
+    for prod in productions:
+        qty = unwrap_unset(prod.quantity, None)
+        if qty is None or qty <= 0:
+            # Reverted/empty productions are skipped — only meaningful
+            # production records get replayed.
+            continue
+        snapshots.append(
+            MOProductionSnapshot(
+                completed_quantity=float(qty),
+                production_date=unwrap_unset(prod.production_date, None),
+                serial_numbers=_serial_numbers_to_strs(prod.serial_numbers),
+            )
+        )
+
+    return MOCloseState(status=status, done_date=done_date, productions=snapshots)
+
+
+# ============================================================================
+# Sales order snapshots
+# ============================================================================
+
+
+# SO statuses where the record is treated as "closed" — entry condition for
+# ``correct_sales_order``.
+SO_CLOSED_STATUSES: frozenset[str] = frozenset({SalesOrderStatus.DELIVERED.value})
+
+# Status to revert to when reopening. Note this references
+# ``UpdateSalesOrderStatus`` (the write enum) since ``PENDING`` is only a
+# valid input — the persisted ``SalesOrderStatus`` enum doesn't include it.
+# Fulfillments must be deleted first or Katana rejects the patch.
+SO_REOPEN_STATUS: str = UpdateSalesOrderStatus.PENDING.value
+
+# Status to restore to once edits and re-fulfillment land.
+SO_RESTORE_STATUS: str = UpdateSalesOrderStatus.DELIVERED.value
+
+
+@dataclass(frozen=True)
+class SOFulfillmentRowSnapshot:
+    """Restorable row inside a fulfillment — references an SO row + qty."""
+
+    sales_order_row_id: int
+    quantity: float
+
+
+@dataclass(frozen=True)
+class SOFulfillmentSnapshot:
+    """Restorable shape of a single fulfillment on an SO.
+
+    Captured before delete, replayed via the create-fulfillment POST body.
+    SO row IDs are preserved across the reopen (we only patch row fields,
+    never delete/add rows in ``correct_sales_order``), so the
+    ``sales_order_row_id`` references stay valid.
+    """
+
+    status: str
+    picked_date: datetime | None
+    conversion_rate: float | None
+    conversion_date: datetime | None
+    tracking_number: str | None
+    tracking_url: str | None
+    tracking_carrier: str | None
+    tracking_method: str | None
+    rows: list[SOFulfillmentRowSnapshot] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SOCloseState:
+    """Snapshot of an SO's close-state metadata, captured before reopen."""
+
+    status: str
+    picked_date: datetime | None
+    delivery_date: datetime | None
+    fulfillments: list[SOFulfillmentSnapshot]
+    fulfillment_ids: list[int]
+
+
+def _fulfillment_rows_from_attrs(value: Any) -> list[SOFulfillmentRowSnapshot]:
+    """Extract row snapshots from an attrs ``list[SalesOrderFulfillmentRow]``."""
+    items = unwrap_unset(value, None)
+    if not items:
+        return []
+    out: list[SOFulfillmentRowSnapshot] = []
+    for item in items:
+        row_id = unwrap_unset(getattr(item, "sales_order_row_id", UNSET), None)
+        qty = unwrap_unset(getattr(item, "quantity", UNSET), None)
+        if not isinstance(row_id, int) or qty is None:
+            continue
+        out.append(
+            SOFulfillmentRowSnapshot(sales_order_row_id=row_id, quantity=float(qty))
+        )
+    return out
+
+
+def _fulfillment_snapshot(fulfillment: SalesOrderFulfillment) -> SOFulfillmentSnapshot:
+    status_enum = unwrap_unset(fulfillment.status, None)
+    status = status_enum.value if status_enum is not None else ""
+    return SOFulfillmentSnapshot(
+        status=status,
+        picked_date=unwrap_unset(fulfillment.picked_date, None),
+        conversion_rate=unwrap_unset(fulfillment.conversion_rate, None),
+        conversion_date=unwrap_unset(fulfillment.conversion_date, None),
+        tracking_number=unwrap_unset(fulfillment.tracking_number, None),
+        tracking_url=unwrap_unset(fulfillment.tracking_url, None),
+        tracking_carrier=unwrap_unset(fulfillment.tracking_carrier, None),
+        tracking_method=unwrap_unset(fulfillment.tracking_method, None),
+        rows=_fulfillment_rows_from_attrs(
+            getattr(fulfillment, "sales_order_fulfillment_rows", UNSET)
+        ),
+    )
+
+
+def snapshot_so_close_state(
+    so: SalesOrder,
+    fulfillments: list[SalesOrderFulfillment],
+) -> SOCloseState:
+    """Build an :class:`SOCloseState` from a fetched SO + its fulfillments."""
+    status_enum = unwrap_unset(so.status, None)
+    status = status_enum.value if status_enum is not None else ""
+    return SOCloseState(
+        status=status,
+        picked_date=unwrap_unset(so.picked_date, None),
+        delivery_date=unwrap_unset(so.delivery_date, None),
+        fulfillments=[_fulfillment_snapshot(f) for f in fulfillments],
+        fulfillment_ids=[f.id for f in fulfillments if isinstance(f.id, int)],
+    )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/__init__.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/__init__.py
@@ -19,6 +19,7 @@ from fastmcp import FastMCP
 
 from .cache_admin import register_tools as register_cache_admin_tools
 from .catalog import register_tools as register_catalog_tools
+from .corrections import register_tools as register_corrections_tools
 from .customers import register_tools as register_customers_tools
 from .inventory import register_tools as register_inventory_tools
 from .items import register_tools as register_items_tools
@@ -47,6 +48,7 @@ def register_all_foundation_tools(mcp: FastMCP) -> None:
     register_stock_transfer_tools(mcp)
     register_reporting_tools(mcp)
     register_cache_admin_tools(mcp)
+    register_corrections_tools(mcp)
 
 
 __all__ = [

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
@@ -1,0 +1,1190 @@
+"""Composite ``correct_<entity>`` tools — transactional edit on closed records.
+
+Lets the operator edit a record that has already reached a terminal status
+(``DONE`` for an MO, ``DELIVERED`` for an SO) without losing the original
+close-state metadata. Internally implements the proven sequence:
+
+1. **Capture** the close-state (status + key timestamps + child snapshots)
+2. **Reopen** by reverting status to an editable value (and, for SO,
+   deleting fulfillments first — the close-state restore re-creates them)
+3. **Apply** the user's edits (recipe row swap, line item update)
+4. **Restore** the close-state, observing the mandatory ordering: status
+   first, then dates (Katana validates date fields against the *current*
+   status, so combined ``status: DONE + done_date`` calls fail).
+
+Composes ``ActionSpec`` lists from :mod:`_modification_dispatch` and the
+existing per-entity request builders. Each phase runs through
+``execute_plan`` separately so fail-fast halts at a phase boundary with the
+captured close-state available for manual recovery.
+
+Tracked under #523 (umbrella). Phase 1 ships MO + SO; PO and stock
+transfer are deferred.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from typing import Annotated, Any, cast
+
+from fastmcp import Context, FastMCP
+from fastmcp.tools import ToolResult
+from pydantic import BaseModel, ConfigDict, Field
+
+from katana_mcp.logging import observe_tool
+from katana_mcp.services import get_services
+from katana_mcp.tools._modification import (
+    ActionResult,
+    ConfirmableRequest,
+    FieldChange,
+    ModificationResponse,
+    to_tool_result,
+)
+from katana_mcp.tools._modification_dispatch import (
+    ActionSpec,
+    ApplyCallable,
+    execute_plan,
+    plan_to_preview_results,
+    serialize_for_prior_state,
+)
+from katana_mcp.tools._reopen import (
+    MO_CLOSED_STATUSES,
+    MO_REOPEN_STATUS,
+    MO_RESTORE_STATUS,
+    SO_CLOSED_STATUSES,
+    SO_REOPEN_STATUS,
+    SO_RESTORE_STATUS,
+    MOCloseState,
+    MOProductionSnapshot,
+    SOCloseState,
+    SOFulfillmentSnapshot,
+    snapshot_mo_close_state,
+    snapshot_so_close_state,
+)
+from katana_mcp.tools.foundation.manufacturing_orders import (
+    MOOperation,
+    _fetch_manufacturing_order_attrs,
+)
+from katana_mcp.tools.foundation.sales_orders import (
+    SOOperation,
+    _fetch_sales_order_attrs,
+)
+from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_mcp.web_urls import katana_web_url
+from katana_public_api_client.api.manufacturing_order import (
+    update_manufacturing_order as api_update_manufacturing_order,
+)
+from katana_public_api_client.api.manufacturing_order_production import (
+    create_manufacturing_order_production as api_create_mo_production,
+    update_manufacturing_order_production as api_update_mo_production,
+)
+from katana_public_api_client.api.manufacturing_order_recipe import (
+    update_manufacturing_order_recipe_rows as api_update_mo_recipe_row,
+)
+from katana_public_api_client.api.sales_order import (
+    update_sales_order as api_update_sales_order,
+)
+from katana_public_api_client.api.sales_order_fulfillment import (
+    create_sales_order_fulfillment as api_create_so_fulfillment,
+    delete_sales_order_fulfillment as api_delete_so_fulfillment,
+    get_all_sales_order_fulfillments as api_get_all_so_fulfillments,
+)
+from katana_public_api_client.api.sales_order_row import (
+    update_sales_order_row as api_update_so_row,
+)
+from katana_public_api_client.domain.converters import to_unset, unwrap_unset
+from katana_public_api_client.models import (
+    CreateManufacturingOrderProductionRequest as APICreateMOProductionRequest,
+    CreateSalesOrderFulfillmentRequest as APICreateSOFulfillmentRequest,
+    ManufacturingOrderProduction,
+    ManufacturingOrderRecipeRow,
+    ManufacturingOrderStatus,
+    SalesOrderFulfillment,
+    SalesOrderFulfillmentRowRequest,
+    SalesOrderFulfillmentStatus,
+    SalesOrderRow,
+    UpdateManufacturingOrderProductionRequest as APIUpdateMOProductionRequest,
+    UpdateManufacturingOrderRecipeRowRequest as APIUpdateMORecipeRowRequest,
+    UpdateManufacturingOrderRequest as APIUpdateManufacturingOrderRequest,
+    UpdateSalesOrderRequest as APIUpdateSalesOrderRequest,
+    UpdateSalesOrderRowRequest as APIUpdateSORowRequest,
+    UpdateSalesOrderStatus,
+)
+from katana_public_api_client.utils import is_success, unwrap, unwrap_as
+
+# ============================================================================
+# Shared apply-builders
+# ============================================================================
+#
+# The composite tools need patch closures that tolerate Katana's empty-200
+# bodies on certain transitions (observed live on ``modify_sales_order`` →
+# DELIVERED). The framework's ``make_patch_apply`` calls ``unwrap_as``,
+# which raises ``APIError("No parsed response data for status 200")`` on
+# empty bodies. We special-case here.
+
+
+def _augment_prior_state_with_snapshot(
+    prior_state: dict[str, Any] | None,
+    snapshot: MOCloseState | SOCloseState,
+) -> dict[str, Any]:
+    """Inject the captured close-state into ``prior_state`` for recovery.
+
+    The framework's :func:`serialize_for_prior_state` only serializes the
+    top-level entity, but the manual-recovery breadcrumb on a failed
+    correction needs the per-production / per-fulfillment snapshot too —
+    that's the data the operator has to replay to finish the close. This
+    splices the dataclass-derived snapshot under a sentinel key.
+    """
+    base: dict[str, Any] = dict(prior_state) if prior_state else {}
+    base["_close_state_snapshot"] = dataclasses.asdict(snapshot)
+    return base
+
+
+async def _run_phases_until_failure(
+    phases: list[list[ActionSpec]],
+) -> tuple[list[ActionResult], bool]:
+    """Run each phase via :func:`execute_plan`; halt on the first failed action.
+
+    Returns ``(aggregated_results, failed)`` — ``failed=True`` means an
+    action raised in some phase and subsequent phases were skipped. Callers
+    use the boolean to branch into success vs failure response building.
+    Empty phases are skipped silently.
+    """
+    aggregated: list[ActionResult] = []
+    for phase in phases:
+        if not phase:
+            continue
+        aggregated.extend(await execute_plan(phase))
+        if any(a.succeeded is False for a in aggregated):
+            return aggregated, True
+    return aggregated, False
+
+
+def _make_tolerant_patch_apply(
+    endpoint: Any, services: Any, target_id: int, body: Any
+) -> ApplyCallable:
+    """Patch apply that returns ``None`` on a successful empty body.
+
+    Mirrors :func:`make_patch_apply` but treats a missing parsed body on a
+    success status as success (``None`` outcome) rather than raising via
+    ``unwrap_as``. Used for status round-trips on closed-record restore
+    where Katana intermittently echoes nothing on the 200.
+    """
+
+    async def apply() -> Any:
+        response = await endpoint.asyncio_detailed(
+            id=target_id, client=services.client, body=body
+        )
+        if response.parsed is not None:
+            return response.parsed
+        if is_success(response):
+            return None
+        # Surfaces the typed APIError on actual failures.
+        unwrap(response)
+        return None  # unreachable; unwrap raises on non-success
+
+    return apply
+
+
+# ============================================================================
+# Manufacturing-order corrections
+# ============================================================================
+
+
+class MOIngredientCorrection(BaseModel):
+    """One recipe-row edit, identified by the variant currently in the row.
+
+    The tool resolves ``old_variant_id`` to the recipe row ID by inspecting
+    the existing MO. If the same variant appears in multiple recipe rows
+    on this MO the tool errors and asks the operator to use
+    ``modify_manufacturing_order`` directly.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    old_variant_id: int = Field(
+        ..., description="Variant currently on the recipe row to be edited."
+    )
+    new_variant_id: int | None = Field(
+        default=None,
+        description="New variant for the row. None = keep the existing variant.",
+    )
+    planned_quantity_per_unit: float | None = Field(
+        default=None,
+        gt=0,
+        description="New per-unit quantity. None = keep the existing quantity.",
+    )
+
+
+class CorrectManufacturingOrderRequest(ConfirmableRequest):
+    """Reopen a closed MO, edit ingredients, restore the original close-state.
+
+    Entry condition: the MO must be in ``DONE`` or ``PARTIALLY_COMPLETED``
+    status. For MOs that haven't shipped yet, use
+    ``modify_manufacturing_order`` directly — there's no close-state to
+    preserve.
+    """
+
+    id: int = Field(..., description="Manufacturing order ID")
+    ingredient_changes: list[MOIngredientCorrection] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Recipe-row edits keyed by current variant. At least one entry "
+            "is required; each must change at least one of new_variant_id "
+            "or planned_quantity_per_unit."
+        ),
+    )
+
+
+def _resolve_recipe_row(
+    mo_id: int,
+    recipe_rows: list[ManufacturingOrderRecipeRow],
+    correction: MOIngredientCorrection,
+) -> ManufacturingOrderRecipeRow:
+    """Find the recipe row matching the correction's ``old_variant_id``.
+
+    Errors on zero or multiple matches — the corrections tool is for
+    unambiguous swaps; ambiguous cases route to ``modify_manufacturing_order``.
+    """
+    matches = [
+        row
+        for row in recipe_rows
+        if unwrap_unset(row.variant_id, None) == correction.old_variant_id
+    ]
+    if not matches:
+        raise ValueError(
+            f"No recipe row on MO {mo_id} has variant_id "
+            f"{correction.old_variant_id}. Use modify_manufacturing_order "
+            "if you need to add the ingredient instead."
+        )
+    if len(matches) > 1:
+        row_ids = [m.id for m in matches]
+        raise ValueError(
+            f"Variant {correction.old_variant_id} appears in multiple "
+            f"recipe rows on MO {mo_id} (rows {row_ids}); "
+            "correct_manufacturing_order can't disambiguate. Use "
+            "modify_manufacturing_order with the explicit row ID."
+        )
+    return matches[0]
+
+
+async def _fetch_mo_recipe_rows_raw(
+    services: Any, mo_id: int
+) -> list[ManufacturingOrderRecipeRow]:
+    """Fetch raw attrs recipe rows for an MO.
+
+    Distinct from :func:`foundation.manufacturing_orders._fetch_mo_recipe_rows`
+    which returns SKU-enriched ``RecipeRowInfo`` for the read tool. Here we
+    need the raw entity for diff and ID resolution.
+    """
+    from katana_public_api_client.api.manufacturing_order_recipe import (
+        get_all_manufacturing_order_recipe_rows,
+    )
+    from katana_public_api_client.utils import unwrap_data
+
+    response = await get_all_manufacturing_order_recipe_rows.asyncio_detailed(
+        client=services.client,
+        manufacturing_order_id=mo_id,
+        limit=250,
+    )
+    return cast(list[ManufacturingOrderRecipeRow], unwrap_data(response, default=[]))
+
+
+async def _fetch_mo_productions_raw(
+    services: Any, mo_id: int
+) -> list[ManufacturingOrderProduction]:
+    """Fetch raw attrs productions for an MO."""
+    from katana_public_api_client.api.manufacturing_order import (
+        get_all_manufacturing_order_productions,
+    )
+    from katana_public_api_client.utils import unwrap_data
+
+    response = await get_all_manufacturing_order_productions.asyncio_detailed(
+        client=services.client,
+        manufacturing_order_ids=[mo_id],
+        limit=250,
+    )
+    return cast(list[ManufacturingOrderProduction], unwrap_data(response, default=[]))
+
+
+def _build_revert_mo_action(mo_id: int, services: Any) -> ActionSpec:
+    """PATCH MO header → status: IN_PROGRESS. Auto-reverses productions."""
+    body = APIUpdateManufacturingOrderRequest(
+        status=ManufacturingOrderStatus(MO_REOPEN_STATUS)
+    )
+    return ActionSpec(
+        operation=MOOperation.UPDATE_HEADER,
+        target_id=mo_id,
+        diff=[FieldChange(field="status", old="DONE", new=MO_REOPEN_STATUS)],
+        apply=_make_tolerant_patch_apply(
+            api_update_manufacturing_order, services, mo_id, body
+        ),
+        verify=None,
+    )
+
+
+def _build_recipe_edit_actions(
+    mo_id: int,
+    recipe_rows: list[ManufacturingOrderRecipeRow],
+    corrections: list[MOIngredientCorrection],
+    services: Any,
+) -> list[ActionSpec]:
+    specs: list[ActionSpec] = []
+    for correction in corrections:
+        if (
+            correction.new_variant_id is None
+            and correction.planned_quantity_per_unit is None
+        ):
+            raise ValueError(
+                f"ingredient_changes entry for variant "
+                f"{correction.old_variant_id}: must supply at least one of "
+                "new_variant_id or planned_quantity_per_unit."
+            )
+        row = _resolve_recipe_row(mo_id, recipe_rows, correction)
+
+        diff: list[FieldChange] = []
+        if correction.new_variant_id is not None:
+            diff.append(
+                FieldChange(
+                    field="variant_id",
+                    old=correction.old_variant_id,
+                    new=correction.new_variant_id,
+                )
+            )
+        if correction.planned_quantity_per_unit is not None:
+            diff.append(
+                FieldChange(
+                    field="planned_quantity_per_unit",
+                    old=unwrap_unset(row.planned_quantity_per_unit, None),
+                    new=correction.planned_quantity_per_unit,
+                )
+            )
+
+        body = APIUpdateMORecipeRowRequest(
+            variant_id=to_unset(correction.new_variant_id),
+            planned_quantity_per_unit=to_unset(correction.planned_quantity_per_unit),
+        )
+        specs.append(
+            ActionSpec(
+                operation=MOOperation.UPDATE_RECIPE_ROW,
+                target_id=row.id,
+                diff=diff,
+                apply=_make_tolerant_patch_apply(
+                    api_update_mo_recipe_row, services, row.id, body
+                ),
+                verify=None,
+            )
+        )
+    return specs
+
+
+def _build_recreate_production_action(
+    mo_id: int,
+    snapshot: MOProductionSnapshot,
+    services: Any,
+) -> ActionSpec:
+    """POST a new production matching the snapshot, then immediately PATCH
+    its ``production_date`` to backdate it.
+
+    Two API calls fused into one ``ActionSpec``: the POST stamps the
+    production with server-time (Katana ignores ``completed_date`` on the
+    create body for the close-state-restore path), the follow-up PATCH
+    backdates ``production_date`` to match the snapshot. Operator-proven
+    sequence from the originating Shopify SP73000→SP73001 correction.
+    Fusion lets the apply phase stay flat — no inter-action data flow
+    needed for the captured-then-patched ID.
+    """
+    create_body = APICreateMOProductionRequest(
+        manufacturing_order_id=mo_id,
+        completed_quantity=snapshot.completed_quantity,
+        serial_numbers=to_unset(
+            list(snapshot.serial_numbers) if snapshot.serial_numbers else None
+        ),
+    )
+
+    async def apply() -> ManufacturingOrderProduction:
+        create_resp = await api_create_mo_production.asyncio_detailed(
+            client=services.client, body=create_body
+        )
+        new_prod = cast(
+            ManufacturingOrderProduction,
+            unwrap_as(create_resp, ManufacturingOrderProduction),
+        )
+        if snapshot.production_date is not None:
+            patch_body = APIUpdateMOProductionRequest(
+                production_date=snapshot.production_date
+            )
+            patch_resp = await api_update_mo_production.asyncio_detailed(
+                id=new_prod.id, client=services.client, body=patch_body
+            )
+            if not is_success(patch_resp):
+                unwrap(patch_resp)
+        return new_prod
+
+    diff: list[FieldChange] = [
+        FieldChange(
+            field="completed_quantity",
+            new=snapshot.completed_quantity,
+            is_added=True,
+        )
+    ]
+    if snapshot.serial_numbers:
+        diff.append(
+            FieldChange(
+                field="serial_numbers",
+                new=list(snapshot.serial_numbers),
+                is_added=True,
+            )
+        )
+    if snapshot.production_date is not None:
+        diff.append(
+            FieldChange(
+                field="production_date",
+                new=snapshot.production_date.isoformat(),
+                is_added=True,
+            )
+        )
+    return ActionSpec(
+        operation=MOOperation.ADD_PRODUCTION,
+        target_id=None,
+        diff=diff,
+        apply=apply,
+        verify=None,
+    )
+
+
+def _build_close_mo_actions(
+    mo_id: int, snapshot: MOCloseState, services: Any
+) -> list[ActionSpec]:
+    """Restore the MO close-state: status first, then ``done_date``.
+
+    Two PATCHes — Katana validates ``done_date`` against the *current*
+    status, so the date assignment can only land after the status patch
+    completes. Restores to the snapshot's original status (DONE or
+    PARTIALLY_COMPLETED), not a hardcoded value, so a PARTIALLY_COMPLETED
+    MO isn't silently promoted to DONE on re-close. ``done_date`` is only
+    patched when the snapshot was DONE *and* carried a date — for the
+    PARTIALLY_COMPLETED path the displayed close timestamp is derived from
+    the latest production_date, which the recreate phase already restored.
+    """
+    target_status = snapshot.status or MO_RESTORE_STATUS
+    status_body = APIUpdateManufacturingOrderRequest(
+        status=ManufacturingOrderStatus(target_status)
+    )
+    actions: list[ActionSpec] = [
+        ActionSpec(
+            operation=MOOperation.UPDATE_HEADER,
+            target_id=mo_id,
+            diff=[FieldChange(field="status", new=target_status)],
+            apply=_make_tolerant_patch_apply(
+                api_update_manufacturing_order, services, mo_id, status_body
+            ),
+            verify=None,
+        )
+    ]
+    if (
+        snapshot.status == ManufacturingOrderStatus.DONE.value
+        and snapshot.done_date is not None
+    ):
+        date_body = APIUpdateManufacturingOrderRequest(done_date=snapshot.done_date)
+        actions.append(
+            ActionSpec(
+                operation=MOOperation.UPDATE_HEADER,
+                target_id=mo_id,
+                diff=[
+                    FieldChange(
+                        field="done_date",
+                        new=snapshot.done_date.isoformat(),
+                        is_added=True,
+                    )
+                ],
+                apply=_make_tolerant_patch_apply(
+                    api_update_manufacturing_order, services, mo_id, date_body
+                ),
+                verify=None,
+            )
+        )
+    return actions
+
+
+async def _correct_manufacturing_order_impl(
+    request: CorrectManufacturingOrderRequest, context: Context
+) -> ModificationResponse:
+    services = get_services(context)
+    katana_url = katana_web_url("manufacturing_order", request.id)
+
+    # The three fetches are independent — gather to halve wall-clock latency.
+    # Validation runs after; on a missing MO the children fetches were cheap.
+    existing_mo, recipe_rows, productions = await asyncio.gather(
+        _fetch_manufacturing_order_attrs(services, request.id),
+        _fetch_mo_recipe_rows_raw(services, request.id),
+        _fetch_mo_productions_raw(services, request.id),
+    )
+    if existing_mo is None:
+        raise ValueError(
+            f"Could not fetch manufacturing order {request.id}; "
+            "verify it exists before applying corrections."
+        )
+    status_enum = unwrap_unset(existing_mo.status, None)
+    status = status_enum.value if status_enum is not None else ""
+    if status not in MO_CLOSED_STATUSES:
+        raise ValueError(
+            f"correct_manufacturing_order requires the MO to be in DONE or "
+            f"PARTIALLY_COMPLETED status; MO {request.id} is in status "
+            f"'{status}'. Use modify_manufacturing_order directly for an "
+            "open MO — there's no close-state to preserve."
+        )
+
+    snapshot = snapshot_mo_close_state(existing_mo, productions)
+
+    # Phases for the apply path (preview flattens them into one action list).
+    # Each phase depends on the previous landing successfully — Katana isn't
+    # transactional across endpoints, so the helper fail-fasts at boundaries.
+    revert_phase = [_build_revert_mo_action(request.id, services)]
+    edit_phase = _build_recipe_edit_actions(
+        request.id, recipe_rows, request.ingredient_changes, services
+    )
+    recreate_phase = [
+        _build_recreate_production_action(request.id, ps, services)
+        for ps in snapshot.productions
+    ]
+    close_phase = _build_close_mo_actions(request.id, snapshot, services)
+    phases = [revert_phase, edit_phase, recreate_phase, close_phase]
+
+    if request.preview:
+        full_plan = [action for phase in phases for action in phase]
+        return ModificationResponse(
+            entity_type="manufacturing_order",
+            entity_id=request.id,
+            is_preview=True,
+            actions=plan_to_preview_results(full_plan),
+            warnings=_close_state_warnings_mo(snapshot),
+            next_actions=[
+                f"Review {len(full_plan)} planned action(s) for MO {request.id}",
+                f"Captured close-state: status={snapshot.status}, "
+                f"done_date={snapshot.done_date}, "
+                f"productions={len(snapshot.productions)}",
+                "Set preview=false to execute the plan",
+            ],
+            katana_url=katana_url,
+            message=(
+                f"Preview: reopen → edit → restore for "
+                f"manufacturing order {request.id} "
+                f"({len(full_plan)} action(s))"
+            ),
+        )
+
+    prior_state = _augment_prior_state_with_snapshot(
+        serialize_for_prior_state(existing_mo), snapshot
+    )
+    aggregated, failed = await _run_phases_until_failure(phases)
+    if failed:
+        return _build_failure_response(
+            request.id, aggregated, prior_state, katana_url, snapshot
+        )
+    return _build_success_response(
+        request.id, aggregated, prior_state, katana_url, snapshot
+    )
+
+
+def _close_state_warnings_mo(snapshot: MOCloseState) -> list[str]:
+    if not snapshot.productions:
+        return [
+            "No productions captured on this MO — the restore step will only "
+            "set status: DONE without re-recording any output. Verify this "
+            "matches reality before applying."
+        ]
+    missing_dates = sum(1 for p in snapshot.productions if p.production_date is None)
+    if missing_dates:
+        return [
+            f"{missing_dates} production(s) have no production_date in the "
+            "snapshot; their re-creations will land at server-time. "
+            "Other productions will be backdated to their original timestamps."
+        ]
+    return []
+
+
+def _build_success_response(
+    mo_id: int,
+    actions: list[ActionResult],
+    prior_state: dict[str, Any] | None,
+    katana_url: str | None,
+    snapshot: MOCloseState,
+) -> ModificationResponse:
+    return ModificationResponse(
+        entity_type="manufacturing_order",
+        entity_id=mo_id,
+        is_preview=False,
+        actions=actions,
+        prior_state=prior_state,
+        warnings=_close_state_warnings_mo(snapshot),
+        next_actions=[
+            f"Manufacturing order {mo_id} corrected — "
+            f"{sum(1 for a in actions if a.succeeded)} action(s) applied",
+            f"Close-state restored: status={snapshot.status}, "
+            f"done_date={snapshot.done_date}, "
+            f"productions={len(snapshot.productions)}",
+        ],
+        katana_url=katana_url,
+        message=(
+            f"Successfully corrected manufacturing order {mo_id} "
+            f"({sum(1 for a in actions if a.succeeded)}/{len(actions)} "
+            "actions applied)"
+        ),
+    )
+
+
+def _build_failure_response(
+    entity_id: int,
+    actions: list[ActionResult],
+    prior_state: dict[str, Any] | None,
+    katana_url: str | None,
+    snapshot: MOCloseState | SOCloseState,
+) -> ModificationResponse:
+    succeeded = sum(1 for a in actions if a.succeeded is True)
+    failed = sum(1 for a in actions if a.succeeded is False)
+    return ModificationResponse(
+        entity_type=(
+            "manufacturing_order"
+            if isinstance(snapshot, MOCloseState)
+            else "sales_order"
+        ),
+        entity_id=entity_id,
+        is_preview=False,
+        actions=actions,
+        prior_state=prior_state,
+        warnings=[
+            "Correction halted mid-flow; the record is left in an "
+            "intermediate (open) state. The captured close-state is in "
+            "``prior_state`` — manually replay the remaining steps via "
+            "modify_<entity> if you want to recover.",
+        ],
+        next_actions=[
+            f"{succeeded} action(s) succeeded; {failed} failed",
+            "Review the FAILED action's error",
+            "Use prior_state + the captured close-state snapshot to "
+            "reconstruct the missing steps",
+        ],
+        katana_url=katana_url,
+        message=(
+            f"Partial: {succeeded}/{len(actions)} action(s) applied to "
+            f"entity {entity_id} before fail-fast halt"
+        ),
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def correct_manufacturing_order(
+    request: Annotated[CorrectManufacturingOrderRequest, Unpack()],
+    context: Context,
+) -> ToolResult:
+    """Edit a closed MO without losing its original close-state.
+
+    Reopens the MO, swaps ingredient(s) keyed by current variant, then
+    re-closes preserving the original status, ``done_date``, and per-
+    production ``production_date`` and serial numbers. Use this instead of
+    ``modify_manufacturing_order`` when the MO is already DONE or
+    PARTIALLY_COMPLETED and you need to fix what was actually consumed.
+
+    Sequence:
+
+    1. Capture close-state (status + done_date + per-production
+       quantity/date/serial_numbers).
+    2. PATCH status: IN_PROGRESS (Katana auto-reverses productions).
+    3. PATCH each recipe row per ``ingredient_changes``.
+    4. POST one production per snapshot, replaying quantity + serial_numbers.
+    5. PATCH each new production's ``production_date`` to the snapshot value.
+    6. PATCH status: DONE.
+
+    Each ``ingredient_changes`` entry is keyed by ``old_variant_id``
+    (looked up in the existing recipe rows). Errors if the variant isn't
+    present, or appears more than once on this MO — use
+    ``modify_manufacturing_order`` with the explicit row ID to disambiguate.
+
+    Two-step flow: ``preview=true`` (default) returns the full action plan
+    (revert + edits + recreate + close); ``preview=false`` runs the plan
+    in phases and aggregates results. Fail-fast halt at any phase boundary
+    leaves the MO in an intermediate state with a breadcrumb in
+    ``prior_state``.
+    """
+    response = await _correct_manufacturing_order_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
+# Sales-order corrections
+# ============================================================================
+
+
+class SOLineCorrection(BaseModel):
+    """One SO line edit, identified by the variant currently on the row.
+
+    Tool resolves ``old_variant_id`` to the row ID by inspecting the
+    existing SO. Errors if the variant isn't present or appears more
+    than once.
+
+    Note: ``correct_sales_order`` only updates existing rows in place; it
+    does not delete or add rows. This keeps the row IDs stable so the
+    re-created fulfillments can reference them by the original
+    ``sales_order_row_id``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    old_variant_id: int = Field(
+        ..., description="Variant currently on the row to be edited."
+    )
+    new_variant_id: int | None = Field(
+        default=None,
+        description="New variant for the row. None = keep the existing variant.",
+    )
+    quantity: float | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "New quantity. None = keep the existing quantity. Must be >= "
+            "the original fulfillment quantity for this row, or Katana will "
+            "reject the re-fulfillment step."
+        ),
+    )
+    price_per_unit: float | None = Field(
+        default=None,
+        description="New unit price. None = keep the existing price.",
+    )
+
+
+class CorrectSalesOrderRequest(ConfirmableRequest):
+    """Reopen a closed SO, edit line items, restore the original close-state.
+
+    Entry condition: the SO must be in ``DELIVERED`` status. For SOs that
+    haven't shipped yet, use ``modify_sales_order`` directly.
+    """
+
+    id: int = Field(..., description="Sales order ID")
+    line_changes: list[SOLineCorrection] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Line-item edits keyed by current variant. At least one entry "
+            "is required; each must change at least one of new_variant_id, "
+            "quantity, or price_per_unit."
+        ),
+    )
+
+
+def _resolve_so_row(
+    so_id: int, rows: list[SalesOrderRow], correction: SOLineCorrection
+) -> SalesOrderRow:
+    matches = [
+        r for r in rows if unwrap_unset(r.variant_id, None) == correction.old_variant_id
+    ]
+    if not matches:
+        raise ValueError(
+            f"No row on SO {so_id} has variant_id {correction.old_variant_id}."
+        )
+    if len(matches) > 1:
+        row_ids = [m.id for m in matches]
+        raise ValueError(
+            f"Variant {correction.old_variant_id} appears in multiple rows "
+            f"on SO {so_id} (rows {row_ids}); correct_sales_order can't "
+            "disambiguate. Use modify_sales_order with the explicit row ID."
+        )
+    return matches[0]
+
+
+def _check_quantity_covers_fulfillments(
+    so_id: int,
+    snapshot: SOCloseState,
+    rows: list[SalesOrderRow],
+    corrections: list[SOLineCorrection],
+) -> None:
+    """Preflight: refuse if any line drops below the row's already-fulfilled qty.
+
+    The re-fulfillment phase replays the original fulfillment quantities; if
+    a row's new quantity is less than what was previously fulfilled, Katana
+    rejects the POST and we'd halt mid-flow with the SO already reverted +
+    fulfillments already deleted. Catching it here keeps the failure clean —
+    no mutations applied yet.
+    """
+    fulfilled_per_row: dict[int, float] = {}
+    for ful in snapshot.fulfillments:
+        for r in ful.rows:
+            fulfilled_per_row[r.sales_order_row_id] = (
+                fulfilled_per_row.get(r.sales_order_row_id, 0.0) + r.quantity
+            )
+
+    for correction in corrections:
+        if correction.quantity is None:
+            continue
+        try:
+            row = _resolve_so_row(so_id, rows, correction)
+        except ValueError:
+            # Resolution errors surface during plan-build; skip here so the
+            # original error message wins.
+            continue
+        already_fulfilled = fulfilled_per_row.get(row.id, 0.0)
+        if correction.quantity < already_fulfilled:
+            raise ValueError(
+                f"line_changes for variant {correction.old_variant_id} on SO "
+                f"{so_id} drops quantity to {correction.quantity}, but "
+                f"{already_fulfilled} was already fulfilled on this row. "
+                "Refusing — the re-fulfillment phase would fail and leave "
+                "the SO in an intermediate (open) state."
+            )
+
+
+async def _fetch_so_fulfillments(
+    services: Any, so_id: int
+) -> list[SalesOrderFulfillment]:
+    """Fetch all fulfillments for an SO."""
+    from katana_public_api_client.utils import unwrap_data
+
+    response = await api_get_all_so_fulfillments.asyncio_detailed(
+        client=services.client,
+        sales_order_id=so_id,
+        limit=250,
+    )
+    return cast(list[SalesOrderFulfillment], unwrap_data(response, default=[]))
+
+
+def _build_delete_fulfillment_action(fulfillment_id: int, services: Any) -> ActionSpec:
+    async def apply() -> None:
+        response = await api_delete_so_fulfillment.asyncio_detailed(
+            id=fulfillment_id, client=services.client
+        )
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    return ActionSpec(
+        operation=SOOperation.DELETE_FULFILLMENT,
+        target_id=fulfillment_id,
+        diff=[],
+        apply=apply,
+        verify=None,
+    )
+
+
+def _build_revert_so_action(so_id: int, services: Any) -> ActionSpec:
+    body = APIUpdateSalesOrderRequest(status=UpdateSalesOrderStatus(SO_REOPEN_STATUS))
+    return ActionSpec(
+        operation=SOOperation.UPDATE_HEADER,
+        target_id=so_id,
+        diff=[FieldChange(field="status", old=SO_RESTORE_STATUS, new=SO_REOPEN_STATUS)],
+        apply=_make_tolerant_patch_apply(api_update_sales_order, services, so_id, body),
+        verify=None,
+    )
+
+
+def _build_so_row_edit_actions(
+    so_id: int,
+    rows: list[SalesOrderRow],
+    corrections: list[SOLineCorrection],
+    services: Any,
+) -> list[ActionSpec]:
+    specs: list[ActionSpec] = []
+    for correction in corrections:
+        if (
+            correction.new_variant_id is None
+            and correction.quantity is None
+            and correction.price_per_unit is None
+        ):
+            raise ValueError(
+                f"line_changes entry for variant {correction.old_variant_id}: "
+                "must supply at least one of new_variant_id, quantity, or "
+                "price_per_unit."
+            )
+        row = _resolve_so_row(so_id, rows, correction)
+
+        diff: list[FieldChange] = []
+        if correction.new_variant_id is not None:
+            diff.append(
+                FieldChange(
+                    field="variant_id",
+                    old=correction.old_variant_id,
+                    new=correction.new_variant_id,
+                )
+            )
+        if correction.quantity is not None:
+            diff.append(
+                FieldChange(
+                    field="quantity",
+                    old=unwrap_unset(row.quantity, None),
+                    new=correction.quantity,
+                )
+            )
+        if correction.price_per_unit is not None:
+            diff.append(
+                FieldChange(
+                    field="price_per_unit",
+                    old=unwrap_unset(row.price_per_unit, None),
+                    new=correction.price_per_unit,
+                )
+            )
+
+        body = APIUpdateSORowRequest(
+            variant_id=to_unset(correction.new_variant_id),
+            quantity=to_unset(correction.quantity),
+            price_per_unit=to_unset(correction.price_per_unit),
+        )
+        specs.append(
+            ActionSpec(
+                operation=SOOperation.UPDATE_ROW,
+                target_id=row.id,
+                diff=diff,
+                apply=_make_tolerant_patch_apply(
+                    api_update_so_row, services, row.id, body
+                ),
+                verify=None,
+            )
+        )
+    return specs
+
+
+def _build_recreate_fulfillment_action(
+    so_id: int,
+    snapshot: SOFulfillmentSnapshot,
+    services: Any,
+) -> ActionSpec:
+    rows = [
+        SalesOrderFulfillmentRowRequest(
+            sales_order_row_id=row.sales_order_row_id, quantity=row.quantity
+        )
+        for row in snapshot.rows
+    ]
+    body = APICreateSOFulfillmentRequest(
+        sales_order_id=so_id,
+        sales_order_fulfillment_rows=rows,
+        status=SalesOrderFulfillmentStatus(snapshot.status or SO_RESTORE_STATUS),
+        picked_date=to_unset(snapshot.picked_date),
+        conversion_rate=to_unset(snapshot.conversion_rate),
+        conversion_date=to_unset(snapshot.conversion_date),
+        tracking_number=to_unset(snapshot.tracking_number),
+        tracking_url=to_unset(snapshot.tracking_url),
+        tracking_carrier=to_unset(snapshot.tracking_carrier),
+        tracking_method=to_unset(snapshot.tracking_method),
+    )
+
+    async def apply() -> SalesOrderFulfillment:
+        response = await api_create_so_fulfillment.asyncio_detailed(
+            client=services.client, body=body
+        )
+        return cast(SalesOrderFulfillment, unwrap_as(response, SalesOrderFulfillment))
+
+    diff: list[FieldChange] = [
+        FieldChange(field="status", new=snapshot.status, is_added=True),
+        FieldChange(
+            field="rows",
+            new=[
+                {"sales_order_row_id": r.sales_order_row_id, "quantity": r.quantity}
+                for r in snapshot.rows
+            ],
+            is_added=True,
+        ),
+    ]
+    if snapshot.picked_date is not None:
+        diff.append(
+            FieldChange(
+                field="picked_date",
+                new=snapshot.picked_date.isoformat(),
+                is_added=True,
+            )
+        )
+    return ActionSpec(
+        operation=SOOperation.ADD_FULFILLMENT,
+        target_id=None,
+        diff=diff,
+        apply=apply,
+        verify=None,
+    )
+
+
+def _build_close_so_action(so_id: int, services: Any) -> ActionSpec:
+    body = APIUpdateSalesOrderRequest(status=UpdateSalesOrderStatus(SO_RESTORE_STATUS))
+    return ActionSpec(
+        operation=SOOperation.UPDATE_HEADER,
+        target_id=so_id,
+        diff=[FieldChange(field="status", new=SO_RESTORE_STATUS)],
+        apply=_make_tolerant_patch_apply(api_update_sales_order, services, so_id, body),
+        verify=None,
+    )
+
+
+async def _correct_sales_order_impl(
+    request: CorrectSalesOrderRequest, context: Context
+) -> ModificationResponse:
+    services = get_services(context)
+    katana_url = katana_web_url("sales_order", request.id)
+
+    existing_so, fulfillments = await asyncio.gather(
+        _fetch_sales_order_attrs(services, request.id),
+        _fetch_so_fulfillments(services, request.id),
+    )
+    if existing_so is None:
+        raise ValueError(f"Could not fetch sales order {request.id}; verify it exists.")
+    status_enum = unwrap_unset(existing_so.status, None)
+    status = status_enum.value if status_enum is not None else ""
+    if status not in SO_CLOSED_STATUSES:
+        raise ValueError(
+            f"correct_sales_order requires the SO to be in DELIVERED status; "
+            f"SO {request.id} is in status '{status}'. Use modify_sales_order "
+            "directly for an open SO — there's no close-state to preserve."
+        )
+
+    rows = [
+        r
+        for r in (unwrap_unset(existing_so.sales_order_rows, []) or [])
+        if r is not None
+    ]
+    snapshot = snapshot_so_close_state(existing_so, fulfillments)
+    _check_quantity_covers_fulfillments(
+        request.id, snapshot, rows, request.line_changes
+    )
+
+    delete_phase = [
+        _build_delete_fulfillment_action(fid, services)
+        for fid in snapshot.fulfillment_ids
+    ]
+    revert_phase = [_build_revert_so_action(request.id, services)]
+    edit_phase = _build_so_row_edit_actions(
+        request.id, rows, request.line_changes, services
+    )
+    recreate_phase = [
+        _build_recreate_fulfillment_action(request.id, fs, services)
+        for fs in snapshot.fulfillments
+    ]
+    close_phase = [_build_close_so_action(request.id, services)]
+    phases = [delete_phase, revert_phase, edit_phase, recreate_phase, close_phase]
+
+    if request.preview:
+        full_plan = [action for phase in phases for action in phase]
+        return ModificationResponse(
+            entity_type="sales_order",
+            entity_id=request.id,
+            is_preview=True,
+            actions=plan_to_preview_results(full_plan),
+            warnings=_close_state_warnings_so(snapshot),
+            next_actions=[
+                f"Review {len(full_plan)} planned action(s) for SO {request.id}",
+                f"Captured close-state: status={snapshot.status}, "
+                f"picked_date={snapshot.picked_date}, "
+                f"fulfillments={len(snapshot.fulfillments)}",
+                "Set preview=false to execute the plan",
+            ],
+            katana_url=katana_url,
+            message=(
+                f"Preview: reopen → edit → restore for sales order "
+                f"{request.id} ({len(full_plan)} action(s))"
+            ),
+        )
+
+    prior_state = _augment_prior_state_with_snapshot(
+        serialize_for_prior_state(existing_so), snapshot
+    )
+    aggregated, failed = await _run_phases_until_failure(phases)
+    if failed:
+        return _build_failure_response(
+            request.id, aggregated, prior_state, katana_url, snapshot
+        )
+
+    return ModificationResponse(
+        entity_type="sales_order",
+        entity_id=request.id,
+        is_preview=False,
+        actions=aggregated,
+        prior_state=prior_state,
+        warnings=_close_state_warnings_so(snapshot),
+        next_actions=[
+            f"Sales order {request.id} corrected — "
+            f"{sum(1 for a in aggregated if a.succeeded)} action(s) applied",
+            f"Close-state restored: status={snapshot.status}, "
+            f"picked_date={snapshot.picked_date}, "
+            f"fulfillments={len(snapshot.fulfillments)}",
+        ],
+        katana_url=katana_url,
+        message=(
+            f"Successfully corrected sales order {request.id} "
+            f"({sum(1 for a in aggregated if a.succeeded)}/"
+            f"{len(aggregated)} actions applied)"
+        ),
+    )
+
+
+def _close_state_warnings_so(snapshot: SOCloseState) -> list[str]:
+    if not snapshot.fulfillments:
+        return [
+            "No fulfillments captured on this SO — the restore step will only "
+            "set status: DELIVERED without re-creating any fulfillment. "
+            "Verify this matches reality before applying."
+        ]
+    return []
+
+
+@observe_tool
+@unpack_pydantic_params
+async def correct_sales_order(
+    request: Annotated[CorrectSalesOrderRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Edit a closed (DELIVERED) SO without losing its picked_date and
+    fulfillment metadata.
+
+    Reopens the SO, edits line items keyed by current variant, then
+    re-closes preserving the original status, ``picked_date``, and per-
+    fulfillment metadata (status, picked_date, tracking_*).
+
+    Sequence:
+
+    1. Capture close-state (status + picked_date + per-fulfillment
+       snapshots).
+    2. DELETE each fulfillment (Katana returns an empty 200 body — the
+       tolerant patch handler treats this as success).
+    3. PATCH SO status: PENDING.
+    4. PATCH each row per ``line_changes``.
+    5. POST one fulfillment per snapshot, replaying status + tracking_* +
+       row references.
+    6. PATCH SO status: DELIVERED.
+
+    Each ``line_changes`` entry is keyed by ``old_variant_id`` (looked up
+    in the existing SO rows). Errors if the variant isn't present or
+    appears more than once on this SO — use ``modify_sales_order`` with
+    the explicit row ID to disambiguate.
+
+    The tool only updates rows in place; it does not delete or add rows.
+    Row IDs must stay stable so the re-created fulfillments can reference
+    them by the original ``sales_order_row_id``. If you need to add or
+    remove a line, use ``modify_sales_order``.
+
+    Two-step flow: ``preview=true`` (default) returns the full action plan;
+    ``preview=false`` runs the plan in phases. Fail-fast halt leaves the
+    SO in an intermediate state with a breadcrumb in ``prior_state``.
+    """
+    response = await _correct_sales_order_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
+# Registration
+# ============================================================================
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register correction tools with the FastMCP instance."""
+    from mcp.types import ToolAnnotations
+
+    _update = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+
+    mcp.tool(
+        tags={"orders", "manufacturing", "write", "correction"},
+        annotations=_update,
+    )(correct_manufacturing_order)
+    mcp.tool(
+        tags={"orders", "sales", "write", "correction"},
+        annotations=_update,
+    )(correct_sales_order)

--- a/katana_mcp_server/tests/tools/test_corrections.py
+++ b/katana_mcp_server/tests/tools/test_corrections.py
@@ -1,0 +1,772 @@
+"""Tests for correct_manufacturing_order and correct_sales_order.
+
+Covers the reopen → modify → restore pattern: snapshot capture, ordering
+of API calls (revert before edits before recreate before close), preview
+shape, and partial-failure breadcrumb.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from katana_mcp.tools.foundation.corrections import (
+    CorrectManufacturingOrderRequest,
+    CorrectSalesOrderRequest,
+    MOIngredientCorrection,
+    SOLineCorrection,
+    _correct_manufacturing_order_impl,
+    _correct_sales_order_impl,
+)
+
+from katana_public_api_client.client_types import UNSET
+from katana_public_api_client.models import (
+    ManufacturingOrder,
+    ManufacturingOrderProduction,
+    ManufacturingOrderRecipeRow,
+    ManufacturingOrderStatus,
+    SalesOrder,
+    SalesOrderFulfillment,
+    SalesOrderFulfillmentStatus,
+    SalesOrderRow,
+    SalesOrderStatus,
+    SerialNumber,
+)
+from tests.conftest import create_mock_context
+from tests.factories import mock_entity_for_modify
+
+# ============================================================================
+# Test fixtures — fully-formed entities (not MagicMocks) so the snapshot
+# code reads real attrs fields.
+# ============================================================================
+
+
+def _make_mo(
+    *,
+    mo_id: int = 42,
+    status: str = "DONE",
+    done_date: datetime | None = None,
+) -> ManufacturingOrder:
+    """Build a real attrs ``ManufacturingOrder`` in the requested status."""
+    mo = mock_entity_for_modify(ManufacturingOrder, id=mo_id)
+    mo.status = ManufacturingOrderStatus(status)
+    mo.done_date = done_date if done_date is not None else UNSET
+    return mo
+
+
+def _make_recipe_row(
+    *, row_id: int, variant_id: int, quantity: float = 1.0
+) -> ManufacturingOrderRecipeRow:
+    row = mock_entity_for_modify(ManufacturingOrderRecipeRow, id=row_id)
+    row.variant_id = variant_id
+    row.planned_quantity_per_unit = quantity
+    return row
+
+
+def _make_production(
+    *,
+    prod_id: int,
+    quantity: float = 1.0,
+    production_date: datetime | None = None,
+    serial_numbers: list[str] | None = None,
+) -> ManufacturingOrderProduction:
+    prod = mock_entity_for_modify(ManufacturingOrderProduction, id=prod_id)
+    prod.manufacturing_order_id = 42
+    prod.quantity = quantity
+    prod.production_date = production_date if production_date is not None else UNSET
+    if serial_numbers:
+        sn_objs = []
+        for sn_str in serial_numbers:
+            sn = mock_entity_for_modify(SerialNumber, id=hash(sn_str) & 0xFFFFFF)
+            sn.serial_number = sn_str
+            sn_objs.append(sn)
+        prod.serial_numbers = sn_objs
+    else:
+        prod.serial_numbers = UNSET
+    return prod
+
+
+def _make_so(
+    *,
+    so_id: int = 99,
+    status: str = "DELIVERED",
+    picked_date: datetime | None = None,
+) -> SalesOrder:
+    so = mock_entity_for_modify(SalesOrder, id=so_id)
+    so.status = SalesOrderStatus(status)
+    so.picked_date = picked_date if picked_date is not None else UNSET
+    so.sales_order_rows = []
+    return so
+
+
+def _make_so_row(
+    *, row_id: int, variant_id: int, quantity: float = 1.0, price: float = 10.0
+) -> SalesOrderRow:
+    row = mock_entity_for_modify(SalesOrderRow, id=row_id)
+    row.variant_id = variant_id
+    row.quantity = quantity
+    row.price_per_unit = price
+    return row
+
+
+def _make_fulfillment(
+    *,
+    ful_id: int,
+    so_id: int,
+    row_id: int,
+    quantity: float = 1.0,
+    picked_date: datetime | None = None,
+    status: str = "DELIVERED",
+) -> SalesOrderFulfillment:
+    ful = mock_entity_for_modify(SalesOrderFulfillment, id=ful_id)
+    ful.sales_order_id = so_id
+    ful.status = SalesOrderFulfillmentStatus(status)
+    ful.picked_date = picked_date if picked_date is not None else UNSET
+    row = MagicMock()
+    row.sales_order_row_id = row_id
+    row.quantity = quantity
+    ful.sales_order_fulfillment_rows = [row]
+    return ful
+
+
+# ============================================================================
+# correct_manufacturing_order — entry-condition checks
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_correct_mo_rejects_open_status():
+    """An MO that's still IN_PROGRESS has no close-state to preserve."""
+    context, _ = create_mock_context()
+    mo = _make_mo(status="IN_PROGRESS")
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=mo,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_recipe_rows_raw",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_productions_raw",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        pytest.raises(ValueError, match="DONE or PARTIALLY_COMPLETED"),
+    ):
+        await _correct_manufacturing_order_impl(
+            CorrectManufacturingOrderRequest(
+                id=42,
+                ingredient_changes=[
+                    MOIngredientCorrection(old_variant_id=100, new_variant_id=200)
+                ],
+            ),
+            context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_correct_mo_rejects_missing_variant():
+    """If old_variant_id isn't on the MO, the tool errors clearly."""
+    context, _ = create_mock_context()
+    mo = _make_mo(status="DONE")
+    rows = [_make_recipe_row(row_id=1, variant_id=100)]
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=mo,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_recipe_rows_raw",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_productions_raw",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        pytest.raises(ValueError, match="No recipe row on MO 42 has variant_id"),
+    ):
+        await _correct_manufacturing_order_impl(
+            CorrectManufacturingOrderRequest(
+                id=42,
+                ingredient_changes=[
+                    MOIngredientCorrection(old_variant_id=999, new_variant_id=200)
+                ],
+            ),
+            context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_correct_mo_rejects_empty_correction():
+    """An ingredient_change with neither new_variant_id nor quantity is a
+    no-op and should error."""
+    context, _ = create_mock_context()
+    mo = _make_mo(status="DONE")
+    rows = [_make_recipe_row(row_id=1, variant_id=100)]
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=mo,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_recipe_rows_raw",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_productions_raw",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        pytest.raises(ValueError, match="must supply at least one"),
+    ):
+        await _correct_manufacturing_order_impl(
+            CorrectManufacturingOrderRequest(
+                id=42,
+                ingredient_changes=[MOIngredientCorrection(old_variant_id=100)],
+            ),
+            context,
+        )
+
+
+# ============================================================================
+# correct_manufacturing_order — preview
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_correct_mo_preview_emits_full_action_plan():
+    """Preview should plan: revert → edit → recreate productions →
+    patch each production_date → close."""
+    context, _ = create_mock_context()
+    done_date = datetime(2026, 4, 15, 18, 20, 0, tzinfo=UTC)
+    prod_date = datetime(2026, 4, 15, 18, 20, 0, tzinfo=UTC)
+
+    mo = _make_mo(status="DONE", done_date=done_date)
+    rows = [_make_recipe_row(row_id=1, variant_id=100)]
+    productions = [
+        _make_production(
+            prod_id=10,
+            quantity=1.0,
+            production_date=prod_date,
+            serial_numbers=["SN-001"],
+        )
+    ]
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=mo,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_recipe_rows_raw",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_productions_raw",
+            new_callable=AsyncMock,
+            return_value=productions,
+        ),
+    ):
+        response = await _correct_manufacturing_order_impl(
+            CorrectManufacturingOrderRequest(
+                id=42,
+                ingredient_changes=[
+                    MOIngredientCorrection(old_variant_id=100, new_variant_id=200)
+                ],
+                preview=True,
+            ),
+            context,
+        )
+
+    assert response.is_preview is True
+    assert response.entity_id == 42
+    # Expected sequence:
+    # 1. update_header (revert: status → IN_PROGRESS)
+    # 2. update_recipe_row (swap)
+    # 3. add_production (fused: POST production + PATCH production_date)
+    # 4. update_header (close: status → DONE)
+    # 5. update_header (close: done_date → snapshot value, only when DONE)
+    operations = [a.operation for a in response.actions]
+    assert operations == [
+        "update_header",
+        "update_recipe_row",
+        "add_production",
+        "update_header",
+        "update_header",
+    ]
+    # The fused add_production action's diff should include production_date
+    add_prod_action = next(
+        a for a in response.actions if a.operation == "add_production"
+    )
+    assert any(c.field == "production_date" for c in add_prod_action.changes)
+    # The final update_header should patch done_date back to the snapshot value
+    final_action = response.actions[-1]
+    assert any(c.field == "done_date" for c in final_action.changes)
+    # All preview-shape: succeeded=None
+    assert all(a.succeeded is None for a in response.actions)
+
+
+@pytest.mark.asyncio
+async def test_correct_mo_preview_skips_production_date_patch_when_none():
+    """If a production has no production_date in the snapshot, no patch
+    action is planned for it."""
+    context, _ = create_mock_context()
+    mo = _make_mo(status="DONE")
+    rows = [_make_recipe_row(row_id=1, variant_id=100)]
+    productions = [_make_production(prod_id=10, quantity=1.0, production_date=None)]
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=mo,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_recipe_rows_raw",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_productions_raw",
+            new_callable=AsyncMock,
+            return_value=productions,
+        ),
+    ):
+        response = await _correct_manufacturing_order_impl(
+            CorrectManufacturingOrderRequest(
+                id=42,
+                ingredient_changes=[
+                    MOIngredientCorrection(old_variant_id=100, new_variant_id=200)
+                ],
+                preview=True,
+            ),
+            context,
+        )
+
+    operations = [a.operation for a in response.actions]
+    # No update_production step since the snapshot has no production_date
+    assert operations == [
+        "update_header",
+        "update_recipe_row",
+        "add_production",
+        "update_header",
+    ]
+
+
+# ============================================================================
+# correct_manufacturing_order — apply
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_correct_mo_apply_executes_phases_in_canonical_order():
+    """Apply should call the API in this order:
+    1. PATCH MO header (revert to IN_PROGRESS)
+    2. PATCH recipe row (swap variant)
+    3. POST production (recreate)
+    4. PATCH production (backdate production_date)
+    5. PATCH MO header (close to DONE)"""
+    context, _ = create_mock_context()
+    prod_date = datetime(2026, 4, 15, 18, 20, 0, tzinfo=UTC)
+    mo = _make_mo(status="DONE", done_date=prod_date)
+    rows = [_make_recipe_row(row_id=1, variant_id=100)]
+    productions = [
+        _make_production(
+            prod_id=10,
+            quantity=1.0,
+            production_date=prod_date,
+            serial_numbers=["SN-001"],
+        )
+    ]
+
+    call_log: list[str] = []
+    new_prod = MagicMock()
+    new_prod.id = 999  # captured for the production_date patch
+
+    async def fake_update_mo(*, id, client, body):
+        # The close-state restore issues a status PATCH then a separate
+        # done_date PATCH; the fake distinguishes them by which field is set.
+        from katana_public_api_client.client_types import UNSET as _UNSET
+
+        if body.status is not _UNSET:
+            call_log.append(f"PATCH MO {id} status={body.status.value}")
+        else:
+            call_log.append(f"PATCH MO {id} done_date={body.done_date.isoformat()}")
+        resp = MagicMock()
+        resp.parsed = mo  # echoed body
+        return resp
+
+    async def fake_update_recipe(*, id, client, body):
+        call_log.append(f"PATCH recipe {id}")
+        resp = MagicMock()
+        resp.parsed = rows[0]
+        return resp
+
+    async def fake_create_production(*, client, body):
+        call_log.append(f"POST production qty={body.completed_quantity}")
+        resp = MagicMock()
+        resp.parsed = new_prod
+        return resp
+
+    async def fake_update_production(*, id, client, body):
+        call_log.append(f"PATCH production {id} production_date")
+        resp = MagicMock()
+        resp.parsed = MagicMock()
+        resp.status_code = 200
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=mo,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_recipe_rows_raw",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_productions_raw",
+            new_callable=AsyncMock,
+            return_value=productions,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_update_manufacturing_order.asyncio_detailed",
+            side_effect=fake_update_mo,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_update_mo_recipe_row.asyncio_detailed",
+            side_effect=fake_update_recipe,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_create_mo_production.asyncio_detailed",
+            side_effect=fake_create_production,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_update_mo_production.asyncio_detailed",
+            side_effect=fake_update_production,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections.unwrap_as",
+            return_value=new_prod,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections.is_success",
+            return_value=True,
+        ),
+    ):
+        response = await _correct_manufacturing_order_impl(
+            CorrectManufacturingOrderRequest(
+                id=42,
+                ingredient_changes=[
+                    MOIngredientCorrection(old_variant_id=100, new_variant_id=200)
+                ],
+                preview=False,
+            ),
+            context,
+        )
+
+    assert response.is_preview is False
+    assert all(a.succeeded is True for a in response.actions)
+    # Status-before-dates: revert lands first, status: DONE before done_date,
+    # done_date PATCH lands last.
+    assert call_log == [
+        "PATCH MO 42 status=IN_PROGRESS",
+        "PATCH recipe 1",
+        "POST production qty=1.0",
+        "PATCH production 999 production_date",
+        "PATCH MO 42 status=DONE",
+        f"PATCH MO 42 done_date={prod_date.isoformat()}",
+    ]
+    assert response.prior_state is not None
+    # Snapshot is in prior_state under the documented sentinel key
+    assert "_close_state_snapshot" in response.prior_state
+
+
+@pytest.mark.asyncio
+async def test_correct_mo_apply_halts_on_revert_failure():
+    """If the revert PATCH fails, no edits or recreates run; the response
+    surfaces the breadcrumb."""
+    context, _ = create_mock_context()
+    mo = _make_mo(status="DONE")
+    rows = [_make_recipe_row(row_id=1, variant_id=100)]
+    productions = [_make_production(prod_id=10, quantity=1.0)]
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("Katana refused to revert")
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=mo,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_recipe_rows_raw",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_mo_productions_raw",
+            new_callable=AsyncMock,
+            return_value=productions,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_update_manufacturing_order.asyncio_detailed",
+            side_effect=boom,
+        ),
+    ):
+        response = await _correct_manufacturing_order_impl(
+            CorrectManufacturingOrderRequest(
+                id=42,
+                ingredient_changes=[
+                    MOIngredientCorrection(old_variant_id=100, new_variant_id=200)
+                ],
+                preview=False,
+            ),
+            context,
+        )
+
+    assert response.is_preview is False
+    # Only the revert action ran, and it failed.
+    assert len(response.actions) == 1
+    assert response.actions[0].succeeded is False
+    # Breadcrumb language flagged
+    assert any("intermediate (open) state" in w for w in response.warnings)
+    assert response.prior_state is not None
+
+
+# ============================================================================
+# correct_sales_order — entry conditions + preview + apply
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_correct_so_rejects_non_delivered_status():
+    context, _ = create_mock_context()
+    so = _make_so(status="NOT_SHIPPED")
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_sales_order_attrs",
+            new_callable=AsyncMock,
+            return_value=so,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_so_fulfillments",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        pytest.raises(ValueError, match="DELIVERED status"),
+    ):
+        await _correct_sales_order_impl(
+            CorrectSalesOrderRequest(
+                id=99,
+                line_changes=[SOLineCorrection(old_variant_id=500, new_variant_id=501)],
+            ),
+            context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_correct_so_rejects_quantity_below_already_fulfilled():
+    """Preflight: refuse when a line_changes drops a row below the
+    already-fulfilled quantity. Catches the failure before any mutations
+    land — without this check, the failure would surface only after
+    fulfillments were deleted and the SO was reverted."""
+    context, _ = create_mock_context()
+    picked = datetime(2026, 4, 15, 21, 18, 0, tzinfo=UTC)
+    so = _make_so(status="DELIVERED", picked_date=picked)
+    # Row with current quantity 5; original fulfillment shipped 3.
+    so.sales_order_rows = [_make_so_row(row_id=10, variant_id=500, quantity=5.0)]
+    fulfillments = [
+        _make_fulfillment(
+            ful_id=77, so_id=99, row_id=10, quantity=3.0, picked_date=picked
+        )
+    ]
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_sales_order_attrs",
+            new_callable=AsyncMock,
+            return_value=so,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_so_fulfillments",
+            new_callable=AsyncMock,
+            return_value=fulfillments,
+        ),
+        pytest.raises(ValueError, match="already fulfilled"),
+    ):
+        # Drop quantity to 2 — below the 3 already fulfilled.
+        await _correct_sales_order_impl(
+            CorrectSalesOrderRequest(
+                id=99,
+                line_changes=[SOLineCorrection(old_variant_id=500, quantity=2.0)],
+            ),
+            context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_correct_so_preview_emits_full_action_plan():
+    """Preview should plan: delete fulfillments → revert → edit → recreate
+    fulfillments → close."""
+    context, _ = create_mock_context()
+    picked = datetime(2026, 4, 15, 21, 18, 0, tzinfo=UTC)
+    so = _make_so(status="DELIVERED", picked_date=picked)
+    so.sales_order_rows = [_make_so_row(row_id=10, variant_id=500)]
+    fulfillments = [
+        _make_fulfillment(ful_id=77, so_id=99, row_id=10, picked_date=picked)
+    ]
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_sales_order_attrs",
+            new_callable=AsyncMock,
+            return_value=so,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_so_fulfillments",
+            new_callable=AsyncMock,
+            return_value=fulfillments,
+        ),
+    ):
+        response = await _correct_sales_order_impl(
+            CorrectSalesOrderRequest(
+                id=99,
+                line_changes=[SOLineCorrection(old_variant_id=500, new_variant_id=501)],
+                preview=True,
+            ),
+            context,
+        )
+
+    assert response.is_preview is True
+    operations = [a.operation for a in response.actions]
+    assert operations == [
+        "delete_fulfillment",
+        "update_header",
+        "update_row",
+        "add_fulfillment",
+        "update_header",
+    ]
+    assert all(a.succeeded is None for a in response.actions)
+
+
+@pytest.mark.asyncio
+async def test_correct_so_apply_executes_phases_in_canonical_order():
+    context, _ = create_mock_context()
+    picked = datetime(2026, 4, 15, 21, 18, 0, tzinfo=UTC)
+    so = _make_so(status="DELIVERED", picked_date=picked)
+    so_row = _make_so_row(row_id=10, variant_id=500)
+    so.sales_order_rows = [so_row]
+    fulfillments = [
+        _make_fulfillment(ful_id=77, so_id=99, row_id=10, picked_date=picked)
+    ]
+
+    call_log: list[str] = []
+    new_fulfillment = MagicMock()
+    new_fulfillment.id = 888
+
+    async def fake_delete_ful(*, id, client):
+        call_log.append(f"DELETE fulfillment {id}")
+        resp = MagicMock()
+        resp.status_code = 204
+        return resp
+
+    async def fake_update_so(*, id, client, body):
+        call_log.append(f"PATCH SO {id} status={body.status.value}")
+        resp = MagicMock()
+        resp.parsed = so
+        return resp
+
+    async def fake_update_row(*, id, client, body):
+        call_log.append(f"PATCH SO row {id}")
+        resp = MagicMock()
+        resp.parsed = so_row
+        return resp
+
+    async def fake_create_ful(*, client, body):
+        call_log.append(f"POST fulfillment status={body.status.value}")
+        resp = MagicMock()
+        resp.parsed = new_fulfillment
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_sales_order_attrs",
+            new_callable=AsyncMock,
+            return_value=so,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_so_fulfillments",
+            new_callable=AsyncMock,
+            return_value=fulfillments,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_delete_so_fulfillment.asyncio_detailed",
+            side_effect=fake_delete_ful,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_update_sales_order.asyncio_detailed",
+            side_effect=fake_update_so,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_update_so_row.asyncio_detailed",
+            side_effect=fake_update_row,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_create_so_fulfillment.asyncio_detailed",
+            side_effect=fake_create_ful,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections.is_success",
+            return_value=True,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections.unwrap_as",
+            return_value=new_fulfillment,
+        ),
+    ):
+        response = await _correct_sales_order_impl(
+            CorrectSalesOrderRequest(
+                id=99,
+                line_changes=[SOLineCorrection(old_variant_id=500, new_variant_id=501)],
+                preview=False,
+            ),
+            context,
+        )
+
+    assert response.is_preview is False
+    assert all(a.succeeded is True for a in response.actions)
+    assert call_log == [
+        "DELETE fulfillment 77",
+        "PATCH SO 99 status=PENDING",
+        "PATCH SO row 10",
+        "POST fulfillment status=DELIVERED",
+        "PATCH SO 99 status=DELIVERED",
+    ]
+    assert response.prior_state is not None


### PR DESCRIPTION
## Summary

Two composite MCP tools that let an operator edit a record already in a terminal status (DONE for an MO, DELIVERED for an SO) without losing the original close-state metadata. Encodes the proven *reopen → modify → restore* sequence once — what previously took ~10 sequential `modify_*` calls (plus several rounds of trial-and-error rediscovering Katana's ordering quirks) is now one tool call.

Phase 1 of #523. Phase 2 sub-issues filed: #532 (PO), #533 (stock transfer), #534 (skill orchestration).

## What ships

- `_reopen.py` — close-state snapshot dataclasses + capture functions for MO and SO. Pure data; no API calls.
- `foundation/corrections.py` — `correct_manufacturing_order` and `correct_sales_order` MCP tools.
- `resources/help.py` — index entries + a new "Closed-Record Corrections" section explaining when to use these vs `modify_<entity>`.
- `tests/tools/test_corrections.py` — 10 tests covering entry conditions, preview shape, apply ordering, and partial-failure breadcrumbs.

## Mechanical quirks the tools encode

- `done_date` can only be set once an MO is `DONE`; combined `status: DONE + done_date` PATCH calls fail (validation runs *before* the status change applies).
- Reverting a DONE MO auto-reverses its productions, so the original per-production `quantity` / `production_date` / serial numbers must be re-played on the way back.
- Re-fulfilling a DELIVERED SO requires deleting fulfillments first (the delete returns an empty 200 body — `unwrap()` correctly raises; tools use `is_success` instead).

## Tool surface

\`\`\`
correct_manufacturing_order(id, ingredient_changes=[{old_variant_id, new_variant_id?, planned_quantity_per_unit?}], preview=True)
correct_sales_order(id, line_changes=[{old_variant_id, new_variant_id?, quantity?, price_per_unit?}], preview=True)
\`\`\`

Edits are keyed by *current variant* on the row (the level the operator thinks at: \"swap SP73000 for SP73001\"); the tools resolve to row IDs and error on ambiguity. Both follow the standard preview/apply pattern and surface a captured close-state in \`prior_state\` on partial failure for manual recovery.

## Implementation notes

- Both impls fetch the entity + children concurrently via \`asyncio.gather\`.
- Phases run via a fail-fast \`_run_phases_until_failure\` helper that wraps \`execute_plan\` and surfaces the first failure with the captured close-state.
- The MO \"recreate production\" action fuses POST + production_date PATCH into one \`ActionSpec\` so the phase pipeline stays flat (no inter-phase data flow for captured IDs).
- A \`_make_tolerant_patch_apply\` closure handles Katana's empty-200-body status round-trips that \`unwrap_as\` correctly rejects.

## Out of scope (Phase 2 — separate issues)

- \`correct_purchase_order\` (#532) — needs upstream unreceive endpoint.
- \`correct_stock_transfer\` (#533) — assess operator value of a row-immutable round-trip.
- \`/correct-shipped-build\` skill (#534) — orchestrates the composite tools with operator-judgment steps (Shopify verification, powerpack split). Blocked on the skills-shipping plan in #525.

## Test plan

- [x] \`uv run poe check\` — 2766 tests + format + lint + type checks all green.
- [x] 10 new tests in \`test_corrections.py\` cover both tools' preview path, apply ordering (revert before edits before recreate before close), entry-condition rejection, and partial-failure breadcrumbs.
- [ ] Live smoke: re-run the originating Shopify SP73000→SP73001 correction on a non-production MO/SO via the MCP server. Confirm one \`correct_manufacturing_order\` + one \`correct_sales_order\` call replaces the ~10 modify calls from the originating session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)