### PR TITLE
fix(mcp): expose configs and config_attributes on modify_item

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -845,10 +845,21 @@ endpoint; variant sub-payloads route to the shared `/variant` family.
   `is_producible` / `is_purchasable` / `is_auto_assembly` /
   `serial_tracked` / `operations_in_sequence` are PRODUCT-only;
   `default_supplier_id` / `batch_tracked` / `purchase_uom` /
-  `purchase_uom_conversion_rate` are PRODUCT/MATERIAL only;
+  `purchase_uom_conversion_rate` / `configs` are PRODUCT/MATERIAL only;
   `sales_price` / `default_cost` / `sku` are SERVICE-only.
   `is_archived` is shared across all three types — set true to archive,
   false to unarchive. Misrouted fields fail fast with a clear error.
+- `update_header.configs` — replace the full set of variant-defining
+  attributes (e.g. `Size`, `Color`). Each entry: `name` (str) and
+  `values` (list[str]). Optional `id` (int) is honored for MATERIAL only
+  to match an existing config; PRODUCT updates always match by `name`.
+  Katana overwrites the full list at apply time — omit a config and it
+  gets deleted, so always send every config you want to keep.
+- `add_variants` / `update_variants[].config_attributes` — pin one
+  value per parent config (e.g. `[{config_name: "Size", config_value:
+  "M"}, ...]`). Names must match a config on the parent;
+  `update_variants[].config_attributes` overwrites the variant's
+  existing list at apply time.
 - `add_variants` — POST `/variant`. Parent `product_id` / `material_id`
   is injected automatically from the request's `type`. Not supported
   for SERVICE (services carry pricing on the header, not on variants).

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -78,13 +78,17 @@ from katana_public_api_client.models import (
     CreateServiceRequest,
     CreateServiceVariantRequest,
     CreateVariantRequest as APICreateVariantRequest,
+    CreateVariantRequestConfigAttributesItem as APICreateVariantConfigItem,
     Material,
     Product,
     Service,
     UpdateMaterialRequest as APIUpdateMaterialRequest,
+    UpdateMaterialRequestConfigsItem as APIUpdateMaterialConfigsItem,
     UpdateProductRequest as APIUpdateProductRequest,
+    UpdateProductRequestConfigsItem as APIUpdateProductConfigsItem,
     UpdateServiceRequest as APIUpdateServiceRequest,
     UpdateVariantRequest as APIUpdateVariantRequest,
+    UpdateVariantRequestConfigAttributesItem as APIUpdateVariantConfigItem,
     Variant,
 )
 
@@ -769,8 +773,53 @@ _PRODUCT_AND_MATERIAL_FIELDS = (
     "batch_tracked",
     "purchase_uom",
     "purchase_uom_conversion_rate",
+    "configs",
 )
 _SERVICE_ONLY_FIELDS = ("sales_price", "default_cost", "sku")
+
+
+class ItemConfigPatch(BaseModel):
+    """A configuration attribute (e.g. ``Size``, ``Teeth``) on a product or material.
+
+    ``configs`` declare the set of attribute *names* a product/material exposes
+    and the allowed *values* for each. Variants pin specific values via
+    ``config_attributes``. The Katana update endpoint replaces the full
+    ``configs`` list at apply time — sending one config entry deletes any
+    others not included, so always send the full set.
+
+    ``id`` is only honored for materials (Katana's product-update DTO ignores
+    it). When omitted, the API matches existing configs by ``name``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., description="Config attribute name (e.g. ``Size``).")
+    values: list[str] = Field(
+        ..., description='Allowed values for this attribute (e.g. ``["S", "M"]``).'
+    )
+    id: int | None = Field(
+        default=None,
+        description=(
+            "Existing config ID to match (MATERIAL only — products are matched "
+            "by ``name`` and ignore ``id``)."
+        ),
+    )
+
+
+class VariantConfigAttributePatch(BaseModel):
+    """A specific config-attribute value pinned to one variant.
+
+    ``config_name`` must match a config defined on the parent product/material;
+    ``config_value`` must be one of that config's allowed values. Sending an
+    unknown name or value yields a 422 from Katana.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    config_name: str = Field(
+        ..., description="Name of the parent's config (e.g. ``Size``)."
+    )
+    config_value: str = Field(..., description="Value for this variant (e.g. ``M``).")
 
 
 class ItemHeaderPatch(BaseModel):
@@ -798,6 +847,15 @@ class ItemHeaderPatch(BaseModel):
     batch_tracked: bool | None = Field(default=None)
     purchase_uom: str | None = Field(default=None)
     purchase_uom_conversion_rate: float | None = Field(default=None)
+    configs: list[ItemConfigPatch] | None = Field(
+        default=None,
+        description=(
+            "Replace the full set of configuration attributes (variant-defining "
+            "axes like ``Size`` / ``Color``). Katana overwrites the existing "
+            "list — omit a config and it gets deleted at apply time, so include "
+            "every config you want to keep. PRODUCT/MATERIAL only."
+        ),
+    )
 
     # Product only:
     is_producible: bool | None = Field(default=None)
@@ -833,6 +891,14 @@ class VariantAdd(BaseModel):
     registered_barcode: str | None = Field(default=None)
     lead_time: int | None = Field(default=None)
     minimum_order_quantity: float | None = Field(default=None)
+    config_attributes: list[VariantConfigAttributePatch] | None = Field(
+        default=None,
+        description=(
+            "Pin one value per parent config to define this variant. Each "
+            "``config_name`` must match a config on the parent and "
+            "``config_value`` must be one of that config's allowed values."
+        ),
+    )
 
 
 class VariantUpdate(BaseModel):
@@ -849,6 +915,13 @@ class VariantUpdate(BaseModel):
     registered_barcode: str | None = Field(default=None)
     lead_time: int | None = Field(default=None)
     minimum_order_quantity: float | None = Field(default=None)
+    config_attributes: list[VariantConfigAttributePatch] | None = Field(
+        default=None,
+        description=(
+            "Replace this variant's pinned config-attribute values. The new "
+            "list overwrites the existing one at apply time."
+        ),
+    )
 
 
 class ModifyItemRequest(ConfirmableRequest):
@@ -914,6 +987,60 @@ def _validate_header_for_type(patch: ItemHeaderPatch, item_type: ItemType) -> No
         )
 
 
+def _coerce_product_configs(
+    raw: list[dict[str, Any]],
+) -> list[APIUpdateProductConfigsItem]:
+    """Map ``ItemConfigPatch`` dicts to the product-update attrs class.
+
+    The product DTO accepts only ``name`` and ``values`` — any ``id`` is
+    dropped here so callers who include it (legitimately, for materials)
+    don't trip ``additionalProperties: false`` on the wire.
+    """
+    return [
+        APIUpdateProductConfigsItem(name=c["name"], values=list(c["values"]))
+        for c in raw
+    ]
+
+
+def _coerce_material_configs(
+    raw: list[dict[str, Any]],
+) -> list[APIUpdateMaterialConfigsItem]:
+    """Map ``ItemConfigPatch`` dicts to the material-update attrs class.
+
+    Materials accept the optional ``id`` for matching existing configs.
+    """
+    return [
+        APIUpdateMaterialConfigsItem(
+            name=c["name"],
+            values=list(c["values"]),
+            id=to_unset(c.get("id")),
+        )
+        for c in raw
+    ]
+
+
+def _coerce_create_variant_config_attributes(
+    raw: list[dict[str, Any]],
+) -> list[APICreateVariantConfigItem]:
+    return [
+        APICreateVariantConfigItem(
+            config_name=c["config_name"], config_value=c["config_value"]
+        )
+        for c in raw
+    ]
+
+
+def _coerce_update_variant_config_attributes(
+    raw: list[dict[str, Any]],
+) -> list[APIUpdateVariantConfigItem]:
+    return [
+        APIUpdateVariantConfigItem(
+            config_name=c["config_name"], config_value=c["config_value"]
+        )
+        for c in raw
+    ]
+
+
 def _build_update_header_request(
     patch: ItemHeaderPatch, item_type: ItemType, existing_item: Any | None = None
 ) -> Any:
@@ -926,13 +1053,16 @@ def _build_update_header_request(
     rename (see its docstring for the full workaround story).
     """
     request_cls = _TYPE_ENDPOINTS[item_type]["update_request"]
+    transforms: dict[str, Any] = {}
     if item_type == ItemType.PRODUCT:
         exclude = _SERVICE_ONLY_FIELDS
+        transforms["configs"] = _coerce_product_configs
     elif item_type == ItemType.MATERIAL:
         exclude = _PRODUCT_ONLY_FIELDS + _SERVICE_ONLY_FIELDS
+        transforms["configs"] = _coerce_material_configs
     else:
         exclude = _PRODUCT_ONLY_FIELDS + _PRODUCT_AND_MATERIAL_FIELDS
-    kwargs = unset_dict(patch, exclude=exclude)
+    kwargs = unset_dict(patch, exclude=exclude, transforms=transforms)
     kwargs["additional_info"] = patch_additional_info(
         patch.additional_info,
         existing_item.additional_info if existing_item is not None else UNSET,
@@ -954,11 +1084,20 @@ def _build_create_variant_request(
         extra["product_id"] = parent_id
     elif item_type == ItemType.MATERIAL:
         extra["material_id"] = parent_id
-    return APICreateVariantRequest(**unset_dict(variant), **extra)
+    kwargs = unset_dict(
+        variant,
+        transforms={"config_attributes": _coerce_create_variant_config_attributes},
+    )
+    return APICreateVariantRequest(**kwargs, **extra)
 
 
 def _build_update_variant_request(patch: VariantUpdate) -> APIUpdateVariantRequest:
-    return APIUpdateVariantRequest(**unset_dict(patch, exclude=("id",)))
+    kwargs = unset_dict(
+        patch,
+        exclude=("id",),
+        transforms={"config_attributes": _coerce_update_variant_config_attributes},
+    )
+    return APIUpdateVariantRequest(**kwargs)
 
 
 async def _fetch_item_for_diff(services: Any, item_id: int, item_type: ItemType) -> Any:

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -979,3 +979,163 @@ def test_build_update_header_no_existing_skips_echo():
     )
 
     assert req.to_dict() == {"name": "RENAMED"}
+
+
+# ============================================================================
+# #503: configs / config_attributes propagate through modify_item
+# ============================================================================
+
+
+def test_build_update_header_product_configs_reaches_wire_body():
+    """``configs`` on a PRODUCT update serializes to the API wire body — the
+    bug in #503 was that the field was silently dropped before reaching the
+    request DTO. With the fix, it appears in ``request.to_dict()`` as the
+    Katana-shaped ``[{name, values}, ...]``."""
+    from katana_mcp.tools.foundation.items import (
+        ItemConfigPatch,
+        ItemHeaderPatch,
+        _build_update_header_request,
+    )
+
+    req = _build_update_header_request(
+        ItemHeaderPatch(
+            configs=[
+                ItemConfigPatch(name="Teeth", values=["32", "34"]),
+                ItemConfigPatch(name="Offset", values=["3mm"]),
+            ]
+        ),
+        ItemType.PRODUCT,
+        None,
+    )
+
+    body = req.to_dict()
+    assert body["configs"] == [
+        {"name": "Teeth", "values": ["32", "34"]},
+        {"name": "Offset", "values": ["3mm"]},
+    ]
+
+
+def test_build_update_header_product_configs_drops_id():
+    """The PRODUCT update DTO doesn't accept ``id`` on configs (only
+    MATERIAL does). When a caller includes one, it must be stripped before
+    reaching the wire — otherwise Katana 422s on ``additionalProperties``."""
+    from katana_mcp.tools.foundation.items import (
+        ItemConfigPatch,
+        ItemHeaderPatch,
+        _build_update_header_request,
+    )
+
+    req = _build_update_header_request(
+        ItemHeaderPatch(configs=[ItemConfigPatch(id=999, name="Teeth", values=["32"])]),
+        ItemType.PRODUCT,
+        None,
+    )
+
+    body = req.to_dict()
+    assert body["configs"] == [{"name": "Teeth", "values": ["32"]}]
+    assert "id" not in body["configs"][0]
+
+
+def test_build_update_header_material_configs_preserves_id_when_set():
+    """MATERIAL update DTO accepts ``id`` to match existing configs by ID
+    (vs. by ``name`` when omitted). Pin both branches."""
+    from katana_mcp.tools.foundation.items import (
+        ItemConfigPatch,
+        ItemHeaderPatch,
+        _build_update_header_request,
+    )
+
+    req = _build_update_header_request(
+        ItemHeaderPatch(
+            configs=[
+                ItemConfigPatch(id=42, name="Grade", values=["A", "B"]),
+                ItemConfigPatch(name="Finish", values=["Matte"]),
+            ]
+        ),
+        ItemType.MATERIAL,
+        None,
+    )
+
+    body = req.to_dict()
+    assert body["configs"] == [
+        {"id": 42, "name": "Grade", "values": ["A", "B"]},
+        {"name": "Finish", "values": ["Matte"]},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_modify_item_rejects_configs_on_service():
+    """SERVICE doesn't support ``configs`` — it's PRODUCT/MATERIAL only.
+    ``_validate_header_for_type`` rejects before any API call, mirroring
+    the existing rejection of other PRODUCT/MATERIAL-only fields."""
+    from katana_mcp.tools.foundation.items import (
+        ItemConfigPatch,
+        ItemHeaderPatch,
+        ModifyItemRequest,
+        _modify_item_impl,
+    )
+
+    context, _ = create_mock_context()
+    request = ModifyItemRequest(
+        id=42,
+        type=ItemType.SERVICE,
+        update_header=ItemHeaderPatch(
+            configs=[ItemConfigPatch(name="Tier", values=["Basic", "Pro"])]
+        ),
+        preview=True,
+    )
+    with pytest.raises(ValueError, match="not valid for type=service"):
+        await _modify_item_impl(request, context)
+
+
+def test_build_create_variant_request_passes_config_attributes():
+    """``add_variants[].config_attributes`` reaches the variant POST body
+    (regression for #503's third silent-drop case)."""
+    from katana_mcp.tools.foundation.items import (
+        VariantAdd,
+        VariantConfigAttributePatch,
+        _build_create_variant_request,
+    )
+
+    req = _build_create_variant_request(
+        parent_id=42,
+        item_type=ItemType.PRODUCT,
+        variant=VariantAdd(
+            sku="CK1459-TMP",
+            config_attributes=[
+                VariantConfigAttributePatch(config_name="Offset", config_value="3mm"),
+                VariantConfigAttributePatch(config_name="Teeth", config_value="34"),
+            ],
+        ),
+    )
+
+    body = req.to_dict()
+    assert body["product_id"] == 42
+    assert body["config_attributes"] == [
+        {"config_name": "Offset", "config_value": "3mm"},
+        {"config_name": "Teeth", "config_value": "34"},
+    ]
+
+
+def test_build_update_variant_request_passes_config_attributes():
+    """``update_variants[].config_attributes`` reaches the variant PATCH
+    body. Pre-fix, this set was silently dropped from the wire body."""
+    from katana_mcp.tools.foundation.items import (
+        VariantConfigAttributePatch,
+        VariantUpdate,
+        _build_update_variant_request,
+    )
+
+    req = _build_update_variant_request(
+        VariantUpdate(
+            id=40312281,
+            config_attributes=[
+                VariantConfigAttributePatch(config_name="Teeth", config_value="34"),
+            ],
+        )
+    )
+
+    body = req.to_dict()
+    assert body["config_attributes"] == [{"config_name": "Teeth", "config_value": "34"}]
+    # ``id`` is the path parameter, not a body field — must not appear in body.
+    assert "id" not in body


### PR DESCRIPTION
## Summary

Three sub-payloads on `modify_item` previously had no path to edit a parent item's variant axes (`configs`) or a variant's pinned values (`config_attributes`). The Katana wire contract supports all three; the typed client generates the right DTOs; only the MCP-layer pydantic patch models were missing the fields. Pre-#487 this was a silent drop ("update succeeded but the value didn't change"); post-#487 with `extra="forbid"` it's a `ValidationError`. Either way, no working path.

This PR adds the fields and wires them through.

| Sub-payload | Field added |
|---|---|
| `update_header.configs` | `list[ItemConfigPatch]` — replace the full set of variant axes |
| `add_variants[].config_attributes` | `list[VariantConfigAttributePatch]` — pin values for a new variant |
| `update_variants[].config_attributes` | `list[VariantConfigAttributePatch]` — replace a variant's pinned values |

## Wire-shape details

- **Products**: `configs[i]` accepts `name + values` only. Katana matches existing configs by `name`. The dispatcher strips `id` from product config patches even if the caller includes one.
- **Materials**: `configs[i]` accepts `id` (optional) for matching by ID, or matches by `name` when omitted. Both branches pinned by tests.
- **Variants**: `config_attributes[i]` is `{config_name, config_value}` for both create (POST `/variant`) and update (PATCH `/variant/{id}`).

## Type-routing

`configs` is added to `_PRODUCT_AND_MATERIAL_FIELDS`, so a SERVICE update with `configs` set fails fast in `_validate_header_for_type` before any API call — same pattern as the existing rejection of `is_producible` etc. on services.

## Test plan

- [x] `uv run poe check` (full validation, 2,870 tests + lint + format)
- [x] 6 new regression tests in `katana_mcp_server/tests/tools/test_items.py`:
  - `test_build_update_header_product_configs_reaches_wire_body`
  - `test_build_update_header_product_configs_drops_id`
  - `test_build_update_header_material_configs_preserves_id_when_set`
  - `test_modify_item_rejects_configs_on_service`
  - `test_build_create_variant_request_passes_config_attributes`
  - `test_build_update_variant_request_passes_config_attributes`

## Notes

Closes #503.

Help resource (`help.py`) updated to document the new payload shapes — this is the canonical surface MCP clients see in tool docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)