### PR TITLE
fix(client)!: align 6 query parameter types with Katana wire contract

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -353,9 +353,15 @@ components:
     batch_tracked:
       name: batch_tracked
       required: false
-      description: Filters records by whether they are batch tracked.
+      description: |-
+        Filters records by batch-tracking status. Send the literal string
+        ``"true"`` or ``"false"`` — Katana matches the wire value, not the JSON
+        boolean.
       schema:
-        type: boolean
+        type: string
+        enum:
+          - "true"
+          - "false"
       in: query
     purchase_uom:
       name: purchase_uom
@@ -418,9 +424,15 @@ components:
     serial_tracked:
       name: serial_tracked
       required: false
-      description: Filters products by a serial_tracked
+      description: |-
+        Filters records by serial-tracking status. Send the literal string
+        ``"true"`` or ``"false"`` — Katana matches the wire value, not the JSON
+        boolean.
       schema:
-        type: boolean
+        type: string
+        enum:
+          - "true"
+          - "false"
       in: query
     operations_in_sequence:
       name: operations_in_sequence
@@ -12863,7 +12875,14 @@ paths:
       operationId: getAllInventoryPoint
       parameters:
         - $ref: "#/components/parameters/location_id"
-        - $ref: "#/components/parameters/variant_id"
+        - name: variant_id
+          in: query
+          required: false
+          description: Filter by one or more variant IDs.
+          schema:
+            type: array
+            items:
+              type: integer
         - $ref: "#/components/parameters/include_archived"
         - $ref: "#/components/parameters/extend_inventory"
         - $ref: "#/components/parameters/limit"
@@ -17714,9 +17733,9 @@ paths:
         - $ref: "#/components/parameters/product_id"
         - name: recipe_row_id
           in: query
-          description: Filter by recipe row ID
+          description: Filter by recipe row ID (UUID).
           schema:
-            type: integer
+            type: string
       responses:
         "200":
           description: List of recipe rows
@@ -20439,7 +20458,7 @@ paths:
           description: Filters stocktakes by stock adjustment ID
           required: false
           schema:
-            type: number
+            type: string
         - $ref: "#/components/parameters/created_at_min"
         - $ref: "#/components/parameters/created_at_max"
         - $ref: "#/components/parameters/updated_at_min"

--- a/katana_public_api_client/api/inventory/get_all_inventory_point.py
+++ b/katana_public_api_client/api/inventory/get_all_inventory_point.py
@@ -14,7 +14,7 @@ from ...models.inventory_list_response import InventoryListResponse
 def _get_kwargs(
     *,
     location_id: int | Unset = UNSET,
-    variant_id: int | Unset = UNSET,
+    variant_id: list[int] | Unset = UNSET,
     include_archived: bool | Unset = UNSET,
     extend: list[GetAllInventoryPointExtendItem] | Unset = UNSET,
     limit: int | Unset = UNSET,
@@ -25,7 +25,11 @@ def _get_kwargs(
 
     params["location_id"] = location_id
 
-    params["variant_id"] = variant_id
+    json_variant_id: list[int] | Unset = UNSET
+    if not isinstance(variant_id, Unset):
+        json_variant_id = variant_id
+
+    params["variant_id"] = json_variant_id
 
     params["include_archived"] = include_archived
 
@@ -97,7 +101,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     location_id: int | Unset = UNSET,
-    variant_id: int | Unset = UNSET,
+    variant_id: list[int] | Unset = UNSET,
     include_archived: bool | Unset = UNSET,
     extend: list[GetAllInventoryPointExtendItem] | Unset = UNSET,
     limit: int | Unset = UNSET,
@@ -111,7 +115,7 @@ def sync_detailed(
 
     Args:
         location_id (int | Unset):
-        variant_id (int | Unset):
+        variant_id (list[int] | Unset):
         include_archived (bool | Unset):
         extend (list[GetAllInventoryPointExtendItem] | Unset):
         limit (int | Unset):  Default: 50.
@@ -147,7 +151,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     location_id: int | Unset = UNSET,
-    variant_id: int | Unset = UNSET,
+    variant_id: list[int] | Unset = UNSET,
     include_archived: bool | Unset = UNSET,
     extend: list[GetAllInventoryPointExtendItem] | Unset = UNSET,
     limit: int | Unset = UNSET,
@@ -161,7 +165,7 @@ def sync(
 
     Args:
         location_id (int | Unset):
-        variant_id (int | Unset):
+        variant_id (list[int] | Unset):
         include_archived (bool | Unset):
         extend (list[GetAllInventoryPointExtendItem] | Unset):
         limit (int | Unset):  Default: 50.
@@ -192,7 +196,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     location_id: int | Unset = UNSET,
-    variant_id: int | Unset = UNSET,
+    variant_id: list[int] | Unset = UNSET,
     include_archived: bool | Unset = UNSET,
     extend: list[GetAllInventoryPointExtendItem] | Unset = UNSET,
     limit: int | Unset = UNSET,
@@ -206,7 +210,7 @@ async def asyncio_detailed(
 
     Args:
         location_id (int | Unset):
-        variant_id (int | Unset):
+        variant_id (list[int] | Unset):
         include_archived (bool | Unset):
         extend (list[GetAllInventoryPointExtendItem] | Unset):
         limit (int | Unset):  Default: 50.
@@ -240,7 +244,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     location_id: int | Unset = UNSET,
-    variant_id: int | Unset = UNSET,
+    variant_id: list[int] | Unset = UNSET,
     include_archived: bool | Unset = UNSET,
     extend: list[GetAllInventoryPointExtendItem] | Unset = UNSET,
     limit: int | Unset = UNSET,
@@ -254,7 +258,7 @@ async def asyncio(
 
     Args:
         location_id (int | Unset):
-        variant_id (int | Unset):
+        variant_id (list[int] | Unset):
         include_archived (bool | Unset):
         extend (list[GetAllInventoryPointExtendItem] | Unset):
         limit (int | Unset):  Default: 50.

--- a/katana_public_api_client/api/material/get_all_materials.py
+++ b/katana_public_api_client/api/material/get_all_materials.py
@@ -8,6 +8,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...client_types import UNSET, Response, Unset
 from ...models.error_response import ErrorResponse
+from ...models.get_all_materials_batch_tracked import GetAllMaterialsBatchTracked
 from ...models.get_all_materials_extend_item import GetAllMaterialsExtendItem
 from ...models.material_list_response import MaterialListResponse
 
@@ -19,7 +20,7 @@ def _get_kwargs(
     uom: str | Unset = UNSET,
     default_supplier_id: int | Unset = UNSET,
     is_sellable: bool | Unset = UNSET,
-    batch_tracked: bool | Unset = UNSET,
+    batch_tracked: GetAllMaterialsBatchTracked | Unset = UNSET,
     purchase_uom: str | Unset = UNSET,
     purchase_uom_conversion_rate: float | Unset = UNSET,
     extend: list[GetAllMaterialsExtendItem] | Unset = UNSET,
@@ -49,7 +50,11 @@ def _get_kwargs(
 
     params["is_sellable"] = is_sellable
 
-    params["batch_tracked"] = batch_tracked
+    json_batch_tracked: str | Unset = UNSET
+    if not isinstance(batch_tracked, Unset):
+        json_batch_tracked = batch_tracked.value
+
+    params["batch_tracked"] = json_batch_tracked
 
     params["purchase_uom"] = purchase_uom
 
@@ -151,7 +156,7 @@ def sync_detailed(
     uom: str | Unset = UNSET,
     default_supplier_id: int | Unset = UNSET,
     is_sellable: bool | Unset = UNSET,
-    batch_tracked: bool | Unset = UNSET,
+    batch_tracked: GetAllMaterialsBatchTracked | Unset = UNSET,
     purchase_uom: str | Unset = UNSET,
     purchase_uom_conversion_rate: float | Unset = UNSET,
     extend: list[GetAllMaterialsExtendItem] | Unset = UNSET,
@@ -175,7 +180,7 @@ def sync_detailed(
         uom (str | Unset):
         default_supplier_id (int | Unset):
         is_sellable (bool | Unset):
-        batch_tracked (bool | Unset):
+        batch_tracked (GetAllMaterialsBatchTracked | Unset):
         purchase_uom (str | Unset):
         purchase_uom_conversion_rate (float | Unset):
         extend (list[GetAllMaterialsExtendItem] | Unset):
@@ -232,7 +237,7 @@ def sync(
     uom: str | Unset = UNSET,
     default_supplier_id: int | Unset = UNSET,
     is_sellable: bool | Unset = UNSET,
-    batch_tracked: bool | Unset = UNSET,
+    batch_tracked: GetAllMaterialsBatchTracked | Unset = UNSET,
     purchase_uom: str | Unset = UNSET,
     purchase_uom_conversion_rate: float | Unset = UNSET,
     extend: list[GetAllMaterialsExtendItem] | Unset = UNSET,
@@ -256,7 +261,7 @@ def sync(
         uom (str | Unset):
         default_supplier_id (int | Unset):
         is_sellable (bool | Unset):
-        batch_tracked (bool | Unset):
+        batch_tracked (GetAllMaterialsBatchTracked | Unset):
         purchase_uom (str | Unset):
         purchase_uom_conversion_rate (float | Unset):
         extend (list[GetAllMaterialsExtendItem] | Unset):
@@ -308,7 +313,7 @@ async def asyncio_detailed(
     uom: str | Unset = UNSET,
     default_supplier_id: int | Unset = UNSET,
     is_sellable: bool | Unset = UNSET,
-    batch_tracked: bool | Unset = UNSET,
+    batch_tracked: GetAllMaterialsBatchTracked | Unset = UNSET,
     purchase_uom: str | Unset = UNSET,
     purchase_uom_conversion_rate: float | Unset = UNSET,
     extend: list[GetAllMaterialsExtendItem] | Unset = UNSET,
@@ -332,7 +337,7 @@ async def asyncio_detailed(
         uom (str | Unset):
         default_supplier_id (int | Unset):
         is_sellable (bool | Unset):
-        batch_tracked (bool | Unset):
+        batch_tracked (GetAllMaterialsBatchTracked | Unset):
         purchase_uom (str | Unset):
         purchase_uom_conversion_rate (float | Unset):
         extend (list[GetAllMaterialsExtendItem] | Unset):
@@ -387,7 +392,7 @@ async def asyncio(
     uom: str | Unset = UNSET,
     default_supplier_id: int | Unset = UNSET,
     is_sellable: bool | Unset = UNSET,
-    batch_tracked: bool | Unset = UNSET,
+    batch_tracked: GetAllMaterialsBatchTracked | Unset = UNSET,
     purchase_uom: str | Unset = UNSET,
     purchase_uom_conversion_rate: float | Unset = UNSET,
     extend: list[GetAllMaterialsExtendItem] | Unset = UNSET,
@@ -411,7 +416,7 @@ async def asyncio(
         uom (str | Unset):
         default_supplier_id (int | Unset):
         is_sellable (bool | Unset):
-        batch_tracked (bool | Unset):
+        batch_tracked (GetAllMaterialsBatchTracked | Unset):
         purchase_uom (str | Unset):
         purchase_uom_conversion_rate (float | Unset):
         extend (list[GetAllMaterialsExtendItem] | Unset):

--- a/katana_public_api_client/api/product/get_all_products.py
+++ b/katana_public_api_client/api/product/get_all_products.py
@@ -8,7 +8,9 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...client_types import UNSET, Response, Unset
 from ...models.error_response import ErrorResponse
+from ...models.get_all_products_batch_tracked import GetAllProductsBatchTracked
 from ...models.get_all_products_extend_item import GetAllProductsExtendItem
+from ...models.get_all_products_serial_tracked import GetAllProductsSerialTracked
 from ...models.product_list_response import ProductListResponse
 
 
@@ -22,8 +24,8 @@ def _get_kwargs(
     is_purchasable: bool | Unset = UNSET,
     is_auto_assembly: bool | Unset = UNSET,
     default_supplier_id: int | Unset = UNSET,
-    batch_tracked: bool | Unset = UNSET,
-    serial_tracked: bool | Unset = UNSET,
+    batch_tracked: GetAllProductsBatchTracked | Unset = UNSET,
+    serial_tracked: GetAllProductsSerialTracked | Unset = UNSET,
     operations_in_sequence: bool | Unset = UNSET,
     purchase_uom: str | Unset = UNSET,
     purchase_uom_conversion_rate: float | Unset = UNSET,
@@ -60,9 +62,17 @@ def _get_kwargs(
 
     params["default_supplier_id"] = default_supplier_id
 
-    params["batch_tracked"] = batch_tracked
+    json_batch_tracked: str | Unset = UNSET
+    if not isinstance(batch_tracked, Unset):
+        json_batch_tracked = batch_tracked.value
 
-    params["serial_tracked"] = serial_tracked
+    params["batch_tracked"] = json_batch_tracked
+
+    json_serial_tracked: str | Unset = UNSET
+    if not isinstance(serial_tracked, Unset):
+        json_serial_tracked = serial_tracked.value
+
+    params["serial_tracked"] = json_serial_tracked
 
     params["operations_in_sequence"] = operations_in_sequence
 
@@ -169,8 +179,8 @@ def sync_detailed(
     is_purchasable: bool | Unset = UNSET,
     is_auto_assembly: bool | Unset = UNSET,
     default_supplier_id: int | Unset = UNSET,
-    batch_tracked: bool | Unset = UNSET,
-    serial_tracked: bool | Unset = UNSET,
+    batch_tracked: GetAllProductsBatchTracked | Unset = UNSET,
+    serial_tracked: GetAllProductsSerialTracked | Unset = UNSET,
     operations_in_sequence: bool | Unset = UNSET,
     purchase_uom: str | Unset = UNSET,
     purchase_uom_conversion_rate: float | Unset = UNSET,
@@ -198,8 +208,8 @@ def sync_detailed(
         is_purchasable (bool | Unset):
         is_auto_assembly (bool | Unset):
         default_supplier_id (int | Unset):
-        batch_tracked (bool | Unset):
-        serial_tracked (bool | Unset):
+        batch_tracked (GetAllProductsBatchTracked | Unset):
+        serial_tracked (GetAllProductsSerialTracked | Unset):
         operations_in_sequence (bool | Unset):
         purchase_uom (str | Unset):
         purchase_uom_conversion_rate (float | Unset):
@@ -265,8 +275,8 @@ def sync(
     is_purchasable: bool | Unset = UNSET,
     is_auto_assembly: bool | Unset = UNSET,
     default_supplier_id: int | Unset = UNSET,
-    batch_tracked: bool | Unset = UNSET,
-    serial_tracked: bool | Unset = UNSET,
+    batch_tracked: GetAllProductsBatchTracked | Unset = UNSET,
+    serial_tracked: GetAllProductsSerialTracked | Unset = UNSET,
     operations_in_sequence: bool | Unset = UNSET,
     purchase_uom: str | Unset = UNSET,
     purchase_uom_conversion_rate: float | Unset = UNSET,
@@ -294,8 +304,8 @@ def sync(
         is_purchasable (bool | Unset):
         is_auto_assembly (bool | Unset):
         default_supplier_id (int | Unset):
-        batch_tracked (bool | Unset):
-        serial_tracked (bool | Unset):
+        batch_tracked (GetAllProductsBatchTracked | Unset):
+        serial_tracked (GetAllProductsSerialTracked | Unset):
         operations_in_sequence (bool | Unset):
         purchase_uom (str | Unset):
         purchase_uom_conversion_rate (float | Unset):
@@ -356,8 +366,8 @@ async def asyncio_detailed(
     is_purchasable: bool | Unset = UNSET,
     is_auto_assembly: bool | Unset = UNSET,
     default_supplier_id: int | Unset = UNSET,
-    batch_tracked: bool | Unset = UNSET,
-    serial_tracked: bool | Unset = UNSET,
+    batch_tracked: GetAllProductsBatchTracked | Unset = UNSET,
+    serial_tracked: GetAllProductsSerialTracked | Unset = UNSET,
     operations_in_sequence: bool | Unset = UNSET,
     purchase_uom: str | Unset = UNSET,
     purchase_uom_conversion_rate: float | Unset = UNSET,
@@ -385,8 +395,8 @@ async def asyncio_detailed(
         is_purchasable (bool | Unset):
         is_auto_assembly (bool | Unset):
         default_supplier_id (int | Unset):
-        batch_tracked (bool | Unset):
-        serial_tracked (bool | Unset):
+        batch_tracked (GetAllProductsBatchTracked | Unset):
+        serial_tracked (GetAllProductsSerialTracked | Unset):
         operations_in_sequence (bool | Unset):
         purchase_uom (str | Unset):
         purchase_uom_conversion_rate (float | Unset):
@@ -450,8 +460,8 @@ async def asyncio(
     is_purchasable: bool | Unset = UNSET,
     is_auto_assembly: bool | Unset = UNSET,
     default_supplier_id: int | Unset = UNSET,
-    batch_tracked: bool | Unset = UNSET,
-    serial_tracked: bool | Unset = UNSET,
+    batch_tracked: GetAllProductsBatchTracked | Unset = UNSET,
+    serial_tracked: GetAllProductsSerialTracked | Unset = UNSET,
     operations_in_sequence: bool | Unset = UNSET,
     purchase_uom: str | Unset = UNSET,
     purchase_uom_conversion_rate: float | Unset = UNSET,
@@ -479,8 +489,8 @@ async def asyncio(
         is_purchasable (bool | Unset):
         is_auto_assembly (bool | Unset):
         default_supplier_id (int | Unset):
-        batch_tracked (bool | Unset):
-        serial_tracked (bool | Unset):
+        batch_tracked (GetAllProductsBatchTracked | Unset):
+        serial_tracked (GetAllProductsSerialTracked | Unset):
         operations_in_sequence (bool | Unset):
         purchase_uom (str | Unset):
         purchase_uom_conversion_rate (float | Unset):

--- a/katana_public_api_client/api/recipe/get_all_recipes.py
+++ b/katana_public_api_client/api/recipe/get_all_recipes.py
@@ -22,7 +22,7 @@ def _get_kwargs(
     ingredient_variant_id: int | Unset = UNSET,
     product_variant_ids: list[int] | Unset = UNSET,
     product_id: int | Unset = UNSET,
-    recipe_row_id: int | Unset = UNSET,
+    recipe_row_id: str | Unset = UNSET,
 ) -> dict[str, Any]:
 
     params: dict[str, Any] = {}
@@ -126,7 +126,7 @@ def sync_detailed(
     ingredient_variant_id: int | Unset = UNSET,
     product_variant_ids: list[int] | Unset = UNSET,
     product_id: int | Unset = UNSET,
-    recipe_row_id: int | Unset = UNSET,
+    recipe_row_id: str | Unset = UNSET,
 ) -> Response[ErrorResponse | RecipeListResponse]:
     """Get all recipes
 
@@ -142,7 +142,7 @@ def sync_detailed(
         ingredient_variant_id (int | Unset):
         product_variant_ids (list[int] | Unset):
         product_id (int | Unset):
-        recipe_row_id (int | Unset):
+        recipe_row_id (str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -185,7 +185,7 @@ def sync(
     ingredient_variant_id: int | Unset = UNSET,
     product_variant_ids: list[int] | Unset = UNSET,
     product_id: int | Unset = UNSET,
-    recipe_row_id: int | Unset = UNSET,
+    recipe_row_id: str | Unset = UNSET,
 ) -> ErrorResponse | RecipeListResponse | None:
     """Get all recipes
 
@@ -201,7 +201,7 @@ def sync(
         ingredient_variant_id (int | Unset):
         product_variant_ids (list[int] | Unset):
         product_id (int | Unset):
-        recipe_row_id (int | Unset):
+        recipe_row_id (str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -239,7 +239,7 @@ async def asyncio_detailed(
     ingredient_variant_id: int | Unset = UNSET,
     product_variant_ids: list[int] | Unset = UNSET,
     product_id: int | Unset = UNSET,
-    recipe_row_id: int | Unset = UNSET,
+    recipe_row_id: str | Unset = UNSET,
 ) -> Response[ErrorResponse | RecipeListResponse]:
     """Get all recipes
 
@@ -255,7 +255,7 @@ async def asyncio_detailed(
         ingredient_variant_id (int | Unset):
         product_variant_ids (list[int] | Unset):
         product_id (int | Unset):
-        recipe_row_id (int | Unset):
+        recipe_row_id (str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -296,7 +296,7 @@ async def asyncio(
     ingredient_variant_id: int | Unset = UNSET,
     product_variant_ids: list[int] | Unset = UNSET,
     product_id: int | Unset = UNSET,
-    recipe_row_id: int | Unset = UNSET,
+    recipe_row_id: str | Unset = UNSET,
 ) -> ErrorResponse | RecipeListResponse | None:
     """Get all recipes
 
@@ -312,7 +312,7 @@ async def asyncio(
         ingredient_variant_id (int | Unset):
         product_variant_ids (list[int] | Unset):
         product_id (int | Unset):
-        recipe_row_id (int | Unset):
+        recipe_row_id (str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/katana_public_api_client/api/stocktake/get_all_stocktakes.py
+++ b/katana_public_api_client/api/stocktake/get_all_stocktakes.py
@@ -19,7 +19,7 @@ def _get_kwargs(
     location_id: int | Unset = UNSET,
     status: str | Unset = UNSET,
     stocktake_number: str | Unset = UNSET,
-    stock_adjustment_id: float | Unset = UNSET,
+    stock_adjustment_id: str | Unset = UNSET,
     created_at_min: datetime.datetime | Unset = UNSET,
     created_at_max: datetime.datetime | Unset = UNSET,
     updated_at_min: datetime.datetime | Unset = UNSET,
@@ -129,7 +129,7 @@ def sync_detailed(
     location_id: int | Unset = UNSET,
     status: str | Unset = UNSET,
     stocktake_number: str | Unset = UNSET,
-    stock_adjustment_id: float | Unset = UNSET,
+    stock_adjustment_id: str | Unset = UNSET,
     created_at_min: datetime.datetime | Unset = UNSET,
     created_at_max: datetime.datetime | Unset = UNSET,
     updated_at_min: datetime.datetime | Unset = UNSET,
@@ -147,7 +147,7 @@ def sync_detailed(
         location_id (int | Unset):
         status (str | Unset):
         stocktake_number (str | Unset):
-        stock_adjustment_id (float | Unset):
+        stock_adjustment_id (str | Unset):
         created_at_min (datetime.datetime | Unset):
         created_at_max (datetime.datetime | Unset):
         updated_at_min (datetime.datetime | Unset):
@@ -194,7 +194,7 @@ def sync(
     location_id: int | Unset = UNSET,
     status: str | Unset = UNSET,
     stocktake_number: str | Unset = UNSET,
-    stock_adjustment_id: float | Unset = UNSET,
+    stock_adjustment_id: str | Unset = UNSET,
     created_at_min: datetime.datetime | Unset = UNSET,
     created_at_max: datetime.datetime | Unset = UNSET,
     updated_at_min: datetime.datetime | Unset = UNSET,
@@ -212,7 +212,7 @@ def sync(
         location_id (int | Unset):
         status (str | Unset):
         stocktake_number (str | Unset):
-        stock_adjustment_id (float | Unset):
+        stock_adjustment_id (str | Unset):
         created_at_min (datetime.datetime | Unset):
         created_at_max (datetime.datetime | Unset):
         updated_at_min (datetime.datetime | Unset):
@@ -254,7 +254,7 @@ async def asyncio_detailed(
     location_id: int | Unset = UNSET,
     status: str | Unset = UNSET,
     stocktake_number: str | Unset = UNSET,
-    stock_adjustment_id: float | Unset = UNSET,
+    stock_adjustment_id: str | Unset = UNSET,
     created_at_min: datetime.datetime | Unset = UNSET,
     created_at_max: datetime.datetime | Unset = UNSET,
     updated_at_min: datetime.datetime | Unset = UNSET,
@@ -272,7 +272,7 @@ async def asyncio_detailed(
         location_id (int | Unset):
         status (str | Unset):
         stocktake_number (str | Unset):
-        stock_adjustment_id (float | Unset):
+        stock_adjustment_id (str | Unset):
         created_at_min (datetime.datetime | Unset):
         created_at_max (datetime.datetime | Unset):
         updated_at_min (datetime.datetime | Unset):
@@ -317,7 +317,7 @@ async def asyncio(
     location_id: int | Unset = UNSET,
     status: str | Unset = UNSET,
     stocktake_number: str | Unset = UNSET,
-    stock_adjustment_id: float | Unset = UNSET,
+    stock_adjustment_id: str | Unset = UNSET,
     created_at_min: datetime.datetime | Unset = UNSET,
     created_at_max: datetime.datetime | Unset = UNSET,
     updated_at_min: datetime.datetime | Unset = UNSET,
@@ -335,7 +335,7 @@ async def asyncio(
         location_id (int | Unset):
         status (str | Unset):
         stocktake_number (str | Unset):
-        stock_adjustment_id (float | Unset):
+        stock_adjustment_id (str | Unset):
         created_at_min (datetime.datetime | Unset):
         created_at_max (datetime.datetime | Unset):
         updated_at_min (datetime.datetime | Unset):

--- a/katana_public_api_client/models/__init__.py
+++ b/katana_public_api_client/models/__init__.py
@@ -194,8 +194,11 @@ from .get_all_manufacturing_order_operation_rows_status import (
     GetAllManufacturingOrderOperationRowsStatus,
 )
 from .get_all_manufacturing_orders_status import GetAllManufacturingOrdersStatus
+from .get_all_materials_batch_tracked import GetAllMaterialsBatchTracked
 from .get_all_materials_extend_item import GetAllMaterialsExtendItem
+from .get_all_products_batch_tracked import GetAllProductsBatchTracked
 from .get_all_products_extend_item import GetAllProductsExtendItem
+from .get_all_products_serial_tracked import GetAllProductsSerialTracked
 from .get_all_sales_order_rows_extend_item import GetAllSalesOrderRowsExtendItem
 from .get_all_sales_order_rows_product_availability import (
     GetAllSalesOrderRowsProductAvailability,
@@ -687,8 +690,11 @@ __all__ = (
     "GetAllInventoryPointExtendItem",
     "GetAllManufacturingOrderOperationRowsStatus",
     "GetAllManufacturingOrdersStatus",
+    "GetAllMaterialsBatchTracked",
     "GetAllMaterialsExtendItem",
+    "GetAllProductsBatchTracked",
     "GetAllProductsExtendItem",
+    "GetAllProductsSerialTracked",
     "GetAllSalesOrderRowsExtendItem",
     "GetAllSalesOrderRowsProductAvailability",
     "GetAllSalesOrdersProductAvailability",

--- a/katana_public_api_client/models/get_all_materials_batch_tracked.py
+++ b/katana_public_api_client/models/get_all_materials_batch_tracked.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class GetAllMaterialsBatchTracked(StrEnum):
+    FALSE = "false"
+    TRUE = "true"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/katana_public_api_client/models/get_all_products_batch_tracked.py
+++ b/katana_public_api_client/models/get_all_products_batch_tracked.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class GetAllProductsBatchTracked(StrEnum):
+    FALSE = "false"
+    TRUE = "true"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/katana_public_api_client/models/get_all_products_serial_tracked.py
+++ b/katana_public_api_client/models/get_all_products_serial_tracked.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class GetAllProductsSerialTracked(StrEnum):
+    FALSE = "false"
+    TRUE = "true"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/tests/test_api_quality_analysis.py
+++ b/tests/test_api_quality_analysis.py
@@ -60,6 +60,22 @@ class TestAPIQualityAnalysis:
                 f"Consider removing them or adding them to relevant endpoints."
             )
 
+    # Parameter names where Katana's wire contract legitimately differs across
+    # endpoints. Each entry maps ``param_name -> {"PATH METHOD", ...}`` of every
+    # endpoint that intentionally diverges from the rest. Verified against
+    # ``docs/upstream-specs/live-gateway.yaml``.
+    DOCUMENTED_PARAMETER_DIVERGENCES: dict[str, set[str]] = {  # noqa: RUF012
+        # ``GET /inventory`` accepts ``variant_id`` as ``array[integer]``
+        # (multi-valued filter); every other endpoint uses a single integer.
+        # Confirmed in ``live-gateway.yaml::InventoryController.getInventories``.
+        "variant_id": {"GET /inventory"},
+        # ``GET /stocktakes`` accepts ``stock_adjustment_id`` as a string per
+        # upstream; ``GET /stocktake_rows`` declares ``number`` (legacy local
+        # divergence — upstream does not expose the parameter at all on
+        # ``stocktake_rows``, so leaving the local shape alone for now).
+        "stock_adjustment_id": {"GET /stocktakes"},
+    }
+
     def test_parameter_consistency_across_endpoints(
         self, api_spec: dict[str, Any]
     ) -> None:
@@ -67,6 +83,8 @@ class TestAPIQualityAnalysis:
         Test that parameters with the same name have consistent definitions across endpoints.
 
         Inconsistent parameter definitions confuse API consumers and indicate design issues.
+        Endpoints listed in :data:`DOCUMENTED_PARAMETER_DIVERGENCES` are exempt — Katana's
+        upstream wire contract genuinely accepts a different shape for that name there.
         """
         # Collect all inline parameters (non-$ref) grouped by name
         parameters_by_name: dict[str, list[dict[str, Any]]] = {}
@@ -99,15 +117,30 @@ class TestAPIQualityAnalysis:
         # Check consistency for parameters that appear multiple times
         inconsistencies = []
 
+        documented = self.DOCUMENTED_PARAMETER_DIVERGENCES
+
         for param_name, param_list in parameters_by_name.items():
             if len(param_list) <= 1:
                 continue  # Can't be inconsistent if it only appears once
 
-            # Use first parameter as reference
-            reference = param_list[0]
+            exempt = documented.get(param_name, set())
+
+            # Filter out exempt endpoints before comparing — they are the
+            # documented divergences that should not fail the test.
+            comparable = [
+                p
+                for p in param_list
+                if f"{p['_context']['method'].upper()} {p['_context']['path']}"
+                not in exempt
+            ]
+            if len(comparable) <= 1:
+                continue
+
+            # Use first comparable parameter as reference
+            reference = comparable[0]
             ref_context = reference["_context"]
 
-            for param in param_list[1:]:
+            for param in comparable[1:]:
                 context = param["_context"]
 
                 # Compare key fields (excluding context)

--- a/tests/test_query_param_types_regression.py
+++ b/tests/test_query_param_types_regression.py
@@ -1,0 +1,152 @@
+"""Regression tests for #570 — six query parameter types now match Katana's wire contract.
+
+Each test asserts the *outgoing* request URL matches what Katana actually accepts:
+arrays for ``/inventory`` ``variant_id``, literal strings for the boolean-look-alike
+flags, and strings for the ID filters that were previously typed as integers.
+"""
+
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from katana_public_api_client import KatanaClient
+from katana_public_api_client.api.inventory import get_all_inventory_point
+from katana_public_api_client.api.material import get_all_materials
+from katana_public_api_client.api.product import get_all_products
+from katana_public_api_client.api.recipe import get_all_recipes
+from katana_public_api_client.api.stocktake import get_all_stocktakes
+from katana_public_api_client.models.get_all_materials_batch_tracked import (
+    GetAllMaterialsBatchTracked,
+)
+from katana_public_api_client.models.get_all_products_batch_tracked import (
+    GetAllProductsBatchTracked,
+)
+from katana_public_api_client.models.get_all_products_serial_tracked import (
+    GetAllProductsSerialTracked,
+)
+
+
+def _client_with_mock_transport(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> KatanaClient:
+    """Build a KatanaClient backed by ``httpx.MockTransport`` (caller manages lifetime)."""
+    return KatanaClient(
+        api_key="test-api-key",
+        base_url="https://api.katana.test",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+@pytest.mark.asyncio
+async def test_inventory_variant_id_serializes_as_array() -> None:
+    """``GET /inventory`` ``variant_id`` is an array — multi-valued filter."""
+    captured: dict[str, list[tuple[str, str]]] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/inventory"
+        captured["params"] = list(request.url.params.multi_items())
+        return httpx.Response(200, json={"data": []})
+
+    async with _client_with_mock_transport(handler) as client:
+        await get_all_inventory_point.asyncio_detailed(
+            client=client,
+            variant_id=[101, 202, 303],
+        )
+
+    variant_params = [v for k, v in captured["params"] if k == "variant_id"]
+    assert variant_params == ["101", "202", "303"]
+
+
+@pytest.mark.asyncio
+async def test_products_batch_tracked_serializes_as_literal_string() -> None:
+    """``GET /products`` ``batch_tracked`` accepts the literal string ``"true"`` / ``"false"``."""
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["batch_tracked"] = request.url.params.get("batch_tracked", "")
+        return httpx.Response(200, json={"data": []})
+
+    async with _client_with_mock_transport(handler) as client:
+        await get_all_products.asyncio_detailed(
+            client=client,
+            batch_tracked=GetAllProductsBatchTracked.TRUE,
+        )
+
+    assert captured["batch_tracked"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_products_serial_tracked_serializes_as_literal_string() -> None:
+    """``GET /products`` ``serial_tracked`` accepts the literal string ``"true"`` / ``"false"``."""
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["serial_tracked"] = request.url.params.get("serial_tracked", "")
+        return httpx.Response(200, json={"data": []})
+
+    async with _client_with_mock_transport(handler) as client:
+        await get_all_products.asyncio_detailed(
+            client=client,
+            serial_tracked=GetAllProductsSerialTracked.FALSE,
+        )
+
+    assert captured["serial_tracked"] == "false"
+
+
+@pytest.mark.asyncio
+async def test_materials_batch_tracked_serializes_as_literal_string() -> None:
+    """``GET /materials`` ``batch_tracked`` accepts the literal string ``"true"`` / ``"false"``."""
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["batch_tracked"] = request.url.params.get("batch_tracked", "")
+        return httpx.Response(200, json={"data": []})
+
+    async with _client_with_mock_transport(handler) as client:
+        await get_all_materials.asyncio_detailed(
+            client=client,
+            batch_tracked=GetAllMaterialsBatchTracked.TRUE,
+        )
+
+    assert captured["batch_tracked"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_recipes_recipe_row_id_serializes_as_string() -> None:
+    """``GET /recipes`` ``recipe_row_id`` is a UUID string, not an int."""
+    captured: dict[str, str] = {}
+    recipe_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["recipe_row_id"] = request.url.params.get("recipe_row_id", "")
+        return httpx.Response(200, json={"data": []})
+
+    async with _client_with_mock_transport(handler) as client:
+        await get_all_recipes.asyncio_detailed(
+            client=client,
+            recipe_row_id=recipe_uuid,
+        )
+
+    assert captured["recipe_row_id"] == recipe_uuid
+
+
+@pytest.mark.asyncio
+async def test_stocktakes_stock_adjustment_id_serializes_as_string() -> None:
+    """``GET /stocktakes`` ``stock_adjustment_id`` is a string per upstream wire contract."""
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["stock_adjustment_id"] = request.url.params.get(
+            "stock_adjustment_id", ""
+        )
+        return httpx.Response(200, json={"data": []})
+
+    async with _client_with_mock_transport(handler) as client:
+        await get_all_stocktakes.asyncio_detailed(
+            client=client,
+            stock_adjustment_id="42",
+        )
+
+    assert captured["stock_adjustment_id"] == "42"


### PR DESCRIPTION
## Summary

Six query parameters in ``docs/katana-openapi.yaml`` declared a different type from what Katana's live API actually accepts on the wire. This forced typed-client callers to either drop down to raw httpx or pass values the API silently mis-handles.

Each finding was verified against `docs/upstream-specs/live-gateway.yaml`:

| Operation | Param | Was | Now |
|---|---|---|---|
| `GET /inventory` | `variant_id` | `integer` | `array[integer]` |
| `GET /products` | `batch_tracked` | `boolean` | string enum (`"true"`/`"false"`) |
| `GET /products` | `serial_tracked` | `boolean` | string enum |
| `GET /materials` | `batch_tracked` | `boolean` | string enum |
| `GET /recipes` | `recipe_row_id` | `integer` | `string` |
| `GET /stocktakes` | `stock_adjustment_id` | `number` | `string` |

`/inventory variant_id` is the high-impact case: callers wanting to filter by multiple variant IDs previously had no path through the typed client. The boolean-look-alike string enums encode the literal strings Katana actually matches.

## Generated impact

- New attrs models: `GetAllProductsBatchTracked`, `GetAllProductsSerialTracked`, `GetAllMaterialsBatchTracked`.
- 5 endpoint modules regenerated with new parameter types (signatures listed in commit message).
- `tests/test_api_quality_analysis.py` gains a documented-divergence allow-list — `variant_id` (`/inventory` only) and `stock_adjustment_id` (`/stocktakes` only) intentionally diverge from sibling endpoints per upstream.
- New `tests/test_query_param_types_regression.py` — 6 mock-transport tests, one per affected endpoint, asserting the wire shape.

## Test plan

- [x] `uv run poe check` (full validation, includes test suite)
- [x] All 6 new regression tests pass

## Notes

Closes #570.

Out of scope but flagged for follow-up: `/stocktake_rows` declares a `stock_adjustment_id` query param that upstream doesn't expose at all. Not a wire-type drift — a "we invented a parameter" drift. Will surface in #395's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)