### PR TITLE
feat(mcp): redesign variant_details card with parent-derived context (#538)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -1236,6 +1236,12 @@ class VariantDetailsResponse(BaseModel):
     """Full variant details. Exhaustive — every field Katana exposes on the
     ``Variant`` attrs model is surfaced, including nested configuration
     attributes and custom fields, so callers don't need follow-up lookups.
+
+    A handful of fields (``uom``, ``default_supplier_*``, ``is_batch_tracked``)
+    live on the parent product/material rather than on the variant attrs
+    model. The impl resolves the parent from the cache and lifts these
+    fields onto the variant response so a single ``get_variant_details``
+    call surfaces every fact a caller typically needs to act on.
     """
 
     # Core fields
@@ -1252,6 +1258,13 @@ class VariantDetailsResponse(BaseModel):
     product_id: int | None = None
     material_id: int | None = None
     product_or_material_name: str | None = None
+
+    # Parent-item context (lifted from the parent product/material —
+    # variants don't carry these on the attrs model directly)
+    uom: str | None = None
+    default_supplier_id: int | None = None
+    default_supplier_name: str | None = None
+    is_batch_tracked: bool | None = None
 
     # Deep-link to the parent product or material — variants don't have
     # their own page in Katana's web app, so callers click through to the
@@ -1302,11 +1315,19 @@ def _iso_or_none(value: Any) -> str | None:
     return str(value)
 
 
-def _dict_to_variant_details(v: dict[str, Any]) -> VariantDetailsResponse:
+def _dict_to_variant_details(
+    v: dict[str, Any],
+    *,
+    parent: dict[str, Any] | None = None,
+    supplier: dict[str, Any] | None = None,
+) -> VariantDetailsResponse:
     """Build a VariantDetailsResponse from a cache/API variant dict.
 
-    Surfaces every field the generated ``Variant`` attrs model exposes, so
-    callers get the full shape in a single call.
+    Surfaces every field the generated ``Variant`` attrs model exposes
+    plus the parent-derived context (``uom``, ``default_supplier_*``,
+    ``is_batch_tracked``) when ``parent`` and/or ``supplier`` dicts are
+    supplied. Both are optional; missing parents/suppliers (cold cache,
+    miss) gracefully degrade to ``None`` for those fields.
     """
     product_id = v.get("product_id")
     material_id = v.get("material_id")
@@ -1317,6 +1338,7 @@ def _dict_to_variant_details(v: dict[str, Any]) -> VariantDetailsResponse:
     parent_url = katana_web_url("product", product_id) or katana_web_url(
         "material", material_id
     )
+    parent_dict = parent or {}
     return VariantDetailsResponse(
         id=v["id"],
         sku=v.get("sku") or "",
@@ -1327,6 +1349,10 @@ def _dict_to_variant_details(v: dict[str, Any]) -> VariantDetailsResponse:
         product_id=product_id,
         material_id=material_id,
         product_or_material_name=v.get("parent_name"),
+        uom=parent_dict.get("uom"),
+        default_supplier_id=parent_dict.get("default_supplier_id"),
+        default_supplier_name=(supplier or {}).get("name"),
+        is_batch_tracked=parent_dict.get("batch_tracked"),
         katana_url=parent_url,
         internal_barcode=v.get("internal_barcode"),
         registered_barcode=v.get("registered_barcode"),
@@ -1339,6 +1365,47 @@ def _dict_to_variant_details(v: dict[str, Any]) -> VariantDetailsResponse:
         updated_at=_iso_or_none(v.get("updated_at")),
         deleted_at=_iso_or_none(v.get("deleted_at")),
     )
+
+
+async def _enrich_variants_with_parent(
+    services: Any, variants: list[dict[str, Any]]
+) -> tuple[
+    dict[int, dict[str, Any]],
+    dict[int, dict[str, Any]],
+    dict[int, dict[str, Any]],
+]:
+    """Bulk-fetch parent products/materials and default suppliers for a
+    set of variants. Returns ``(products_by_id, materials_by_id,
+    supplier_by_id)`` — separate maps per entity type so callers can
+    select the correct parent based on whether the variant carries
+    ``product_id`` or ``material_id``.
+
+    Product and material IDs are NOT guaranteed disjoint (the cache
+    keys rows by ``(entity_type, id)``), so merging into a single map
+    keyed only by numeric ID would mis-associate parents on collision.
+
+    Splits parent IDs by entity type and uses ``get_many_by_ids`` per
+    type so we make at most three cache queries total
+    (parents-product, parents-material, suppliers) regardless of how
+    many variants are in the input.
+    """
+    product_ids = {v.get("product_id") for v in variants if v.get("product_id")}
+    material_ids = {v.get("material_id") for v in variants if v.get("material_id")}
+    products, materials = await asyncio.gather(
+        services.cache.get_many_by_ids(EntityType.PRODUCT, product_ids),
+        services.cache.get_many_by_ids(EntityType.MATERIAL, material_ids),
+    )
+    # Pull supplier IDs from both parent dicts, then bulk-resolve
+    # supplier names — usually a small unique set even for big variant lists.
+    supplier_ids = {
+        p.get("default_supplier_id")
+        for p in (*products.values(), *materials.values())
+        if p.get("default_supplier_id")
+    }
+    supplier_by_id = await services.cache.get_many_by_ids(
+        EntityType.SUPPLIER, supplier_ids
+    )
+    return products, materials, supplier_by_id
 
 
 async def _fetch_variant_by_id(services: Any, variant_id: int) -> dict[str, Any] | None:
@@ -1404,15 +1471,35 @@ async def _get_variant_details_impl(
         asyncio.gather(*(_fetch_variant_by_id(services, v) for v in variant_ids)),
     )
 
-    results: list[VariantDetailsResponse] = []
+    found: list[dict[str, Any]] = []
     for sku, v in zip(sku_cleaned, sku_variants, strict=True):
         if not v:
             raise ValueError(f"Variant with SKU '{sku}' not found")
-        results.append(_dict_to_variant_details(v))
+        found.append(v)
     for variant_id, v in zip(variant_ids, id_variants, strict=True):
         if v is None:
             raise ValueError(f"Variant ID {variant_id} not found")
-        results.append(_dict_to_variant_details(v))
+        found.append(v)
+
+    # Bulk-fetch parents + suppliers once for the whole batch so the
+    # response includes UoM, default supplier name, and batch-tracked
+    # status without a per-variant follow-up call (#538).
+    products, materials, supplier_by_id = await _enrich_variants_with_parent(
+        services, found
+    )
+    results: list[VariantDetailsResponse] = []
+    for v in found:
+        # Pick the parent map by which ID the variant carries — product
+        # and material IDs may collide, so a merged map would mis-attach.
+        if v.get("product_id"):
+            parent = products.get(v["product_id"])
+        elif v.get("material_id"):
+            parent = materials.get(v["material_id"])
+        else:
+            parent = None
+        sup_id = (parent or {}).get("default_supplier_id")
+        supplier = supplier_by_id.get(sup_id) if sup_id else None
+        results.append(_dict_to_variant_details(v, parent=parent, supplier=supplier))
 
     return results
 

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -232,66 +232,152 @@ def build_search_results_ui(
     return app
 
 
+def _variant_header_section(variant: dict[str, Any]) -> None:
+    """Render variant card header: title, badges, parent, config-attribute pills."""
+    with Row(gap=2):
+        CardTitle(content=variant.get("name", "Unknown"))
+        Badge(label=variant.get("sku", ""), variant="outline")
+        if variant.get("type"):
+            Badge(label=variant["type"], variant="secondary")
+        if variant.get("is_batch_tracked"):
+            Badge(label="Batch tracked", variant="secondary")
+    parent_name = variant.get("product_or_material_name")
+    if parent_name:
+        Muted(content=f"Part of: {parent_name}")
+    # Config-attribute pills (size / color / volume) inline so the
+    # variant's distinguishing axes are visible without scrolling.
+    config_attrs = variant.get("config_attributes") or []
+    if config_attrs:
+        with Row(gap=2):
+            for attr in config_attrs:
+                if not isinstance(attr, dict):
+                    continue
+                label = attr.get("config_name") or ""
+                value = attr.get("config_value") or ""
+                if label and value:
+                    Badge(label=f"{label}: {value}", variant="outline")
+
+
+def _variant_supplier_line(variant: dict[str, Any]) -> None:
+    """Render the default-supplier text row when name and/or id is set."""
+    name = variant.get("default_supplier_name")
+    sid = variant.get("default_supplier_id")
+    if name and sid:
+        Text(content=f"Default Supplier: {name} ({sid})")
+    elif name:
+        Text(content=f"Default Supplier: {name}")
+    elif sid:
+        Text(content=f"Default Supplier ID: {sid}")
+
+
+def _variant_barcode_line(variant: dict[str, Any]) -> None:
+    """Render the barcode text row when at least one barcode is set."""
+    parts = []
+    if variant.get("internal_barcode"):
+        parts.append(f"internal={variant['internal_barcode']}")
+    if variant.get("registered_barcode"):
+        parts.append(f"registered={variant['registered_barcode']}")
+    if parts:
+        Text(content=f"Barcodes: {', '.join(parts)}")
+
+
+def _variant_id_line(variant: dict[str, Any]) -> None:
+    """IDs deprioritized to a single Muted row at the bottom — they're
+    useful for follow-up tool calls but not the primary signal a human
+    reader needs.
+    """
+    id_parts = [f"variant_id={variant.get('id', 'N/A')}"]
+    if variant.get("product_id"):
+        id_parts.append(f"product_id={variant['product_id']}")
+    if variant.get("material_id"):
+        id_parts.append(f"material_id={variant['material_id']}")
+    Muted(content=" · ".join(id_parts))
+
+
+def _variant_reference_section(variant: dict[str, Any]) -> None:
+    """Render the reference data block (UoM, supplier, lead time, codes, IDs)."""
+    if variant.get("uom"):
+        Text(content=f"UoM: {variant['uom']}")
+    _variant_supplier_line(variant)
+    if variant.get("lead_time") is not None:
+        Text(content=f"Lead Time: {variant['lead_time']} days")
+    if variant.get("minimum_order_quantity") is not None:
+        Text(content=f"Min Order Qty: {variant['minimum_order_quantity']}")
+    _variant_barcode_line(variant)
+    if variant.get("supplier_item_codes"):
+        Muted(content="Supplier Codes:")
+        with ForEach("variant.supplier_item_codes"):
+            Text(content="{{ $item }}")
+    _variant_id_line(variant)
+
+
+def _variant_footer_section(variant: dict[str, Any]) -> None:
+    """Render footer action buttons."""
+    sku = variant.get("sku", "")
+    if variant.get("katana_url"):
+        Button(
+            label="View in Katana",
+            variant="outline",
+            on_click=SendMessage(f"Open the Katana URL: {variant['katana_url']}"),
+        )
+    Button(
+        label="Check Inventory",
+        variant="outline",
+        on_click=SendMessage(f"Check inventory for SKU {sku}"),
+    )
+    Button(
+        label="Create Purchase Order",
+        variant="outline",
+        on_click=SendMessage(f"Draft a purchase order for SKU {sku}"),
+    )
+    if variant.get("type") == "material" and variant.get("id"):
+        Button(
+            label="List MOs Using This",
+            variant="outline",
+            on_click=SendMessage(
+                f"List manufacturing orders that use variant_id {variant['id']}"
+            ),
+        )
+
+
 def build_variant_details_ui(
     variant: dict[str, Any],
 ) -> PrefabApp:
-    """Build a detail card for a variant."""
+    """Build a detail card for a variant.
+
+    Designed for the "should I order more / where is this used / how is
+    it tracked" decisions. Surfaces the facts an inventory-aware agent
+    needs first (UoM, default supplier, batch tracking, config
+    attributes), with raw IDs deprioritized to a footer-style row. See
+    #538 for the design rationale.
+    """
+    uom = variant.get("uom")
+
+    def _price_display(p: float | None) -> str:
+        if p is None:
+            return "N/A"
+        suffix = f" / {uom}" if uom and uom not in ("pcs", "ea") else ""
+        return f"${p:,.2f}{suffix}"
+
     with PrefabApp(state={"variant": variant}, css_class="p-4") as app, Card():
-        with CardHeader(), Row(gap=2):
-            CardTitle(content=variant.get("name", "Unknown"))
-            Badge(label=variant.get("sku", ""), variant="outline")
-            if variant.get("type"):
-                Badge(
-                    label=variant["type"],
-                    variant="secondary",
-                )
+        with CardHeader(), Column(gap=1):
+            _variant_header_section(variant)
 
         with CardContent(), Column(gap=3):
             with Row(gap=4):
                 Metric(
                     label="Sales Price",
-                    value=f"${variant.get('sales_price', 0):,.2f}"
-                    if variant.get("sales_price") is not None
-                    else "N/A",
+                    value=_price_display(variant.get("sales_price")),
                 )
                 Metric(
                     label="Purchase Price",
-                    value=f"${variant.get('purchase_price', 0):,.2f}"
-                    if variant.get("purchase_price") is not None
-                    else "N/A",
+                    value=_price_display(variant.get("purchase_price")),
                 )
-
             Separator()
-
-            with Row(gap=4):
-                Text(content=f"ID: {variant.get('id', 'N/A')}")
-                if variant.get("product_id"):
-                    Text(content=f"Product ID: {variant['product_id']}")
-                if variant.get("material_id"):
-                    Text(content=f"Material ID: {variant['material_id']}")
-                if variant.get("lead_time") is not None:
-                    Text(content=f"Lead Time: {variant['lead_time']} days")
-
-            if variant.get("supplier_item_codes"):
-                Muted(content="Supplier Codes:")
-                with ForEach("variant.supplier_item_codes"):
-                    Text(content="{{ $item }}")
+            _variant_reference_section(variant)
 
         with CardFooter(), Row(gap=2):
-            Button(
-                label="Check Inventory",
-                variant="outline",
-                on_click=SendMessage(
-                    f"Check inventory for SKU {variant.get('sku', '')}"
-                ),
-            )
-            Button(
-                label="Create Purchase Order",
-                variant="outline",
-                on_click=SendMessage(
-                    f"Draft a purchase order for SKU {variant.get('sku', '')}"
-                ),
-            )
+            _variant_footer_section(variant)
     return app
 
 

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -91,6 +91,93 @@ class TestBuildVariantDetailsUI:
         app = build_variant_details_ui(variant)
         _assert_valid_prefab(app)
 
+    def test_includes_uom_when_set(self):
+        """UoM should render in the reference section when the parent supplied it."""
+        variant = {
+            "id": 100,
+            "sku": "SEAL-250",
+            "name": "Tubeless Sealant",
+            "uom": "ml",
+            "sales_price": 12.99,
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "UoM: ml" in rendered
+        # Price should use uom suffix when uom isn't pcs/ea.
+        assert "$12.99 / ml" in rendered
+
+    def test_omits_uom_when_unset(self):
+        """No UoM line and no /uom price suffix when parent didn't supply uom."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "sales_price": 10.0,
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "UoM:" not in rendered
+        assert "$10.00" in rendered
+        # No `/ <uom>` suffix on the bare price.
+        assert "$10.00 /" not in rendered
+
+    def test_includes_config_attributes_as_badges(self):
+        """Config attributes should appear inline so the variant axes are visible."""
+        variant = {
+            "id": 100,
+            "sku": "SHIRT-RED-L",
+            "name": "T-Shirt",
+            "config_attributes": [
+                {"config_name": "Color", "config_value": "Red"},
+                {"config_name": "Size", "config_value": "Large"},
+            ],
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Color: Red" in rendered
+        assert "Size: Large" in rendered
+
+    def test_includes_default_supplier_name(self):
+        """Supplier name (with id in parens) should appear in the reference section."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "default_supplier_id": 42,
+            "default_supplier_name": "Acme Industrial",
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Default Supplier: Acme Industrial (42)" in rendered
+
+    def test_renders_when_parent_lookup_returns_nothing(self):
+        """When parent enrichment finds nothing (uom/supplier/batch all None),
+        the card still renders without crashing and skips the parent-derived rows.
+        """
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Orphan Variant",
+            "sales_price": 5.0,
+            "uom": None,
+            "default_supplier_id": None,
+            "default_supplier_name": None,
+            "is_batch_tracked": None,
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "UoM:" not in rendered
+        assert "Default Supplier" not in rendered
+        assert "Batch tracked" not in rendered
+        # Identity still renders.
+        assert "Orphan Variant" in rendered
+        assert "SKU-001" in rendered
+
 
 class TestBuildItemDetailUI:
     def test_product(self):

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -539,6 +539,58 @@ def test_dict_to_variant_details_no_parent_returns_none_url():
     assert response.katana_url is None
 
 
+def test_dict_to_variant_details_supplier_lifted_from_supplier_dict():
+    """``default_supplier_name`` comes from the *supplier* dict, while
+    ``default_supplier_id`` and ``uom`` come from the *parent* dict — pinning
+    the source-of-truth contract so a future refactor can't quietly swap them.
+    """
+    from katana_mcp.tools.foundation.items import _dict_to_variant_details
+
+    response = _dict_to_variant_details(
+        {"id": 1, "sku": "P-1", "product_id": 42},
+        parent={"uom": "ml", "default_supplier_id": 7, "batch_tracked": True},
+        supplier={"name": "Acme Industrial"},
+    )
+    assert response.uom == "ml"
+    assert response.default_supplier_id == 7
+    assert response.default_supplier_name == "Acme Industrial"
+    assert response.is_batch_tracked is True
+
+
+@pytest.mark.asyncio
+async def test_enrich_variants_keeps_product_and_material_maps_separate():
+    """Product IDs and material IDs are NOT guaranteed disjoint (the cache
+    keys rows by ``(entity_type, id)``). A previous version merged them into
+    one ``parent_by_id`` keyed on numeric ID, which would mis-attach a
+    material parent to a product variant when IDs collided. This test
+    constructs a colliding-ID scenario and pins the per-type lookup so the
+    bug can't regress (Copilot review on #542).
+    """
+    from katana_mcp.cache import EntityType
+    from katana_mcp.tools.foundation.items import _enrich_variants_with_parent
+
+    services = MagicMock()
+    services.cache = MagicMock()
+    services.cache.get_many_by_ids = AsyncMock(
+        side_effect=lambda entity_type, _ids: {
+            EntityType.PRODUCT: {42: {"id": 42, "uom": "pcs", "name": "Widget"}},
+            EntityType.MATERIAL: {42: {"id": 42, "uom": "ml", "name": "Sealant"}},
+            EntityType.SUPPLIER: {},
+        }[entity_type]
+    )
+
+    variants = [
+        {"id": 1, "sku": "P-COL", "product_id": 42},
+        {"id": 2, "sku": "M-COL", "material_id": 42},
+    ]
+    products, materials, _ = await _enrich_variants_with_parent(services, variants)
+
+    assert products[42]["uom"] == "pcs"
+    assert products[42]["name"] == "Widget"
+    assert materials[42]["uom"] == "ml"
+    assert materials[42]["name"] == "Sealant"
+
+
 def test_item_katana_url_returns_none_for_service_type(_no_web_base_url: None):
     """Services have no per-item page in Katana's web app. Products and
     materials route to distinct singular paths (``/product/{id}`` and

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.56.2"
+version = "0.58.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1306,7 +1306,7 @@ requires-dist = [
 
 [[package]]
 name = "katana-openapi-client"
-version = "0.57.0"
+version = "0.58.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

The previous variant-details card forced agents to guess UoM ("250 = 250ml presumably") because UoM, default supplier, and batch-tracking live on the parent product/material — not on the variant attrs model itself. This PR fetches parent context from the cache and surfaces the facts an inventory-aware agent needs.

- **Backend**: 4 new fields on `VariantDetailsResponse` (`uom`, `default_supplier_id`, `default_supplier_name`, `is_batch_tracked`) populated via `_enrich_variants_with_parent` — 3 bulk cache queries (products, materials, suppliers) per call, regardless of variant count
- **UI**: 4-tier card layout (identity → metrics → reference → actions). Header shows config-attribute pills inline ("Color: Red", "Size: Large"). Price displays `$X / uom` when UoM isn't `pcs`/`ea`. IDs deprioritized to a single footer Muted row
- **Tests**: 5 new behavior tests covering UoM render/omit, config-attr badges, supplier name+id rendering, and graceful fallback when parent lookup returns nothing

First card-redesign delivery from the umbrella issue (#537).

## Test plan
- [x] `uv run poe check` — all 2786 tests pass, formatting/lint clean
- [ ] Visually inspect the rendered card in Claude Desktop for a real variant with config attributes (e.g., a tubeless sealant with Volume: 250ml)
- [ ] Verify a variant whose parent has no default supplier renders without crashing
- [ ] Verify a service-type variant (no parent) still renders identity + actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)