### PR TITLE
fix(client)!: declare 200 response bodies for update_sales_order + update_customer_address

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -17916,6 +17916,10 @@ paths:
               $ref: "#/components/headers/X-Ratelimit-Remaining"
             X-Ratelimit-Reset:
               $ref: "#/components/headers/X-Ratelimit-Reset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SalesOrder"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
         "404":
@@ -19286,6 +19290,10 @@ paths:
               $ref: "#/components/headers/X-Ratelimit-Remaining"
             X-Ratelimit-Reset:
               $ref: "#/components/headers/X-Ratelimit-Reset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CustomerAddress"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
         "404":

--- a/katana_public_api_client/api/customer_address/update_customer_address.py
+++ b/katana_public_api_client/api/customer_address/update_customer_address.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -7,6 +7,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...client_types import Response
+from ...models.customer_address import CustomerAddress
 from ...models.error_response import ErrorResponse
 from ...models.update_customer_address_request import UpdateCustomerAddressRequest
 
@@ -35,9 +36,10 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Any | ErrorResponse | None:
+) -> CustomerAddress | ErrorResponse | None:
     if response.status_code == 200:
-        response_200 = cast(Any, None)
+        response_200 = CustomerAddress.from_dict(response.json())
+
         return response_200
 
     if response.status_code == 401:
@@ -68,7 +70,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Any | ErrorResponse]:
+) -> Response[CustomerAddress | ErrorResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -82,7 +84,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: UpdateCustomerAddressRequest,
-) -> Response[Any | ErrorResponse]:
+) -> Response[CustomerAddress | ErrorResponse]:
     """Update a customer address
 
      Updates a customer address.
@@ -98,7 +100,7 @@ def sync_detailed(
 
 
     Returns:
-        Response[Any | ErrorResponse]
+        Response[CustomerAddress | ErrorResponse]
     """
 
     kwargs = _get_kwargs(
@@ -118,7 +120,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: UpdateCustomerAddressRequest,
-) -> Any | ErrorResponse | None:
+) -> CustomerAddress | ErrorResponse | None:
     """Update a customer address
 
      Updates a customer address.
@@ -134,7 +136,7 @@ def sync(
 
 
     Returns:
-        Any | ErrorResponse
+        CustomerAddress | ErrorResponse
     """
 
     return sync_detailed(
@@ -149,7 +151,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: UpdateCustomerAddressRequest,
-) -> Response[Any | ErrorResponse]:
+) -> Response[CustomerAddress | ErrorResponse]:
     """Update a customer address
 
      Updates a customer address.
@@ -165,7 +167,7 @@ async def asyncio_detailed(
 
 
     Returns:
-        Response[Any | ErrorResponse]
+        Response[CustomerAddress | ErrorResponse]
     """
 
     kwargs = _get_kwargs(
@@ -183,7 +185,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: UpdateCustomerAddressRequest,
-) -> Any | ErrorResponse | None:
+) -> CustomerAddress | ErrorResponse | None:
     """Update a customer address
 
      Updates a customer address.
@@ -199,7 +201,7 @@ async def asyncio(
 
 
     Returns:
-        Any | ErrorResponse
+        CustomerAddress | ErrorResponse
     """
 
     return (

--- a/katana_public_api_client/api/sales_order/update_sales_order.py
+++ b/katana_public_api_client/api/sales_order/update_sales_order.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -8,6 +8,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...client_types import Response
 from ...models.error_response import ErrorResponse
+from ...models.sales_order import SalesOrder
 from ...models.update_sales_order_request import UpdateSalesOrderRequest
 
 
@@ -35,9 +36,10 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Any | ErrorResponse | None:
+) -> ErrorResponse | SalesOrder | None:
     if response.status_code == 200:
-        response_200 = cast(Any, None)
+        response_200 = SalesOrder.from_dict(response.json())
+
         return response_200
 
     if response.status_code == 401:
@@ -68,7 +70,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Any | ErrorResponse]:
+) -> Response[ErrorResponse | SalesOrder]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -82,7 +84,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: UpdateSalesOrderRequest,
-) -> Response[Any | ErrorResponse]:
+) -> Response[ErrorResponse | SalesOrder]:
     """Update a sales order
 
      Updates a sales order.
@@ -97,7 +99,7 @@ def sync_detailed(
 
 
     Returns:
-        Response[Any | ErrorResponse]
+        Response[ErrorResponse | SalesOrder]
     """
 
     kwargs = _get_kwargs(
@@ -117,7 +119,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: UpdateSalesOrderRequest,
-) -> Any | ErrorResponse | None:
+) -> ErrorResponse | SalesOrder | None:
     """Update a sales order
 
      Updates a sales order.
@@ -132,7 +134,7 @@ def sync(
 
 
     Returns:
-        Any | ErrorResponse
+        ErrorResponse | SalesOrder
     """
 
     return sync_detailed(
@@ -147,7 +149,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: UpdateSalesOrderRequest,
-) -> Response[Any | ErrorResponse]:
+) -> Response[ErrorResponse | SalesOrder]:
     """Update a sales order
 
      Updates a sales order.
@@ -162,7 +164,7 @@ async def asyncio_detailed(
 
 
     Returns:
-        Response[Any | ErrorResponse]
+        Response[ErrorResponse | SalesOrder]
     """
 
     kwargs = _get_kwargs(
@@ -180,7 +182,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: UpdateSalesOrderRequest,
-) -> Any | ErrorResponse | None:
+) -> ErrorResponse | SalesOrder | None:
     """Update a sales order
 
      Updates a sales order.
@@ -195,7 +197,7 @@ async def asyncio(
 
 
     Returns:
-        Any | ErrorResponse
+        ErrorResponse | SalesOrder
     """
 
     return (

--- a/tests/test_update_endpoint_regression.py
+++ b/tests/test_update_endpoint_regression.py
@@ -1,0 +1,88 @@
+"""Regression tests for #527 — empty 200 schemas on the two PATCH update endpoints caused ``unwrap_as`` to raise on success."""
+
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from katana_public_api_client import KatanaClient
+from katana_public_api_client.api.customer_address import update_customer_address
+from katana_public_api_client.api.sales_order import update_sales_order
+from katana_public_api_client.models.customer_address import CustomerAddress
+from katana_public_api_client.models.sales_order import SalesOrder
+from katana_public_api_client.models.update_customer_address_request import (
+    UpdateCustomerAddressRequest,
+)
+from katana_public_api_client.models.update_sales_order_request import (
+    UpdateSalesOrderRequest,
+)
+from katana_public_api_client.utils import unwrap_as
+
+
+def _client_with_mock_transport(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> KatanaClient:
+    """Build a KatanaClient backed by an ``httpx.MockTransport``; caller must use ``async with`` to close it."""
+    return KatanaClient(
+        api_key="test-api-key",
+        base_url="https://api.katana.test",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_sales_order_parses_200_body() -> None:
+    """Successful PATCH /sales_orders/{id} returns a parsed SalesOrder (regression for #527)."""
+    sales_order_payload = {
+        "id": 42,
+        "customer_id": 7,
+        "order_no": "SO-000042",
+        "location_id": 1,
+        "status": "NOT_SHIPPED",
+        "order_created_date": "2026-05-06T10:00:00Z",
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == "/sales_orders/42"
+        return httpx.Response(200, json=sales_order_payload)
+
+    async with _client_with_mock_transport(handler) as client:
+        response = await update_sales_order.asyncio_detailed(
+            id=42,
+            client=client,
+            body=UpdateSalesOrderRequest(),
+        )
+
+    order = unwrap_as(response, SalesOrder)
+    assert isinstance(order, SalesOrder)
+    assert order.id == 42
+    assert order.order_no == "SO-000042"
+
+
+@pytest.mark.asyncio
+async def test_update_customer_address_parses_200_body() -> None:
+    """Successful PATCH /customer_addresses/{id} returns a parsed CustomerAddress (regression for #527)."""
+    customer_address_payload = {
+        "id": 99,
+        "customer_id": 7,
+        "entity_type": "shipping",
+        "city": "Springfield",
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == "/customer_addresses/99"
+        return httpx.Response(200, json=customer_address_payload)
+
+    async with _client_with_mock_transport(handler) as client:
+        response = await update_customer_address.asyncio_detailed(
+            id=99,
+            client=client,
+            body=UpdateCustomerAddressRequest(),
+        )
+
+    address = unwrap_as(response, CustomerAddress)
+    assert isinstance(address, CustomerAddress)
+    assert address.id == 99
+    assert address.city == "Springfield"


### PR DESCRIPTION
## Summary

Closes #527.

`PATCH /sales_orders/{id}` and `PATCH /customer_addresses/{id}` declared their 200 responses in `docs/katana-openapi.yaml` with **no `content:` block**, so `openapi-python-client` emitted `response_200 = cast(Any, None)` and `Response.parsed` was always `None` on success. Every successful PATCH raised `APIError: No parsed response data for status 200` through `unwrap_as` — including the path used by MCP `modify_sales_order`.

The fix is straightforward: add `$ref: SalesOrder` / `$ref: CustomerAddress` content blocks to the two 200 responses (matching the shape of the sibling `POST /sales_orders`, `GET /sales_orders/{id}`, `POST /customer_addresses`, and `GET /customer_addresses/{id}` responses), then regenerate.

## Why this slipped past CI

The existing MCP test for `modify_sales_order` (`katana_mcp_server/tests/tools/test_sales_orders.py:1750`) patches `_modify_SO_UNWRAP_AS_LOCAL` directly, sidestepping `unwrap_as`. The bug was caught only via real-API testing after #524 landed `PENDING` on `SalesOrderStatus`.

`audit-spec` doesn't cover response shapes (it focuses on request DTOs); `validate-response-examples` only validates README example payloads against the schema, not whether a schema is declared at all. Filed as a tooling gap in #572.

## Changes

- **`docs/katana-openapi.yaml`** — added `content: application/json: schema: $ref: ...` to both PATCH 200 responses (4 lines each, 8 lines total).
- **Regenerated** `katana_public_api_client/api/sales_order/update_sales_order.py` and `katana_public_api_client/api/customer_address/update_customer_address.py` — `_parse_response` now emits `<Model>.from_dict(response.json())` instead of `cast(Any, None)`.
- **Pydantic regen ran** — no diff (no new schemas; both `SalesOrder` and `CustomerAddress` already exist as components).
- **New `tests/test_update_endpoint_regression.py`** — exercises both endpoints end-to-end through `asyncio_detailed` + `unwrap_as` via `httpx.MockTransport`. Reverting the spec change makes both tests fail with the original `APIError` (verified by reasoning through the unwrap path; could be re-confirmed by checking out main and running the tests against the pre-fix generated code).

## Test plan

- [x] `uv run poe check` clean (2797 passed, 2 pre-existing skips)
- [x] `uv run poe docs-build` clean (only pre-existing unrelated link warnings)
- [x] `grep "cast(Any, None)" katana_public_api_client/api/{sales_order/update_sales_order.py,customer_address/update_customer_address.py}` empty
- [x] Both new regression tests pass and would fail-on-revert
- [ ] (Optional, post-merge) Smoke test via MCP `modify_sales_order` against a known test SO — pre-fix raises, post-fix succeeds

## Breaking change

The generated return type narrows from `Optional[Any]` to `Optional[SalesOrder]` / `Optional[CustomerAddress]`. Any caller that asserted `response.parsed is None` on success was already broken (the call would raise via `unwrap_as` before reaching the assertion in any real flow), but downstream type checkers may flag the narrowing. Per CLAUDE.md ''Schema and Generator Changes,'' the commit uses `fix(client)!:` with a `BREAKING CHANGE:` footer naming the affected operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)