### PR TITLE
feat(mcp): add list_* tool wrappers for reference resources (#530)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -75,6 +75,14 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **modify_stock_transfer** - Unified modify: header body fields and/or status transition in one call (preview/apply). Hides Katana's two-endpoint split.
 - **delete_stock_transfer** - Delete a transfer
 
+### Reference Data
+- **list_locations** - List warehouses and facilities (id, name, address, primary flag). Use for `location_id` lookups on orders and inventory queries.
+- **list_suppliers** - List suppliers (id, name, contact info, currency). Use for `supplier_id` / `default_supplier_id` on POs and materials.
+- **list_tax_rates** - List configured tax rates (id, rate, defaults). Use for `tax_rate_id` on order line items.
+- **list_operators** - List manufacturing operators (id, name). Use for `operator_id` / `packer_id` on MO operations and SO fulfillments.
+- **list_additional_costs** - List the additional-cost catalog (freight, duties, handling). Use for `additional_cost_id` on `modify_purchase_order`.
+- (Equivalent to the `katana://locations` / `katana://suppliers` / `katana://tax-rates` / `katana://operators` / `katana://additional-costs` resources — same cache, same data.)
+
 ### Cache Administration
 - **rebuild_cache** - Force-rebuild the local typed cache for one or more transactional entity types (PO, SO, MO, stock adjustment, stock transfer). Truncates the cache table(s), clears the sync watermark, and re-fetches from Katana. Use when the cache has phantom rows (entities present locally but missing from Katana). Destructive; preview/apply.
 
@@ -1521,6 +1529,78 @@ Delete a stock transfer. Destructive — the transfer record is removed.
 **Parameters:**
 - `id` (required): Stock transfer ID
 - `preview` (optional, default true): true=preview, false=delete
+
+---
+
+## Reference Data Tools
+
+These tools surface the same cache-backed reference data as the
+`katana://locations` / `katana://suppliers` / `katana://tax-rates` /
+`katana://operators` / `katana://additional-costs` resources, but as
+`tools/list` entries so LLM agents discover them through the surface
+they reach for first. Use whichever surface your harness prefers — the
+underlying cache reads are identical.
+
+### list_locations
+List all warehouses and facilities. Returns each location's id, name,
+address, and primary flag. Use the `id` value when creating orders or
+filtering inventory queries.
+
+**Parameters:** _(none)_
+
+**Returns:** `{generated_at, summary: {total_locations}, locations: [{id,
+name, address, city, country, is_primary}], next_actions: [...]}`.
+
+---
+
+### list_suppliers
+List all suppliers. Returns each supplier's id, name, contact info, and
+currency. Use the `id` value when creating purchase orders or setting a
+default supplier on a material.
+
+**Parameters:** _(none)_
+
+**Returns:** `{generated_at, summary: {total_suppliers}, suppliers: [{id,
+name, email, phone, currency, comment}], next_actions: [...]}`.
+
+---
+
+### list_tax_rates
+List all configured tax rates. Returns each tax rate's id, name, rate,
+display name, and default-for-sales / default-for-purchases flags. Use
+the `id` value when creating sales orders or purchase-order line items
+with explicit tax assignments.
+
+**Parameters:** _(none)_
+
+**Returns:** `{generated_at, summary: {total_tax_rates}, tax_rates: [{id,
+name, rate, display_name, is_default_sales, is_default_purchases}],
+next_actions: [...]}`.
+
+---
+
+### list_operators
+List all manufacturing operators. Returns each operator's id and name.
+Use the `id` value when assigning operators to manufacturing-order
+operation rows or naming the packer on a sales order.
+
+**Parameters:** _(none)_
+
+**Returns:** `{generated_at, summary: {total_operators}, operators: [{id,
+name}], next_actions: [...]}`.
+
+---
+
+### list_additional_costs
+List the additional-cost catalog (freight, duties, handling fees, etc.).
+Returns each entry's id and name. Use the `id` value when calling
+`modify_purchase_order` with `add_additional_costs=[...]`. Pair with
+`list_tax_rates` for the matching `tax_rate_id`.
+
+**Parameters:** _(none)_
+
+**Returns:** `{generated_at, summary: {total_additional_costs},
+additional_costs: [{id, name}], next_actions: [...]}`.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/server.py
+++ b/katana_mcp_server/src/katana_mcp/server.py
@@ -279,6 +279,11 @@ Browse cached reference data:
   handling) for modify_purchase_order add_additional_costs
 - katana://help — detailed workflow guides and tool reference
 
+Each reference resource also has a tool wrapper (`list_locations`,
+`list_suppliers`, `list_tax_rates`, `list_operators`,
+`list_additional_costs`) returning identical data — use whichever surface
+your harness prefers.
+
 For transactional data (orders, stock movements), use the corresponding tools.
 """,
 )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/__init__.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/__init__.py
@@ -12,6 +12,8 @@ Organization:
 - catalog.py: Create products and materials (dedicated catalog management)
 - manufacturing_orders.py: Create manufacturing orders
 - orders.py: Fulfill manufacturing orders and sales orders
+- reference.py: Thin tool wrappers for reference-data resources
+  (locations, suppliers, tax rates, operators, additional costs)
 - cache_admin.py: Cache administration (rebuild_cache for typed cache)
 """
 
@@ -26,6 +28,7 @@ from .items import register_tools as register_items_tools
 from .manufacturing_orders import register_tools as register_manufacturing_order_tools
 from .orders import register_tools as register_order_tools
 from .purchase_orders import register_tools as register_purchase_order_tools
+from .reference import register_tools as register_reference_tools
 from .reporting import register_tools as register_reporting_tools
 from .sales_orders import register_tools as register_sales_order_tools
 from .stock_transfers import register_tools as register_stock_transfer_tools
@@ -46,6 +49,7 @@ def register_all_foundation_tools(mcp: FastMCP) -> None:
     register_manufacturing_order_tools(mcp)
     register_order_tools(mcp)
     register_stock_transfer_tools(mcp)
+    register_reference_tools(mcp)
     register_reporting_tools(mcp)
     register_cache_admin_tools(mcp)
     register_corrections_tools(mcp)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
@@ -49,7 +49,12 @@ class CreateProductRequest(BaseModel):
     is_purchasable: bool = Field(True, description="Can be purchased")
     sales_price: float | None = Field(None, description="Sales price per unit")
     purchase_price: float | None = Field(None, description="Purchase cost per unit")
-    default_supplier_id: int | None = Field(None, description="Default supplier ID")
+    default_supplier_id: int | None = Field(
+        None,
+        description=(
+            "Default supplier ID. Look up via `list_suppliers` or `katana://suppliers`."
+        ),
+    )
     additional_info: str | None = Field(None, description="Additional notes")
 
 
@@ -182,7 +187,12 @@ class CreateMaterialRequest(BaseModel):
     is_sellable: bool = Field(False, description="Whether material can be sold")
     sales_price: float | None = Field(None, description="Sales price per unit")
     purchase_price: float | None = Field(None, description="Purchase cost per unit")
-    default_supplier_id: int | None = Field(None, description="Default supplier ID")
+    default_supplier_id: int | None = Field(
+        None,
+        description=(
+            "Default supplier ID. Look up via `list_suppliers` or `katana://suppliers`."
+        ),
+    )
     additional_info: str | None = Field(None, description="Additional notes")
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -66,8 +66,8 @@ class CheckInventoryRequest(BaseModel):
         default=None,
         description=(
             "Filter to a single warehouse/facility. When set, the response "
-            "totals and `by_location` only include this location. Look up "
-            "location IDs via the `katana://locations` resource."
+            "totals and `by_location` only include this location. "
+            "Look up via `list_locations` or `katana://locations`."
         ),
     )
     format: Literal["markdown", "json"] = Field(
@@ -831,7 +831,13 @@ class CreateStockAdjustmentRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    location_id: int = Field(..., description="Location ID for the adjustment")
+    location_id: int = Field(
+        ...,
+        description=(
+            "Location ID for the adjustment. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
+    )
     rows: list[StockAdjustmentRow] = Field(..., description="Line items to adjust")
     reason: str | None = Field(
         default=None, description="Reason for adjustment (e.g., 'Sample received')"
@@ -1003,7 +1009,13 @@ class ListStockAdjustmentsRequest(BaseModel):
             "Invalid pages (0, negative) are rejected at the schema boundary."
         ),
     )
-    location_id: int | None = Field(default=None, description="Filter by location ID")
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "Filter by location ID. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
+    )
     ids: CoercedIntListOpt = Field(
         default=None,
         description=(
@@ -1367,7 +1379,11 @@ class UpdateStockAdjustmentParams(BaseModel):
         default=None, description="New adjustment date (ISO-8601, optional)"
     )
     location_id: int | None = Field(
-        default=None, description="New location ID (optional)"
+        default=None,
+        description=(
+            "New location ID (optional). "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     reason: str | None = Field(default=None, description="New reason (optional)")
     additional_info: str | None = Field(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -275,7 +275,12 @@ class CreateItemRequest(BaseModel):
     )
 
     # Optional common fields
-    default_supplier_id: int | None = Field(None, description="Default supplier ID")
+    default_supplier_id: int | None = Field(
+        None,
+        description=(
+            "Default supplier ID. Look up via `list_suppliers` or `katana://suppliers`."
+        ),
+    )
     additional_info: str | None = Field(None, description="Additional notes")
 
 
@@ -843,7 +848,13 @@ class ItemHeaderPatch(BaseModel):
     custom_field_collection_id: int | None = Field(default=None)
 
     # Product + Material only:
-    default_supplier_id: int | None = Field(default=None)
+    default_supplier_id: int | None = Field(
+        default=None,
+        description=(
+            "New default supplier ID. "
+            "Look up via `list_suppliers` or `katana://suppliers`."
+        ),
+    )
     batch_tracked: bool | None = Field(default=None)
     purchase_uom: str | None = Field(default=None)
     purchase_uom_conversion_rate: float | None = Field(default=None)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -151,7 +151,10 @@ class CreateManufacturingOrderRequest(BaseModel):
     )
     location_id: int | None = Field(
         default=None,
-        description="Production location ID (required for standalone MOs)",
+        description=(
+            "Production location ID (required for standalone MOs). "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     sales_order_row_id: int | None = Field(
         default=None,
@@ -1596,7 +1599,11 @@ class ListManufacturingOrdersRequest(BaseModel):
         ),
     )
     location_id: int | None = Field(
-        default=None, description="Filter by production location ID"
+        default=None,
+        description=(
+            "Filter by production location ID. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     variant_ids: CoercedIntListOpt = Field(
         default=None,
@@ -1978,7 +1985,10 @@ class ListBlockingIngredientsRequest(BaseModel):
     )
     location_id: int | None = Field(
         default=None,
-        description="Restrict the rollup to MOs at this production location.",
+        description=(
+            "Restrict the rollup to MOs at this production location. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     production_deadline_after: str | None = Field(
         default=None,
@@ -2507,7 +2517,13 @@ class MOHeaderPatch(BaseModel):
 
     order_no: str | None = Field(default=None)
     variant_id: int | None = Field(default=None)
-    location_id: int | None = Field(default=None)
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "New production location ID. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
+    )
     status: ManufacturingOrderStatusLiteral | None = Field(
         default=None,
         description=(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -121,7 +121,13 @@ class PurchaseOrderItem(BaseModel):
     variant_id: int = Field(..., description="Variant ID to purchase")
     quantity: float = Field(..., description="Quantity to order", gt=0)
     price_per_unit: float = Field(..., description="Unit price")
-    tax_rate_id: int | None = Field(None, description="Tax rate ID (optional)")
+    tax_rate_id: int | None = Field(
+        None,
+        description=(
+            "Tax rate ID (optional). "
+            "Look up via `list_tax_rates` or `katana://tax-rates`."
+        ),
+    )
     purchase_uom: str | None = Field(None, description="Purchase unit of measure")
     purchase_uom_conversion_rate: float | None = Field(
         None, description="Conversion rate for purchase UOM"
@@ -134,9 +140,18 @@ class CreatePurchaseOrderRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    supplier_id: int = Field(..., description="Supplier ID")
+    supplier_id: int = Field(
+        ...,
+        description=(
+            "Supplier ID. Look up via `list_suppliers` or `katana://suppliers`."
+        ),
+    )
     location_id: int = Field(
-        ..., description="Location ID where items will be received"
+        ...,
+        description=(
+            "Location ID where items will be received. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     order_number: str = Field(..., description="Purchase order number")
     items: list[PurchaseOrderItem] = Field(..., description="Line items", min_length=1)
@@ -1764,7 +1779,11 @@ class ListPurchaseOrdersRequest(BaseModel):
         default=None, description="Filter by currency code (e.g. 'USD')"
     )
     location_id: int | None = Field(
-        default=None, description="Filter by receiving location ID"
+        default=None,
+        description=(
+            "Filter by receiving location ID. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     tracking_location_id: int | None = Field(
         default=None,
@@ -1772,10 +1791,17 @@ class ListPurchaseOrdersRequest(BaseModel):
             "Filter by tracking location ID (outsourced POs). The cache "
             "stores this as a hoisted column on every row; regular POs "
             "match only when ``None`` is filtered, which doesn't apply "
-            "here — pair with ``entity_type='outsourced'`` to scope."
+            "here — pair with ``entity_type='outsourced'`` to scope. "
+            "Look up via `list_locations` or `katana://locations`."
         ),
     )
-    supplier_id: int | None = Field(default=None, description="Filter by supplier ID")
+    supplier_id: int | None = Field(
+        default=None,
+        description=(
+            "Filter by supplier ID. "
+            "Look up via `list_suppliers` or `katana://suppliers`."
+        ),
+    )
     include_deleted: bool | None = Field(
         default=None, description="When true, include soft-deleted purchase orders."
     )
@@ -2229,13 +2255,26 @@ class POHeaderPatch(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     order_no: str | None = Field(default=None, description="New PO number")
-    supplier_id: int | None = Field(default=None, description="New supplier ID")
+    supplier_id: int | None = Field(
+        default=None,
+        description=(
+            "New supplier ID. Look up via `list_suppliers` or `katana://suppliers`."
+        ),
+    )
     currency: str | None = Field(default=None, description="New currency code")
     location_id: int | None = Field(
-        default=None, description="New receiving location ID"
+        default=None,
+        description=(
+            "New receiving location ID. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     tracking_location_id: int | None = Field(
-        default=None, description="New tracking location ID"
+        default=None,
+        description=(
+            "New tracking location ID. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     status: PurchaseOrderStatusLiteral | None = Field(
         default=None,
@@ -2263,7 +2302,12 @@ class PORowAdd(BaseModel):
     variant_id: int = Field(..., description="Variant ID")
     quantity: float = Field(..., description="Quantity", gt=0)
     price_per_unit: float = Field(..., description="Unit price")
-    tax_rate_id: int | None = Field(default=None, description="Tax rate ID")
+    tax_rate_id: int | None = Field(
+        default=None,
+        description=(
+            "Tax rate ID. Look up via `list_tax_rates` or `katana://tax-rates`."
+        ),
+    )
     tax_name: str | None = Field(default=None, description="Tax name")
     tax_rate: str | None = Field(default=None, description="Tax rate value")
     currency: str | None = Field(default=None, description="Currency code")
@@ -2284,7 +2328,12 @@ class PORowUpdate(BaseModel):
     id: int = Field(..., description="Row ID to update")
     quantity: float | None = Field(default=None, description="New quantity", gt=0)
     variant_id: int | None = Field(default=None, description="New variant ID")
-    tax_rate_id: int | None = Field(default=None, description="New tax rate ID")
+    tax_rate_id: int | None = Field(
+        default=None,
+        description=(
+            "New tax rate ID. Look up via `list_tax_rates` or `katana://tax-rates`."
+        ),
+    )
     tax_name: str | None = Field(default=None, description="New tax name")
     tax_rate: str | None = Field(default=None, description="New tax rate value")
     price_per_unit: float | None = Field(default=None, description="New unit price")
@@ -2310,8 +2359,19 @@ class POAdditionalCostAdd(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    additional_cost_id: int = Field(..., description="Additional-cost catalog entry ID")
-    tax_rate_id: int = Field(..., description="Tax rate ID")
+    additional_cost_id: int = Field(
+        ...,
+        description=(
+            "Additional-cost catalog entry ID. "
+            "Look up via `list_additional_costs` or `katana://additional-costs`."
+        ),
+    )
+    tax_rate_id: int = Field(
+        ...,
+        description=(
+            "Tax rate ID. Look up via `list_tax_rates` or `katana://tax-rates`."
+        ),
+    )
     price: float = Field(..., description="Cost amount")
     distribution_method: CostDistributionMethodLiteral | None = Field(
         default=None,
@@ -2333,9 +2393,18 @@ class POAdditionalCostUpdate(BaseModel):
 
     id: int = Field(..., description="Cost row ID to update")
     additional_cost_id: int | None = Field(
-        default=None, description="New catalog entry ID"
+        default=None,
+        description=(
+            "New catalog entry ID. "
+            "Look up via `list_additional_costs` or `katana://additional-costs`."
+        ),
     )
-    tax_rate_id: int | None = Field(default=None, description="New tax rate ID")
+    tax_rate_id: int | None = Field(
+        default=None,
+        description=(
+            "New tax rate ID. Look up via `list_tax_rates` or `katana://tax-rates`."
+        ),
+    )
     price: float | None = Field(default=None, description="New price")
     distribution_method: CostDistributionMethodLiteral | None = Field(
         default=None, description="New distribution method"

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
@@ -1,0 +1,169 @@
+"""Reference data tool wrappers for Katana MCP Server.
+
+These tools expose the same cached reference data as the
+``katana://locations`` / ``katana://suppliers`` / ``katana://tax-rates`` /
+``katana://operators`` / ``katana://additional-costs`` resources, but as
+``tools/list`` entries so LLM agents discover them through the surface
+they reach for first.
+
+Each tool is a thin wrapper around the corresponding resource handler in
+``katana_mcp.resources.reference`` — same cache, same shape, same data.
+The duplication is intentional: ``tools/list`` is what LLMs scan; making
+reference data discoverable there closes a long-standing gap where agents
+would fall back to the Katana web UI or ask the user for IDs that the
+server already had cached locally.
+
+(``list_items`` is intentionally **not** exposed here — ``search_items``
+already covers the catalog surface.)
+"""
+
+# NOTE: Do not use 'from __future__ import annotations' in this module.
+# FastMCP requires Context to be the actual class, not a string annotation —
+# matching the convention used in ``katana_mcp.resources.reference``.
+
+import json
+
+from fastmcp import Context, FastMCP
+from fastmcp.tools import ToolResult
+
+from katana_mcp.logging import observe_tool
+from katana_mcp.resources.reference import (
+    get_additional_costs,
+    get_locations,
+    get_operators,
+    get_suppliers,
+    get_tax_rates,
+)
+
+
+async def _to_tool_result(payload: str) -> ToolResult:
+    """Wrap a resource's JSON-string payload as a ``ToolResult``.
+
+    The resource handlers return ``str`` (JSON-serialized); ``ToolResult``
+    needs both a ``content`` string and ``structured_content`` dict, so we
+    parse once and feed both. Exposing the parsed dict as
+    ``structured_content`` lets downstream tools / aggregations consume the
+    payload without re-parsing.
+    """
+    return ToolResult(
+        content=payload,
+        structured_content=json.loads(payload),
+    )
+
+
+# ============================================================================
+# list_locations — wraps katana://locations
+# ============================================================================
+
+
+@observe_tool
+async def list_locations(context: Context) -> ToolResult:
+    """List all warehouses and facilities. Returns each location's id, name,
+    address, and primary flag. Use the `id` value when creating orders or
+    filtering inventory queries.
+
+    This is the tool surface for the `katana://locations` resource; both
+    return the same cache-backed data.
+    """
+    payload = await get_locations(context)
+    return await _to_tool_result(payload)
+
+
+# ============================================================================
+# list_suppliers — wraps katana://suppliers
+# ============================================================================
+
+
+@observe_tool
+async def list_suppliers(context: Context) -> ToolResult:
+    """List all suppliers. Returns each supplier's id, name, contact info,
+    and currency. Use the `id` value when creating purchase orders or setting
+    a default supplier on a material.
+
+    This is the tool surface for the `katana://suppliers` resource; both
+    return the same cache-backed data.
+    """
+    payload = await get_suppliers(context)
+    return await _to_tool_result(payload)
+
+
+# ============================================================================
+# list_tax_rates — wraps katana://tax-rates
+# ============================================================================
+
+
+@observe_tool
+async def list_tax_rates(context: Context) -> ToolResult:
+    """List all configured tax rates. Returns each tax rate's id, name, rate,
+    display name, and default-for-sales / default-for-purchases flags. Use
+    the `id` value when creating sales orders or purchase-order line items
+    with explicit tax assignments.
+
+    This is the tool surface for the `katana://tax-rates` resource; both
+    return the same cache-backed data.
+    """
+    payload = await get_tax_rates(context)
+    return await _to_tool_result(payload)
+
+
+# ============================================================================
+# list_operators — wraps katana://operators
+# ============================================================================
+
+
+@observe_tool
+async def list_operators(context: Context) -> ToolResult:
+    """List all manufacturing operators. Returns each operator's id and name.
+    Use the `id` value when assigning operators to manufacturing-order
+    operation rows or naming the packer on a sales order.
+
+    This is the tool surface for the `katana://operators` resource; both
+    return the same cache-backed data.
+    """
+    payload = await get_operators(context)
+    return await _to_tool_result(payload)
+
+
+# ============================================================================
+# list_additional_costs — wraps katana://additional-costs
+# ============================================================================
+
+
+@observe_tool
+async def list_additional_costs(context: Context) -> ToolResult:
+    """List the additional-cost catalog (freight, duties, handling fees, etc.).
+    Returns each entry's id and name. Use the `id` value when calling
+    `modify_purchase_order` with `add_additional_costs=[...]`. Pair with
+    `list_tax_rates` for the matching `tax_rate_id`.
+
+    This is the tool surface for the `katana://additional-costs` resource;
+    both return the same cache-backed data.
+    """
+    payload = await get_additional_costs(context)
+    return await _to_tool_result(payload)
+
+
+# ============================================================================
+# Registration
+# ============================================================================
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register reference-data list tools with the FastMCP instance."""
+    from mcp.types import ToolAnnotations
+
+    _read = ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+
+    mcp.tool(tags={"reference", "read"}, annotations=_read)(list_locations)
+    mcp.tool(tags={"reference", "read"}, annotations=_read)(list_suppliers)
+    mcp.tool(tags={"reference", "read"}, annotations=_read)(list_tax_rates)
+    mcp.tool(tags={"reference", "read"}, annotations=_read)(list_operators)
+    mcp.tool(tags={"reference", "read"}, annotations=_read)(list_additional_costs)
+
+
+__all__ = ["register_tools"]

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -248,7 +248,11 @@ class TopSellingVariantsRequest(BaseModel):
         description="Sort key: 'units' (quantity sold) or 'revenue' (dollar volume)",
     )
     location_id: int | None = Field(
-        default=None, description="Optional location ID to filter by"
+        default=None,
+        description=(
+            "Optional location ID to filter by. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     format: Literal["markdown", "json"] = Field(
         default="markdown",

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -139,9 +139,19 @@ class SalesOrderItem(BaseModel):
         default=None,
         description="Override price per unit (uses default if not specified)",
     )
-    tax_rate_id: int | None = Field(default=None, description="Tax rate ID (optional)")
+    tax_rate_id: int | None = Field(
+        default=None,
+        description=(
+            "Tax rate ID (optional). "
+            "Look up via `list_tax_rates` or `katana://tax-rates`."
+        ),
+    )
     location_id: int | None = Field(
-        default=None, description="Location to pick from (optional)"
+        default=None,
+        description=(
+            "Location to pick from (optional). "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     total_discount: float | None = Field(
         default=None, description="Discount for this line item (optional)"
@@ -179,7 +189,11 @@ class CreateSalesOrderRequest(BaseModel):
     order_number: str = Field(..., description="Unique sales order number")
     items: list[SalesOrderItem] = Field(..., description="Line items", min_length=1)
     location_id: int | None = Field(
-        default=None, description="Primary fulfillment location ID (optional)"
+        default=None,
+        description=(
+            "Primary fulfillment location ID (optional). "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     delivery_date: datetime | None = Field(
         default=None, description="Requested delivery date (optional)"
@@ -457,7 +471,13 @@ class ListSalesOrdersRequest(BaseModel):
         ),
     )
     customer_id: int | None = Field(default=None, description="Filter by customer ID")
-    location_id: int | None = Field(default=None, description="Filter by location ID")
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "Filter by location ID. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
+    )
     status: str | None = Field(
         default=None, description="Filter by sales order status (e.g. NOT_SHIPPED)"
     )
@@ -1486,7 +1506,12 @@ class SOHeaderPatch(BaseModel):
 
     order_no: str | None = Field(default=None, description="New SO number")
     customer_id: int | None = Field(default=None, description="New customer ID")
-    location_id: int | None = Field(default=None, description="New location ID")
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "New location ID. Look up via `list_locations` or `katana://locations`."
+        ),
+    )
     status: SalesOrderStatusLiteral | None = Field(
         default=None,
         description="New status — NOT_SHIPPED / PENDING / PACKED / DELIVERED",
@@ -1521,8 +1546,18 @@ class SORowAdd(BaseModel):
     variant_id: int = Field(..., description="Variant ID")
     quantity: float = Field(..., description="Quantity", gt=0)
     price_per_unit: float | None = Field(default=None, description="Unit price")
-    tax_rate_id: int | None = Field(default=None, description="Tax rate ID")
-    location_id: int | None = Field(default=None, description="Location ID")
+    tax_rate_id: int | None = Field(
+        default=None,
+        description=(
+            "Tax rate ID. Look up via `list_tax_rates` or `katana://tax-rates`."
+        ),
+    )
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "Location ID. Look up via `list_locations` or `katana://locations`."
+        ),
+    )
     total_discount: float | None = Field(default=None, description="Total discount")
 
 
@@ -1535,8 +1570,18 @@ class SORowUpdate(BaseModel):
     variant_id: int | None = Field(default=None, description="New variant ID")
     quantity: float | None = Field(default=None, description="New quantity", gt=0)
     price_per_unit: float | None = Field(default=None, description="New unit price")
-    tax_rate_id: int | None = Field(default=None, description="New tax rate ID")
-    location_id: int | None = Field(default=None, description="New location ID")
+    tax_rate_id: int | None = Field(
+        default=None,
+        description=(
+            "New tax rate ID. Look up via `list_tax_rates` or `katana://tax-rates`."
+        ),
+    )
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "New location ID. Look up via `list_locations` or `katana://locations`."
+        ),
+    )
     total_discount: float | None = Field(default=None, description="New discount")
 
 
@@ -1613,7 +1658,13 @@ class SOFulfillmentUpdate(BaseModel):
     id: int = Field(..., description="Fulfillment ID to update")
     status: FulfillmentStatusLiteral | None = Field(default=None)
     picked_date: datetime | None = Field(default=None)
-    packer_id: int | None = Field(default=None, description="New packer (operator)")
+    packer_id: int | None = Field(
+        default=None,
+        description=(
+            "New packer (operator). "
+            "Look up via `list_operators` or `katana://operators`."
+        ),
+    )
     conversion_rate: float | None = Field(default=None)
     conversion_date: datetime | None = Field(default=None)
     tracking_number: str | None = Field(default=None)
@@ -1629,7 +1680,12 @@ class SOShippingFeeAdd(BaseModel):
 
     amount: str = Field(..., description="Fee amount (decimal string)")
     description: str | None = Field(default=None)
-    tax_rate_id: int | None = Field(default=None)
+    tax_rate_id: int | None = Field(
+        default=None,
+        description=(
+            "Tax rate ID. Look up via `list_tax_rates` or `katana://tax-rates`."
+        ),
+    )
 
 
 class SOShippingFeeUpdate(BaseModel):
@@ -1645,7 +1701,12 @@ class SOShippingFeeUpdate(BaseModel):
     id: int = Field(..., description="Shipping fee ID to update")
     amount: str = Field(..., description="Fee amount (required by API)")
     description: str | None = Field(default=None)
-    tax_rate_id: int | None = Field(default=None)
+    tax_rate_id: int | None = Field(
+        default=None,
+        description=(
+            "Tax rate ID. Look up via `list_tax_rates` or `katana://tax-rates`."
+        ),
+    )
 
 
 class ModifySalesOrderRequest(ConfirmableRequest):

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -161,9 +161,18 @@ class CreateStockTransferRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    source_location_id: int = Field(..., description="Source location ID")
+    source_location_id: int = Field(
+        ...,
+        description=(
+            "Source location ID. Look up via `list_locations` or `katana://locations`."
+        ),
+    )
     destination_location_id: int = Field(
-        ..., description="Destination location ID (target_location_id in API terms)"
+        ...,
+        description=(
+            "Destination location ID (target_location_id in API terms). "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     expected_arrival_date: datetime = Field(
         ..., description="Expected arrival date at the destination location"
@@ -490,11 +499,18 @@ class ListStockTransfersRequest(BaseModel):
         description="Filter by transfer status (DRAFT, IN_TRANSIT, RECEIVED)",
     )
     source_location_id: int | None = Field(
-        default=None, description="Filter by source location ID"
+        default=None,
+        description=(
+            "Filter by source location ID. "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     destination_location_id: int | None = Field(
         default=None,
-        description="Filter by destination location ID (target_location_id).",
+        description=(
+            "Filter by destination location ID (target_location_id). "
+            "Look up via `list_locations` or `katana://locations`."
+        ),
     )
     stock_transfer_number: str | None = Field(
         default=None, description="Filter by exact stock transfer number"

--- a/katana_mcp_server/tests/tools/test_reference.py
+++ b/katana_mcp_server/tests/tools/test_reference.py
@@ -1,0 +1,262 @@
+"""Tests for reference-data tool wrappers (`list_locations`, `list_suppliers`,
+`list_tax_rates`, `list_operators`, `list_additional_costs`).
+
+Each tool is a thin wrapper around the corresponding resource handler in
+``katana_mcp.resources.reference``. These tests assert that the tool returns
+the **same data** as reading the resource directly — the contract callers
+rely on for swapping between surfaces.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.tools import ToolResult
+from katana_mcp.resources.reference import (
+    get_additional_costs,
+    get_locations,
+    get_operators,
+    get_suppliers,
+    get_tax_rates,
+)
+from katana_mcp.tools.foundation.reference import (
+    list_additional_costs,
+    list_locations,
+    list_operators,
+    list_suppliers,
+    list_tax_rates,
+    register_tools,
+)
+from mcp.types import TextContent
+
+from tests.conftest import create_mock_context
+
+
+def _extract_text(tool_result: ToolResult) -> str:
+    """Return the text payload from the first ``TextContent`` block.
+
+    Tool results are stored as a list of content blocks (text, image, etc.).
+    Reference tools always emit a single JSON-serialized text block — this
+    helper unwraps it for the assertion.
+    """
+    assert tool_result.content, "ToolResult.content is empty"
+    block = tool_result.content[0]
+    assert isinstance(block, TextContent), (
+        f"Expected TextContent, got {type(block).__name__}"
+    )
+    return block.text
+
+
+def _make_context_with_cache(cached_entities: list[dict]):
+    """Mock context whose CatalogCache returns a fixed list from ``get_all``."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.cache.get_all = AsyncMock(return_value=cached_entities)
+    return context
+
+
+# ============================================================================
+# Tool/resource parity — the core contract these tools exist to honor
+# ============================================================================
+
+
+class TestToolResourceParity:
+    """Each ``list_*`` tool must return the same data as calling the
+    corresponding resource handler directly. The tool serializes through
+    ``ToolResult`` (content + structured_content); both surfaces must agree.
+    """
+
+    @pytest.mark.asyncio
+    async def test_list_locations_matches_resource(self):
+        cached = [
+            {
+                "id": 100,
+                "name": "Main Warehouse",
+                "address": "123 Industrial Way",
+                "city": "Portland",
+                "country": "US",
+                "is_primary": True,
+            },
+            {
+                "id": 101,
+                "name": "Satellite",
+                "address": "456 Side St",
+                "city": "Eugene",
+                "country": "US",
+                "is_primary": False,
+            },
+        ]
+        context = _make_context_with_cache(cached)
+        with patch(
+            "katana_mcp.resources.reference.ensure_locations_synced",
+            new_callable=AsyncMock,
+        ):
+            resource_payload = json.loads(await get_locations(context))
+        # Re-mock the cache for the second call (AsyncMock state stays fine,
+        # but a fresh resource sync needs patching for the tool's call too).
+        with patch(
+            "katana_mcp.resources.reference.ensure_locations_synced",
+            new_callable=AsyncMock,
+        ):
+            tool_result = await list_locations(context)
+
+        assert isinstance(tool_result, ToolResult)
+        assert tool_result.structured_content is not None
+        # `summary` and the data list must match between surfaces. (The
+        # `generated_at` timestamps differ between the two calls — that's
+        # expected and not part of the contract.)
+        assert tool_result.structured_content["summary"] == resource_payload["summary"]
+        assert (
+            tool_result.structured_content["locations"] == resource_payload["locations"]
+        )
+        # Content blocks expose the JSON payload as text; it must round-trip
+        # to the same structured payload.
+        assert json.loads(_extract_text(tool_result)) == tool_result.structured_content
+
+    @pytest.mark.asyncio
+    async def test_list_suppliers_matches_resource(self):
+        cached = [
+            {
+                "id": 1,
+                "name": "Acme Corp",
+                "email": "sales@acme.com",
+                "phone": "555-0100",
+                "currency": "USD",
+                "comment": None,
+            },
+        ]
+        context = _make_context_with_cache(cached)
+        with patch(
+            "katana_mcp.resources.reference.ensure_suppliers_synced",
+            new_callable=AsyncMock,
+        ):
+            resource_payload = json.loads(await get_suppliers(context))
+        with patch(
+            "katana_mcp.resources.reference.ensure_suppliers_synced",
+            new_callable=AsyncMock,
+        ):
+            tool_result = await list_suppliers(context)
+
+        assert tool_result.structured_content is not None
+        assert tool_result.structured_content["summary"] == resource_payload["summary"]
+        assert (
+            tool_result.structured_content["suppliers"] == resource_payload["suppliers"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_tax_rates_matches_resource(self):
+        cached = [
+            {
+                "id": 1,
+                "name": "Standard",
+                "rate": 8.5,
+                "display_name": "CA Sales Tax",
+                "is_default_sales": True,
+                "is_default_purchases": False,
+            },
+        ]
+        context = _make_context_with_cache(cached)
+        with patch(
+            "katana_mcp.resources.reference.ensure_tax_rates_synced",
+            new_callable=AsyncMock,
+        ):
+            resource_payload = json.loads(await get_tax_rates(context))
+        with patch(
+            "katana_mcp.resources.reference.ensure_tax_rates_synced",
+            new_callable=AsyncMock,
+        ):
+            tool_result = await list_tax_rates(context)
+
+        assert tool_result.structured_content is not None
+        assert tool_result.structured_content["summary"] == resource_payload["summary"]
+        assert (
+            tool_result.structured_content["tax_rates"] == resource_payload["tax_rates"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_operators_matches_resource(self):
+        cached = [
+            {"id": 1, "name": "Alice"},
+            {"id": 2, "name": "Bob"},
+        ]
+        context = _make_context_with_cache(cached)
+        with patch(
+            "katana_mcp.resources.reference.ensure_operators_synced",
+            new_callable=AsyncMock,
+        ):
+            resource_payload = json.loads(await get_operators(context))
+        with patch(
+            "katana_mcp.resources.reference.ensure_operators_synced",
+            new_callable=AsyncMock,
+        ):
+            tool_result = await list_operators(context)
+
+        assert tool_result.structured_content is not None
+        assert tool_result.structured_content["summary"] == resource_payload["summary"]
+        assert (
+            tool_result.structured_content["operators"] == resource_payload["operators"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_additional_costs_matches_resource(self):
+        cached = [
+            {"id": 1, "name": "Shipping Cost"},
+            {"id": 2, "name": "Import Duty"},
+        ]
+        context = _make_context_with_cache(cached)
+        with patch(
+            "katana_mcp.resources.reference.ensure_additional_costs_synced",
+            new_callable=AsyncMock,
+        ):
+            resource_payload = json.loads(await get_additional_costs(context))
+        with patch(
+            "katana_mcp.resources.reference.ensure_additional_costs_synced",
+            new_callable=AsyncMock,
+        ):
+            tool_result = await list_additional_costs(context)
+
+        assert tool_result.structured_content is not None
+        assert tool_result.structured_content["summary"] == resource_payload["summary"]
+        assert (
+            tool_result.structured_content["additional_costs"]
+            == resource_payload["additional_costs"]
+        )
+
+
+# ============================================================================
+# Registration
+# ============================================================================
+
+
+class TestRegistration:
+    def test_registers_all_five_tools(self):
+        """``register_tools`` must register exactly the 5 reference tools."""
+        mcp = MagicMock()
+        # ``mcp.tool`` is called as ``mcp.tool(tags=..., annotations=...)``,
+        # which returns a decorator that wraps the tool function.
+        tool_decorator = MagicMock(side_effect=lambda fn: fn)
+        mcp.tool = MagicMock(return_value=tool_decorator)
+
+        register_tools(mcp)
+
+        # Five tool decorators should have been created
+        assert mcp.tool.call_count == 5
+        # All registered tools should be tagged 'reference' + 'read'
+        for call in mcp.tool.call_args_list:
+            assert "reference" in call.kwargs["tags"]
+            assert "read" in call.kwargs["tags"]
+            # All annotations should mark the tools read-only and idempotent
+            ann = call.kwargs["annotations"]
+            assert ann.readOnlyHint is True
+            assert ann.destructiveHint is False
+            assert ann.idempotentHint is True
+
+        # Each of the 5 tool functions should have been passed through the
+        # decorator returned by ``mcp.tool(...)``.
+        decorated = {call.args[0].__name__ for call in tool_decorator.call_args_list}
+        assert decorated == {
+            "list_locations",
+            "list_suppliers",
+            "list_tax_rates",
+            "list_operators",
+            "list_additional_costs",
+        }


### PR DESCRIPTION
Closes #530

## Rationale

The Katana MCP server already exposes reference data at
`katana://locations`, `katana://suppliers`, `katana://tax-rates`,
`katana://operators`, and `katana://additional-costs` — but LLM agents in
real sessions don't discover them. They reach for tools first, fall back
to the Katana web UI, or ask the user. The data was always there;
`resources/list` is just a less-prominent MCP surface than `tools/list`.

This PR closes that gap with the **A + B** option from the issue: add tool
wrappers that re-expose the data through `tools/list`, **and** annotate
every ID field in the foundation request models with a one-line
cross-reference pointing back at both surfaces.

## Part A — Five thin tool wrappers

| New tool | Wraps |
|---|---|
| `list_locations` | `katana://locations` |
| `list_suppliers` | `katana://suppliers` |
| `list_tax_rates` | `katana://tax-rates` |
| `list_operators` | `katana://operators` |
| `list_additional_costs` | `katana://additional-costs` |

Each tool reads the same cache as the corresponding resource — same
shape, same data, same fast path. `list_items` is intentionally **not**
added — `search_items` already covers that surface.

Implementation lives in `katana_mcp_server/src/katana_mcp/tools/foundation/reference.py`
(new file). Each tool delegates to the existing resource handler, wraps
the JSON payload as a `ToolResult`, and is tagged `read` + `reference`
with `readOnlyHint=True` / `idempotentHint=True` annotations.

## Part B — ID-field cross-references

44 `Field(...)` descriptions across 8 foundation files now end with a
one-line cross-reference, e.g.:

> `Look up via \`list_locations\` or \`katana://locations\`.`

Coverage:

- `inventory.py` (4) — `location_id` on `check_inventory`,
  `create_stock_adjustment`, `list_stock_adjustments`,
  `update_stock_adjustment`
- `purchase_orders.py` (15) — `supplier_id`, `location_id`,
  `tracking_location_id`, `tax_rate_id`, `additional_cost_id` across
  create / list / modify
- `sales_orders.py` (12) — `location_id`, `tax_rate_id`, `packer_id`
  across create / list / modify (header, rows, shipping fees)
- `manufacturing_orders.py` (4) — `location_id` on create / list / rollup
  / modify
- `stock_transfers.py` (4) — `source_location_id`,
  `destination_location_id` on create / list
- `items.py` (2), `catalog.py` (2) — `default_supplier_id` on
  create_item / modify_item / create_product / create_material
- `reporting.py` (1) — `location_id` on `top_selling_variants`

## Other touchpoints

- `katana_mcp_server/src/katana_mcp/server.py` — instructions block notes
  the new tools alongside the existing resource list
- `katana_mcp_server/src/katana_mcp/resources/help.py` — adds a new
  "Reference Data Tools" section under the tool reference, plus an entry
  in the Core Capabilities index (known help-resource drift point per
  CLAUDE.md)
- `katana_mcp_server/src/katana_mcp/tools/foundation/__init__.py` —
  registers the new module

## Test plan

- [x] New `katana_mcp_server/tests/tools/test_reference.py` — 6 tests
      asserting each `list_*` tool returns the same `summary` and data
      list as reading the corresponding resource directly, plus the
      registration covers all 5 tools with the expected tags / annotations
- [x] `uv run poe check` — all 2886 tests pass; ruff format, ruff check,
      ty type check, yamllint all green (yamllint warnings are
      pre-existing and unrelated)
- [ ] Smoke check on a live host (Claude Desktop / MCP Inspector) that
      `tools/list` surfaces the 5 new tools and they return data

🤖 Generated with [Claude Code](https://claude.com/claude-code)