### PR TITLE
refactor(mcp): address Copilot findings on #503 modify_item configs

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -855,9 +855,10 @@ endpoint; variant sub-payloads route to the shared `/variant` family.
   to match an existing config; PRODUCT updates always match by `name`.
   Katana overwrites the full list at apply time — omit a config and it
   gets deleted, so always send every config you want to keep.
-- `add_variants` / `update_variants[].config_attributes` — pin one
-  value per parent config (e.g. `[{config_name: "Size", config_value:
-  "M"}, ...]`). Names must match a config on the parent;
+- `add_variants[].config_attributes` /
+  `update_variants[].config_attributes` — pin one value per parent
+  config on each variant entry (e.g. `[{config_name: "Size",
+  config_value: "M"}, ...]`). Names must match a config on the parent;
   `update_variants[].config_attributes` overwrites the variant's
   existing list at apply time.
 - `add_variants` — POST `/variant`. Parent `product_id` / `material_id`

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -1019,24 +1019,16 @@ def _coerce_material_configs(
     ]
 
 
-def _coerce_create_variant_config_attributes(
+def _coerce_variant_config_attributes(
     raw: list[dict[str, Any]],
-) -> list[APICreateVariantConfigItem]:
+    item_cls: type[APICreateVariantConfigItem] | type[APIUpdateVariantConfigItem],
+) -> list[Any]:
+    """Map ``VariantConfigAttributePatch`` dicts to the create- or update-side
+    attrs class. Both target classes share the ``config_name`` /
+    ``config_value`` shape — ``item_cls`` chooses which one fits the
+    sibling Update*Request."""
     return [
-        APICreateVariantConfigItem(
-            config_name=c["config_name"], config_value=c["config_value"]
-        )
-        for c in raw
-    ]
-
-
-def _coerce_update_variant_config_attributes(
-    raw: list[dict[str, Any]],
-) -> list[APIUpdateVariantConfigItem]:
-    return [
-        APIUpdateVariantConfigItem(
-            config_name=c["config_name"], config_value=c["config_value"]
-        )
+        item_cls(config_name=c["config_name"], config_value=c["config_value"])
         for c in raw
     ]
 
@@ -1086,7 +1078,11 @@ def _build_create_variant_request(
         extra["material_id"] = parent_id
     kwargs = unset_dict(
         variant,
-        transforms={"config_attributes": _coerce_create_variant_config_attributes},
+        transforms={
+            "config_attributes": lambda raw: _coerce_variant_config_attributes(
+                raw, APICreateVariantConfigItem
+            ),
+        },
     )
     return APICreateVariantRequest(**kwargs, **extra)
 
@@ -1095,7 +1091,11 @@ def _build_update_variant_request(patch: VariantUpdate) -> APIUpdateVariantReque
     kwargs = unset_dict(
         patch,
         exclude=("id",),
-        transforms={"config_attributes": _coerce_update_variant_config_attributes},
+        transforms={
+            "config_attributes": lambda raw: _coerce_variant_config_attributes(
+                raw, APIUpdateVariantConfigItem
+            ),
+        },
     )
     return APIUpdateVariantRequest(**kwargs)
 


### PR DESCRIPTION
## Summary

Two follow-up findings from Copilot's review of #581 that landed after the PR auto-merged:

1. **Help text disambiguation** — clarify that `add_variants` / `update_variants` accept `config_attributes` *per variant entry* (i.e. `add_variants[].config_attributes`), not on the array itself.
2. **Helper consolidation** — `_coerce_create_variant_config_attributes` and `_coerce_update_variant_config_attributes` were identical aside from the target attrs class; collapsed into a single `_coerce_variant_config_attributes(raw, item_cls)` parameterized at the call site.

No behavior change.

## Test plan

- [x] `uv run poe check` (full validation, all 2,870 tests pass)
- [x] All 6 #503 regression tests still pin the same wire-shape behavior

## Notes

Both findings are at https://github.com/dougborg/katana-openapi-client/pull/581#discussion (Copilot inline review). Replies will be posted on those threads once this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)