### PR TITLE
docs: 2026-05-05 session retro + cache-IDs pitfall + harness upstream config

### DIFF
--- a/.claude/harness-upstream
+++ b/.claude/harness-upstream
@@ -1,0 +1,1 @@
+dougborg/harness-kit

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "harness-kit@harness-kit": true
+  }
+}

--- a/.harness-lock.json
+++ b/.harness-lock.json
@@ -2,20 +2,23 @@
   "$comment": "Tracks provenance of files in .claude/. 'source: harness-kit' files came from the upstream plugin baseline; 'source: local' are project-specific. Run /harness-kit:harness update to sync upstream changes.",
   "sources": {
     "harness-kit": {
-      "version": "0.4.0",
-      "installed": "2026-04-27"
+      "version": "0.5.1",
+      "installed": "2026-04-27",
+      "lastReviewed": "2026-05-05",
+      "repo": "dougborg/harness-kit",
+      "note": "Reviewed 0.4.0 → 0.5.1 baseline 2026-05-05. Both modified files (code-reviewer, verifier) intentionally diverge from upstream — see per-file notes. New v0.5.0+ skills (harness-issue, standup, feature-spec, etc.) accessible via the harness-kit: plugin namespace; not copied locally."
     }
   },
   "files": {
     ".claude/agents/code-reviewer.md": {
       "source": "harness-kit",
       "modified": true,
-      "note": "Project-tuned with Katana conventions (UNSET, unwrap_*, generated-file boundaries, list data envelope, help-resource sync)"
+      "note": "Project-tuned with Katana conventions (UNSET, unwrap_*, generated-file boundaries, list data envelope, help-resource sync). Reviewed against v0.5.1 upstream 2026-05-05 — kept local; upstream's generic structure would lose the Katana-specific checks."
     },
     ".claude/agents/verifier.md": {
       "source": "harness-kit",
       "modified": true,
-      "note": "Project-tuned with hardcoded uv run poe check verification command"
+      "note": "Project-tuned with hardcoded uv run poe check verification command + Katana-specific generated-file checks (api/, models/, client.py) and scopes (client, mcp). Reviewed against v0.5.1 upstream 2026-05-05 — kept local; the v0.5.0 discovery script would simplify the allowed-tools but the Katana checks in the body are load-bearing."
     },
     ".claude/agents/domain-advisor.md": {
       "source": "local"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,21 @@ Common mistakes to avoid:
   **exclude the path in tool config** — never `rm -rf` the directory. Treat
   `.claude/worktrees/` as off-limits for destructive operations.
 
+- **Cache IDs are not globally unique — never merge cross-entity maps by numeric ID
+  alone** - The legacy `CatalogCache` (`katana_mcp/cache.py`) — and `services.cache` by
+  extension — keys rows by `(entity_type, id)`, so a product with `id=42` and a material
+  with `id=42` are both legal. When enriching a list of variants with parent context (or
+  any other cross-entity batch fetch), keep separate per-type maps (`products`,
+  `materials`) and select based on which ID the variant carries (`v.product_id` vs
+  `v.material_id`). Merging into a single dict via `{**products, **materials}`
+  mis-attaches parents on collision — Python dict-unpack iterates left-to-right and
+  later keys win, so the material entry silently overwrites the product entry on shared
+  IDs. The bug is symmetric in practice: every product variant whose ID also exists as a
+  material ID looks up the material's data instead (and vice versa if you reorder the
+  unpack). Caught in #542 (variant card redesign) by Copilot review; regression test
+  pins the case in
+  `test_items.py::test_enrich_variants_keeps_product_and_material_maps_separate`.
+
 - **First push of a feature branch — use `HEAD:refs/heads/<name>`, not bare branch
   name** - When a local branch was created via `git checkout -b <name> origin/main`, its
   upstream is set to `origin/main`. A subsequent `git push -u origin <name>` then
@@ -395,10 +410,39 @@ status = unwrap_unset(order.status, None)
 ## Claude Code Harness
 
 The harness lives in `.claude/skills/` (workflows) and `.claude/agents/` (delegated
-sub-agents). Provenance is tracked in `.harness-lock.json`. The
-[harness-kit plugin](https://github.com/dougborg/harness-kit) is loaded — its skills
-appear under the `harness-kit:` prefix and its meta-skill `/harness-kit:harness` runs
-audits and updates.
+sub-agents). Provenance is tracked in `.harness-lock.json`. The project's upstream is
+configured in `.claude/harness-upstream`
+([dougborg/harness-kit](https://github.com/dougborg/harness-kit)) — used by
+`/harness-issue` (when the plugin is installed) to file Issues / PRs against the right
+repo.
+
+**Plugin baseline:** the project tracks harness-kit at the version recorded in
+`.harness-lock.json` (`sources.harness-kit.version`). The `.claude/` files were
+originally seeded via `/harness bootstrap` and the two upstream-sourced agents
+(`code-reviewer`, `verifier`) are intentionally locally modified with Katana-specific
+content — `/harness update` knows to leave them alone.
+
+**To enable the plugin (one-time per developer):**
+
+```bash
+/plugin marketplace add dougborg/harness-kit
+/plugin install harness-kit@harness-kit
+```
+
+`.claude/settings.json` already lists `harness-kit@harness-kit` under `enabledPlugins`,
+so once installed locally the plugin auto-enables for this repo. The install itself
+isn't auto-bootstrapped from a clone (Claude Code doesn't install plugins on clone) —
+but the enable step is shared, so contributors only need to run the two `/plugin`
+commands above once.
+
+After install, the namespaced skills (`/harness-kit:harness`,
+`/harness-kit:harness-issue`, `/harness-kit:standup`, `/harness-kit:feature-spec`,
+`/harness-kit:skill-writer`, etc.) become available. To pull a newer baseline into
+`.claude/` after upgrading the plugin, run `/harness update`.
+
+Project-local skills below shadow / extend the plugin's generic versions where they
+exist; both are valid (use the project-local `/open-pr` for the Katana flavor; use
+`harness-kit:open-pr` for a generic fallback).
 
 ### Skills (slash commands)
 
@@ -436,7 +480,8 @@ Configured in `.claude/settings.local.json` (gitignored):
 - **PostToolUse / Edit|Write|MultiEdit** — runs `uv run poe fix` silently after any
   Python file is edited. Fixes lint/format issues before Claude reads the result.
 - **Stop** — when the session touched more than 3 files, prints a reminder to run
-  `/harness-kit:harness retro` to capture learnings.
+  `/harness retro` to capture learnings. (When the harness-kit plugin is installed, also
+  consider `/session-retro` — see harness-kit#30 — for project-side learnings.)
 
 ## Detailed Documentation
 

--- a/docs/sessions/2026-05-05-mcp-fulfillment-and-card-redesign.md
+++ b/docs/sessions/2026-05-05-mcp-fulfillment-and-card-redesign.md
@@ -1,0 +1,190 @@
+# Session 2026-05-05 — MCP fulfillment + variant card redesign + PM groom
+
+First applied session-retro doc, written manually (the `/session-retro` skill is
+proposed in [harness-kit#30](https://github.com/dougborg/harness-kit/issues/30) and
+tracked for adoption here as #561). Captures the cause-and-effect chain of a
+high-density working session so patterns accumulate instead of scattering across one-off
+bug reports.
+
+## Goal
+
+Two parallel objectives:
+
+1. Ship the first card-redesign delivery (#538 — `get_variant_details`) as a working
+   template for the rest of the umbrella (#537).
+1. Test the MCP-backed shop-floor agent on a real Shopify→Katana sales-order fulfillment
+   flow (SO #WEB20387, Carbon Rocker v2 / variant 33331882).
+
+## What happened (chronological)
+
+### Morning: PR #535 review feedback
+
+Addressed Copilot review on PR #535 (`check_inventory` per-location DataTable):
+
+- Single-item Prefab card path didn't render `by_location` — added DataTable + "N
+  locations" badge when `len(by_location) > 1`
+- N+1 cache lookups — switched from `services.cache.get_by_id()` per row to bulk
+  `services.cache.get_many_by_ids(EntityType.LOCATION, unique_loc_ids)`
+- DataTable column type — switched from raw `dict` to `DataTableColumn(...)` to match
+  the existing search-results pattern
+
+### Midday: variant card redesign (#542)
+
+Implemented the four-tier framework (identity → metrics → reference → actions) on
+`get_variant_details`:
+
+- 4 new fields on `VariantDetailsResponse` (`uom`, `default_supplier_id`,
+  `default_supplier_name`, `is_batch_tracked`) populated from the parent
+  product/material — variants don't carry these on the attrs model directly
+- `_enrich_variants_with_parent` helper does at most 3 bulk cache queries (products,
+  materials, suppliers) regardless of variant count
+- Card rewritten with extracted section helpers to stay under ruff complexity
+- 5 behavior tests + 1 regression test for the per-type parent-map fix
+
+PR opened, CI green, Copilot caught a real bug: merging `products` and `materials` into
+a single `parent_by_id` keyed only by numeric ID would mis-attach parents on collision
+(cache rows are keyed by `(entity_type, id)`). Fixed via per-type maps; this lesson is
+now in CLAUDE.md "Known Pitfalls."
+
+### Afternoon: live fulfillment session — bugs cascade
+
+User ran a real fulfillment for SO #WEB20387 against the dev MCP server. The session
+produced a chain of issues, each compounding the next:
+
+1. **`search_items` iframe stuck on "Waiting for content…"** — happens both during AND
+   after execution on 0-result paths. Updated #470 with new symptom data; root cause
+   likely envelope delivery on the empty-state branch.
+
+1. **Stale items cache, no MCP recovery path** — `search_items` returned 0 for an SKU
+   the user knew existed. Agent tried `rebuild_cache`, found it only covers
+   transactional entities (PO/SO/MO/ST/SA), gave up and went to the browser. Updated
+   #472 to flag this as a recovery-path requirement on the WS-0 cache unification
+   milestone.
+
+1. **Preview→apply UX produces duplicate confirmation paths** — `fulfill_order` preview
+   rendered correctly with a "Confirm Fulfillment" button, but the agent ALSO wrote
+   "Please confirm the fulfillment:" with a bullet list. Two paths, ambiguous which one
+   the user takes. Filed as #544.
+
+1. **Confirm-button apply errors are opaque** — user clicked Confirm, apply failed with
+   a 422, toast said only "Fulfillment for #WEB20387 failed" with no reason. The actual
+   `UnprocessableEntityError: sum of serial number quantity (current: 0) must match fulfillment row quantity (expected: 1)`
+   was visible only via tooltip on a small warning icon. Filed as #545.
+
+1. **`fulfill_order` can't ship serial-tracked variants** — Rocker v2 is serial-tracked;
+   tool has no `serial_numbers` parameter; agent diagnosed correctly and bailed to the
+   browser. Filed as #547 with a 2-phase fix proposal (preview-time block warning +
+   per-row override).
+
+### Evening: backlog groom
+
+Used `general-purpose` agent (briefed as a PM — there's no dedicated project-manager
+agent yet) to survey 66 open issues. Output: a 5-PR P1 hotfix train (#527 → #544+#545 →
+#547 → #499+#517), a stale-issue list, and a gap list. The PM brief itself was ad-hoc;
+codifying it as a `/groom` skill is filed as
+[harness-kit#26](https://github.com/dougborg/harness-kit/issues/26).
+
+Filed 14 backlog gap issues (#548–#561):
+
+- 10 sub-issues for the remaining card builders in #537 (#548–#557)
+- 1 audit issue for `additional_info` echo helper generalization (#558)
+- 1 bug for "agent re-runs preview after Confirm-button apply succeeded" (#559)
+- 1 docs sync for help-resource drift after the new `correct_*` tools (#560)
+- 1 process issue for the session-retro pattern (#561 — meta)
+
+### Late evening: harness retro
+
+Ran `/harness retro` and surfaced 5 findings to file in upstream `dougborg/harness-kit`:
+
+1. `/groom` skill + `project-manager` agent —
+   [harness-kit#26](https://github.com/dougborg/harness-kit/issues/26)
+1. `discover-verification-cmd.sh` doesn't know about uv+poe — already fixed in v0.5.0
+   (PR #19) — closed as duplicate
+1. `poll-review.sh` classifies overall-only reviews as `comments` —
+   [harness-kit#28](https://github.com/dougborg/harness-kit/issues/28)
+1. `/commit` should auto-stage uv.lock to avoid pre-commit auto-stash race —
+   [harness-kit#29](https://github.com/dougborg/harness-kit/issues/29)
+1. `/session-retro` skill —
+   [harness-kit#30](https://github.com/dougborg/harness-kit/issues/30)
+
+## What worked
+
+- **Four-tier card framework held up under stress test.** No contortions on the variant
+  card; Header → Metrics → Reference → Actions mapped cleanly. The remaining 10 card
+  sub-issues can use it verbatim.
+- **`/simplify` triple-agent review** caught the unused supplier-rendering 3-arm
+  conditional and the redundant comment narration. Ran in parallel, finished in ~30s,
+  cost ~3k tokens.
+- **Copilot caught a real bug none of my agent reviewers found.** The parent-map
+  ID-collision was subtle — required understanding cache key uniqueness semantics.
+  Treating Copilot as a peer reviewer (open the PR, wait for the review) costs nothing
+  and pays off.
+- **`/open-pr` → CI poll → review poll → `/review-pr` cascade.** End-to-end flow ran
+  without manual intervention except for the `npm test` glitch (the discover script
+  doesn't know about uv+poe — fixed upstream in v0.5.0).
+- **PM groom output structure** — top-line state / umbrellas / next 5–10 PRs / stale /
+  gaps. Opinionated, scanned in ~30s, surfaced both a clear plan and meaningful gaps.
+
+## What didn't work
+
+- **Agent fell back to the browser twice in one session** — once for stale items cache
+  (#472), once for serial-tracked fulfillment (#547). Both are real product gaps that
+  defeat the MCP-as-shop-floor-surface vision. These are the most important class of bug
+  to surface from live sessions.
+- **Preview→apply pattern produces visibly confused UX in the wild** — #544 + #545 +
+  #558 are all symptoms of the same architectural issue. The mechanical bugs (#491,
+  #495) are fixed but the conversational UX still feels broken.
+- **`discover-verification-cmd.sh` returned wrong command** for this stack — fixed
+  upstream in harness-kit v0.5.0 but not yet pulled into this project (still on v0.4.0).
+  Plugin install + `/harness update` is the resolution.
+- **Manually filing 14 issues + 5 upstream issues** — should have been one
+  `/harness-issue` invocation per upstream issue (skill exists in v0.5.0).
+
+## Lessons / patterns
+
+- **Cache rows are keyed by `(entity_type, id)`** — never merge cross-entity maps by
+  numeric ID alone. Now in CLAUDE.md "Known Pitfalls."
+- **The four-tier card framework is the template.** Subsequent cards should follow the
+  variant card's structure: extract section helpers from the start to stay under ruff
+  complexity (`C901` ≤ 15 branches).
+- **Live sessions produce ~10x the bug density of synthetic testing.** A single
+  fulfillment flow surfaced 5 issues — bugs the test suite couldn't have found because
+  the agent's reasoning is the thing being tested.
+- **Bugs compound — file the chain, not just the symptom.** The fulfillment failure was
+  three independent bugs (#544, #545, #547) layered on top of each other. Filing each in
+  isolation loses the cause-and-effect; the cross-references between them are
+  load-bearing context.
+- **Plugin-shaped tooling beats one-off prompts.** The PM groom and the upstream
+  issue-filing both worked but were ad-hoc; codifying them as skills (`/groom` and
+  `/harness-issue` respectively) makes the patterns recur reliably.
+
+## Issues filed (consolidated)
+
+**Project-local (`dougborg/katana-openapi-client`):**
+
+- Fulfillment chain: #544, #545, #547
+- Updates: #470 (new symptom), #472 (recovery-path requirement)
+- Card sub-issues: #548–#557 (10 cards — #557 is `batch_recipe_update_ui`, re-fired
+  after the first parallel batch hit a missing label and cascade-cancelled)
+- Audits: #558 (additional_info), #560 (help-resource drift)
+- Process: #559 (agent re-runs preview), #561 (session-retro adoption)
+- This PR: CLAUDE.md "cache IDs not globally unique" pitfall +
+  `.claude/harness-upstream` config + this doc
+
+**Upstream (`dougborg/harness-kit`):**
+
+- New skills/agents: #26 (`/groom` + `project-manager`), #30 (`/session-retro`)
+- Bugs: #28 (`poll-review.sh` classification), #29 (`/commit` uv.lock auto-stash race)
+- Closed as duplicate: #27 (already fixed in v0.5.0)
+
+## Next session priorities
+
+Per the PM groom (full text in conversation transcript):
+
+1. **#527** — fix `update_sales_order` empty-200 schema (every PATCH currently raises).
+   Breaks `correct_sales_order`.
+1. **#544 + #545 bundled** — the duplicate-confirmation + opaque-error bugs.
+1. **#547** — `fulfill_order` serial_numbers parameter.
+1. **#499 + #517 bundled** — surface 422 details on opaque create errors.
+1. **Install harness-kit plugin** + `/harness update` — pulls v0.4.0 → v0.5.1 baseline,
+   unlocks `/harness-issue` and `/standup`, fixes the discover-cmd glitch.


### PR DESCRIPTION
## Summary

Captures retro outputs from a long session that shipped PR #542 (variant card redesign), filed 3 critical bugs (#544 / #545 / #547) + 14 backlog gap issues (#548–#561), set up project board #5, and integrated the harness-kit plugin properly. Pure docs / config — no code changes.

### What's in the PR

- **`CLAUDE.md` "Known Pitfalls"** — added "Cache IDs are not globally unique" pitfall. Real lesson from PR #542 review (Copilot caught the parent-map collision bug). Updated per Copilot review on this PR to correctly describe Python dict-unpack semantics AND name the legacy `CatalogCache` (not the typed cache) as the affected subsystem.
- **`CLAUDE.md` "Claude Code Harness"** — corrected the stale paragraph that claimed the harness-kit plugin was loaded. Now describes the actual install flow (one-time `/plugin marketplace add` + `/plugin install` per developer) and the role of `.claude/settings.json` (auto-enable once installed). References `.harness-lock.json` as the version source-of-truth rather than hardcoding a version number.
- **`.claude/harness-upstream`** — points the new `harness-kit:harness-issue` skill at `dougborg/harness-kit` so future upstream feedback doesn't require ad-hoc `gh` CLI calls.
- **`.claude/settings.json`** — enables the harness-kit plugin in shared project settings. **Note**: this only takes effect after a developer has installed the plugin locally — Claude Code doesn't auto-install plugins on clone. The committed setting saves the enable step, not the install step.
- **`.harness-lock.json`** — bumped source version from v0.4.0 → v0.5.1 with `lastReviewed` date, `repo` field, and per-file notes refreshed for both intentionally-modified files (code-reviewer, verifier).
- **`docs/sessions/2026-05-05-mcp-fulfillment-and-card-redesign.md`** — first applied session-retro doc, written manually as the worked example for the `/session-retro` skill proposed in [harness-kit#30](https://github.com/dougborg/harness-kit/issues/30) (and tracked here as #561). Captures the cause-and-effect chain across PR #535, PR #542, and the fulfillment-failure cascade. Issue numbering corrected per Copilot review.

### Why this PR is independent of any code change

Everything here is project-local docs / config. The plugin install (`/plugin install harness-kit@harness-kit`) was done interactively before this PR; the only file that change touched in the project is `.claude/settings.json` (committed here).

## Copilot review — addressed

8 unresolved comments across two passes; all addressed:

### Pass 1 (pre-rebase, against original diff including PR #542 code)

| # | File | Resolution |
|---|------|-----------|
| 3192580522 | items.py | Out of scope post-rebase. Filed as **#564**. |
| 3192580544 | items.py | Out of scope. Filed as **#565** (subsumed by **#567** umbrella, then closed). |
| 3192580562 | session retro doc | Fixed in a6fa6378 — issue numbering corrected (#548–#557 = 10 cards). |
| 3192580576 | CLAUDE.md | Fixed in a6fa6378 — pitfall corrected for dict-unpack later-wins semantics. |
| 3192580585 | items.py | Out of scope. Filed as **#566** (compounds with #472). |

### Pass 2 (post-fixup, against current diff)

| # | File | Resolution |
|---|------|-----------|
| 3192633163 | settings.json | Fixed in 6b09d600 — clarified that `enabledPlugins` requires plugin install first; updated CLAUDE.md and this PR description. |
| 3192633180 | CLAUDE.md | Fixed in 6b09d600 — removed the v0.4.0 self-contradiction; references `.harness-lock.json` as source-of-truth. |
| 3192633190 | CLAUDE.md | Fixed in 6b09d600 — pitfall now correctly attributes the `(entity_type, id)` keying to the legacy `CatalogCache` in `katana_mcp/cache.py`. |

All 8 review threads resolved.

## Test plan

- [x] `uv run poe check` clean (2795 tests pass, no lint/format errors)
- [x] mdformat-compliant (auto-fixed during commit)
- [x] No code changes — docs and config only
- [x] Rebased clean onto current main (PR #542's variant card commit dropped automatically since now on main)

## Related

- harness-kit#26–#31 — upstream feedback filed during this session (one closed as duplicate, five open)
- #561 — adoption of `/session-retro` once the skill ships in harness-kit
- #564, #566 — follow-up bugs filed from this PR's Copilot review against PR #542's now-merged code
- #565 — closed (subsumed by #567)
- #567 — markdown-collapse umbrella (same architectural family as #565)
- #568 — project-board integration into daily workflow
- #569 — README + docs sweep
- Project board #5 — [Katana MCP — Rolling Backlog](https://github.com/users/dougborg/projects/5) — 47 items classified

🤖 Generated with [Claude Code](https://claude.com/claude-code)