### PR TITLE
feat(mcp): fulfill_order supports serial-tracked MO variants (#586)

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -3258,6 +3258,13 @@ components:
           description: Batch transactions for produced items
           items:
             $ref: "#/components/schemas/BatchTransaction"
+        serial_numbers:
+          type: array
+          description: Serial number IDs allocated to the produced units of this
+            manufacturing order. Required when the MO's finished-good variant is
+            serial-tracked; the count must equal `actual_quantity`.
+          items:
+            type: integer
       example:
         planned_quantity: 75
         additional_info: Increased quantity due to additional customer demand

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1433,6 +1433,12 @@ Complete a manufacturing or sales order.
   equal the row's ordered quantity. **Required** when the row's variant is
   serial-tracked — without it, the tool emits a `BLOCK:` warning at preview
   and refuses on direct apply (Katana would 422 the request).
+- `serial_numbers` (optional, manufacturing orders only): List of pre-existing
+  `SerialNumber` IDs to attach to the produced units when marking the MO
+  DONE. Length must equal `actual_quantity`. **Required** when the MO's
+  finished-good variant is serial-tracked — without it, the tool emits a
+  `BLOCK:` warning at preview and refuses on direct apply (Katana would 422
+  the request).
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -83,6 +83,16 @@ class FulfillOrderRequest(BaseModel):
             "Sales orders only — ignored for order_type='manufacturing'."
         ),
     )
+    serial_numbers: list[int] | None = Field(
+        default=None,
+        description=(
+            "Pre-existing SerialNumber IDs to attach to the produced units of a "
+            "manufacturing order on completion. Length must equal "
+            "``actual_quantity``. Required when the MO's finished-good variant "
+            "is serial-tracked. Manufacturing orders only — ignored for "
+            "order_type='sales' (use ``rows`` for per-row sales-order serials)."
+        ),
+    )
 
 
 class FulfillOrderResponse(BaseModel):
@@ -122,7 +132,14 @@ def _fulfill_response_to_tool_result(response: FulfillOrderResponse) -> ToolResu
 async def _fulfill_manufacturing_order(
     request: FulfillOrderRequest, context: Context
 ) -> FulfillOrderResponse:
-    """Fulfill a manufacturing order by marking it as DONE."""
+    """Fulfill a manufacturing order by marking it as DONE.
+
+    Serial-tracked finished-good variants need ``serial_numbers`` IDs
+    attached on completion; callers pass them via ``request.serial_numbers``.
+    Without them, Katana 422s on apply, so the tool emits a ``BLOCK:``
+    warning at preview time and refuses on direct apply (parity with the
+    sales-order serial-tracked guard added in #547).
+    """
     from katana_public_api_client.api.manufacturing_order import (
         get_manufacturing_order as api_get_manufacturing_order,
     )
@@ -134,12 +151,20 @@ async def _fulfill_manufacturing_order(
     mo = unwrap_as(mo_response, ManufacturingOrder)
     order_number = unwrap_unset(mo.order_no, f"MO-{request.order_id}")
     current_status = mo.status.value if mo.status else "UNKNOWN"
+    variant_id = unwrap_unset(mo.variant_id, None)
+    actual_quantity = unwrap_unset(mo.actual_quantity, None)
+
+    is_serial_tracked, sku = await _resolve_variant_serial_info(services, variant_id)
 
     inventory_updates = [
         "Manufacturing order completion will update inventory based on BOM",
         "Finished goods will be added to stock",
         "Raw materials will be consumed from inventory",
     ]
+    if is_serial_tracked and request.serial_numbers:
+        inventory_updates.append(
+            f"Finished-good serials to attach: {request.serial_numbers}"
+        )
 
     warnings: list[str] = []
     if current_status == "DONE":
@@ -152,16 +177,30 @@ async def _fulfill_manufacturing_order(
             f"Manufacturing order {order_number} is blocked - review before completing"
         )
 
+    warnings.extend(
+        _build_mo_serial_warnings(
+            order_number=order_number,
+            sku=sku,
+            is_serial_tracked=is_serial_tracked,
+            actual_quantity=actual_quantity,
+            serial_numbers=request.serial_numbers,
+        )
+    )
+
     if request.preview:
-        next_actions = (
-            ["Order is already completed - no action needed"]
-            if current_status == "DONE"
-            else [
+        has_block = any(w.startswith(BLOCK_WARNING_PREFIX) for w in warnings)
+        if current_status == "DONE":
+            next_actions = ["Order is already completed - no action needed"]
+        elif has_block:
+            next_actions = [
+                "Resolve the issue above (cancel and inspect via the Katana UI)"
+            ]
+        else:
+            next_actions = [
                 "Review the manufacturing order details",
                 "Verify all production steps are complete",
                 "Set preview=false to mark order as DONE",
             ]
-        )
         return FulfillOrderResponse(
             order_id=request.order_id,
             order_type="manufacturing",
@@ -174,6 +213,10 @@ async def _fulfill_manufacturing_order(
             message=f"Preview: Would mark manufacturing order {order_number} as DONE (currently {current_status})",
         )
 
+    # Refuse on apply if any BLOCK warning is present — the preview would have
+    # suppressed the Confirm button in the iframe, but we re-check here so
+    # direct/programmatic callers (skipping the UI) get the same protection.
+    has_block = any(w.startswith(BLOCK_WARNING_PREFIX) for w in warnings)
     if current_status == "DONE":
         return FulfillOrderResponse(
             order_id=request.order_id,
@@ -186,6 +229,24 @@ async def _fulfill_manufacturing_order(
             next_actions=["Order is already completed"],
             message=f"Manufacturing order {order_number} is already completed",
         )
+    if has_block:
+        return FulfillOrderResponse(
+            order_id=request.order_id,
+            order_type="manufacturing",
+            order_number=order_number,
+            status=current_status,
+            is_preview=False,
+            inventory_updates=[],
+            warnings=warnings,
+            next_actions=[
+                "Resolve the issue(s) above and retry with the corrected request"
+            ],
+            message=(
+                f"Refused: Manufacturing order {order_number} completion blocked by "
+                f"{sum(1 for w in warnings if w.startswith(BLOCK_WARNING_PREFIX))} "
+                "issue(s); no status change made."
+            ),
+        )
 
     from katana_public_api_client.api.manufacturing_order import (
         update_manufacturing_order as api_update_manufacturing_order,
@@ -196,6 +257,7 @@ async def _fulfill_manufacturing_order(
 
     update_req = UpdateManufacturingOrderRequest(
         status=ManufacturingOrderStatus.DONE,
+        serial_numbers=to_unset(request.serial_numbers),
     )
     update_response = await api_update_manufacturing_order.asyncio_detailed(
         id=request.order_id, client=services.client, body=update_req
@@ -314,6 +376,97 @@ async def _resolve_row_serial_info(
             parent = None
         serial_tracked[row.id] = bool(parent and parent.get("serial_tracked"))
     return serial_tracked, skus
+
+
+async def _resolve_variant_serial_info(
+    services: Any, variant_id: int | None
+) -> tuple[bool, str]:
+    """Return ``(is_serial_tracked, sku)`` for a single variant.
+
+    Single-variant counterpart to ``_resolve_row_serial_info`` used by the
+    manufacturing-order path (MOs reference one variant, not per-row). Cache
+    misses fall back to a per-ID API fetch so a cold / stale cache doesn't
+    silently mis-classify a serial-tracked MO as "OK to mark DONE without
+    serials" and surface the original Katana 422 on apply. If the variant
+    can't be resolved at all, returns ``(False, f"variant {id}")`` —
+    best-effort, same as if the entity didn't exist.
+    """
+    if variant_id is None:
+        return False, "variant ?"
+    from katana_public_api_client.api.material import get_material
+    from katana_public_api_client.api.product import get_product
+    from katana_public_api_client.api.variant import get_variant
+
+    variants_by_id = await services.cache.get_many_by_ids(
+        EntityType.VARIANT, {variant_id}
+    )
+    await _fetch_missing_from_api(services, variants_by_id, {variant_id}, get_variant)
+    variant = variants_by_id.get(variant_id)
+    sku = (variant or {}).get("sku") or f"variant {variant_id}"
+    if variant is None:
+        return False, sku
+
+    product_id = variant.get("product_id")
+    material_id = variant.get("material_id")
+    if product_id:
+        products = await services.cache.get_many_by_ids(
+            EntityType.PRODUCT, {product_id}
+        )
+        await _fetch_missing_from_api(services, products, {product_id}, get_product)
+        parent = products.get(product_id)
+    elif material_id:
+        materials = await services.cache.get_many_by_ids(
+            EntityType.MATERIAL, {material_id}
+        )
+        await _fetch_missing_from_api(services, materials, {material_id}, get_material)
+        parent = materials.get(material_id)
+    else:
+        parent = None
+    return bool(parent and parent.get("serial_tracked")), sku
+
+
+def _build_mo_serial_warnings(
+    *,
+    order_number: str,
+    sku: str,
+    is_serial_tracked: bool,
+    actual_quantity: float | None,
+    serial_numbers: list[int] | None,
+) -> list[str]:
+    """Return ``BLOCK:`` warnings for a manufacturing-order serial mismatch.
+
+    Mirrors ``_build_row_override_warnings`` but for the single-variant MO
+    shape: a serial-tracked MO needs serials attached on completion, the
+    count must equal ``actual_quantity``, and a fractional ``actual_quantity``
+    is incompatible with serial tracking (each serial represents a whole
+    unit). Numeric equality with ``int(qty)`` matches Python's ``2 == 2.0``
+    behaviour; non-integral qty on a serial-tracked MO is blocked separately.
+    """
+    warnings: list[str] = []
+    if not is_serial_tracked:
+        return warnings
+    qty = actual_quantity
+    if qty is not None and qty != int(qty):
+        warnings.append(
+            f"{BLOCK_WARNING_PREFIX} Manufacturing order {order_number} "
+            f"({sku}) is serial-tracked but actual_quantity ({qty}) is not a "
+            "whole number; serial-tracked variants must be produced in "
+            "integer units."
+        )
+        return warnings
+    if not serial_numbers and (qty or 0) > 0:
+        warnings.append(
+            f"{BLOCK_WARNING_PREFIX} Manufacturing order {order_number} "
+            f"({sku}) is serial-tracked. Pass serial_numbers (one "
+            "SerialNumber ID per unit produced) to mark the order DONE."
+        )
+    elif serial_numbers is not None and qty is not None and len(serial_numbers) != qty:
+        warnings.append(
+            f"{BLOCK_WARNING_PREFIX} Manufacturing order {order_number} "
+            f"({sku}): serial_numbers count ({len(serial_numbers)}) must "
+            f"equal actual_quantity ({qty})."
+        )
+    return warnings
 
 
 def _build_row_override_warnings(

--- a/katana_mcp_server/tests/tools/test_orders.py
+++ b/katana_mcp_server/tests/tools/test_orders.py
@@ -837,3 +837,306 @@ async def test_fulfill_sales_order_non_serial_tracked_no_change():
     from katana_public_api_client.client_types import UNSET
 
     assert sent_rows[0].serial_numbers is UNSET
+
+
+# ============================================================================
+# Manufacturing Order — Serial-Tracked Variant Tests (#586)
+# ============================================================================
+
+
+def _make_serial_tracked_mo(
+    *, order_no: str, variant_id: int = 100, actual_quantity: float = 1.0
+):
+    """Build a serial-tracked ManufacturingOrder mock with the fields the tool reads.
+
+    The MO path reads ``order_no``, ``status``, ``variant_id``, and
+    ``actual_quantity`` — set them explicitly rather than letting MagicMock
+    autogen child mocks (which interact poorly with ``unwrap_unset`` +
+    cache lookups by ID).
+    """
+    mock_mo = MagicMock(spec=ManufacturingOrder)
+    mock_mo.order_no = order_no
+    mock_mo.status = ManufacturingOrderStatus.IN_PROGRESS
+    mock_mo.variant_id = variant_id
+    mock_mo.actual_quantity = actual_quantity
+    return mock_mo
+
+
+@pytest.mark.asyncio
+async def test_fulfill_manufacturing_order_preview_blocks_serial_tracked_without_serials():
+    """Serial-tracked MO + no serial_numbers → BLOCK warning naming the SKU."""
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_mo = _make_serial_tracked_mo(order_no="MO-SN-1", actual_quantity=1.0)
+    mock_response = MagicMock(status_code=200, parsed=mock_mo)
+
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+    )
+
+    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    request = FulfillOrderRequest(order_id=42, order_type="manufacturing", preview=True)
+    result = await _fulfill_order_impl(request, context)
+
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert len(block_warnings) == 1
+    assert "serial-tracked" in block_warnings[0]
+    assert "ROCKER-V2" in block_warnings[0]
+    assert "Resolve the issue" in result.next_actions[0]
+
+
+@pytest.mark.asyncio
+async def test_fulfill_manufacturing_order_preview_accepts_serial_numbers():
+    """Serial-tracked MO + matching serial_numbers → no BLOCK, serials in preview."""
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_mo = _make_serial_tracked_mo(order_no="MO-SN-2", actual_quantity=1.0)
+    mock_response = MagicMock(status_code=200, parsed=mock_mo)
+
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+    )
+
+    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    request = FulfillOrderRequest(
+        order_id=42,
+        order_type="manufacturing",
+        preview=True,
+        serial_numbers=[501],
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    assert not [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any("[501]" in u for u in result.inventory_updates)
+
+
+@pytest.mark.asyncio
+async def test_fulfill_manufacturing_order_apply_passes_serials_to_api():
+    """Apply with serial_numbers → update_manufacturing_order body carries them."""
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_mo = _make_serial_tracked_mo(order_no="MO-SN-3", actual_quantity=2.0)
+    mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
+
+    mock_updated_mo = MagicMock(spec=ManufacturingOrder)
+    mock_updated_mo.order_no = "MO-SN-3"
+    mock_updated_mo.status = ManufacturingOrderStatus.DONE
+    mock_update_response = MagicMock(status_code=200, parsed=mock_updated_mo)
+
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+        update_manufacturing_order,
+    )
+
+    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    update_mock = AsyncMock(return_value=mock_update_response)
+    update_manufacturing_order.asyncio_detailed = update_mock
+
+    request = FulfillOrderRequest(
+        order_id=42,
+        order_type="manufacturing",
+        preview=False,
+        serial_numbers=[501, 502],
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.is_preview is False
+    assert result.status == "DONE"
+    update_mock.assert_called_once()
+    sent_body = update_mock.call_args.kwargs["body"]
+    assert sent_body.serial_numbers == [501, 502]
+
+
+@pytest.mark.asyncio
+async def test_fulfill_manufacturing_order_apply_refuses_serial_tracked_without_serials():
+    """Direct apply (preview=False) without serial_numbers → refusal, no API call."""
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_mo = _make_serial_tracked_mo(order_no="MO-SN-4", actual_quantity=1.0)
+    mock_response = MagicMock(status_code=200, parsed=mock_mo)
+
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+        update_manufacturing_order,
+    )
+
+    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    update_mock = AsyncMock()
+    update_manufacturing_order.asyncio_detailed = update_mock
+
+    request = FulfillOrderRequest(
+        order_id=42, order_type="manufacturing", preview=False
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.is_preview is False
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any("serial-tracked" in w for w in block_warnings)
+    assert "Refused" in result.message
+    update_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fulfill_manufacturing_order_blocks_quantity_serials_mismatch():
+    """len(serial_numbers) != actual_quantity → BLOCK warning."""
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    # actual_quantity=2 but only 1 serial provided.
+    mock_mo = _make_serial_tracked_mo(order_no="MO-SN-5", actual_quantity=2.0)
+    mock_response = MagicMock(status_code=200, parsed=mock_mo)
+
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+    )
+
+    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    request = FulfillOrderRequest(
+        order_id=42,
+        order_type="manufacturing",
+        preview=True,
+        serial_numbers=[501],
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any("count (1) must equal actual_quantity (2" in w for w in block_warnings)
+
+
+@pytest.mark.asyncio
+async def test_fulfill_manufacturing_order_blocks_serial_tracked_non_integer_quantity():
+    """Serial-tracked MO with non-integer actual_quantity → BLOCK warning.
+
+    Each serial number represents a whole unit; a fractional ``actual_quantity``
+    is incompatible with serial tracking.
+    """
+    context, lifespan_ctx = create_mock_context()
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+
+    mock_mo = _make_serial_tracked_mo(order_no="MO-SN-FRAC", actual_quantity=1.5)
+    mock_response = MagicMock(status_code=200, parsed=mock_mo)
+
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+    )
+
+    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    request = FulfillOrderRequest(
+        order_id=42,
+        order_type="manufacturing",
+        preview=True,
+        serial_numbers=[501],
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any(
+        "serial-tracked but actual_quantity (1.5) is not a whole number" in w
+        for w in block_warnings
+    )
+
+
+@pytest.mark.asyncio
+async def test_fulfill_manufacturing_order_serial_tracked_detection_falls_back_to_api():
+    """Cold / stale cache: variant + product missing from cache.
+
+    Without the API fallback, a cold cache silently classifies the MO as
+    not-serial-tracked, so the BLOCK warning never fires and the user hits
+    the original Katana 422 on apply. With the fallback, the per-ID API
+    fetch resolves the variant + product and the BLOCK warning fires.
+    """
+    context, _lifespan_ctx = create_mock_context()
+    # Default mock cache returns {} for every get_many_by_ids — simulating
+    # a cold cache. We do NOT call _wire_serial_tracked_cache here.
+
+    mock_mo = _make_serial_tracked_mo(order_no="MO-SN-COLD", actual_quantity=1.0)
+    mock_get_mo_response = MagicMock(status_code=200, parsed=mock_mo)
+
+    # API fallback: get_variant returns a variant pointing at product 9100;
+    # get_product returns a serial-tracked product.
+    variant_obj = MagicMock()
+    variant_obj.to_dict = MagicMock(
+        return_value={"id": 100, "sku": "ROCKER-V2", "product_id": 9100}
+    )
+    mock_get_variant_response = MagicMock(status_code=200, parsed=variant_obj)
+
+    product_obj = MagicMock()
+    product_obj.to_dict = MagicMock(return_value={"id": 9100, "serial_tracked": True})
+    mock_get_product_response = MagicMock(status_code=200, parsed=product_obj)
+
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+    )
+    from katana_public_api_client.api.product import get_product
+    from katana_public_api_client.api.variant import get_variant
+
+    get_manufacturing_order.asyncio_detailed = AsyncMock(
+        return_value=mock_get_mo_response
+    )
+    get_variant.asyncio_detailed = AsyncMock(return_value=mock_get_variant_response)
+    get_product.asyncio_detailed = AsyncMock(return_value=mock_get_product_response)
+
+    request = FulfillOrderRequest(order_id=42, order_type="manufacturing", preview=True)
+    result = await _fulfill_order_impl(request, context)
+
+    block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
+    assert any("serial-tracked" in w and "ROCKER-V2" in w for w in block_warnings)
+    # Verify both API endpoints were hit.
+    get_variant.asyncio_detailed.assert_called_once()
+    get_product.asyncio_detailed.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fulfill_manufacturing_order_non_serial_tracked_no_change():
+    """Non-serial-tracked MO + no serials → behaves as before (no BLOCK,
+    apply path passes UNSET for serial_numbers).
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    async def _get_many(entity_type: str, ids):
+        ids = list(ids or [])
+        if entity_type == EntityType.VARIANT and 100 in ids:
+            return {100: {"id": 100, "sku": "PLAIN-WIDGET", "product_id": 9100}}
+        if entity_type == EntityType.PRODUCT and 9100 in ids:
+            return {9100: {"id": 9100, "serial_tracked": False}}
+        return {}
+
+    lifespan_ctx.cache.get_many_by_ids = AsyncMock(side_effect=_get_many)
+
+    mock_mo = _make_serial_tracked_mo(order_no="MO-SN-7", actual_quantity=2.0)
+    mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
+
+    mock_updated_mo = MagicMock(spec=ManufacturingOrder)
+    mock_updated_mo.order_no = "MO-SN-7"
+    mock_updated_mo.status = ManufacturingOrderStatus.DONE
+    mock_update_response = MagicMock(status_code=200, parsed=mock_updated_mo)
+
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+        update_manufacturing_order,
+    )
+
+    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    update_mock = AsyncMock(return_value=mock_update_response)
+    update_manufacturing_order.asyncio_detailed = update_mock
+
+    request = FulfillOrderRequest(
+        order_id=42, order_type="manufacturing", preview=False
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.status == "DONE"
+    assert not [w for w in result.warnings if w.startswith("BLOCK:")]
+    sent_body = update_mock.call_args.kwargs["body"]
+    # serial_numbers should be UNSET (omitted from wire), not an empty list.
+    from katana_public_api_client.client_types import UNSET
+
+    assert sent_body.serial_numbers is UNSET

--- a/katana_public_api_client/models/update_manufacturing_order_request.py
+++ b/katana_public_api_client/models/update_manufacturing_order_request.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -40,6 +40,7 @@ class UpdateManufacturingOrderRequest:
     done_date: datetime.datetime | Unset = UNSET
     additional_info: str | Unset = UNSET
     batch_transactions: list[BatchTransaction] | Unset = UNSET
+    serial_numbers: list[int] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -78,6 +79,10 @@ class UpdateManufacturingOrderRequest:
                 batch_transactions_item = batch_transactions_item_data.to_dict()
                 batch_transactions.append(batch_transactions_item)
 
+        serial_numbers: list[int] | Unset = UNSET
+        if not isinstance(self.serial_numbers, Unset):
+            serial_numbers = self.serial_numbers
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -103,6 +108,8 @@ class UpdateManufacturingOrderRequest:
             field_dict["additional_info"] = additional_info
         if batch_transactions is not UNSET:
             field_dict["batch_transactions"] = batch_transactions
+        if serial_numbers is not UNSET:
+            field_dict["serial_numbers"] = serial_numbers
 
         return field_dict
 
@@ -162,6 +169,8 @@ class UpdateManufacturingOrderRequest:
 
                 batch_transactions.append(batch_transactions_item)
 
+        serial_numbers = cast(list[int], d.pop("serial_numbers", UNSET))
+
         update_manufacturing_order_request = cls(
             status=status,
             order_no=order_no,
@@ -174,6 +183,7 @@ class UpdateManufacturingOrderRequest:
             done_date=done_date,
             additional_info=additional_info,
             batch_transactions=batch_transactions,
+            serial_numbers=serial_numbers,
         )
 
         update_manufacturing_order_request.additional_properties = d

--- a/katana_public_api_client/models_pydantic/_generated/manufacturing.py
+++ b/katana_public_api_client/models_pydantic/_generated/manufacturing.py
@@ -145,6 +145,12 @@ class UpdateManufacturingOrderRequest(KatanaPydanticBase):
         list[BatchTransaction] | None,
         Field(description="Batch transactions for produced items"),
     ] = None
+    serial_numbers: Annotated[
+        list[int] | None,
+        Field(
+            description="Serial number IDs allocated to the produced units of this manufacturing order. Required when the MO's finished-good variant is serial-tracked; the count must equal `actual_quantity`."
+        ),
+    ] = None
 
 
 class UpdateManufacturingOrderProductionRequest(KatanaPydanticBase):


### PR DESCRIPTION
## Summary

Closes #586 — manufacturing orders whose finished-good variant is serial-tracked couldn't be marked DONE via MCP. Same parity gap on the MO side as #547 closed on the SO side. Two changes:

1. **Spec + regen** (`feat(client)`): added `serial_numbers: array[integer]` to `UpdateManufacturingOrderRequest` in `docs/katana-openapi.yaml`. The wire format already supported it (Katana 422s without it on serial-tracked MOs at status=DONE), but the request schema was missing the field. Additive optional — no breaking marker. Regenerated attrs + pydantic in the same commit.

2. **MCP tool** (`feat(mcp)`): `fulfill_order` grew an optional `serial_numbers: list[int] | None` parameter directly on `FulfillOrderRequest` (sibling, not nested in `rows`, since MOs reference a single variant — not per-row like SOs). Wires through to `PATCH /manufacturing_orders/{id}`. Preview-time detection looks up the MO's variant + parent product/material from cache (with API fallback for cold cache — same `_fetch_missing_from_api` helper #547 introduced) to read `serial_tracked` and emits `BLOCK:` warnings when:
   - the MO is serial-tracked with no `serial_numbers` (names the SKU)
   - `len(serial_numbers) != actual_quantity`
   - `actual_quantity` is non-integer on a serial-tracked MO

   The Confirm button suppresses on `BLOCK:` warnings via the existing `prefab_ui.split_warnings` wiring. Apply path re-checks BLOCK warnings (parallel to the existing already-DONE guard) so direct/programmatic callers skipping the UI get the same protection.

The MO branch reuses the SO-side helpers where possible (`_fetch_missing_from_api`, the cache+API resolution pattern). Adds a new single-variant variant `_resolve_variant_serial_info` (vs. the SO's per-row `_resolve_row_serial_info`) and `_build_mo_serial_warnings` (vs. SO's `_build_row_override_warnings`).

## Schema change

Spec change is additive and non-breaking: a new optional `serial_numbers` array property on `UpdateManufacturingOrderRequest`. Existing callers that don't set it pass `UNSET` on the wire — same behaviour as before.

Generated-file impact:
- `katana_public_api_client/models/update_manufacturing_order_request.py`: new field + ser/deser
- `katana_public_api_client/models_pydantic/_generated/manufacturing.py`: new pydantic field

## Reference

- SO parity: #547 (issue) / #580 (PR / commits ba314241 + a3a3f92c)
- Out of scope (same as #547): creating new `SerialNumber` records, enumerating *available* SerialNumber IDs in preview, surfacing `batch_transactions` overrides for MO completion.

## Test plan

- [x] `uv run poe check` passes (2888 tests pass, 2 preexisting skips)
- [x] `uv run poe full-check` passes (full validation tier including mkdocs build)
- [x] `uv run poe validate-examples` passes (280 examples checked, 0 failures)
- [x] 8 new tests in `katana_mcp_server/tests/tools/test_orders.py` cover all three BLOCK cases (no serials, count mismatch, non-integer actual_quantity), both apply paths (serials passed through → API call body, no serials needed → `UNSET` on wire), the cold-cache API-fallback regression, and a non-serial-tracked MO sanity check
- [ ] **Manual verification (post-merge):** if a serial-tracked MO is available in dev/staging, run preview → confirm `BLOCK:` warning lists the SKU, then apply with `serial_numbers=[Y, Z, ...]` → MO marked DONE with serials attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)