### PR TITLE
feat(mcp): correct_purchase_order — composite closed-record edits on POs (#532)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -53,6 +53,7 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **get_purchase_order** - Look up a PO by number or ID — exhaustive detail (every PO/row field, additional cost rows, accounting metadata)
 - **modify_purchase_order** - Unified modify: header, rows, additional-cost rows in one call (typed sub-payload slots, multi-action, preview/apply)
 - **delete_purchase_order** - Delete a PO (Katana cascades child rows)
+- **correct_purchase_order** - Edit a closed (RECEIVED / PARTIALLY_RECEIVED) PO without losing its per-row `received_date` / batch-transaction metadata. Reverts to NOT_RECEIVED, edits rows keyed by row ID, then replays the original receipts via `/purchase_order_receive` to restore close-state. See "Closed-Record Corrections" below.
 
 ### Manufacturing & Sales
 - **create_manufacturing_order** - Create production work orders
@@ -154,10 +155,12 @@ keeping them separate makes the destructiveHint annotation honest.
 
 ## Closed-Record Corrections
 
-Two specialized tools — `correct_manufacturing_order` and
-`correct_sales_order` — exist for the case where you need to edit a record
-that has *already* reached a terminal status (DONE for an MO, DELIVERED for
-an SO) without losing the original close-state metadata.
+Three specialized tools — `correct_manufacturing_order`,
+`correct_sales_order`, and `correct_purchase_order` — exist for the case
+where you need to edit a record that has *already* reached a terminal
+status (DONE for an MO, DELIVERED for an SO, RECEIVED /
+PARTIALLY_RECEIVED for a PO) without losing the original close-state
+metadata.
 
 The standard `modify_<entity>` tool can technically do this, but the
 operator has to discover and sequence several mechanical quirks each time:
@@ -173,6 +176,13 @@ operator has to discover and sequence several mechanical quirks each time:
   as `APIError`; callers should use `is_success`), then patching the
   status, editing lines, and re-creating fulfillments with the original
   `picked_date` / tracking metadata.
+- A RECEIVED / PARTIALLY_RECEIVED PO has rows whose `quantity` /
+  `variant_id` / `price_per_unit` are immutable while `received_date` is
+  non-null. The reopen path is PATCH `/purchase_orders/{id}` with status
+  → NOT_RECEIVED (which clears each row's `received_date`); the restore
+  path is `POST /purchase_order_receive` with the captured per-row
+  quantity / `received_date` / batch_transactions, which auto-promotes
+  status back to RECEIVED.
 
 The correction tools encode the proven sequence once. Each takes the edits
 keyed by the *current* variant on the row (not the row ID), so the operator
@@ -181,31 +191,26 @@ SP73001 on this MO"). Both follow the standard preview/apply pattern.
 
 Use the regular `modify_<entity>` tool when:
 - The record is still open (no close-state to preserve).
-- The edits don't fit the variant-keyed shape — e.g. you need to add a row,
-  delete a row, or change something other than variant/quantity.
-- The same variant appears on multiple rows and you want to disambiguate
-  with the explicit row ID.
+- The edits don't fit the variant-keyed (MO/SO) or row-id-keyed (PO)
+  shape — e.g. you need to add a row, delete a row, or change something
+  other than variant/quantity/price.
+- The same variant appears on multiple rows on the same MO/SO and you want
+  to disambiguate with the explicit row ID.
 
-**No `correct_purchase_order` or `correct_stock_transfer`** — those entity
-types don't fit the pattern:
+**Note**: `correct_purchase_order` keys edits by row ID (not variant ID
+like the MO/SO siblings). The receive endpoint may split a partially-
+received row into two physical rows post-receipt — both rows can carry
+the same `variant_id`, so variant-keyed lookup would be ambiguous. Look
+up current row IDs via `get_purchase_order` before calling
+`correct_purchase_order`.
 
-- **Purchase orders** — Katana's receipt records are append-only at the row
-  level. `modify_purchase_order` can patch a row's `received_date` (when
-  already set), but it **cannot zero out a row's `received_quantity`** —
-  there's no unreceive endpoint, and `quantity` / `variant_id` on a row are
-  only updatable when `received_date` is null. So a clean reopen path
-  doesn't exist (tracked in #532). For inventory-level recovery today:
-  `create_stock_adjustment` at the original cost basis to undo the
-  receipt's stock effect — this fixes inventory, but the PO record's
-  received quantities remain historically incorrect until Katana exposes an
-  unreceive / reset mechanism. Plan for the audit trail to show the
-  original receipt + the compensating adjustment, not a corrected receipt.
-- **Stock transfers** — no completion timestamp on the model and rows are
-  immutable, so the close-state pattern adds no value. For corrections:
-  `create_stock_adjustment` at the destination location for quantity
-  discrepancies; `delete_stock_transfer` + `create_stock_transfer` for wrong
-  variants; `modify_stock_transfer` for header metadata (works on RECEIVED
-  transfers as-is).
+**No `correct_stock_transfer`** — stock transfers don't fit the pattern:
+no completion timestamp on the model and rows are immutable, so the
+close-state pattern adds no value. For corrections:
+`create_stock_adjustment` at the destination location for quantity
+discrepancies; `delete_stock_transfer` + `create_stock_transfer` for
+wrong variants; `modify_stock_transfer` for header metadata (works on
+RECEIVED transfers as-is).
 
 ## Output Format
 
@@ -1420,6 +1425,63 @@ there's no close-state to preserve.
 **Returns:** A `ModificationResponse` with one `ActionResult` per phase
 step. Fail-fast halt leaves the SO in an intermediate (open) state with
 the captured close-state in `prior_state`.
+
+---
+
+### correct_purchase_order
+Edit a closed PO (status RECEIVED or PARTIALLY_RECEIVED) without losing
+its original receipt metadata. Reverts to NOT_RECEIVED (clearing each
+row's `received_date` so per-row fields become editable again), edits
+rows keyed by row ID, then re-receives via `POST /purchase_order_receive`
+to restore the captured per-row `quantity` / `received_date` /
+`batch_transactions`. The receive endpoint promotes status back to
+RECEIVED automatically once every row is fully received.
+
+For a PO that hasn't been received yet, use `modify_purchase_order`
+directly — there's no close-state to preserve.
+
+**Parameters:**
+- `id` (required): Purchase order ID
+- `row_changes` (required, min_length=1): list of row edits. Each entry:
+  `row_id` (existing row ID — find via `get_purchase_order`, required),
+  `new_variant_id` (optional), `quantity` (optional, >0), `price_per_unit`
+  (optional, >=0). At least one of the latter three must be set.
+- `preview` (optional, default true): true=preview, false=execute
+
+**Sequence executed (in order):**
+1. PATCH PO status → NOT_RECEIVED (clears each row's `received_date`)
+2. PATCH each row per `row_changes` (Katana now allows
+   variant_id / quantity / price_per_unit edits since `received_date` is null)
+3. POST `/purchase_order_receive` once per captured receipt, replaying
+   `quantity` + `received_date` + `batch_transactions`. The endpoint
+   auto-promotes status back to RECEIVED.
+
+**Errors when:**
+- The PO isn't in RECEIVED / PARTIALLY_RECEIVED status (use `modify_purchase_order`).
+- A `row_id` doesn't match any current row on the PO.
+- A `row_changes` entry sets none of `new_variant_id` / `quantity` /
+  `price_per_unit`.
+- A `quantity` drops below the originally-received quantity for that row
+  (the receipt replay would fail and leave the PO mid-flow).
+
+**Constraints:**
+- Only updates rows in place; doesn't add or delete rows. Row IDs must
+  stay stable so the re-receive POST can reference them by the original
+  `purchase_order_row_id`. To add or remove a line, use `modify_purchase_order`
+  (after the correction lands), or delete + recreate the PO.
+- Edits are keyed by row ID, **not** by variant ID. The receive endpoint
+  may split partially-received rows post-receipt — both halves can share
+  the same variant — so variant-keyed lookup would be ambiguous on a
+  PARTIALLY_RECEIVED PO.
+- A PARTIALLY_RECEIVED PO's unreceived remnant rows stay open after the
+  correction lands; re-issue `receive_purchase_order` for those when the
+  rest of the shipment arrives.
+
+**Returns:** A `ModificationResponse` with one `ActionResult` per phase
+step (revert + edits + per-row re-receives). Fail-fast halt leaves the PO
+in an intermediate (open) state — typically NOT_RECEIVED with edits
+applied but receipts not replayed — with the captured close-state in
+`prior_state` for manual recovery via `receive_purchase_order`.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/_reopen.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_reopen.py
@@ -1,8 +1,9 @@
 """Close-state snapshots for the reopen → modify → restore pattern.
 
 The composite ``correct_<entity>`` tools (``correct_manufacturing_order``,
-``correct_sales_order``) edit records that have already reached a terminal
-status (DONE / DELIVERED) without losing the original close-state metadata.
+``correct_sales_order``, ``correct_purchase_order``) edit records that
+have already reached a terminal status (DONE / DELIVERED / RECEIVED)
+without losing the original close-state metadata.
 
 This module owns the **what to capture and replay** — it doesn't run any
 API calls. The composite tools in ``foundation/corrections.py`` consume
@@ -22,6 +23,16 @@ State-machine quirks the snapshots paper over:
   ``is_success`` instead of ``unwrap``) and patching status back to PENDING.
   Restore means re-creating each fulfillment with its original
   ``picked_date``.
+- **PO**: a RECEIVED PO has rows whose ``quantity`` / ``variant_id`` /
+  ``price_per_unit`` are immutable while ``received_date`` is non-null.
+  Reverting status to ``NOT_RECEIVED`` clears each row's ``received_date``
+  (the spec for ``/purchase_order_receive`` is explicit: "Reverting the
+  receive must also be done through that endpoint" — i.e. PATCH
+  ``/purchase_orders/{id}``). After edits, the receipt is replayed via
+  ``POST /purchase_order_receive`` with the captured per-row quantity,
+  ``received_date``, and ``batch_transactions``; the receive endpoint
+  promotes status to RECEIVED automatically when every row is fully
+  received.
 """
 
 from __future__ import annotations
@@ -36,6 +47,8 @@ from katana_public_api_client.models import (
     ManufacturingOrder,
     ManufacturingOrderProduction,
     ManufacturingOrderStatus,
+    PurchaseOrderStatus,
+    RegularPurchaseOrder,
     SalesOrder,
     SalesOrderFulfillment,
     SalesOrderStatus,
@@ -246,3 +259,147 @@ def snapshot_so_close_state(
         fulfillments=[_fulfillment_snapshot(f) for f in fulfillments],
         fulfillment_ids=[f.id for f in fulfillments if isinstance(f.id, int)],
     )
+
+
+# ============================================================================
+# Purchase order snapshots
+# ============================================================================
+
+
+# PO statuses where the record is treated as "closed" — entry conditions for
+# ``correct_purchase_order``. PARTIALLY_RECEIVED is included alongside
+# RECEIVED because partially-received POs have at least one row whose
+# ``received_date`` is non-null, and that row is immutable until the PO is
+# reverted to NOT_RECEIVED.
+PO_CLOSED_STATUSES: frozenset[str] = frozenset(
+    {
+        PurchaseOrderStatus.RECEIVED.value,
+        PurchaseOrderStatus.PARTIALLY_RECEIVED.value,
+    }
+)
+
+# Status to revert to when reopening — clears each row's ``received_date``
+# so quantity / variant_id / price_per_unit become editable again. Per the
+# OpenAPI spec on /purchase_order_receive: "Reverting the receive must also
+# be done through that endpoint" (PATCH /purchase_orders/{id}).
+PO_REOPEN_STATUS: str = PurchaseOrderStatus.NOT_RECEIVED.value
+
+# Status to restore to once edits and re-receipt land. The receive endpoint
+# auto-promotes to RECEIVED when every row is fully received, so this is
+# only used as a target string for diff display, not for an explicit PATCH.
+PO_RESTORE_STATUS: str = PurchaseOrderStatus.RECEIVED.value
+
+
+@dataclass(frozen=True)
+class PORowBatchSnapshot:
+    """Restorable shape of one batch transaction within a row receipt.
+
+    Mirrors :class:`PurchaseOrderRowBatchTransactionsItem` on the wire.
+    Replayed on the re-receive POST so batch-tracked materials land back
+    on the original batch records (Katana enforces the per-batch split on
+    receipt for batch-tracked variants).
+    """
+
+    batch_id: int | None
+    quantity: float
+
+
+@dataclass(frozen=True)
+class PORowReceiptSnapshot:
+    """Restorable shape of a single row's receipt on a PO.
+
+    Captured by reading the persisted entity (``PurchaseOrderRow``);
+    replayed via ``POST /purchase_order_receive`` with one
+    ``PurchaseOrderReceiveRow`` per snapshot.
+
+    Only rows with a non-null ``received_date`` are captured — unreceived
+    rows on a PARTIALLY_RECEIVED PO don't need replay (they stay open
+    after reopen → restore).
+    """
+
+    purchase_order_row_id: int
+    quantity: float
+    received_date: datetime
+    variant_id: int | None
+    batch_transactions: list[PORowBatchSnapshot] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class POCloseState:
+    """Snapshot of a PO's close-state metadata, captured before reopen.
+
+    The PO header itself doesn't carry a ``done_date``-equivalent — receipt
+    is the close-state, and per-row ``received_date`` is the timestamp
+    that needs preserving. Status is captured for round-tripping (and so
+    a PARTIALLY_RECEIVED PO isn't silently promoted to RECEIVED).
+    """
+
+    status: str
+    receipts: list[PORowReceiptSnapshot]
+
+
+def _batch_transactions_from_attrs(value: Any) -> list[PORowBatchSnapshot]:
+    """Extract batch-transaction snapshots from the persisted entity."""
+    items = unwrap_unset(value, None)
+    if not items:
+        return []
+    out: list[PORowBatchSnapshot] = []
+    for item in items:
+        qty = unwrap_unset(getattr(item, "quantity", UNSET), None)
+        batch_id = unwrap_unset(getattr(item, "batch_id", UNSET), None)
+        if qty is None:
+            continue
+        out.append(
+            PORowBatchSnapshot(
+                batch_id=batch_id if isinstance(batch_id, int) else None,
+                quantity=float(qty),
+            )
+        )
+    return out
+
+
+def snapshot_po_close_state(po: RegularPurchaseOrder) -> POCloseState:
+    """Build a :class:`POCloseState` from a fetched PO.
+
+    Walks ``po.purchase_order_rows`` and captures every row that has a
+    non-null ``received_date``. Rows where ``received_date`` is null are
+    skipped — they're already in the "open" state and don't need replay
+    after the reopen.
+
+    Note: the receive endpoint splits a partially-received row into a
+    received row + an unreceived remnant row at receipt time. Both rows
+    persist after reopen (the reopen clears each one's ``received_date``
+    but doesn't merge them), so a PARTIALLY_RECEIVED PO with one
+    user-created row may carry two rows in the snapshot — the previously-
+    received split (with its full receipt detail) and the previously-
+    unreceived split (skipped here).
+    """
+    status_enum = unwrap_unset(po.status, None)
+    status = status_enum.value if status_enum is not None else ""
+
+    rows = unwrap_unset(po.purchase_order_rows, None) or []
+    receipts: list[PORowReceiptSnapshot] = []
+    for row in rows:
+        received_date = unwrap_unset(getattr(row, "received_date", UNSET), None)
+        if received_date is None:
+            continue
+        qty = unwrap_unset(getattr(row, "quantity", UNSET), None)
+        if qty is None or qty <= 0:
+            continue
+        row_id = unwrap_unset(getattr(row, "id", UNSET), None)
+        if not isinstance(row_id, int):
+            continue
+        variant_id = unwrap_unset(getattr(row, "variant_id", UNSET), None)
+        receipts.append(
+            PORowReceiptSnapshot(
+                purchase_order_row_id=row_id,
+                quantity=float(qty),
+                received_date=received_date,
+                variant_id=variant_id if isinstance(variant_id, int) else None,
+                batch_transactions=_batch_transactions_from_attrs(
+                    getattr(row, "batch_transactions", UNSET)
+                ),
+            )
+        )
+
+    return POCloseState(status=status, receipts=receipts)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
@@ -1,24 +1,30 @@
 """Composite ``correct_<entity>`` tools — transactional edit on closed records.
 
 Lets the operator edit a record that has already reached a terminal status
-(``DONE`` for an MO, ``DELIVERED`` for an SO) without losing the original
-close-state metadata. Internally implements the proven sequence:
+(``DONE`` for an MO, ``DELIVERED`` for an SO, ``RECEIVED`` /
+``PARTIALLY_RECEIVED`` for a PO) without losing the original close-state
+metadata. Internally implements the proven sequence:
 
 1. **Capture** the close-state (status + key timestamps + child snapshots)
 2. **Reopen** by reverting status to an editable value (and, for SO,
    deleting fulfillments first — the close-state restore re-creates them)
-3. **Apply** the user's edits (recipe row swap, line item update)
-4. **Restore** the close-state, observing the mandatory ordering: status
-   first, then dates (Katana validates date fields against the *current*
-   status, so combined ``status: DONE + done_date`` calls fail).
+3. **Apply** the user's edits (recipe row swap, line item update, PO row
+   variant/quantity/price)
+4. **Restore** the close-state. For MO this is status → DONE then
+   ``done_date`` (Katana validates date fields against the *current*
+   status, so combined ``status: DONE + done_date`` calls fail). For SO
+   this is re-create fulfillments → status → DELIVERED. For PO this is a
+   single ``POST /purchase_order_receive`` per captured receipt — the
+   receive endpoint promotes status back to RECEIVED automatically.
 
 Composes ``ActionSpec`` lists from :mod:`_modification_dispatch` and the
 existing per-entity request builders. Each phase runs through
 ``execute_plan`` separately so fail-fast halts at a phase boundary with the
 captured close-state available for manual recovery.
 
-Tracked under #523 (umbrella). Phase 1 ships MO + SO; PO and stock
-transfer are deferred.
+Tracked under #523 (umbrella). MO + SO shipped in #536 / #546; PO ships
+under #532. Stock transfer remains deferred — its model has no close-state
+worth preserving (see help.py's "Closed-Record Corrections" section).
 """
 
 from __future__ import annotations
@@ -51,19 +57,28 @@ from katana_mcp.tools._reopen import (
     MO_CLOSED_STATUSES,
     MO_REOPEN_STATUS,
     MO_RESTORE_STATUS,
+    PO_CLOSED_STATUSES,
+    PO_REOPEN_STATUS,
     SO_CLOSED_STATUSES,
     SO_REOPEN_STATUS,
     SO_RESTORE_STATUS,
     MOCloseState,
     MOProductionSnapshot,
+    POCloseState,
+    PORowReceiptSnapshot,
     SOCloseState,
     SOFulfillmentSnapshot,
     snapshot_mo_close_state,
+    snapshot_po_close_state,
     snapshot_so_close_state,
 )
 from katana_mcp.tools.foundation.manufacturing_orders import (
     MOOperation,
     _fetch_manufacturing_order_attrs,
+)
+from katana_mcp.tools.foundation.purchase_orders import (
+    POOperation,
+    _fetch_purchase_order_attrs,
 )
 from katana_mcp.tools.foundation.sales_orders import (
     SOOperation,
@@ -80,6 +95,13 @@ from katana_public_api_client.api.manufacturing_order_production import (
 )
 from katana_public_api_client.api.manufacturing_order_recipe import (
     update_manufacturing_order_recipe_rows as api_update_mo_recipe_row,
+)
+from katana_public_api_client.api.purchase_order import (
+    receive_purchase_order as api_receive_purchase_order,
+    update_purchase_order as api_update_purchase_order,
+)
+from katana_public_api_client.api.purchase_order_row import (
+    update_purchase_order_row as api_update_purchase_order_row,
 )
 from katana_public_api_client.api.sales_order import (
     update_sales_order as api_update_sales_order,
@@ -99,6 +121,10 @@ from katana_public_api_client.models import (
     ManufacturingOrderProduction,
     ManufacturingOrderRecipeRow,
     ManufacturingOrderStatus,
+    PurchaseOrderReceiveRow,
+    PurchaseOrderReceiveRowBatchTransactionsItem,
+    PurchaseOrderRow,
+    PurchaseOrderStatus,
     SalesOrderFulfillment,
     SalesOrderFulfillmentRowRequest,
     SalesOrderFulfillmentStatus,
@@ -106,6 +132,8 @@ from katana_public_api_client.models import (
     UpdateManufacturingOrderProductionRequest as APIUpdateMOProductionRequest,
     UpdateManufacturingOrderRecipeRowRequest as APIUpdateMORecipeRowRequest,
     UpdateManufacturingOrderRequest as APIUpdateManufacturingOrderRequest,
+    UpdatePurchaseOrderRequest as APIUpdatePurchaseOrderRequest,
+    UpdatePurchaseOrderRowRequest as APIUpdatePORowRequest,
     UpdateSalesOrderRequest as APIUpdateSalesOrderRequest,
     UpdateSalesOrderRowRequest as APIUpdateSORowRequest,
     UpdateSalesOrderStatus,
@@ -125,7 +153,7 @@ from katana_public_api_client.utils import is_success, unwrap, unwrap_as
 
 def _augment_prior_state_with_snapshot(
     prior_state: dict[str, Any] | None,
-    snapshot: MOCloseState | SOCloseState,
+    snapshot: MOCloseState | SOCloseState | POCloseState,
 ) -> dict[str, Any]:
     """Inject the captured close-state into ``prior_state`` for recovery.
 
@@ -635,21 +663,30 @@ def _build_success_response(
     )
 
 
+def _entity_type_for_snapshot(
+    snapshot: MOCloseState | SOCloseState | POCloseState,
+) -> str:
+    """Map a close-state dataclass to the canonical entity-type string used
+    on :class:`ModificationResponse.entity_type` and the preview/failure
+    breadcrumb messaging."""
+    if isinstance(snapshot, MOCloseState):
+        return "manufacturing_order"
+    if isinstance(snapshot, SOCloseState):
+        return "sales_order"
+    return "purchase_order"
+
+
 def _build_failure_response(
     entity_id: int,
     actions: list[ActionResult],
     prior_state: dict[str, Any] | None,
     katana_url: str | None,
-    snapshot: MOCloseState | SOCloseState,
+    snapshot: MOCloseState | SOCloseState | POCloseState,
 ) -> ModificationResponse:
     succeeded = sum(1 for a in actions if a.succeeded is True)
     failed = sum(1 for a in actions if a.succeeded is False)
     return ModificationResponse(
-        entity_type=(
-            "manufacturing_order"
-            if isinstance(snapshot, MOCloseState)
-            else "sales_order"
-        ),
+        entity_type=_entity_type_for_snapshot(snapshot),
         entity_id=entity_id,
         is_preview=False,
         actions=actions,
@@ -1165,6 +1202,456 @@ async def correct_sales_order(
 
 
 # ============================================================================
+# Purchase-order corrections
+# ============================================================================
+
+
+class PORowCorrection(BaseModel):
+    """One PO row edit, identified by the ID of the row currently on the PO.
+
+    Unlike SO/MO corrections (which key by ``old_variant_id`` to give the
+    operator a content-addressed handle), PO corrections key by row ID
+    because the receive endpoint may split a partially-received row into
+    two physical rows post-receipt — both rows can carry the same
+    ``variant_id``, so variant-keyed lookup would be ambiguous on a
+    PARTIALLY_RECEIVED PO. The operator looks up the current row IDs via
+    ``get_purchase_order`` first.
+
+    ``correct_purchase_order`` only updates existing rows in place; it
+    doesn't add or delete rows. This keeps row IDs stable so the
+    re-receive POST can reference them by the original
+    ``purchase_order_row_id``. To add or remove a line, use
+    ``modify_purchase_order`` (after receiving) or delete + recreate the PO.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    row_id: int = Field(
+        ..., description="Existing row ID on the PO (find via get_purchase_order)."
+    )
+    new_variant_id: int | None = Field(
+        default=None,
+        description="New variant for the row. None = keep the existing variant.",
+    )
+    quantity: float | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "New quantity. None = keep the existing quantity. Must be >= "
+            "the originally received quantity for this row, or the receipt "
+            "replay step would fail."
+        ),
+    )
+    price_per_unit: float | None = Field(
+        default=None,
+        ge=0,
+        description="New unit price. None = keep the existing price.",
+    )
+
+
+class CorrectPurchaseOrderRequest(ConfirmableRequest):
+    """Reopen a closed PO, edit rows, restore the original close-state.
+
+    Entry condition: the PO must be in ``RECEIVED`` or
+    ``PARTIALLY_RECEIVED`` status. For POs that haven't been received yet,
+    use ``modify_purchase_order`` directly — there's no close-state to
+    preserve.
+    """
+
+    id: int = Field(..., description="Purchase order ID")
+    row_changes: list[PORowCorrection] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Row edits keyed by row ID. At least one entry is required; "
+            "each must change at least one of new_variant_id, quantity, "
+            "or price_per_unit."
+        ),
+    )
+
+
+def _resolve_po_row(
+    po_id: int, rows: list[PurchaseOrderRow], correction: PORowCorrection
+) -> PurchaseOrderRow:
+    matches = [r for r in rows if r.id == correction.row_id]
+    if not matches:
+        raise ValueError(
+            f"No row on PO {po_id} has id {correction.row_id}. Look up "
+            "current row IDs with get_purchase_order before retrying."
+        )
+    return matches[0]
+
+
+def _check_quantity_covers_receipts(
+    po_id: int,
+    snapshot: POCloseState,
+    rows: list[PurchaseOrderRow],
+    corrections: list[PORowCorrection],
+) -> None:
+    """Preflight: refuse if any row drops below its already-received qty.
+
+    The re-receive phase replays the original receipt quantities; if a
+    row's new quantity is less than what was previously received, Katana
+    rejects the receive POST and the PO would be stuck in NOT_RECEIVED
+    with the close-state already cleared. Catching it here keeps the
+    failure clean — no mutations applied yet.
+
+    Honors the snapshot semantics where a row that was split during
+    receipt is captured by ID; if the operator targets the unreceived
+    remnant row (no entry in ``snapshot.receipts`` for that row_id), the
+    quantity guard is a no-op for that row.
+    """
+    received_per_row = {r.purchase_order_row_id: r.quantity for r in snapshot.receipts}
+
+    for correction in corrections:
+        if correction.quantity is None:
+            continue
+        try:
+            _resolve_po_row(po_id, rows, correction)
+        except ValueError:
+            # Resolution errors surface during plan-build; skip here so
+            # the original error message wins.
+            continue
+        already_received = received_per_row.get(correction.row_id, 0.0)
+        if correction.quantity < already_received:
+            raise ValueError(
+                f"row_changes for row {correction.row_id} on PO {po_id} "
+                f"drops quantity to {correction.quantity}, but "
+                f"{already_received} was already received on this row. "
+                "Refusing — the re-receive phase would fail and leave "
+                "the PO in an intermediate (open) state."
+            )
+
+
+def _build_revert_po_action(po_id: int, prior_status: str, services: Any) -> ActionSpec:
+    """PATCH PO header → status: NOT_RECEIVED.
+
+    Per the OpenAPI spec, this is the API-sanctioned reopen path: the
+    PATCH endpoint accepts a status transition out of RECEIVED, which
+    clears each row's ``received_date`` and re-opens the per-row fields
+    (``quantity`` / ``variant_id`` / ``price_per_unit``) for editing.
+
+    ``prior_status`` carries the actual current status (RECEIVED or
+    PARTIALLY_RECEIVED) so the preview/apply ``FieldChange.old`` reports
+    what the PO was reverted *from* — a partially received PO would
+    otherwise misreport "RECEIVED" as the prior state.
+    """
+    body = APIUpdatePurchaseOrderRequest(status=PurchaseOrderStatus(PO_REOPEN_STATUS))
+    return ActionSpec(
+        operation=POOperation.UPDATE_HEADER,
+        target_id=po_id,
+        diff=[
+            FieldChange(
+                field="status",
+                old=prior_status,
+                new=PO_REOPEN_STATUS,
+            )
+        ],
+        apply=_make_tolerant_patch_apply(
+            api_update_purchase_order, services, po_id, body
+        ),
+        verify=None,
+    )
+
+
+def _build_po_row_edit_actions(
+    po_id: int,
+    rows: list[PurchaseOrderRow],
+    corrections: list[PORowCorrection],
+    services: Any,
+) -> list[ActionSpec]:
+    specs: list[ActionSpec] = []
+    for correction in corrections:
+        if (
+            correction.new_variant_id is None
+            and correction.quantity is None
+            and correction.price_per_unit is None
+        ):
+            raise ValueError(
+                f"row_changes entry for row {correction.row_id}: must "
+                "supply at least one of new_variant_id, quantity, or "
+                "price_per_unit."
+            )
+        row = _resolve_po_row(po_id, rows, correction)
+
+        diff: list[FieldChange] = []
+        if correction.new_variant_id is not None:
+            diff.append(
+                FieldChange(
+                    field="variant_id",
+                    old=unwrap_unset(row.variant_id, None),
+                    new=correction.new_variant_id,
+                )
+            )
+        if correction.quantity is not None:
+            diff.append(
+                FieldChange(
+                    field="quantity",
+                    old=unwrap_unset(row.quantity, None),
+                    new=correction.quantity,
+                )
+            )
+        if correction.price_per_unit is not None:
+            diff.append(
+                FieldChange(
+                    field="price_per_unit",
+                    old=unwrap_unset(row.price_per_unit, None),
+                    new=correction.price_per_unit,
+                )
+            )
+
+        body = APIUpdatePORowRequest(
+            variant_id=to_unset(correction.new_variant_id),
+            quantity=to_unset(correction.quantity),
+            price_per_unit=to_unset(correction.price_per_unit),
+        )
+        specs.append(
+            ActionSpec(
+                operation=POOperation.UPDATE_ROW,
+                target_id=row.id,
+                diff=diff,
+                apply=_make_tolerant_patch_apply(
+                    api_update_purchase_order_row, services, row.id, body
+                ),
+                verify=None,
+            )
+        )
+    return specs
+
+
+def _build_re_receive_action(
+    po_id: int,
+    receipt: PORowReceiptSnapshot,
+    services: Any,
+) -> ActionSpec:
+    """POST one ``PurchaseOrderReceiveRow`` to replay the captured receipt.
+
+    Builds a single-row receive request (the receive endpoint also
+    accepts arrays, but per-row actions keep the ``ActionResult`` list
+    legible — one entry per replayed receipt). Re-receiving an already
+    re-receivable row promotes the PO toward RECEIVED automatically; once
+    every row is fully received, status flips back to RECEIVED without
+    a follow-up PATCH.
+    """
+    batch_transactions: list[PurchaseOrderReceiveRowBatchTransactionsItem] | Any
+    batch_transactions = []
+    for bt in receipt.batch_transactions or []:
+        if bt.batch_id is None:
+            continue
+        batch_transactions.append(
+            PurchaseOrderReceiveRowBatchTransactionsItem(
+                batch_id=bt.batch_id,
+                quantity=bt.quantity,
+            )
+        )
+    if not batch_transactions:
+        batch_transactions = to_unset(None)
+
+    receive_row = PurchaseOrderReceiveRow(
+        purchase_order_row_id=receipt.purchase_order_row_id,
+        quantity=receipt.quantity,
+        received_date=receipt.received_date,
+        batch_transactions=batch_transactions,
+    )
+
+    async def apply() -> None:
+        response = await api_receive_purchase_order.asyncio_detailed(
+            client=services.client, body=receive_row
+        )
+        if not is_success(response):
+            unwrap(response)
+        return None
+
+    diff: list[FieldChange] = [
+        FieldChange(
+            field="quantity",
+            new=receipt.quantity,
+            is_added=True,
+        ),
+        FieldChange(
+            field="received_date",
+            new=receipt.received_date.isoformat(),
+            is_added=True,
+        ),
+    ]
+    if receipt.batch_transactions:
+        diff.append(
+            FieldChange(
+                field="batch_transactions",
+                new=[
+                    {"batch_id": bt.batch_id, "quantity": bt.quantity}
+                    for bt in receipt.batch_transactions
+                ],
+                is_added=True,
+            )
+        )
+    return ActionSpec(
+        operation=POOperation.RECEIVE,
+        target_id=receipt.purchase_order_row_id,
+        diff=diff,
+        apply=apply,
+        verify=None,
+    )
+
+
+async def _correct_purchase_order_impl(
+    request: CorrectPurchaseOrderRequest, context: Context
+) -> ModificationResponse:
+    services = get_services(context)
+    katana_url = katana_web_url("purchase_order", request.id)
+
+    existing_po = await _fetch_purchase_order_attrs(services, request.id)
+    if existing_po is None:
+        raise ValueError(
+            f"Could not fetch purchase order {request.id}; verify it exists."
+        )
+    status_enum = unwrap_unset(existing_po.status, None)
+    status = status_enum.value if status_enum is not None else ""
+    if status not in PO_CLOSED_STATUSES:
+        raise ValueError(
+            f"correct_purchase_order requires the PO to be in RECEIVED or "
+            f"PARTIALLY_RECEIVED status; PO {request.id} is in status "
+            f"'{status}'. Use modify_purchase_order directly for an open "
+            "PO — there's no close-state to preserve."
+        )
+
+    rows = [
+        r
+        for r in (unwrap_unset(existing_po.purchase_order_rows, []) or [])
+        if r is not None
+    ]
+    snapshot = snapshot_po_close_state(existing_po)
+    _check_quantity_covers_receipts(request.id, snapshot, rows, request.row_changes)
+
+    revert_phase = [_build_revert_po_action(request.id, snapshot.status, services)]
+    edit_phase = _build_po_row_edit_actions(
+        request.id, rows, request.row_changes, services
+    )
+    receive_phase = [
+        _build_re_receive_action(request.id, receipt, services)
+        for receipt in snapshot.receipts
+    ]
+    phases = [revert_phase, edit_phase, receive_phase]
+
+    if request.preview:
+        full_plan = [action for phase in phases for action in phase]
+        return ModificationResponse(
+            entity_type="purchase_order",
+            entity_id=request.id,
+            is_preview=True,
+            actions=plan_to_preview_results(full_plan),
+            warnings=_close_state_warnings_po(snapshot),
+            next_actions=[
+                f"Review {len(full_plan)} planned action(s) for PO {request.id}",
+                f"Captured close-state: status={snapshot.status}, "
+                f"receipts={len(snapshot.receipts)}",
+                "Set preview=false to execute the plan",
+            ],
+            katana_url=katana_url,
+            message=(
+                f"Preview: reopen → edit → re-receive for purchase order "
+                f"{request.id} ({len(full_plan)} action(s))"
+            ),
+        )
+
+    prior_state = _augment_prior_state_with_snapshot(
+        serialize_for_prior_state(existing_po), snapshot
+    )
+    aggregated, failed = await _run_phases_until_failure(phases)
+    if failed:
+        return _build_failure_response(
+            request.id, aggregated, prior_state, katana_url, snapshot
+        )
+
+    return ModificationResponse(
+        entity_type="purchase_order",
+        entity_id=request.id,
+        is_preview=False,
+        actions=aggregated,
+        prior_state=prior_state,
+        warnings=_close_state_warnings_po(snapshot),
+        next_actions=[
+            f"Purchase order {request.id} corrected — "
+            f"{sum(1 for a in aggregated if a.succeeded)} action(s) applied",
+            f"Close-state restored: status={snapshot.status}, "
+            f"receipts={len(snapshot.receipts)}",
+        ],
+        katana_url=katana_url,
+        message=(
+            f"Successfully corrected purchase order {request.id} "
+            f"({sum(1 for a in aggregated if a.succeeded)}/"
+            f"{len(aggregated)} actions applied)"
+        ),
+    )
+
+
+def _close_state_warnings_po(snapshot: POCloseState) -> list[str]:
+    if not snapshot.receipts:
+        return [
+            "No receipts captured on this PO — the reopen step will only "
+            "flip status to NOT_RECEIVED without a re-receive phase. "
+            "Verify this matches reality before applying."
+        ]
+    if snapshot.status == PurchaseOrderStatus.PARTIALLY_RECEIVED.value:
+        return [
+            "PO was PARTIALLY_RECEIVED — only the previously-received "
+            "rows are replayed. The unreceived remnant row(s) stay open "
+            "after the correction lands; re-issue receive_purchase_order "
+            "for those when the rest of the shipment arrives."
+        ]
+    return []
+
+
+@observe_tool
+@unpack_pydantic_params
+async def correct_purchase_order(
+    request: Annotated[CorrectPurchaseOrderRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Edit a closed (RECEIVED / PARTIALLY_RECEIVED) PO without losing
+    the original receipt metadata.
+
+    Reopens the PO (PATCH status: NOT_RECEIVED — Katana clears each row's
+    ``received_date`` so per-row fields become editable again), edits
+    rows keyed by row ID, then re-receives via POST
+    ``/purchase_order_receive`` to restore the captured per-row
+    ``quantity`` / ``received_date`` / ``batch_transactions``. The
+    receive endpoint promotes the PO back to RECEIVED automatically when
+    every row is fully received.
+
+    Sequence:
+
+    1. Capture close-state (status + per-row purchase_order_row_id /
+       quantity / received_date / batch_transactions for every row whose
+       ``received_date`` is non-null).
+    2. PATCH PO status: NOT_RECEIVED (clears each row's received_date,
+       making variant_id / quantity / price_per_unit editable again).
+    3. PATCH each row per ``row_changes``.
+    4. POST /purchase_order_receive once per captured receipt, replaying
+       quantity + received_date + batch_transactions.
+
+    Each ``row_changes`` entry is keyed by the row's current ID (look up
+    via ``get_purchase_order``). PO row IDs persist across the reopen, so
+    the re-receive can reference them by their original
+    ``purchase_order_row_id``.
+
+    The tool only updates rows in place; it doesn't delete or add rows.
+    To add or remove a line, use ``modify_purchase_order`` (after the
+    correction lands), or delete + recreate the PO.
+
+    Two-step flow: ``preview=true`` (default) returns the full action
+    plan; ``preview=false`` runs the plan in phases. Fail-fast halt
+    leaves the PO in an intermediate state (typically NOT_RECEIVED with
+    edits applied but receipts not replayed) with a breadcrumb in
+    ``prior_state``.
+
+    For a PO that hasn't been received yet, use ``modify_purchase_order``
+    directly — there's no close-state to preserve.
+    """
+    response = await _correct_purchase_order_impl(request, context)
+    return to_tool_result(response)
+
+
+# ============================================================================
 # Registration
 # ============================================================================
 
@@ -1192,5 +1679,11 @@ def register_tools(mcp: FastMCP) -> None:
         mcp,
         correct_sales_order,
         tags={"orders", "sales", "write", "correction"},
+        annotations=_correct,
+    )
+    register_preview_tool(
+        mcp,
+        correct_purchase_order,
+        tags={"orders", "purchasing", "write", "correction"},
         annotations=_correct,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -2192,6 +2192,12 @@ class POOperation(StrEnum):
     ADD_ADDITIONAL_COST = "add_additional_cost"
     UPDATE_ADDITIONAL_COST = "update_additional_cost"
     DELETE_ADDITIONAL_COST = "delete_additional_cost"
+    # Receipt-replay step emitted by ``correct_purchase_order`` — POSTs
+    # one ``PurchaseOrderReceiveRow`` batch to ``/purchase_order_receive``
+    # to restore the captured close-state after edits land. Distinct from
+    # ``UPDATE_HEADER`` so the replay step is identifiable in
+    # ``ActionResult`` lists.
+    RECEIVE = "receive"
 
 
 # Tool-facing uppercase status literal — values match the API StrEnum's

--- a/katana_mcp_server/tests/tools/test_corrections.py
+++ b/katana_mcp_server/tests/tools/test_corrections.py
@@ -1,4 +1,5 @@
-"""Tests for correct_manufacturing_order and correct_sales_order.
+"""Tests for correct_manufacturing_order, correct_sales_order, and
+correct_purchase_order.
 
 Covers the reopen → modify → restore pattern: snapshot capture, ordering
 of API calls (revert before edits before recreate before close), preview
@@ -11,10 +12,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from katana_mcp.tools.foundation.corrections import (
     CorrectManufacturingOrderRequest,
+    CorrectPurchaseOrderRequest,
     CorrectSalesOrderRequest,
     MOIngredientCorrection,
+    PORowCorrection,
     SOLineCorrection,
     _correct_manufacturing_order_impl,
+    _correct_purchase_order_impl,
     _correct_sales_order_impl,
 )
 
@@ -24,6 +28,9 @@ from katana_public_api_client.models import (
     ManufacturingOrderProduction,
     ManufacturingOrderRecipeRow,
     ManufacturingOrderStatus,
+    PurchaseOrderRow,
+    PurchaseOrderStatus,
+    RegularPurchaseOrder,
     SalesOrder,
     SalesOrderFulfillment,
     SalesOrderFulfillmentStatus,
@@ -769,4 +776,389 @@ async def test_correct_so_apply_executes_phases_in_canonical_order():
         "POST fulfillment status=DELIVERED",
         "PATCH SO 99 status=DELIVERED",
     ]
+    assert response.prior_state is not None
+
+
+# ============================================================================
+# correct_purchase_order — fixtures
+# ============================================================================
+
+
+def _make_po(
+    *,
+    po_id: int = 156,
+    status: str = "RECEIVED",
+    rows: list[PurchaseOrderRow] | None = None,
+) -> RegularPurchaseOrder:
+    """Build a real attrs ``RegularPurchaseOrder`` in the requested status."""
+    po = mock_entity_for_modify(RegularPurchaseOrder, id=po_id)
+    po.status = PurchaseOrderStatus(status)
+    po.purchase_order_rows = rows if rows is not None else []
+    return po
+
+
+def _make_po_row(
+    *,
+    row_id: int,
+    variant_id: int,
+    quantity: float = 10.0,
+    price_per_unit: float = 5.0,
+    received_date: datetime | None = None,
+) -> PurchaseOrderRow:
+    row = mock_entity_for_modify(PurchaseOrderRow, id=row_id)
+    row.variant_id = variant_id
+    row.quantity = quantity
+    row.price_per_unit = price_per_unit
+    row.received_date = received_date if received_date is not None else UNSET
+    row.batch_transactions = UNSET
+    return row
+
+
+# ============================================================================
+# correct_purchase_order — entry-condition checks
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_correct_po_rejects_open_status():
+    """A PO that's still NOT_RECEIVED has no close-state to preserve."""
+    context, _ = create_mock_context()
+    po = _make_po(status="NOT_RECEIVED")
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_purchase_order_attrs",
+            new_callable=AsyncMock,
+            return_value=po,
+        ),
+        pytest.raises(ValueError, match="RECEIVED or PARTIALLY_RECEIVED"),
+    ):
+        await _correct_purchase_order_impl(
+            CorrectPurchaseOrderRequest(
+                id=156,
+                row_changes=[PORowCorrection(row_id=501, new_variant_id=600)],
+            ),
+            context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_correct_po_rejects_missing_row_id():
+    """If row_id isn't on the PO, the tool errors clearly."""
+    context, _ = create_mock_context()
+    received = datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC)
+    rows = [
+        _make_po_row(row_id=501, variant_id=300, received_date=received),
+    ]
+    po = _make_po(status="RECEIVED", rows=rows)
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_purchase_order_attrs",
+            new_callable=AsyncMock,
+            return_value=po,
+        ),
+        pytest.raises(ValueError, match="No row on PO 156 has id 999"),
+    ):
+        await _correct_purchase_order_impl(
+            CorrectPurchaseOrderRequest(
+                id=156,
+                row_changes=[PORowCorrection(row_id=999, new_variant_id=600)],
+            ),
+            context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_correct_po_rejects_empty_correction():
+    """A row_changes entry with neither variant nor quantity nor price is a
+    no-op and should error."""
+    context, _ = create_mock_context()
+    received = datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC)
+    rows = [
+        _make_po_row(row_id=501, variant_id=300, received_date=received),
+    ]
+    po = _make_po(status="RECEIVED", rows=rows)
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_purchase_order_attrs",
+            new_callable=AsyncMock,
+            return_value=po,
+        ),
+        pytest.raises(ValueError, match="must supply at least one"),
+    ):
+        await _correct_purchase_order_impl(
+            CorrectPurchaseOrderRequest(
+                id=156,
+                row_changes=[PORowCorrection(row_id=501)],
+            ),
+            context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_correct_po_rejects_quantity_below_already_received():
+    """Preflight: refuse when row_changes drops quantity below the
+    already-received qty for that row. Catches the failure before any
+    mutations land — the receive replay would otherwise fail and leave the
+    PO stuck NOT_RECEIVED with the close-state already cleared."""
+    context, _ = create_mock_context()
+    received = datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC)
+    rows = [
+        _make_po_row(row_id=501, variant_id=300, quantity=10.0, received_date=received),
+    ]
+    po = _make_po(status="RECEIVED", rows=rows)
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_purchase_order_attrs",
+            new_callable=AsyncMock,
+            return_value=po,
+        ),
+        pytest.raises(ValueError, match="already received"),
+    ):
+        await _correct_purchase_order_impl(
+            CorrectPurchaseOrderRequest(
+                id=156,
+                # Drop quantity to 5 — below the 10 already received.
+                row_changes=[PORowCorrection(row_id=501, quantity=5.0)],
+            ),
+            context,
+        )
+
+
+# ============================================================================
+# correct_purchase_order — preview
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_correct_po_preview_emits_full_action_plan():
+    """Preview should plan: revert → edit → re-receive (per row).
+
+    No final close PATCH — the receive endpoint auto-promotes status back
+    to RECEIVED when every row is fully received.
+    """
+    context, _ = create_mock_context()
+    received = datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC)
+    rows = [
+        _make_po_row(
+            row_id=501,
+            variant_id=300,
+            quantity=10.0,
+            received_date=received,
+        ),
+    ]
+    po = _make_po(status="RECEIVED", rows=rows)
+
+    with patch(
+        "katana_mcp.tools.foundation.corrections._fetch_purchase_order_attrs",
+        new_callable=AsyncMock,
+        return_value=po,
+    ):
+        response = await _correct_purchase_order_impl(
+            CorrectPurchaseOrderRequest(
+                id=156,
+                row_changes=[PORowCorrection(row_id=501, new_variant_id=400)],
+                preview=True,
+            ),
+            context,
+        )
+
+    assert response.is_preview is True
+    assert response.entity_id == 156
+    operations = [a.operation for a in response.actions]
+    # Revert + edit + receive (one per receipt; here exactly one).
+    assert operations == ["update_header", "update_row", "receive"]
+    receive_action = response.actions[-1]
+    # The receive action's diff includes received_date and quantity.
+    fields = {c.field for c in receive_action.changes}
+    assert "received_date" in fields
+    assert "quantity" in fields
+    # All preview-shape: succeeded=None
+    assert all(a.succeeded is None for a in response.actions)
+
+
+@pytest.mark.asyncio
+async def test_correct_po_preview_partially_received_warns():
+    """A PARTIALLY_RECEIVED PO surfaces a warning that the unreceived
+    remnant rows stay open after the correction lands."""
+    context, _ = create_mock_context()
+    received = datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC)
+    rows = [
+        # Received split — appears in snapshot.
+        _make_po_row(
+            row_id=501,
+            variant_id=300,
+            quantity=7.0,
+            received_date=received,
+        ),
+        # Unreceived remnant — skipped from snapshot.
+        _make_po_row(
+            row_id=502,
+            variant_id=300,
+            quantity=3.0,
+            received_date=None,
+        ),
+    ]
+    po = _make_po(status="PARTIALLY_RECEIVED", rows=rows)
+
+    with patch(
+        "katana_mcp.tools.foundation.corrections._fetch_purchase_order_attrs",
+        new_callable=AsyncMock,
+        return_value=po,
+    ):
+        response = await _correct_purchase_order_impl(
+            CorrectPurchaseOrderRequest(
+                id=156,
+                row_changes=[PORowCorrection(row_id=501, new_variant_id=400)],
+                preview=True,
+            ),
+            context,
+        )
+
+    # Only one re-receive (for the row that had a received_date).
+    operations = [a.operation for a in response.actions]
+    assert operations == ["update_header", "update_row", "receive"]
+    # Warning about unreceived remnant rows.
+    assert any("unreceived remnant" in w for w in response.warnings)
+
+
+# ============================================================================
+# correct_purchase_order — apply
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_correct_po_apply_executes_phases_in_canonical_order():
+    """Apply order:
+    1. PATCH PO header (revert: status → NOT_RECEIVED)
+    2. PATCH each row per row_changes
+    3. POST /purchase_order_receive once per captured receipt"""
+    context, _ = create_mock_context()
+    received = datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC)
+    rows = [
+        _make_po_row(
+            row_id=501,
+            variant_id=300,
+            quantity=10.0,
+            received_date=received,
+        ),
+    ]
+    po = _make_po(status="RECEIVED", rows=rows)
+
+    call_log: list[str] = []
+
+    async def fake_update_po(*, id, client, body):
+        call_log.append(f"PATCH PO {id} status={body.status.value}")
+        resp = MagicMock()
+        resp.parsed = po
+        return resp
+
+    async def fake_update_row(*, id, client, body):
+        call_log.append(f"PATCH PO row {id}")
+        resp = MagicMock()
+        resp.parsed = rows[0]
+        return resp
+
+    async def fake_receive(*, client, body):
+        # body is a PurchaseOrderReceiveRow when single-row.
+        call_log.append(
+            f"POST receive row={body.purchase_order_row_id} qty={body.quantity}"
+        )
+        resp = MagicMock()
+        resp.status_code = 204
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_purchase_order_attrs",
+            new_callable=AsyncMock,
+            return_value=po,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_update_purchase_order.asyncio_detailed",
+            side_effect=fake_update_po,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_update_purchase_order_row.asyncio_detailed",
+            side_effect=fake_update_row,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_receive_purchase_order.asyncio_detailed",
+            side_effect=fake_receive,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections.is_success",
+            return_value=True,
+        ),
+    ):
+        response = await _correct_purchase_order_impl(
+            CorrectPurchaseOrderRequest(
+                id=156,
+                row_changes=[
+                    PORowCorrection(row_id=501, new_variant_id=400, quantity=12.0)
+                ],
+                preview=False,
+            ),
+            context,
+        )
+
+    assert response.is_preview is False
+    assert all(a.succeeded is True for a in response.actions)
+    assert call_log == [
+        "PATCH PO 156 status=NOT_RECEIVED",
+        "PATCH PO row 501",
+        "POST receive row=501 qty=10.0",
+    ]
+    # Snapshot is in prior_state under the documented sentinel key.
+    assert response.prior_state is not None
+    assert "_close_state_snapshot" in response.prior_state
+
+
+@pytest.mark.asyncio
+async def test_correct_po_apply_halts_on_revert_failure():
+    """If the revert PATCH fails, no edits or receives run; the response
+    surfaces the breadcrumb."""
+    context, _ = create_mock_context()
+    received = datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC)
+    rows = [
+        _make_po_row(row_id=501, variant_id=300, received_date=received),
+    ]
+    po = _make_po(status="RECEIVED", rows=rows)
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("Katana refused to revert")
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.corrections._fetch_purchase_order_attrs",
+            new_callable=AsyncMock,
+            return_value=po,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.corrections."
+            "api_update_purchase_order.asyncio_detailed",
+            side_effect=boom,
+        ),
+    ):
+        response = await _correct_purchase_order_impl(
+            CorrectPurchaseOrderRequest(
+                id=156,
+                row_changes=[PORowCorrection(row_id=501, new_variant_id=400)],
+                preview=False,
+            ),
+            context,
+        )
+
+    assert response.is_preview is False
+    # Only the revert action ran, and it failed.
+    assert len(response.actions) == 1
+    assert response.actions[0].succeeded is False
+    # Breadcrumb language flagged.
+    assert any("intermediate (open) state" in w for w in response.warnings)
     assert response.prior_state is not None


### PR DESCRIPTION
## Summary

Adds the third member of the `correct_<entity>` family — closes #532. Lets the operator edit a `RECEIVED` or `PARTIALLY_RECEIVED` purchase order without losing per-row receipt metadata (`received_date`, `quantity`, `batch_transactions`).

**Path used: A** (status round-trip). The `UpdatePurchaseOrderRequest` schema accepts `status: PurchaseOrderStatus` (which includes `NOT_RECEIVED`), and the OpenAPI spec on `/purchase_order_receive` explicitly states *"Reverting the receive must also be done through that endpoint"* — i.e., PATCH `/purchase_orders/{id}` with status: NOT_RECEIVED is the API-sanctioned reverse of receive. The reopen clears each row's `received_date` so `quantity` / `variant_id` / `price_per_unit` become editable again; `POST /purchase_order_receive` then replays the captured close-state and auto-promotes status back to RECEIVED.

## Sequence

1. Capture close-state (per-row `purchase_order_row_id` / `quantity` / `received_date` / `batch_transactions`).
2. PATCH `/purchase_orders/{id}` with `status: NOT_RECEIVED` (clears each row's `received_date`).
3. PATCH each row per `row_changes` (now editable since `received_date` is null).
4. POST `/purchase_order_receive` once per captured receipt (auto-promotes status to RECEIVED).

## Differs from SO/MO siblings

- **Edits keyed by `row_id`, not `variant_id`** — receive may split a partially-received row into two physical rows that share the same `variant_id`, so variant-keyed lookup is ambiguous on a `PARTIALLY_RECEIVED` PO. Operator looks up row IDs via `get_purchase_order` first.
- **No final close PATCH** — the receive endpoint auto-promotes status when every row is fully received.

## BLOCK guards (preflight)

- Refuses if status isn't `RECEIVED` / `PARTIALLY_RECEIVED` (use `modify_purchase_order` directly for open POs).
- Refuses if a `row_id` doesn't match any current row.
- Refuses if a row's new `quantity` drops below the already-received qty (the receive replay would fail and leave the PO stuck `NOT_RECEIVED` with the close-state cleared).
- Refuses if a `row_changes` entry sets none of `new_variant_id` / `quantity` / `price_per_unit`.

## Files changed

- **New tool**: `katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py` — `PORowCorrection`, `CorrectPurchaseOrderRequest`, plan-builders, `_correct_purchase_order_impl`, `correct_purchase_order` tool, registration.
- **Snapshot machinery**: `katana_mcp_server/src/katana_mcp/tools/_reopen.py` — `PO_CLOSED_STATUSES`, `PO_REOPEN_STATUS`, `PO_RESTORE_STATUS`, `PORowReceiptSnapshot`, `POCloseState`, `snapshot_po_close_state()`.
- **POOperation enum**: `katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py` — added `RECEIVE = "receive"` for the receipt-replay step.
- **Help resource**: `katana_mcp_server/src/katana_mcp/resources/help.py` — added entry to PO list, replaced the "no `correct_purchase_order`" deferred-feature note with the new per-tool block, updated the Closed-Record Corrections section header to mention all three tools.
- **Tests**: `katana_mcp_server/tests/tools/test_corrections.py` — 7 new tests (entry conditions, preflight quantity guard, preview shape, partially-received-warns, apply-canonical-order, halt-on-revert-failure).

No generated files touched.

## Test plan

- [x] `uv run poe check` — green (ruff format, mdformat, ruff check, ty check, yamllint pre-existing warnings only, pytest 2892 passed)
- [x] `correct_po_rejects_open_status` — entry-condition check
- [x] `correct_po_rejects_missing_row_id` — row-resolution error
- [x] `correct_po_rejects_empty_correction` — no-op refusal
- [x] `correct_po_rejects_quantity_below_already_received` — preflight quantity guard
- [x] `correct_po_preview_emits_full_action_plan` — preview shape (revert + edit + receive)
- [x] `correct_po_preview_partially_received_warns` — PARTIALLY_RECEIVED warning + remnant skipped
- [x] `correct_po_apply_executes_phases_in_canonical_order` — call-order assertion
- [x] `correct_po_apply_halts_on_revert_failure` — fail-fast breadcrumb

Closes #532. Umbrella: #523. Siblings: #536 (MO), #546 (SO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)