### PR TITLE
fix(mcp): search_items renders proper empty-state UI when 0 results (#470)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -300,6 +300,11 @@ def build_search_results_ui(
     - Sortable, searchable, paginated DataTable
     - Row-click fires CallTool to get_variant_details, renders in Slot
     - Summary badges for query and count
+
+    When ``total_count == 0``, drops the DataTable / drill-down Slot /
+    "Check inventory" button — they all reference nonexistent results — and
+    renders a friendly hint suggesting partial-SKU / name fallbacks. Closes
+    #470.
     """
     with (
         PrefabApp(
@@ -312,6 +317,16 @@ def build_search_results_ui(
             H3(content="Search Results")
             Badge(label=f"Query: {query}", variant="outline")
             Badge(label=f"{total_count} items", variant="secondary")
+
+        if total_count == 0:
+            Muted(
+                content=(
+                    f'No items match "{query}". Try a partial SKU, variant '
+                    "name, or parent product/material name — search uses "
+                    "FTS5 with fuzzy fallback."
+                )
+            )
+            return app
 
         DataTable(
             columns=[
@@ -629,7 +644,13 @@ def build_low_stock_ui(
     threshold: int,
     total_count: int,
 ) -> PrefabApp:
-    """Build a low stock report with table and reorder action."""
+    """Build a low stock report with table and reorder action.
+
+    When ``total_count == 0``, drops the DataTable and "Create Restock
+    Orders" button — they reference nonexistent items — and renders a
+    friendly "all clear" hint instead. Bundled with the #470 search empty-
+    state fix because the pattern is identical.
+    """
     with (
         PrefabApp(
             state={"items": items},
@@ -644,6 +665,15 @@ def build_low_stock_ui(
                 label=f"{total_count} items",
                 variant="destructive" if total_count > 0 else "secondary",
             )
+
+        if total_count == 0:
+            Muted(
+                content=(
+                    f"No items below the threshold of {threshold}. "
+                    "Inventory levels are healthy."
+                )
+            )
+            return app
 
         DataTable(
             columns=[

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -64,9 +64,77 @@ class TestBuildSearchResultsUI:
         app = build_search_results_ui(items, "widget", 2)
         _assert_valid_prefab(app)
 
+    def test_with_items_renders_table_and_buttons(self):
+        """Regression guard for #470 — the existing populated-results path
+        must still render the DataTable, the drill-down Slot, and the
+        "Check inventory" button. Pairs with
+        ``test_empty_results_omits_table_and_buttons``.
+        """
+        items = [
+            {"id": 1, "sku": "SKU-001", "name": "Widget", "is_sellable": True},
+        ]
+        app = build_search_results_ui(items, "widget", 1)
+        envelope = app.to_json()
+        assert _has_node_of_type(envelope, "DataTable"), (
+            "Populated search results must render a DataTable."
+        )
+        assert _has_node_of_type(envelope, "Slot"), (
+            "Populated search results must render the drill-down Slot."
+        )
+        check_inventory_buttons = _find_buttons_by_label(
+            envelope, "Check inventory for search results"
+        )
+        assert len(check_inventory_buttons) == 1, (
+            "Populated search results must render the 'Check inventory' button."
+        )
+
     def test_empty_results(self):
         app = build_search_results_ui([], "nothing", 0)
         _assert_valid_prefab(app)
+
+    def test_empty_results_omits_table_and_buttons(self):
+        """#470 — when ``total_count == 0`` we render the header + badges
+        + a Muted hint, but no DataTable, no Slot, and no "Check
+        inventory" button (all of which would reference nonexistent
+        results).
+        """
+        app = build_search_results_ui([], "00.4021.018.003", 0)
+        envelope = app.to_json()
+
+        assert not _has_node_of_type(envelope, "DataTable"), (
+            "Empty search results must not render a DataTable."
+        )
+        assert not _has_node_of_type(envelope, "Slot"), (
+            "Empty search results must not render the drill-down Slot."
+        )
+        check_inventory_buttons = _find_buttons_by_label(
+            envelope, "Check inventory for search results"
+        )
+        assert len(check_inventory_buttons) == 0, (
+            "Empty search results must not render the 'Check inventory' button."
+        )
+
+        # Empty-state hint must mention the query and surface the fallback
+        # advice so a user pasting a full SKU knows to try a substring.
+        # Assert on the Muted node's actual content rather than
+        # ``str(envelope)`` — the header badge renders ``Query: ...``
+        # unconditionally, so an envelope-wide substring check would pass
+        # even if the Muted hint regressed.
+        muted_contents = _collect_node_content(envelope, "Muted")
+        hint = next(
+            (c for c in muted_contents if c.startswith("No items match")),
+            None,
+        )
+        assert hint is not None, (
+            f"Empty-state must render a 'No items match' Muted hint; "
+            f"got Muted contents: {muted_contents!r}"
+        )
+        assert '"00.4021.018.003"' in hint, (
+            f"Empty-state hint must echo the original query; got {hint!r}"
+        )
+        assert "partial SKU" in hint, (
+            f"Empty-state hint must suggest a partial-SKU/name fallback; got {hint!r}"
+        )
 
 
 class TestBuildVariantDetailsUI:
@@ -237,9 +305,66 @@ class TestBuildLowStockUI:
         app = build_low_stock_ui(items, 10, 1)
         _assert_valid_prefab(app)
 
+    def test_with_items_renders_table_and_restock_button(self):
+        """Regression guard for the empty-state fix bundled with #470 —
+        the populated path must still render the DataTable and the
+        "Create Restock Orders" button.
+        """
+        items = [
+            {
+                "sku": "SKU-001",
+                "product_name": "Widget",
+                "current_stock": 3,
+                "threshold": 10,
+            },
+        ]
+        app = build_low_stock_ui(items, 10, 1)
+        envelope = app.to_json()
+        assert _has_node_of_type(envelope, "DataTable"), (
+            "Populated low-stock report must render a DataTable."
+        )
+        restock_buttons = _find_buttons_by_label(envelope, "Create Restock Orders")
+        assert len(restock_buttons) == 1, (
+            "Populated low-stock report must render the 'Create Restock Orders' button."
+        )
+
     def test_empty(self):
         app = build_low_stock_ui([], 10, 0)
         _assert_valid_prefab(app)
+
+    def test_empty_omits_table_and_restock_button(self):
+        """#470-adjacent — when ``total_count == 0`` (no items below the
+        threshold) the report drops the empty DataTable and the
+        "Create Restock Orders" button (both reference nonexistent rows)
+        and renders an "all clear" Muted hint instead.
+        """
+        app = build_low_stock_ui([], 10, 0)
+        envelope = app.to_json()
+
+        assert not _has_node_of_type(envelope, "DataTable"), (
+            "Empty low-stock report must not render a DataTable."
+        )
+        restock_buttons = _find_buttons_by_label(envelope, "Create Restock Orders")
+        assert len(restock_buttons) == 0, (
+            "Empty low-stock report must not render the 'Create Restock Orders' button."
+        )
+
+        # Assert on the Muted node's actual content rather than
+        # ``str(envelope)`` — the header badge renders ``Threshold: 10``
+        # unconditionally, so a substring check on the whole envelope
+        # would pass even if the Muted hint regressed.
+        muted_contents = _collect_node_content(envelope, "Muted")
+        hint = next(
+            (c for c in muted_contents if "threshold of" in c),
+            None,
+        )
+        assert hint is not None, (
+            f"Empty-state must render a 'threshold of …' Muted hint; "
+            f"got Muted contents: {muted_contents!r}"
+        )
+        assert "threshold of 10" in hint, (
+            f"Empty-state hint must echo the threshold value; got {hint!r}"
+        )
 
 
 class TestBuildOrderPreviewUI:
@@ -973,6 +1098,39 @@ def _find_buttons_by_label(tree: object, label: str) -> list[dict]:
     elif isinstance(tree, list):
         for item in tree:
             found.extend(_find_buttons_by_label(item, label))
+    return found
+
+
+def _has_node_of_type(tree: object, node_type: str) -> bool:
+    """Return ``True`` if any node anywhere in the Prefab envelope has
+    ``type == node_type``. Used by empty-state tests (#470) to assert
+    that DataTable / Slot are or aren't rendered.
+    """
+    if isinstance(tree, dict):
+        if tree.get("type") == node_type:
+            return True
+        return any(_has_node_of_type(v, node_type) for v in tree.values())
+    if isinstance(tree, list):
+        return any(_has_node_of_type(item, node_type) for item in tree)
+    return False
+
+
+def _collect_node_content(tree: object, node_type: str) -> list[str]:
+    """Walk a Prefab envelope and return every ``content`` string from
+    nodes whose ``type`` equals ``node_type``. Used by empty-state tests
+    to assert on the actual hint text rendered by ``Muted`` (rather than
+    on ``str(envelope)``, which also matches header badges and would
+    pass even if the hint regressed).
+    """
+    found: list[str] = []
+    if isinstance(tree, dict):
+        if tree.get("type") == node_type and isinstance(tree.get("content"), str):
+            found.append(tree["content"])
+        for v in tree.values():
+            found.extend(_collect_node_content(v, node_type))
+    elif isinstance(tree, list):
+        for item in tree:
+            found.extend(_collect_node_content(item, node_type))
     return found
 
 


### PR DESCRIPTION
## Summary

Closes #470.

`search_items` (and `list_low_stock_items`) returned an empty `items` list but the
prefab UI still rendered a full DataTable, drill-down Slot, and action button —
all referencing nonexistent rows. The result was a misleading empty UI for any
zero-match query (e.g. `\"00.4021.018.003\"` against a cache that doesn't contain it).

### Before / After

**Before** (`total_count == 0`):

- `H3` "Search Results" + query/count badges
- Empty DataTable with "no rows" placeholder
- Slot: "Click a row to see variant details" — no row to click
- Button: "Check inventory for search results" — no results to check

**After** (`total_count == 0`):

- `H3` "Search Results" + query/count badges (kept — useful context)
- `Muted`: `No items match \"<query>\". Try a partial SKU, name, or category — search uses FTS5 with fuzzy fallback.`
- No DataTable / Slot / Button

The populated path (`total_count > 0`) is unchanged — pinned by a new regression
test that asserts DataTable + Slot + button all still render.

### Adjacent fix bundled

`build_low_stock_ui` had the identical pattern: zero items below threshold rendered
an empty DataTable plus a "Create Restock Orders" button. Same `total_count == 0`
branch added with an "all clear" hint. Bundled here because the fix is 5 lines and
the regression test mirrors the search one.

Other `build_*_ui` functions (`build_verification_ui`, `build_batch_recipe_update_ui`,
etc.) were audited and either already conditional or had design considerations that
warrant a separate PR — not bundled here.

## Test plan

- [x] `uv run poe check` — passes (ruff format/check, mdformat, ty, yamllint, pytest 2884 passed / 2 skipped, ~16s)
- [x] New: `test_empty_results_omits_table_and_buttons` — asserts no DataTable / no Slot / no "Check inventory" button when `total_count == 0`, plus the empty-state hint echoes the query and surfaces the partial-SKU advice
- [x] New: `test_with_items_renders_table_and_buttons` — regression guard pinning the populated path
- [x] New: `test_empty_omits_table_and_restock_button` (low-stock empty-state)
- [x] New: `test_with_items_renders_table_and_restock_button` (low-stock populated regression)
- [x] Manual repro covered — query "00.4021.018.003" against a cache that doesn't contain it now renders the friendly Muted hint

## Files changed

- `katana_mcp_server/src/katana_mcp/tools/prefab_ui.py` — empty-state branches in `build_search_results_ui` and `build_low_stock_ui`
- `katana_mcp_server/tests/test_prefab_ui.py` — 4 new tests + `_has_node_of_type` helper for envelope-walking assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)