### PR TITLE
feat(mcp): fulfill_order supports serial-tracked variants (#547)

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -12180,6 +12180,12 @@ components:
         quantity:
           type: number
           description: Quantity to fulfill
+        serial_numbers:
+          type: array
+          description: Serial number IDs allocated to this fulfillment row. Required
+            when the row's variant is serial-tracked; the count must equal `quantity`.
+          items:
+            type: integer
     CreateSalesOrderFulfillmentRequest:
       description: Request payload for creating a new sales order fulfillment
       type: object

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1427,6 +1427,12 @@ Complete a manufacturing or sales order.
 - `order_id` (required): Order ID to fulfill
 - `order_type` (required): "manufacturing" or "sales"
 - `preview` (optional, default true): true=preview, false=fulfill
+- `rows` (optional, sales orders only): Per-row overrides
+  `[{sales_order_row_id, serial_numbers?}]`. `serial_numbers` is a list of
+  pre-existing `SerialNumber` IDs to attach to that row; the count must
+  equal the row's ordered quantity. **Required** when the row's variant is
+  serial-tracked — without it, the tool emits a `BLOCK:` warning at preview
+  and refuses on direct apply (Katana would 422 the request).
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -8,12 +8,15 @@ These tools provide:
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+import asyncio
+from collections import Counter
+from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
 from pydantic import BaseModel, ConfigDict, Field
 
+from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.tool_result_utils import (
@@ -22,7 +25,7 @@ from katana_mcp.tools.tool_result_utils import (
     make_tool_result,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
-from katana_public_api_client.domain.converters import unwrap_unset
+from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     ManufacturingOrder,
     SalesOrder,
@@ -37,6 +40,28 @@ logger = get_logger(__name__)
 # ============================================================================
 
 
+class FulfillRowOverride(BaseModel):
+    """Per-row override for sales-order fulfillment.
+
+    Currently carries serial-number IDs to attach to a specific row. Used
+    when a row's variant is serial-tracked: Katana's
+    ``POST /sales_order_fulfillments`` rejects the request with HTTP 422
+    unless the row carries one ``SerialNumber`` ID per unit shipped.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    sales_order_row_id: int = Field(..., description="Sales order row ID to override")
+    serial_numbers: list[int] | None = Field(
+        default=None,
+        description=(
+            "Pre-existing SerialNumber IDs to attach to this fulfillment row. "
+            "Length must equal the row's ordered quantity. Required when the "
+            "row's variant is serial-tracked."
+        ),
+    )
+
+
 class FulfillOrderRequest(BaseModel):
     """Request to fulfill an order."""
 
@@ -49,6 +74,14 @@ class FulfillOrderRequest(BaseModel):
     preview: bool = Field(
         default=True,
         description="If true (default), returns preview. If false, fulfills order.",
+    )
+    rows: list[FulfillRowOverride] | None = Field(
+        default=None,
+        description=(
+            "Per-row overrides (currently: serial_numbers). When omitted, the "
+            "tool ships the full ordered quantity with no serials attached. "
+            "Sales orders only — ignored for order_type='manufacturing'."
+        ),
     )
 
 
@@ -188,6 +221,173 @@ async def _fulfill_manufacturing_order(
     )
 
 
+async def _fetch_missing_from_api(
+    services: Any,
+    cached: dict[int, dict[str, Any]],
+    needed_ids: set[int],
+    api_get_fn: Any,
+) -> None:
+    """Fill ``cached`` in-place with API fetches for IDs not already present.
+
+    Used to backstop cache misses so a cold or stale cache doesn't mask
+    serial-tracking detection. Failures (404 / network) are swallowed and
+    the ID stays absent from ``cached`` — callers treat that as "unknown,
+    don't block" (best-effort, same fallback as a cache miss).
+    """
+    from katana_public_api_client.models import ErrorResponse
+    from katana_public_api_client.utils import unwrap
+
+    missing = [eid for eid in needed_ids if eid not in cached]
+    if not missing:
+        return
+    responses = await asyncio.gather(
+        *(
+            api_get_fn.asyncio_detailed(id=eid, client=services.client)
+            for eid in missing
+        ),
+        return_exceptions=True,
+    )
+    for eid, response in zip(missing, responses, strict=True):
+        if isinstance(response, BaseException):
+            continue
+        obj = unwrap(response, raise_on_error=False)
+        if obj is None or isinstance(obj, ErrorResponse):
+            continue
+        cached[eid] = obj.to_dict()
+
+
+async def _resolve_row_serial_info(
+    services: Any, so_rows: list[Any]
+) -> tuple[dict[int, bool], dict[int, str]]:
+    """Return ``(serial_tracked_by_row, sku_by_row)`` from cache + API fallback.
+
+    The ``serial_tracked`` flag lives on the parent Product/Material, not on
+    Variant — so we fan out variant-by-id, then group parent IDs by type
+    and bulk-resolve. Cache misses fall back to a per-ID API fetch (parallel)
+    so a cold / stale cache doesn't silently mis-classify a serial-tracked
+    row as "OK to ship without serials" and surface the original Katana 422
+    on apply. IDs that resolve neither in cache nor via API stay marked
+    ``serial_tracked=False`` and ``"variant {id}"`` for SKUs (best-effort,
+    same as if the entity didn't exist). The two parent maps are kept
+    separate per CLAUDE.md "Cache IDs are not globally unique".
+    """
+    if not so_rows:
+        return {}, {}
+    from katana_public_api_client.api.material import get_material
+    from katana_public_api_client.api.product import get_product
+    from katana_public_api_client.api.variant import get_variant
+
+    variant_ids = {row.variant_id for row in so_rows if row.variant_id is not None}
+    variants_by_id = await services.cache.get_many_by_ids(
+        EntityType.VARIANT, variant_ids
+    )
+    await _fetch_missing_from_api(services, variants_by_id, variant_ids, get_variant)
+
+    product_ids = {
+        v.get("product_id") for v in variants_by_id.values() if v.get("product_id")
+    }
+    material_ids = {
+        v.get("material_id") for v in variants_by_id.values() if v.get("material_id")
+    }
+    products, materials = await asyncio.gather(
+        services.cache.get_many_by_ids(EntityType.PRODUCT, product_ids),
+        services.cache.get_many_by_ids(EntityType.MATERIAL, material_ids),
+    )
+    await asyncio.gather(
+        _fetch_missing_from_api(services, products, product_ids, get_product),
+        _fetch_missing_from_api(services, materials, material_ids, get_material),
+    )
+
+    serial_tracked: dict[int, bool] = {}
+    skus: dict[int, str] = {}
+    for row in so_rows:
+        variant = variants_by_id.get(row.variant_id)
+        skus[row.id] = (variant or {}).get("sku") or f"variant {row.variant_id}"
+        if variant is None:
+            serial_tracked[row.id] = False
+            continue
+        if variant.get("product_id"):
+            parent = products.get(variant["product_id"])
+        elif variant.get("material_id"):
+            parent = materials.get(variant["material_id"])
+        else:
+            parent = None
+        serial_tracked[row.id] = bool(parent and parent.get("serial_tracked"))
+    return serial_tracked, skus
+
+
+def _build_row_override_warnings(
+    *,
+    so_rows: list[Any],
+    request_rows: list[FulfillRowOverride],
+    overrides_by_row: dict[int, list[int]],
+    serial_tracked_by_row: dict[int, bool],
+    sku_by_row: dict[int, str],
+    order_number: str,
+) -> list[str]:
+    """Return all ``BLOCK:`` warnings driven by ``request.rows`` content.
+
+    Covers: unknown row IDs, duplicate overrides, serial-tracked rows
+    missing serials, count/quantity mismatches, and non-integer quantity
+    on serial-tracked rows. Numeric comparisons use ``qty`` directly —
+    Python equality treats ``2 == 2.0`` as ``True``, so an integer-valued
+    ``2.0`` qty still matches ``len(serials) == 2``. Non-integral qty on a
+    serial-tracked row is blocked separately, since each serial number
+    represents a whole unit.
+    """
+    warnings: list[str] = []
+    so_row_ids = {row.id for row in so_rows}
+
+    for ovr in request_rows:
+        if ovr.sales_order_row_id not in so_row_ids:
+            warnings.append(
+                f"{BLOCK_WARNING_PREFIX} Row override references unknown "
+                f"sales_order_row_id={ovr.sales_order_row_id} "
+                f"(sales order {order_number} has rows {sorted(so_row_ids)})."
+            )
+
+    # A row appearing twice in `rows=` would silently keep only the last
+    # entry (dict-comp last-key-wins) — flag it so the caller fixes the input.
+    duplicate_override_ids = sorted(
+        rid
+        for rid, count in Counter(
+            ovr.sales_order_row_id for ovr in request_rows
+        ).items()
+        if count > 1
+    )
+    if duplicate_override_ids:
+        warnings.append(
+            f"{BLOCK_WARNING_PREFIX} Multiple overrides for the same "
+            f"sales_order_row_id ({duplicate_override_ids}); each row may "
+            "appear at most once in rows=."
+        )
+
+    for row in so_rows:
+        rid = row.id
+        qty = row.quantity
+        is_tracked = serial_tracked_by_row.get(rid, False)
+        serials = overrides_by_row.get(rid)
+        if is_tracked and qty is not None and qty != int(qty):
+            warnings.append(
+                f"{BLOCK_WARNING_PREFIX} Row {rid} ({sku_by_row.get(rid)}) is "
+                f"serial-tracked but quantity ({qty}) is not a whole number; "
+                "serial-tracked variants must ship in integer units."
+            )
+        elif is_tracked and not serials and (qty or 0) > 0:
+            warnings.append(
+                f"{BLOCK_WARNING_PREFIX} Row {rid} ({sku_by_row.get(rid)}) is "
+                "serial-tracked. Pass serial_numbers via the rows= override "
+                "(one SerialNumber ID per unit)."
+            )
+        elif serials is not None and qty is not None and len(serials) != qty:
+            warnings.append(
+                f"{BLOCK_WARNING_PREFIX} Row {rid} ({sku_by_row.get(rid)}): "
+                f"serial_numbers count ({len(serials)}) must equal quantity "
+                f"({qty})."
+            )
+    return warnings
+
+
 async def _fulfill_sales_order(
     request: FulfillOrderRequest, context: Context
 ) -> FulfillOrderResponse:
@@ -200,6 +400,11 @@ async def _fulfill_sales_order(
     "deliver everything ordered" case. For partial fulfillments the user
     should use the Katana UI directly; the tool's MCP surface intentionally
     keeps the simple case simple.
+
+    Serial-tracked variants need ``serial_numbers`` IDs attached per row;
+    callers pass them via ``request.rows`` (``FulfillRowOverride``). Without
+    them, Katana 422s on apply, so the tool emits a ``BLOCK:`` warning at
+    preview time and refuses on direct apply.
     """
     from katana_public_api_client.api.sales_order import (
         get_sales_order as api_get_sales_order,
@@ -214,15 +419,25 @@ async def _fulfill_sales_order(
     current_status = so.status.value if so.status else "UNKNOWN"
     so_rows = unwrap_unset(so.sales_order_rows, []) or []
 
-    # SKU isn't resolved per row — that would cost an N-row variant fetch on
-    # every preview. variant_id + qty is enough to recognise the shipment.
+    overrides_by_row: dict[int, list[int]] = {
+        ovr.sales_order_row_id: ovr.serial_numbers or []
+        for ovr in (request.rows or [])
+        if ovr.serial_numbers is not None
+    }
+
+    serial_tracked_by_row, sku_by_row = await _resolve_row_serial_info(
+        services, so_rows
+    )
+
     inventory_updates: list[str] = []
     for row in so_rows:
         rid = row.id
         vid = row.variant_id
         qty = row.quantity
+        serials = overrides_by_row.get(rid)
+        suffix = f" with serials {serials}" if serials else ""
         inventory_updates.append(
-            f"Row {rid}: ship {qty} of variant {vid} (full ordered quantity)"
+            f"Row {rid}: ship {qty} of variant {vid} (full ordered quantity){suffix}"
         )
     if not inventory_updates:
         inventory_updates.append("(no rows on this sales order)")
@@ -237,6 +452,17 @@ async def _fulfill_sales_order(
         warnings.append(
             f"{BLOCK_WARNING_PREFIX} Sales order {order_number} has no rows to fulfill."
         )
+
+    warnings.extend(
+        _build_row_override_warnings(
+            so_rows=so_rows,
+            request_rows=request.rows or [],
+            overrides_by_row=overrides_by_row,
+            serial_tracked_by_row=serial_tracked_by_row,
+            sku_by_row=sku_by_row,
+            order_number=order_number,
+        )
+    )
 
     if request.preview:
         has_block = any(w.startswith(BLOCK_WARNING_PREFIX) for w in warnings)
@@ -263,10 +489,10 @@ async def _fulfill_sales_order(
             ),
         )
 
-    # Refuse on apply if the order is already in a delivered state — the
-    # preview's BLOCK warning would have suppressed the Confirm button in
-    # the iframe, but we re-check here so direct/programmatic callers
-    # (skipping the UI) get the same protection.
+    # Refuse on apply if any BLOCK warning is present — the preview would have
+    # suppressed the Confirm button in the iframe, but we re-check here so
+    # direct/programmatic callers (skipping the UI) get the same protection.
+    has_block = any(w.startswith(BLOCK_WARNING_PREFIX) for w in warnings)
     if current_status in ("DELIVERED", "PARTIALLY_DELIVERED"):
         return FulfillOrderResponse(
             order_id=request.order_id,
@@ -297,6 +523,24 @@ async def _fulfill_sales_order(
                 "no fulfillment created."
             ),
         )
+    if has_block:
+        return FulfillOrderResponse(
+            order_id=request.order_id,
+            order_type="sales",
+            order_number=order_number,
+            status=current_status,
+            is_preview=False,
+            inventory_updates=[],
+            warnings=warnings,
+            next_actions=[
+                "Resolve the issue(s) above and retry with the corrected request"
+            ],
+            message=(
+                f"Refused: Sales order {order_number} fulfillment blocked by "
+                f"{sum(1 for w in warnings if w.startswith(BLOCK_WARNING_PREFIX))} "
+                "issue(s); no fulfillment created."
+            ),
+        )
 
     from katana_public_api_client.api.sales_order_fulfillment import (
         create_sales_order_fulfillment as api_create_fulfillment,
@@ -312,6 +556,7 @@ async def _fulfill_sales_order(
         SalesOrderFulfillmentRowRequest(
             sales_order_row_id=row.id,
             quantity=row.quantity,
+            serial_numbers=to_unset(overrides_by_row.get(row.id)),
         )
         for row in so_rows
     ]

--- a/katana_mcp_server/tests/tools/test_orders.py
+++ b/katana_mcp_server/tests/tools/test_orders.py
@@ -3,8 +3,10 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from katana_mcp.cache import EntityType
 from katana_mcp.tools.foundation.orders import (
     FulfillOrderRequest,
+    FulfillRowOverride,
     _fulfill_order_impl,
 )
 
@@ -441,3 +443,397 @@ async def test_fulfill_manufacturing_order_api_error():
 # ``test_fulfill_sales_order_confirm_not_implemented``). Once the tool is
 # extended to send the live-required ``sales_order_fulfillment_rows``,
 # restore an API-error test that exercises the row-aware path.
+
+
+# ============================================================================
+# Sales Order — Serial-Tracked Variant Tests (#547)
+# ============================================================================
+
+
+def _wire_serial_tracked_cache(
+    lifespan_ctx, *, variant_id: int, sku: str, parent_kind: str = "product"
+) -> None:
+    """Configure the mock cache so a row's variant resolves as serial-tracked.
+
+    ``parent_kind`` selects whether the variant is parented to a product or a
+    material — both surface ``serial_tracked`` on the parent.
+    """
+    parent_id = 9000 + variant_id
+    parent_key = f"{parent_kind}_id"
+    variant_data = {"id": variant_id, "sku": sku, parent_key: parent_id}
+    parent_data = {"id": parent_id, "serial_tracked": True}
+
+    async def _get_many(entity_type: str, ids):
+        ids = list(ids or [])
+        if entity_type == EntityType.VARIANT and variant_id in ids:
+            return {variant_id: variant_data}
+        if entity_type == EntityType.PRODUCT and parent_kind == "product":
+            return {parent_id: parent_data} if parent_id in ids else {}
+        if entity_type == EntityType.MATERIAL and parent_kind == "material":
+            return {parent_id: parent_data} if parent_id in ids else {}
+        return {}
+
+    lifespan_ctx.cache.get_many_by_ids = AsyncMock(side_effect=_get_many)
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_preview_blocks_serial_tracked_without_override():
+    """Serial-tracked variant + no rows override → BLOCK warning naming the SKU."""
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-SN-1"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 1.0)]
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+
+    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    request = FulfillOrderRequest(order_id=42, order_type="sales", preview=True)
+    result = await _fulfill_order_impl(request, context)
+
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert len(block_warnings) == 1
+    assert "serial-tracked" in block_warnings[0]
+    assert "ROCKER-V2" in block_warnings[0]
+    assert "Resolve the issue" in result.next_actions[0]
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_preview_accepts_serial_override():
+    """Serial-tracked variant + matching override → no BLOCK warning, serials in preview."""
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-SN-2"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 1.0)]
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+
+    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    request = FulfillOrderRequest(
+        order_id=42,
+        order_type="sales",
+        preview=True,
+        rows=[FulfillRowOverride(sales_order_row_id=1, serial_numbers=[501])],
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    assert not [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any("serials [501]" in u for u in result.inventory_updates)
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_apply_passes_serials_to_api():
+    """Apply with override → POST body row carries serial_numbers."""
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-SN-3"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 1.0)]
+
+    mock_get_response = MagicMock(status_code=200, parsed=mock_so)
+
+    from katana_public_api_client.api.sales_order import get_sales_order
+    from katana_public_api_client.api.sales_order_fulfillment import (
+        create_sales_order_fulfillment,
+    )
+    from katana_public_api_client.models import SalesOrderFulfillment
+
+    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    fulfillment_obj = MagicMock(spec=SalesOrderFulfillment)
+    fulfillment_obj.id = 7777
+    mock_create_response = MagicMock(status_code=201, parsed=fulfillment_obj)
+    create_mock = AsyncMock(return_value=mock_create_response)
+    create_sales_order_fulfillment.asyncio_detailed = create_mock
+
+    request = FulfillOrderRequest(
+        order_id=42,
+        order_type="sales",
+        preview=False,
+        rows=[FulfillRowOverride(sales_order_row_id=1, serial_numbers=[501])],
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.is_preview is False
+    assert result.status == "DELIVERED"
+    create_mock.assert_called_once()
+    sent_body = create_mock.call_args.kwargs["body"]
+    sent_rows = sent_body.sales_order_fulfillment_rows
+    assert len(sent_rows) == 1
+    assert sent_rows[0].sales_order_row_id == 1
+    assert sent_rows[0].serial_numbers == [501]
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_apply_refuses_serial_tracked_without_override():
+    """Direct apply (preview=False) without override → refusal, no API call."""
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-SN-4"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 1.0)]
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+
+    from katana_public_api_client.api.sales_order import get_sales_order
+    from katana_public_api_client.api.sales_order_fulfillment import (
+        create_sales_order_fulfillment,
+    )
+
+    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    create_mock = AsyncMock()
+    create_sales_order_fulfillment.asyncio_detailed = create_mock
+
+    request = FulfillOrderRequest(order_id=42, order_type="sales", preview=False)
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.is_preview is False
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any("serial-tracked" in w for w in block_warnings)
+    assert "Refused" in result.message
+    create_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_blocks_quantity_serials_mismatch():
+    """len(serial_numbers) != quantity → BLOCK warning."""
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-SN-5"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    # qty=2 but only 1 serial provided.
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 2.0)]
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+
+    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    request = FulfillOrderRequest(
+        order_id=42,
+        order_type="sales",
+        preview=True,
+        rows=[FulfillRowOverride(sales_order_row_id=1, serial_numbers=[501])],
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any("count (1) must equal quantity (2" in w for w in block_warnings)
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_blocks_unknown_row_override():
+    """Override referencing a row ID not on the SO → BLOCK warning."""
+    context, _lifespan_ctx = create_mock_context()
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-SN-6"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 1.0)]
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+
+    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    request = FulfillOrderRequest(
+        order_id=42,
+        order_type="sales",
+        preview=True,
+        rows=[FulfillRowOverride(sales_order_row_id=999, serial_numbers=[501])],
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any("unknown sales_order_row_id=999" in w for w in block_warnings)
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_serial_tracked_detection_falls_back_to_api():
+    """Cold / stale cache: variant + product missing from cache.
+
+    Without the API fallback, a cold cache silently classifies the row as
+    not-serial-tracked, so the BLOCK warning never fires and the user hits
+    the original Katana 422 on apply. With the fallback, the per-ID API
+    fetch resolves the variant + product and the BLOCK warning fires.
+    """
+    context, _lifespan_ctx = create_mock_context()
+    # Default mock cache returns {} for every get_many_by_ids — simulating
+    # a cold cache. We do NOT call _wire_serial_tracked_cache here.
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-SN-COLD"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 1.0)]
+
+    mock_get_so_response = MagicMock(status_code=200, parsed=mock_so)
+
+    # API fallback: get_variant returns a variant pointing at product 9100;
+    # get_product returns a serial-tracked product.
+    variant_obj = MagicMock()
+    variant_obj.to_dict = MagicMock(
+        return_value={"id": 100, "sku": "ROCKER-V2", "product_id": 9100}
+    )
+    mock_get_variant_response = MagicMock(status_code=200, parsed=variant_obj)
+
+    product_obj = MagicMock()
+    product_obj.to_dict = MagicMock(return_value={"id": 9100, "serial_tracked": True})
+    mock_get_product_response = MagicMock(status_code=200, parsed=product_obj)
+
+    from katana_public_api_client.api.product import get_product
+    from katana_public_api_client.api.sales_order import get_sales_order
+    from katana_public_api_client.api.variant import get_variant
+
+    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_get_so_response)
+    get_variant.asyncio_detailed = AsyncMock(return_value=mock_get_variant_response)
+    get_product.asyncio_detailed = AsyncMock(return_value=mock_get_product_response)
+
+    request = FulfillOrderRequest(order_id=42, order_type="sales", preview=True)
+    result = await _fulfill_order_impl(request, context)
+
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any("serial-tracked" in w and "ROCKER-V2" in w for w in block_warnings)
+    # Verify both API endpoints were hit.
+    get_variant.asyncio_detailed.assert_called_once()
+    get_product.asyncio_detailed.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_blocks_duplicate_row_override():
+    """Two overrides for the same sales_order_row_id → BLOCK warning.
+
+    Without this check the dict-comp would silently keep only the last
+    override (last-key-wins), hiding conflicting input from the caller.
+    """
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-SN-DUP"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 2.0)]
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+
+    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    request = FulfillOrderRequest(
+        order_id=42,
+        order_type="sales",
+        preview=True,
+        rows=[
+            FulfillRowOverride(sales_order_row_id=1, serial_numbers=[501, 502]),
+            FulfillRowOverride(sales_order_row_id=1, serial_numbers=[601, 602]),
+        ],
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any(
+        "Multiple overrides for the same sales_order_row_id ([1])" in w
+        for w in block_warnings
+    )
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_blocks_serial_tracked_non_integer_quantity():
+    """Serial-tracked variant with non-integer qty → BLOCK warning.
+
+    Previously the code used ``len(serials) != int(qty)``, which silently
+    truncated 1.5 → 1 and could mask genuine mismatches.
+    """
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-SN-FRAC"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 1.5)]
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+
+    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    request = FulfillOrderRequest(
+        order_id=42,
+        order_type="sales",
+        preview=True,
+        rows=[FulfillRowOverride(sales_order_row_id=1, serial_numbers=[501])],
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any(
+        "serial-tracked but quantity (1.5) is not a whole number" in w
+        for w in block_warnings
+    )
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_non_serial_tracked_no_change():
+    """Non-serial-tracked variant + no rows override → behaves as before
+    (no BLOCK warning, apply path passes UNSET for serial_numbers).
+
+    Wires the cache so the variant resolves to a non-serial-tracked product
+    — keeps detection from spuriously firing and confirms the API fallback
+    isn't required in the warm-cache path.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    async def _get_many(entity_type: str, ids):
+        ids = list(ids or [])
+        if entity_type == EntityType.VARIANT and 100 in ids:
+            return {100: {"id": 100, "sku": "PLAIN-WIDGET", "product_id": 9100}}
+        if entity_type == EntityType.PRODUCT and 9100 in ids:
+            return {9100: {"id": 9100, "serial_tracked": False}}
+        return {}
+
+    lifespan_ctx.cache.get_many_by_ids = AsyncMock(side_effect=_get_many)
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-SN-7"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 2.0)]
+
+    mock_get_response = MagicMock(status_code=200, parsed=mock_so)
+
+    from katana_public_api_client.api.sales_order import get_sales_order
+    from katana_public_api_client.api.sales_order_fulfillment import (
+        create_sales_order_fulfillment,
+    )
+    from katana_public_api_client.models import SalesOrderFulfillment
+
+    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    fulfillment_obj = MagicMock(spec=SalesOrderFulfillment)
+    fulfillment_obj.id = 8888
+    mock_create_response = MagicMock(status_code=201, parsed=fulfillment_obj)
+    create_mock = AsyncMock(return_value=mock_create_response)
+    create_sales_order_fulfillment.asyncio_detailed = create_mock
+
+    request = FulfillOrderRequest(order_id=42, order_type="sales", preview=False)
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.status == "DELIVERED"
+    assert not [w for w in result.warnings if w.startswith("BLOCK:")]
+    sent_body = create_mock.call_args.kwargs["body"]
+    sent_rows = sent_body.sales_order_fulfillment_rows
+    # serial_numbers should be UNSET (omitted from wire), not an empty list.
+    from katana_public_api_client.client_types import UNSET
+
+    assert sent_rows[0].serial_numbers is UNSET

--- a/katana_public_api_client/models/sales_order_fulfillment_row_request.py
+++ b/katana_public_api_client/models/sales_order_fulfillment_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -19,12 +19,17 @@ class SalesOrderFulfillmentRowRequest:
 
     sales_order_row_id: int | Unset = UNSET
     quantity: float | Unset = UNSET
+    serial_numbers: list[int] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         sales_order_row_id = self.sales_order_row_id
 
         quantity = self.quantity
+
+        serial_numbers: list[int] | Unset = UNSET
+        if not isinstance(self.serial_numbers, Unset):
+            serial_numbers = self.serial_numbers
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -33,6 +38,8 @@ class SalesOrderFulfillmentRowRequest:
             field_dict["sales_order_row_id"] = sales_order_row_id
         if quantity is not UNSET:
             field_dict["quantity"] = quantity
+        if serial_numbers is not UNSET:
+            field_dict["serial_numbers"] = serial_numbers
 
         return field_dict
 
@@ -43,9 +50,12 @@ class SalesOrderFulfillmentRowRequest:
 
         quantity = d.pop("quantity", UNSET)
 
+        serial_numbers = cast(list[int], d.pop("serial_numbers", UNSET))
+
         sales_order_fulfillment_row_request = cls(
             sales_order_row_id=sales_order_row_id,
             quantity=quantity,
+            serial_numbers=serial_numbers,
         )
 
         sales_order_fulfillment_row_request.additional_properties = d

--- a/katana_public_api_client/models_pydantic/_generated/sales_orders.py
+++ b/katana_public_api_client/models_pydantic/_generated/sales_orders.py
@@ -685,6 +685,12 @@ class SalesOrderFulfillmentRowRequest(KatanaPydanticBase):
         int | None, Field(description="Sales order row ID")
     ] = None
     quantity: Annotated[float | None, Field(description="Quantity to fulfill")] = None
+    serial_numbers: Annotated[
+        list[int] | None,
+        Field(
+            description="Serial number IDs allocated to this fulfillment row. Required when the row's variant is serial-tracked; the count must equal `quantity`."
+        ),
+    ] = None
 
 
 class CreateSalesOrderFulfillmentRequest(KatanaPydanticBase):


### PR DESCRIPTION
## Summary

Closes #547 — sales orders with serial-tracked variants couldn't ship via MCP. Two changes:

1. **Spec + regen** (`feat(client)`): added `serial_numbers: array[integer]` to `SalesOrderFulfillmentRowRequest` in `docs/katana-openapi.yaml`. The wire format always supported it (response schema documents it; Katana 422s without it on serial-tracked rows), but the request schema was missing the field. Additive optional — no breaking marker. Regenerated attrs + pydantic in the same commit.

2. **MCP tool** (`feat(mcp)`): `fulfill_order` grew an optional `rows: list[FulfillRowOverride]` parameter on `FulfillOrderRequest`, where each override carries `sales_order_row_id` + `serial_numbers: list[int] | None`. Wires through to `POST /sales_order_fulfillments`. Preview-time detection looks up each row's variant + parent product/material from cache to read `serial_tracked` and emits `BLOCK:` warnings when:
   - a serial-tracked row has no override (names the SKU)
   - `len(serial_numbers) != quantity`
   - an override references a `sales_order_row_id` not on the SO

   The Confirm button suppresses on `BLOCK:` warnings via the existing `prefab_ui.split_warnings` wiring, so the iframe shows a clear "this can't ship as-is" instead of a cryptic 422 toast post-confirm. Apply path re-checks BLOCK warnings (parallel to the existing already-DELIVERED guard) so direct/programmatic callers skipping the UI get the same protection.

Live session 2026-05-05 repro: SO #WEB20387 (Carbon Rocker v2 / serial CSD00501) — agent diagnosed the gap correctly and bailed to the browser. Same gap surfaces on every serial-tracked SKU, which is meaningful share of inventory for hardware shops with regulatory traceability.

## Out of scope

- **Manufacturing-order fulfillment** has the same gap (`ManufacturingOrder.serial_numbers`) — file a follow-up issue.
- `batch_transactions` per-row override — adjacent but not user-blocking on this ticket.
- Enumerating *available* `SerialNumber` IDs in the preview (would require a `GET /serial_numbers` cache fan-out).
- Creating new serial numbers (`POST /serial_numbers`).

## Pre-existing failures unrelated to this PR

`uv run poe validate-examples` and `validate-response-examples` already fail on `main` for `ManufacturingOrderOperationRow.example` (`type='Production'` not in enum) and `SalesOrderShippingFee.amount` (numeric vs string). Confirmed via stash-and-rerun on `main` — unchanged by this diff.

## Test plan

- [x] `uv run poe check` passes (2865 tests pass, 2 skipped — all preexisting skips)
- [x] 7 new tests in `katana_mcp_server/tests/tools/test_orders.py` cover all four BLOCK cases, both apply paths (serials passed through → API call body, no serials needed → `UNSET` on wire), and a regression for non-serial-tracked variants
- [ ] **Manual verification (post-merge):** if a serial-tracked SO is available in dev/staging, run preview → confirm `BLOCK:` warning lists the SKU, then apply with `rows=[{sales_order_row_id: X, serial_numbers: [Y]}]` → fulfillment created with serial attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)