### PR TITLE
feat(client): adaptive rate-limit transport reading X-Ratelimit-* + Retry-After (#590)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -156,11 +156,6 @@ _PARENT_BY_VARIANT_TYPE: dict[str, tuple[EntityType, str]] = {
     "service": (EntityType.SERVICE, "product_id"),
 }
 
-# Cap concurrent ``/inventory`` requests for ``inventory_velocity`` batches.
-# Transport-layer rate limiting handles 429s, but a semaphore prevents 100+
-# simultaneous requests from saturating the HTTP connection pool.
-_STOCK_FETCH_CONCURRENCY = 10
-
 
 async def _resolve_variant_info(
     services: Any,
@@ -900,18 +895,17 @@ async def _inventory_velocity_impl(
     recipe_rows: list[Any] = fetch_results[1] if request.include_mo_consumption else []
 
     # Stock-on-hand must be fetched per variant (separate API call each).
-    # Cap concurrency so a 100-variant batch doesn't burst 100 simultaneous
-    # ``/inventory`` requests at the connection pool — transport-layer
-    # rate limiting handles 429s, but a semaphore prevents the burst
-    # entirely.
-    stock_fetch_semaphore = asyncio.Semaphore(_STOCK_FETCH_CONCURRENCY)
-
-    async def _fetch_stock_limited(variant_id: int) -> float:
-        async with stock_fetch_semaphore:
-            return await _fetch_stock_on_hand(services, variant_id)
-
+    # The prior application-level ``asyncio.Semaphore`` capping concurrency
+    # at 10 was removed because the transport-layer ``RateLimitTransport``
+    # (#590) caps the *rate* at 60 req/min, which bounds the amount of work
+    # that can outrun httpx's default connection pool (max 100). Note:
+    # this is rate-limiting, not concurrency-limiting — bursts up to the
+    # bucket size can still fire concurrently, but pyrate stalls the rest
+    # before they reach the pool. If a future workload needs a stricter
+    # concurrency cap (e.g., to be friendlier to a downstream API the
+    # rate limit doesn't constrain), reintroduce a semaphore here.
     stock_values = await asyncio.gather(
-        *(_fetch_stock_limited(variant_id) for variant_id, _ in resolved)
+        *(_fetch_stock_on_hand(services, variant_id) for variant_id, _ in resolved)
     )
 
     # Pre-aggregate demand per variant in a single pass over each row source,

--- a/katana_public_api_client/docs/guide.md
+++ b/katana_public_api_client/docs/guide.md
@@ -77,17 +77,57 @@ async with KatanaClient(max_retries=5) as client:
 
 ### Rate Limit Handling
 
+The client throttles requests in two layers, both automatic:
+
+1. **Proactive throttling** via `RateLimitTransport` — every outgoing request passes
+   through a [pyrate-limiter](https://github.com/vutran1710/PyrateLimiter) token bucket
+   sized to Katana's documented 60 req/min budget. Concurrent and paginated workloads
+   pace cleanly without thrashing 429s.
+1. **Reactive `Retry-After` handling** in `RetryTransport` — if a 429 still slips
+   through (e.g. another client is sharing the API key), the retry layer honors
+   `Retry-After` (numeric seconds or HTTP-date) before the next attempt.
+
+The proactive layer also reads `X-Ratelimit-Remaining` and `X-Ratelimit-Reset` on every
+response and **adapts**:
+
+- If the server reports fewer remaining tokens than the local estimate (e.g., another
+  client consumed budget), the local bucket is drained to match.
+- When `X-Ratelimit-Remaining` hits 0, future requests are gated by an `asyncio.Event`
+  until `X-Ratelimit-Reset` elapses.
+
 ```python
-# Automatic rate limit handling with Retry-After header support
+# Default behavior — 60/min budget, fully automatic.
 async with KatanaClient() as client:
-    # These calls will automatically be rate limited
-    for i in range(100):
+    # 100 calls fire as fast as the rate limit allows; no manual pacing
+    # needed. We don't pass an explicit ``page`` parameter — that would
+    # disable auto-pagination — so each call here is a full-result fetch
+    # demonstrating throttling.
+    for _ in range(100):
         response = await get_all_products.asyncio_detailed(
             client=client,
-            page=i,
-            limit=50
+            limit=50,
         )
-        # Client automatically waits when rate limited
+```
+
+#### Tuning the budget
+
+If your account has a different rate limit (some Katana plans differ), pass
+`requests_per_minute=`:
+
+```python
+async with KatanaClient(requests_per_minute=120) as client:
+    ...  # paces at 120/min instead of 60/min
+```
+
+#### Opting out
+
+If you want to manage throttling yourself (or in a test that needs raw throughput), pass
+`requests_per_minute=None` to skip the rate-limit layer entirely:
+
+```python
+# Reactive 429-retry only; no proactive throttling.
+async with KatanaClient(requests_per_minute=None) as client:
+    ...
 ```
 
 ### Error Recovery

--- a/katana_public_api_client/katana_client.py
+++ b/katana_public_api_client/katana_client.py
@@ -6,11 +6,13 @@ rate limiting, error handling, and pagination for all API calls without any
 decorators or wrapper methods needed.
 """
 
+import asyncio
 import contextlib
 import json
 import logging
 import netrc
 import os
+import time
 from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from pathlib import Path
@@ -19,8 +21,9 @@ from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 
 import httpx
 from dotenv import load_dotenv
-from httpx import AsyncHTTPTransport
+from httpx import AsyncBaseTransport, AsyncHTTPTransport
 from httpx_retries import Retry, RetryTransport
+from pyrate_limiter import Duration, Limiter, Rate
 
 from ._logging import Logger
 from .api_wrapper import ApiNamespace
@@ -244,17 +247,20 @@ def _extract_nested_error(
     return name, message, status_code, details
 
 
-class ErrorLoggingTransport(AsyncHTTPTransport):
+class ErrorLoggingTransport(AsyncBaseTransport):
     """
     Transport layer that adds detailed error logging for 4xx client errors.
 
-    This transport wraps another AsyncHTTPTransport and intercepts responses
-    to log detailed error information using the generated error models.
+    This transport wraps another transport and intercepts responses to log
+    detailed error information using the generated error models. Inherits
+    from ``AsyncBaseTransport`` (not ``AsyncHTTPTransport``) so we don't
+    spin up an unused connection pool inside this layer; all I/O goes
+    through the wrapped transport.
     """
 
     def __init__(
         self,
-        wrapped_transport: AsyncHTTPTransport | None = None,
+        wrapped_transport: AsyncBaseTransport | None = None,
         logger: Logger | None = None,
         **kwargs: Any,
     ):
@@ -266,7 +272,6 @@ class ErrorLoggingTransport(AsyncHTTPTransport):
             logger: Logger instance for capturing error details. If None, creates a default logger.
             **kwargs: Additional arguments passed to AsyncHTTPTransport if wrapped_transport is None.
         """
-        super().__init__()
         if wrapped_transport is None:
             wrapped_transport = AsyncHTTPTransport(**kwargs)
         self._wrapped_transport = wrapped_transport
@@ -281,6 +286,10 @@ class ErrorLoggingTransport(AsyncHTTPTransport):
             await self._log_client_error(response, request)
 
         return response
+
+    async def aclose(self) -> None:
+        """Propagate close down the wrapped chain so inner transports release resources."""
+        await self._wrapped_transport.aclose()
 
     async def _log_client_error(
         self, response: httpx.Response, request: httpx.Request
@@ -608,12 +617,14 @@ class ErrorLoggingTransport(AsyncHTTPTransport):
         self.logger.error(log_message)
 
 
-class PaginationTransport(AsyncHTTPTransport):
+class PaginationTransport(AsyncBaseTransport):
     """
     Transport layer that adds automatic pagination for GET requests.
 
     This transport wraps another transport and automatically collects all pages
-    for GET requests by default.
+    for GET requests by default. Inherits from ``AsyncBaseTransport`` (not
+    ``AsyncHTTPTransport``) so we don't spin up an unused connection pool
+    inside this layer; all I/O goes through the wrapped transport.
 
     Auto-pagination behavior:
     - ON by default for GET requests with NO page parameter in URL
@@ -631,7 +642,7 @@ class PaginationTransport(AsyncHTTPTransport):
 
     def __init__(
         self,
-        wrapped_transport: AsyncHTTPTransport | None = None,
+        wrapped_transport: AsyncBaseTransport | None = None,
         max_pages: int = 100,
         logger: Logger | None = None,
         **kwargs: Any,
@@ -645,16 +656,16 @@ class PaginationTransport(AsyncHTTPTransport):
             logger: Logger instance for capturing pagination operations. If None, creates a default logger.
             **kwargs: Additional arguments passed to AsyncHTTPTransport if wrapped_transport is None.
         """
-        # If no wrapped transport provided, create a base one
         if wrapped_transport is None:
             wrapped_transport = AsyncHTTPTransport(**kwargs)
-            super().__init__()
-        else:
-            super().__init__()
 
         self._wrapped_transport = wrapped_transport
         self.max_pages = max_pages
         self.logger: Logger = logger or logging.getLogger(__name__)
+
+    async def aclose(self) -> None:
+        """Propagate close down the wrapped chain so inner transports release resources."""
+        await self._wrapped_transport.aclose()
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         """Handle request with automatic pagination for GET requests.
@@ -1071,25 +1082,371 @@ class PaginationTransport(AsyncHTTPTransport):
         return pagination_info if pagination_info else None
 
 
+# Bucket identifier for pyrate's per-name limiter. We have a single global
+# budget, so all requests share one bucket name.
+_RATE_LIMIT_BUCKET_NAME = "katana"
+
+# Spec-documented response headers we observe — see
+# ``docs/katana-openapi.yaml`` (``X-Pagination`` siblings under ``components/headers``).
+_HEADER_REMAINING = "X-Ratelimit-Remaining"
+_HEADER_RESET = "X-Ratelimit-Reset"
+
+
+class RateLimitTransport(AsyncBaseTransport):
+    """Proactive rate-limiter that respects Katana's X-Ratelimit-* headers.
+
+    Wraps another transport and gates each request through a pyrate-limiter
+    token bucket sized for Katana's documented rate limit (60 req/min by
+    default, ``X-Ratelimit-Limit`` per the spec). After every response the
+    transport reads ``X-Ratelimit-Remaining`` / ``X-Ratelimit-Reset`` and
+    adapts:
+
+    - **Sync down**: when the server reports fewer remaining tokens than our
+      local estimate (e.g., another client is sharing the API key), drain
+      the local bucket to match. We never sync *up* — the server is
+      authoritative on the lower bound only.
+    - **Reset gate**: when remaining hits 0, an ``asyncio.Event`` blocks all
+      future requests until ``X-Ratelimit-Reset`` elapses. This prevents
+      pyrate's bucket from racing ahead of Katana's window.
+
+    Stack placement is innermost (above the base ``AsyncHTTPTransport``):
+    every actual HTTP request — including retries from ``RetryTransport``
+    above and per-page paginated fetches from ``PaginationTransport`` —
+    consumes one token, matching how Katana counts requests server-side.
+
+    ``Retry-After`` waiting on 429 responses stays in ``RetryTransport``
+    (urllib3.Retry honors the header via ``respect_retry_after_header=True``).
+    Sleeping in this transport on 429 would double-delay; we only update the
+    reset gate from headers and let retry handle the actual wait.
+
+    Out-of-order responses are handled correctly: the sync-down logic only
+    fires when the response's ``remaining`` is *below* the current estimate,
+    so a delayed earlier response with a higher ``remaining`` value won't
+    overwrite a fresher (lower) estimate.
+
+    Inherits from ``AsyncBaseTransport`` (not ``AsyncHTTPTransport``) because
+    we delegate every request to ``_wrapped_transport`` — there's no need to
+    spin up an unused connection pool inside this layer.
+    """
+
+    def __init__(
+        self,
+        wrapped_transport: AsyncBaseTransport | None = None,
+        *,
+        requests_per_minute: int = 60,
+        logger: Logger | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the rate-limit transport.
+
+        Args:
+            wrapped_transport: The transport to wrap. If None, creates a new
+                AsyncHTTPTransport.
+            requests_per_minute: Steady-state request budget. Must be ``> 0``;
+                callers wanting to disable the limiter entirely should omit
+                this transport from the chain rather than passing 0.
+            logger: Logger instance for capturing state changes. If None,
+                creates a default logger.
+            **kwargs: Additional arguments passed to AsyncHTTPTransport if
+                wrapped_transport is None.
+        """
+        if requests_per_minute <= 0:
+            msg = (
+                f"requests_per_minute must be positive, got {requests_per_minute}; "
+                "to disable rate limiting, omit this transport from the chain"
+            )
+            raise ValueError(msg)
+        if wrapped_transport is None:
+            wrapped_transport = AsyncHTTPTransport(**kwargs)
+        self._wrapped_transport = wrapped_transport
+        self._rpm = requests_per_minute
+        self._limiter = Limiter(
+            Rate(requests_per_minute, Duration.MINUTE), buffer_ms=50
+        )
+        self._reset_gate = asyncio.Event()
+        self._reset_gate.set()  # initially open — no active reset window
+        self._reset_handle: asyncio.TimerHandle | None = None
+        # Epoch-ms deadline of the active gate (or ``None`` when the gate is
+        # open). Tracks the *latest* observed reset so out-of-order responses
+        # with an earlier deadline can't shorten the gate, and so a timer
+        # callback whose deadline has been superseded can no-op.
+        self._reset_until_epoch_ms: int | None = None
+        self._release_task: asyncio.Task[None] | None = None
+        self._lock = asyncio.Lock()
+        self._estimated_remaining = requests_per_minute
+        self.logger: Logger = logger or logging.getLogger(__name__)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        """Acquire a token, forward the request, and observe rate-limit headers."""
+        # Block on any active reset window (set when remaining hit 0 on a
+        # prior response). Acts as the override on top of pyrate's bucket
+        # so we don't fire the burst-budget into a window the server has
+        # already declared exhausted.
+        await self._reset_gate.wait()
+
+        await self._limiter.try_acquire_async(name=_RATE_LIMIT_BUCKET_NAME)
+
+        # Re-check the gate after acquiring. While this request was queued
+        # on pyrate's bucket, a concurrent response observer may have seen
+        # ``X-Ratelimit-Remaining: 0`` and engaged the gate; without the
+        # second wait, we'd slip past it into the now-exhausted window.
+        # Loop until the gate is stably open through both checks: an even
+        # later engage during this wait should re-block us. The acquired
+        # token is held across the wait — pyrate refills its bucket over
+        # the window naturally, so this is not a wasted budget.
+        while not self._reset_gate.is_set():
+            await self._reset_gate.wait()
+
+        # Optimistically debit our local estimate to match what the server
+        # is about to see. Without this, the server's ``X-Ratelimit-Remaining``
+        # response would always be one lower than our untouched estimate,
+        # causing ``_observe_response`` to drain a redundant token on every
+        # request and effectively halve our usable budget. The lock keeps
+        # the debit and any concurrent sync-down consistent.
+        async with self._lock:
+            self._estimated_remaining = max(0, self._estimated_remaining - 1)
+
+        response = await self._wrapped_transport.handle_async_request(request)
+
+        await self._observe_response(response)
+        return response
+
+    async def _observe_response(self, response: httpx.Response) -> None:
+        """Parse rate-limit headers and update local state.
+
+        Defensive: many endpoints (auth flows, redirects, error pages) omit
+        these headers — silent no-op when absent. Only successful API
+        responses on the rate-limited paths populate them.
+        """
+        remaining_str = response.headers.get(_HEADER_REMAINING)
+        reset_str = response.headers.get(_HEADER_RESET)
+        if remaining_str is None or reset_str is None:
+            return
+
+        try:
+            remaining = int(remaining_str)
+            reset_epoch_ms = int(reset_str)
+        except (ValueError, TypeError):
+            self.logger.warning(
+                "Invalid rate-limit headers: remaining=%r reset=%r",
+                remaining_str,
+                reset_str,
+            )
+            return
+
+        # Stale-window guard: if the response's reset deadline is already in
+        # the past, this response describes a window that has rolled. Acting
+        # on its ``remaining`` (drain or gate-engage) would clamp the local
+        # limiter based on outdated state — and under the never-sync-up rule
+        # that artificial clamp can persist for the rest of the process.
+        # Drop the entire observation rather than just suppressing one path.
+        now_ms = int(time.time() * 1000)
+        if reset_epoch_ms <= now_ms:
+            return
+
+        # Skip the lock entirely when no update is possible — sync-down is
+        # only triggered by ``remaining < estimate`` and the reset gate only
+        # by ``remaining == 0``. Lock-free fast path for the common case
+        # where the server has at least as much budget as we think we do.
+        if remaining > 0 and remaining >= self._estimated_remaining:
+            return
+
+        async with self._lock:
+            # Sync down only — out-of-order responses with a higher
+            # ``remaining`` value must not overwrite a fresher (lower) estimate.
+            #
+            # When remaining=0, the reset gate alone is enough: it blocks
+            # until the server's window rolls. We deliberately do *not*
+            # drain pyrate's bucket here, because doing so would deplete
+            # pyrate of its tokens (e.g., a single response with
+            # remaining=0 would consume the rest of pyrate's burst budget),
+            # forcing the next request to wait pyrate's full window after
+            # the gate opens — even though Katana's window has already
+            # rolled. Sub-zero pyrate state and the gate are redundant; the
+            # gate is the override.
+            if 0 < remaining < self._estimated_remaining:
+                drain = self._estimated_remaining - remaining
+                # Best-effort: pyrate may have already drifted, so non-blocking
+                # drain.
+                await self._limiter.try_acquire_async(
+                    name=_RATE_LIMIT_BUCKET_NAME, weight=drain, blocking=False
+                )
+                self._estimated_remaining = remaining
+                self.logger.info(
+                    "Rate limit synced down: drained %d tokens, remote remaining=%d",
+                    drain,
+                    remaining,
+                )
+
+            if remaining == 0:
+                self._engage_reset_gate(reset_epoch_ms)
+
+    def _engage_reset_gate(self, reset_epoch_ms: int) -> None:
+        """Close the reset gate until ``reset_epoch_ms`` arrives.
+
+        Called under ``self._lock`` from ``_observe_response``.
+
+        Two guards on the deadline:
+
+        - **Stale earlier resets**: if there's already an active gate with a
+          *later* deadline, ignore this engage. Otherwise an earlier-window
+          response could shorten the gate and let requests through before
+          the server's true reset.
+        - **Fresh later resets**: cancel the existing timer and reschedule
+          for the new (later) deadline.
+
+        Past-due resets are filtered by ``_observe_response`` before reaching
+        this method (stale-window guard); the redundant ``wait_ms <= 0``
+        check below is defensive in case future callers bypass that filter.
+
+        ``_estimated_remaining = 0`` is pinned only after the gate actually
+        engages, so a stale ``remaining=0`` response can't permanently stick
+        the estimate at 0 (which under the never-sync-up rule would silently
+        disable sync-down for the rest of the client's lifetime).
+        """
+        now_ms = int(time.time() * 1000)
+        wait_ms = reset_epoch_ms - now_ms
+        if wait_ms <= 0:
+            return  # Reset already passed; nothing to gate against.
+
+        # If a gate is already engaged for a *later* deadline, keep it.
+        if (
+            self._reset_until_epoch_ms is not None
+            and reset_epoch_ms <= self._reset_until_epoch_ms
+        ):
+            return
+
+        wait_s = wait_ms / 1000.0
+        self._reset_until_epoch_ms = reset_epoch_ms
+        self._estimated_remaining = 0
+
+        if self._reset_gate.is_set():
+            self._reset_gate.clear()
+            self.logger.info(
+                "Rate limit reset gate engaged for %.2fs (server reports remaining=0)",
+                wait_s,
+            )
+
+        # Cancel any prior pending release so the (later) deadline replaces it.
+        if self._reset_handle is not None and not self._reset_handle.cancelled():
+            self._reset_handle.cancel()
+
+        loop = asyncio.get_running_loop()
+        self._reset_handle = loop.call_later(
+            wait_s, self._schedule_release, reset_epoch_ms
+        )
+
+    def _schedule_release(self, deadline_epoch_ms: int) -> None:
+        """Sync callback fired by ``loop.call_later`` at the deadline.
+
+        Spawns the async release helper so we can take ``self._lock`` for
+        the state mutation. Passes the deadline through so the helper can
+        verify this firing wasn't superseded by a later ``_engage_reset_gate``
+        call (in which case ``_reset_handle`` was replaced and we'd race
+        with whichever timer fires last). Stores the task reference so
+        Python doesn't garbage-collect the coroutine before it runs (asyncio
+        only holds weak refs to background tasks).
+        """
+        task = asyncio.create_task(self._release_reset_gate(deadline_epoch_ms))
+        self._release_task = task
+        task.add_done_callback(self._clear_release_task)
+
+    def _clear_release_task(self, task: asyncio.Task[None]) -> None:
+        """Drop our strong reference once the release helper completes — but only if it's still the current one.
+
+        Without the identity check, a stale callback can clear a fresher
+        in-flight task: timer A fires, spawns task A, and stores it as
+        ``self._release_task``; while task A is waiting on ``self._lock``,
+        a later ``_engage_reset_gate`` schedules timer B, which fires and
+        overwrites ``self._release_task = task_B``. When task A completes
+        (its deadline-mismatch no-op path), its ``add_done_callback``
+        would naively set ``self._release_task = None``, losing the
+        reference to the still-running task B and causing ``aclose()`` to
+        skip cancelling it.
+        """
+        if self._release_task is task:
+            self._release_task = None
+
+    async def _release_reset_gate(self, deadline_epoch_ms: int) -> None:
+        """Reopen the gate and reset estimate, atomically.
+
+        Ignores stale firings: if a subsequent ``_engage_reset_gate`` replaced
+        the deadline, our ``deadline_epoch_ms`` no longer matches
+        ``self._reset_until_epoch_ms`` and we leave the gate alone — the
+        replacement timer will fire later and own the release.
+        """
+        async with self._lock:
+            if self._reset_until_epoch_ms != deadline_epoch_ms:
+                # A fresher engage replaced this deadline; let its timer run.
+                return
+            self._reset_until_epoch_ms = None
+            self._reset_handle = None
+            self._estimated_remaining = self._rpm
+            self._reset_gate.set()
+            self.logger.info("Rate limit reset gate released")
+
+    async def aclose(self) -> None:
+        """Cancel the pending reset timer and any in-flight release, then close the wrapped transport.
+
+        Two cancellation paths must run before delegating ``aclose`` down
+        the chain:
+
+        1. ``_reset_handle`` — the ``loop.call_later`` callback. If it
+           fires after the loop is cleaned up, we get scheduling errors.
+        2. ``_release_task`` — the async ``_release_reset_gate`` task
+           spawned when the timer fired. If the timer fired *just before*
+           shutdown, the task may still be running (waiting on
+           ``self._lock``); without explicit cancel + await, asyncio
+           emits "Task was destroyed but it is pending" and the task can
+           race with the wrapped transport's own shutdown.
+        """
+        if self._reset_handle is not None and not self._reset_handle.cancelled():
+            self._reset_handle.cancel()
+        self._reset_handle = None
+
+        if self._release_task is not None and not self._release_task.done():
+            self._release_task.cancel()
+            # Suppress the cancellation so it doesn't propagate; we just
+            # want the task off the loop before we close the wrapped
+            # transport.
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._release_task
+        self._release_task = None
+
+        await self._wrapped_transport.aclose()
+
+
 def ResilientAsyncTransport(
     max_retries: int = 5,
     max_pages: int = 100,
     logger: Logger | None = None,
+    *,
+    requests_per_minute: int | None = 60,
     **kwargs: Any,
 ) -> RetryTransport:
     """
     Factory function that creates a chained transport with error logging,
-    pagination, and retry capabilities.
+    pagination, rate limiting, and retry capabilities.
 
-    This function chains multiple transport layers:
+    This function chains multiple transport layers (innermost → outermost):
     1. AsyncHTTPTransport (base HTTP transport)
-    2. ErrorLoggingTransport (logs detailed 4xx errors)
-    3. PaginationTransport (auto-collects paginated responses)
-    4. RetryTransport (handles retries with Retry-After header support)
+    2. RateLimitTransport (proactive 60-req/min throttle, header-aware)
+    3. ErrorLoggingTransport (logs detailed 4xx errors)
+    4. PaginationTransport (auto-collects paginated responses)
+    5. RetryTransport (handles retries with Retry-After header support)
+
+    The rate limiter is innermost (above the base) because Katana counts
+    *every* HTTP request — retries from the outer ``RetryTransport`` and
+    individual paginated pages from ``PaginationTransport`` all consume
+    server-side budget. Placing the limiter higher up would under-count.
 
     Args:
         max_retries: Maximum number of retry attempts for failed requests. Defaults to 5.
         max_pages: Maximum number of pages to collect during auto-pagination. Defaults to 100.
+        requests_per_minute: Steady-state request budget for the rate-limit
+            transport. Defaults to 60 (Katana's documented default). Pass ``None``
+            to omit the rate-limit layer entirely (e.g. when the caller is
+            responsible for throttling, or for tests that need raw throughput).
         logger: Logger instance for capturing operations. If None, creates a default logger.
         **kwargs: Additional arguments passed to the base AsyncHTTPTransport.
             Common parameters include:
@@ -1120,15 +1477,25 @@ def ResilientAsyncTransport(
 
     # Build the transport chain from inside out:
     # 1. Base AsyncHTTPTransport
-    base_transport = AsyncHTTPTransport(**kwargs)
+    inner_transport: AsyncBaseTransport = AsyncHTTPTransport(**kwargs)
 
-    # 2. Wrap with error logging
+    # 2. Wrap with rate limiting (innermost wrapping layer — every actual
+    #    HTTP request, including retries and per-page paginated fetches,
+    #    consumes one token. ``None`` skips this layer entirely.)
+    if requests_per_minute is not None:
+        inner_transport = RateLimitTransport(
+            wrapped_transport=inner_transport,
+            requests_per_minute=requests_per_minute,
+            logger=resolved_logger,
+        )
+
+    # 3. Wrap with error logging
     error_logging_transport = ErrorLoggingTransport(
-        wrapped_transport=base_transport,
+        wrapped_transport=inner_transport,
         logger=resolved_logger,
     )
 
-    # 3. Wrap with pagination
+    # 4. Wrap with pagination
     pagination_transport = PaginationTransport(
         wrapped_transport=error_logging_transport,
         max_pages=max_pages,
@@ -1301,6 +1668,8 @@ class KatanaClient(AuthenticatedClient):
         max_retries: int = 5,
         max_pages: int = 100,
         logger: Logger | None = None,
+        *,
+        requests_per_minute: int | None = 60,
         **httpx_kwargs: Any,
     ):
         """
@@ -1313,6 +1682,14 @@ class KatanaClient(AuthenticatedClient):
             timeout: Request timeout in seconds. Defaults to 30.0.
             max_retries: Maximum number of retry attempts for failed requests. Defaults to 5.
             max_pages: Maximum number of pages to collect during auto-pagination. Defaults to 100.
+            requests_per_minute: Steady-state request budget for the proactive
+                rate limiter. Defaults to 60 (Katana's documented limit). Set to
+                ``None`` to disable the rate limiter entirely (e.g. when callers
+                want to manage throttling themselves, or for tests that need raw
+                throughput). When the limiter is active, every actual HTTP
+                request — including retries and per-page paginated fetches —
+                consumes one token, and the transport adapts to the server's
+                ``X-Ratelimit-Remaining`` / ``X-Ratelimit-Reset`` headers.
             logger: Any object whose debug/info/warning/error methods accept
                 (msg, *args, **kwargs) — the standard logging.Logger call convention
                 (e.g. logging.Logger, structlog.BoundLogger). If None, creates a
@@ -1427,6 +1804,7 @@ class KatanaClient(AuthenticatedClient):
             transport = ResilientAsyncTransport(
                 max_retries=max_retries,
                 max_pages=max_pages,
+                requests_per_minute=requests_per_minute,
                 logger=self.logger,
                 **httpx_kwargs,  # Pass through http2, limits, verify, cert, trust_env, etc.
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,12 @@ dependencies = [
   "email-validator>=2.2.0",  # Required for Pydantic EmailStr fields
   "typing-extensions>=4.13.0",
   "httpx-retries>=0.4.5",
+  # Token-bucket rate limiter underlying the proactive RateLimitTransport
+  # (see #590). Wraps a leaky/token bucket for honoring Katana's 60-req/min
+  # API limit; we layer header-aware adaptation (X-Ratelimit-Remaining/Reset)
+  # on top in katana_client.py rather than using httpx-limiter, since we
+  # need full control over the response-observation hook.
+  "pyrate-limiter>=3.0.0",
   # SQLModel unifies pydantic validation with SQLAlchemy ORM — used as the
   # base class for all generated domain models so a single class can serve as
   # both API response shape and cache table definition (see #342).
@@ -77,6 +83,11 @@ dev = [
   "pytest-mock>=3.14.0",
   "pytest-timeout>=2.4.0",
   "pytest-xdist>=3.6.1",
+  # Asyncio fake-clock for integration tests that exercise time-dependent
+  # transports (rate limiter reset gate, RetryTransport's Retry-After wait).
+  # Lets ``asyncio.sleep(5)`` and ``loop.call_later(5, ...)`` fire instantly
+  # in real time while the loop perceives 5 seconds elapsed.
+  "looptime>=0.7",
   "tox>=4.25.0",
   # Code quality and linting
   "ruff>=0.14.0",
@@ -221,6 +232,7 @@ markers = [
   "asyncio: marks tests as async tests",
   "docs: marks tests as documentation tests (slow, only run in CI docs jobs)",
   "schema_validation: marks tests that validate OpenAPI schema quality (run with pytest-xdist disabled)",
+  "looptime: marks tests that use the looptime fake-clock asyncio loop (the looptime plugin auto-registers this marker; explicit registration here keeps the suite robust under --strict-markers if plugin autoload is ever disabled)",
 ]
 
 [tool.coverage.run]

--- a/tests/test_rate_limit_retry.py
+++ b/tests/test_rate_limit_retry.py
@@ -5,9 +5,15 @@ This module tests the custom retry logic that distinguishes between:
 - Server errors (502/503/504): Retry ONLY idempotent methods (GET, PUT, DELETE, etc.)
 """
 
+import asyncio
+import time
+from email.utils import formatdate
 from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
+from httpx_retries import RetryTransport
 
 from katana_public_api_client.katana_client import RateLimitAwareRetry
 
@@ -458,3 +464,249 @@ class TestRateLimitAwareRetryStateMachine:
 
         # Back to 429 should still work
         assert retry.is_retryable_status_code(429)
+
+
+@pytest.mark.unit
+class TestRetryAfterEndToEndIntegration:
+    """End-to-end integration tests exercising ``RetryTransport``'s retry loop.
+
+    Uses ``looptime`` to fake the asyncio event loop's clock so the actual
+    ``await asyncio.sleep(retry_after)`` inside ``Retry.asleep`` runs in
+    virtual time — the test loop perceives the configured delay elapsing
+    while real wall-clock time stays at zero. This is the equivalent of
+    ``trio.testing.MockClock`` for asyncio.
+
+    All tests drive requests through the public
+    ``RetryTransport.handle_async_request`` API and assert on observed
+    behavior (response status, retry count, virtual time elapsed) — no
+    coupling to private helpers like ``_calculate_sleep``. Together they
+    cover both the Retry-After path (numeric, HTTP-date, header-overrides-
+    backoff, multi-retry accumulation) and the backoff fallback path
+    (header absent, header malformed) end-to-end.
+    """
+
+    @staticmethod
+    def _build_transport(
+        responses: list[httpx.Response | MagicMock], *, backoff_factor: float = 10.0
+    ) -> tuple[RetryTransport, AsyncMock]:
+        """Build a real ``RetryTransport`` over a mocked inner transport.
+
+        ``backoff_jitter=0`` makes the backoff deterministic (the
+        ``httpx_retries`` default of 1.0 multiplies the backoff by
+        ``random.uniform(0, 1)``, which would make timing assertions
+        flaky and can interact poorly with ``looptime`` when the
+        randomized value is very small).
+        """
+        retry = RateLimitAwareRetry(
+            total=3,
+            backoff_factor=backoff_factor,
+            backoff_jitter=0.0,
+            respect_retry_after_header=True,
+            status_forcelist=[429, 502, 503, 504],
+            allowed_methods=["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"],
+        )
+        inner = AsyncMock(spec=httpx.AsyncHTTPTransport)
+        inner.handle_async_request.side_effect = responses
+        return RetryTransport(transport=inner, retry=retry), inner
+
+    @staticmethod
+    def _resp(status: int, headers: dict[str, str] | None = None) -> MagicMock:
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = status
+        response.headers = headers or {}
+        return response
+
+    @pytest.mark.asyncio
+    @pytest.mark.looptime
+    async def test_retry_after_delays_full_chain_by_header_value(self) -> None:
+        """A 429 + ``Retry-After: 5`` makes the retry loop wait 5 virtual seconds.
+
+        Goes through the *real* code path: ``RetryTransport.handle_async_request``
+        receives the 429, computes the delay from the header, calls its
+        async ``asleep()``, and the second attempt fires only after the
+        loop's clock has advanced by 5 seconds.
+        """
+        transport, inner = self._build_transport(
+            [
+                self._resp(429, {"Retry-After": "5"}),
+                self._resp(200),
+            ]
+        )
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        response = await transport.handle_async_request(
+            httpx.Request("GET", "https://api.example.test/items")
+        )
+        elapsed = loop.time() - start
+
+        assert response.status_code == 200
+        assert inner.handle_async_request.call_count == 2
+        # Loop time should have advanced by ~5s (the Retry-After value).
+        # Allow a small tolerance for the buffer pyrate-style libraries may
+        # add. A clean Retry-After integer landing within [4.5, 5.5] proves
+        # the header drove the delay, not the configured 10s backoff.
+        assert 4.5 <= elapsed <= 5.5, (
+            f"Retry-After: 5 should produce ~5s loop-time delay; got {elapsed:.2f}s"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.looptime
+    async def test_retry_after_dominates_long_backoff_end_to_end(self) -> None:
+        """Header takes precedence over a much longer configured backoff.
+
+        ``backoff_factor=100`` would normally pace the first retry around
+        100 seconds. ``Retry-After: 2`` must override and land at ~2s of
+        loop time.
+        """
+        transport, _inner = self._build_transport(
+            [
+                self._resp(429, {"Retry-After": "2"}),
+                self._resp(200),
+            ],
+            backoff_factor=100.0,
+        )
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        response = await transport.handle_async_request(
+            httpx.Request("GET", "https://api.example.test/items")
+        )
+        elapsed = loop.time() - start
+
+        assert response.status_code == 200
+        assert elapsed <= 5.0, (
+            f"Retry-After: 2 should override 100s backoff; got {elapsed:.2f}s"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.looptime
+    async def test_http_date_retry_after_paces_end_to_end(self) -> None:
+        """RFC 7231 HTTP-date Retry-After format paces the retry by the absolute deadline.
+
+        Builds a retry-after date 5 seconds in the future (real wall-clock
+        ``time.time()``, since httpx-retries computes the delay as
+        ``deadline - now`` against the wall clock). Under ``looptime``,
+        the loop's clock is virtual but ``time.time()`` is real — so we
+        format an absolute date that resolves to ~5s of delay when
+        ``asleep()`` parses it, and looptime fast-forwards the resulting
+        ``asyncio.sleep`` virtually.
+        """
+        retry_at = formatdate(timeval=time.time() + 5, usegmt=True)
+        transport, _inner = self._build_transport(
+            [
+                self._resp(429, {"Retry-After": retry_at}),
+                self._resp(200),
+            ]
+        )
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        response = await transport.handle_async_request(
+            httpx.Request("GET", "https://api.example.test/items")
+        )
+        elapsed = loop.time() - start
+
+        assert response.status_code == 200
+        # HTTP-date has 1-second resolution; the parse may land in
+        # [4s, 6s] depending on how time.time() ticked between format and
+        # parse. Tolerance is wider than the numeric integration test.
+        assert 4.0 <= elapsed <= 6.5, (
+            f"HTTP-date Retry-After should pace ~5s of loop time; got {elapsed:.2f}s"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.looptime
+    async def test_no_retry_after_falls_back_to_backoff(self) -> None:
+        """Without a Retry-After header, the retry waits ``backoff_factor`` instead.
+
+        Inverse property of the Retry-After tests — proves the header path
+        and the backoff path are distinct, so the Retry-After tests above
+        are actually exercising the header (not coincidentally matching
+        whatever the backoff produced).
+        """
+        transport, _inner = self._build_transport(
+            [
+                self._resp(429),  # NO Retry-After header
+                self._resp(200),
+            ],
+            backoff_factor=4.0,
+        )
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        response = await transport.handle_async_request(
+            httpx.Request("GET", "https://api.example.test/items")
+        )
+        elapsed = loop.time() - start
+
+        assert response.status_code == 200
+        # With ``backoff_jitter=0`` the backoff is deterministic:
+        # ``backoff_factor * 2 ** attempts_made`` = 4 * 2 = 8s after the
+        # first retry. Tight bound proves the path was taken (anything
+        # outside this range would mean Retry-After parsing fired
+        # somehow, or the formula changed in a dependency upgrade).
+        assert 7.5 <= elapsed <= 8.5, (
+            f"absent Retry-After should pace via deterministic backoff (~8s); "
+            f"got {elapsed:.2f}s"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.looptime
+    async def test_unparseable_retry_after_falls_back_to_backoff(self) -> None:
+        """A malformed Retry-After value falls back to the configured backoff.
+
+        Tolerates servers that send garbage in the header — the retry layer
+        logs a warning and uses backoff instead of crashing.
+        """
+        transport, _inner = self._build_transport(
+            [
+                self._resp(429, {"Retry-After": "not-a-number"}),
+                self._resp(200),
+            ],
+            backoff_factor=4.0,
+        )
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        response = await transport.handle_async_request(
+            httpx.Request("GET", "https://api.example.test/items")
+        )
+        elapsed = loop.time() - start
+
+        assert response.status_code == 200
+        # Same deterministic backoff math as the no-header case (~8s).
+        assert 7.5 <= elapsed <= 8.5, (
+            f"malformed Retry-After should fall back to backoff (~8s); "
+            f"got {elapsed:.2f}s"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.looptime
+    async def test_multiple_retries_accumulate_delay(self) -> None:
+        """Successive 429s each pace by their Retry-After value.
+
+        Three responses: 429+Retry-After:3, 429+Retry-After:7, 200.
+        Total loop-time delay should be ~10s (3 + 7) regardless of backoff
+        configuration — proves both retries honor the header.
+        """
+        transport, inner = self._build_transport(
+            [
+                self._resp(429, {"Retry-After": "3"}),
+                self._resp(429, {"Retry-After": "7"}),
+                self._resp(200),
+            ]
+        )
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        response = await transport.handle_async_request(
+            httpx.Request("GET", "https://api.example.test/items")
+        )
+        elapsed = loop.time() - start
+
+        assert response.status_code == 200
+        assert inner.handle_async_request.call_count == 3
+        assert 9.0 <= elapsed <= 11.0, (
+            f"Two retries with Retry-After 3 + 7 should pace ~10s; got {elapsed:.2f}s"
+        )

--- a/tests/test_rate_limit_transport.py
+++ b/tests/test_rate_limit_transport.py
@@ -1,0 +1,857 @@
+"""Tests for ``RateLimitTransport`` — proactive rate-limiter with header awareness.
+
+Covers the eight behaviors from #590's plan:
+
+1. Token bucket throttles when budget is exceeded.
+2. ``X-Ratelimit-Remaining`` lower than local estimate → drain to match.
+3. ``X-Ratelimit-Remaining: 0`` → reset gate engages until ``X-Ratelimit-Reset``.
+4. Missing rate-limit headers → silent no-op, request proceeds normally.
+5. 5xx responses without rate-limit headers → no state change. (Header parsing
+   is status-agnostic — Katana could legitimately send the headers on errors —
+   but in the absence of headers, nothing happens regardless of status code.)
+6. Streaming responses pass through the layer unchanged.
+7. ``requests_per_minute=None`` on ``KatanaClient`` omits the layer entirely.
+8. Limiter composes cleanly with the rest of the resilient transport stack.
+
+Tests instantiate a fresh ``RateLimitTransport`` per test (and therefore a fresh
+``pyrate_limiter.Limiter``) — pyrate has process-global state with some
+backends, and bleed across tests would mask real failures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from katana_public_api_client import KatanaClient
+from katana_public_api_client.katana_client import (
+    PaginationTransport,
+    RateLimitTransport,
+)
+
+
+def _build_response(
+    *,
+    status: int = 200,
+    remaining: int | None = None,
+    reset_offset_seconds: float | None = None,
+    extra_headers: dict[str, str] | None = None,
+) -> MagicMock:
+    """Construct a MagicMock httpx.Response with optional rate-limit headers."""
+    headers: dict[str, str] = {}
+    if remaining is not None:
+        headers["X-Ratelimit-Remaining"] = str(remaining)
+    if reset_offset_seconds is not None:
+        # Spec defines X-Ratelimit-Reset as epoch ms.
+        reset_ms = int((time.time() + reset_offset_seconds) * 1000)
+        headers["X-Ratelimit-Reset"] = str(reset_ms)
+    if extra_headers:
+        headers.update(extra_headers)
+
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status
+    response.headers = headers
+    return response
+
+
+@pytest.fixture
+def mock_wrapped_transport() -> AsyncMock:
+    """Fresh AsyncMock wrapped transport per test."""
+    return AsyncMock(spec=httpx.AsyncHTTPTransport)
+
+
+def _make_request() -> httpx.Request:
+    return httpx.Request("GET", "https://api.example.test/manufacturing_orders")
+
+
+@pytest.mark.unit
+class TestRateLimitTransportInit:
+    """Validation at construction time."""
+
+    @pytest.mark.parametrize("rpm", [0, -1, -60])
+    def test_rejects_non_positive_rpm(self, rpm: int) -> None:
+        with pytest.raises(ValueError, match="must be positive"):
+            RateLimitTransport(requests_per_minute=rpm)
+
+    def test_creates_default_wrapped_when_none(self) -> None:
+        transport = RateLimitTransport(requests_per_minute=60)
+        assert transport._wrapped_transport is not None
+
+
+@pytest.mark.unit
+class TestRateLimitTransportThrottling:
+    """Pacing behavior when callers exceed the budget."""
+
+    @pytest.mark.asyncio
+    async def test_acquires_token_before_forwarding(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """Single request inside burst budget passes straight through."""
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+        mock_wrapped_transport.handle_async_request.return_value = _build_response()
+
+        await transport.handle_async_request(_make_request())
+
+        assert mock_wrapped_transport.handle_async_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_each_request_acquires_a_token(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """The transport must await ``try_acquire_async`` once per request.
+
+        Spies on the pyrate Limiter's acquire method rather than measuring
+        wall-time pacing — pacing is pyrate's contract (covered by its own
+        tests), our contract is "acquire before forwarding". A wall-time
+        test would be slow, scheduling-jittery, and would re-test pyrate.
+        """
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+        mock_wrapped_transport.handle_async_request.return_value = _build_response()
+
+        # Replace the real limiter's acquire path with a spy that returns
+        # immediately. ``cast(Any, ...)`` lets us monkey-patch a method on
+        # pyrate's ``Limiter`` (which doesn't expose a public swap hook)
+        # without tripping the static type checker on a method-assign.
+        spy = AsyncMock(return_value=True)
+        cast(Any, transport._limiter).try_acquire_async = spy
+
+        for _ in range(3):
+            await transport.handle_async_request(_make_request())
+
+        assert spy.await_count == 3, (
+            f"expected 3 token acquisitions for 3 requests, got {spy.await_count}"
+        )
+        # Verify each acquire used the consistent bucket name.
+        for call in spy.call_args_list:
+            assert call.kwargs.get("name") == "katana"
+
+    @pytest.mark.asyncio
+    async def test_acquires_before_forwarding(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """Acquire must happen before the wrapped transport sees the request."""
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+        mock_wrapped_transport.handle_async_request.return_value = _build_response()
+
+        order: list[str] = []
+
+        async def acquire_spy(*_args: object, **_kwargs: object) -> bool:
+            order.append("acquire")
+            return True
+
+        async def forward_spy(*_args: object, **_kwargs: object) -> MagicMock:
+            order.append("forward")
+            return _build_response()
+
+        cast(Any, transport._limiter).try_acquire_async = acquire_spy
+        mock_wrapped_transport.handle_async_request.side_effect = forward_spy
+
+        await transport.handle_async_request(_make_request())
+
+        assert order == ["acquire", "forward"], (
+            f"acquire must precede forward, got {order}"
+        )
+
+
+@pytest.mark.unit
+class TestRateLimitTransportSyncDown:
+    """``X-Ratelimit-Remaining`` smaller than local estimate drains the bucket."""
+
+    @pytest.mark.asyncio
+    async def test_syncs_down_when_remote_lower_than_estimate(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """When server reports remaining < local estimate, drain to match."""
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+        # Server says we have 5 left — much lower than our default-of-60 estimate.
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=5, reset_offset_seconds=30
+        )
+
+        await transport.handle_async_request(_make_request())
+
+        assert transport._estimated_remaining == 5
+
+    @pytest.mark.asyncio
+    async def test_does_not_sync_up_on_out_of_order_response(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """A late-arriving response with higher remaining must not overwrite a fresher (lower) estimate.
+
+        Simulates: response B (remaining=3) lands first, then response A
+        (remaining=4) arrives. The estimate should not climb back up.
+
+        Each request also decrements the estimate by 1 optimistically (so the
+        local estimate stays in lock-step with what the server is about to
+        see), so after the second request the estimate is one less than
+        whatever the latest sync-down produced — but it must still be ≤ 3.
+        """
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+
+        # First response: remaining=3 → sync-down to 3, then optimistic
+        # decrement on the *next* request would make it 2.
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=3, reset_offset_seconds=30
+        )
+        await transport.handle_async_request(_make_request())
+        assert transport._estimated_remaining == 3
+
+        # Out-of-order: remaining=4 — must NOT sync up. Optimistic decrement
+        # before this request brought estimate to 2; remaining=4 > 2 so no
+        # sync, estimate stays at 2.
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=4, reset_offset_seconds=30
+        )
+        await transport.handle_async_request(_make_request())
+        assert transport._estimated_remaining <= 3, (
+            "estimate should never sync upward on a higher-remaining response"
+        )
+
+
+@pytest.mark.unit
+class TestRateLimitTransportResetGate:
+    """``X-Ratelimit-Remaining: 0`` engages the gate; release after reset."""
+
+    @pytest.mark.asyncio
+    async def test_engages_gate_on_remaining_zero(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """A response with remaining=0 closes the reset gate."""
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+        # Reset window 30s out, no remaining budget.
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=0, reset_offset_seconds=30
+        )
+
+        await transport.handle_async_request(_make_request())
+
+        assert not transport._reset_gate.is_set(), (
+            "reset gate should be cleared after remaining=0 response"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.looptime
+    async def test_blocks_subsequent_request_until_gate_releases(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """Integration: a closed gate blocks subsequent requests until ``loop.call_later`` fires.
+
+        Uses ``looptime`` to fake the asyncio clock so the real
+        ``loop.call_later`` chain (engage gate → schedule release → fire
+        callback → spawn ``_release_reset_gate`` task → reopen gate) runs
+        end-to-end through the production code path, without real wall
+        time elapsing. The loop perceives ``reset_offset_seconds`` of
+        virtual time passing; the test completes in milliseconds.
+
+        Verifies:
+        - the gate is closed after a remaining=0 response
+        - a subsequent request parks on the gate (not done)
+        - the gate reopens automatically once the virtual deadline elapses
+        - the parked request then completes
+        """
+        # Important — looptime fast-forwards ``loop.time()`` but
+        # ``time.time()`` (used by ``_engage_reset_gate`` for epoch-ms math)
+        # is real wall-clock. Use a small offset so the wait_ms math lands
+        # on a small positive value relative to the virtual loop clock.
+        # The actual ``loop.call_later(wait_s, ...)`` schedules against
+        # the loop's clock, so ``looptime`` advances over wait_s of
+        # virtual time when the test ``awaits`` the gate.
+        gate_seconds = 5.0
+
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=0, reset_offset_seconds=gate_seconds
+        )
+
+        loop = asyncio.get_running_loop()
+        await transport.handle_async_request(_make_request())
+        assert not transport._reset_gate.is_set()
+
+        # Second request: should block on the gate until the real
+        # ``loop.call_later`` fires after ``gate_seconds`` of virtual time.
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=10, reset_offset_seconds=600
+        )
+
+        start = loop.time()
+        await transport.handle_async_request(_make_request())
+        elapsed = loop.time() - start
+
+        # Loop time should have advanced by ~gate_seconds; real wall time
+        # is ~zero (looptime). Without looptime this would take 5 real
+        # seconds — slow and timing-jittery. With looptime the same code
+        # path runs through the actual production scheduler.
+        assert elapsed >= gate_seconds * 0.5, (
+            f"gate should have blocked ≥{gate_seconds * 0.5}s of loop time; "
+            f"got {elapsed:.2f}s"
+        )
+        assert transport._reset_gate.is_set(), (
+            "gate should have reopened via the real call_later → release chain"
+        )
+
+    @pytest.mark.asyncio
+    async def test_past_reset_does_not_engage_gate(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """A response whose ``X-Ratelimit-Reset`` is already in the past must not engage.
+
+        Out-of-order/stale responses from a previous window can carry an
+        already-expired reset timestamp. Three things must hold:
+
+        1. The gate stays open (no stalling future requests for no reason).
+        2. ``_reset_until_epoch_ms`` stays None (no phantom active deadline).
+        3. ``_estimated_remaining`` is **not** pinned to 0 — under the
+           never-sync-up rule, that would silently disable sync-down for
+           the rest of the client lifetime, masking a real regression.
+           Only the optimistic per-request decrement should apply.
+        """
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=0,
+            reset_offset_seconds=-5,  # 5 seconds in the past
+        )
+
+        await transport.handle_async_request(_make_request())
+
+        assert transport._reset_gate.is_set(), (
+            "past-due reset should not engage the gate"
+        )
+        assert transport._reset_until_epoch_ms is None
+        # Estimate should reflect only the optimistic per-request decrement
+        # (60 → 59), NOT be pinned to 0 by the no-op'd gate engagement.
+        assert transport._estimated_remaining == 59, (
+            "past-due reset must not pin _estimated_remaining to 0"
+        )
+
+    @pytest.mark.asyncio
+    async def test_past_reset_with_nonzero_remaining_is_ignored(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """A stale response with ``remaining=N`` AND past-due reset must not drain.
+
+        The original past-reset guard only protected the gate-engage path.
+        A stale response from a previous window with, say, ``remaining=5``
+        and a reset 5 seconds in the past would still trigger sync-down,
+        clamping pyrate to 5 tokens — but those 5 tokens described a window
+        that has *already rolled*. Under the never-sync-up rule, that
+        artificial clamp persists.
+
+        Fix: ``_observe_response`` now treats any past-due reset as a
+        full no-op for header observation, regardless of ``remaining``.
+        """
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+        # Stale response: remaining=5 with past reset.
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=5, reset_offset_seconds=-5
+        )
+
+        await transport.handle_async_request(_make_request())
+
+        # Estimate must reflect ONLY the optimistic per-request decrement
+        # (60 → 59), not be drained to the stale remaining=5.
+        assert transport._estimated_remaining == 59, (
+            f"past-due reset with remaining=5 should be ignored; "
+            f"got {transport._estimated_remaining}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_sync_down_still_works_after_past_due_reset(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """Regression guard: a stale remaining=0 response must not disable future sync-down.
+
+        Under the never-sync-up rule, if a past-due ``remaining=0`` had
+        permanently pinned ``_estimated_remaining=0``, no later response
+        could ever trigger the sync-down path (the condition
+        ``remaining < estimate`` with estimate=0 is never true). This
+        proves the invariant holds: a fresh (future-dated)
+        ``remaining=N`` response after a stale one *does* drain.
+        """
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+
+        # Stale remaining=0 with past reset.
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=0, reset_offset_seconds=-5
+        )
+        await transport.handle_async_request(_make_request())
+
+        # Fresh response with real remaining=10 should still trigger sync-down.
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=10, reset_offset_seconds=60
+        )
+        await transport.handle_async_request(_make_request())
+
+        assert transport._estimated_remaining == 10, (
+            "fresh remaining=10 should sync down even after a prior stale "
+            "remaining=0 with past-due reset"
+        )
+
+    @pytest.mark.asyncio
+    async def test_request_queued_at_acquire_waits_if_gate_closes(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """A request that's mid-acquire when the gate closes must re-wait, not slip through.
+
+        Race scenario:
+        1. Request A enters ``handle_async_request``, finds the gate open,
+           and starts ``try_acquire_async`` (queued on pyrate's bucket).
+        2. While A is queued, request X (already in flight) gets a 429
+           response with ``X-Ratelimit-Remaining: 0`` — engages the gate.
+        3. Without the post-acquire re-check, A would proceed past the
+           closed gate into the exhausted window.
+
+        This test simulates the race by manually closing the gate
+        between acquire and forward, verifying the request blocks until
+        we explicitly reopen it.
+        """
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+        mock_wrapped_transport.handle_async_request.return_value = _build_response()
+
+        # Replace pyrate's acquire with a spy that lets us close the gate
+        # while the request is "queued" (i.e., between the first
+        # gate-wait and the forward).
+        async def acquire_then_close_gate(*_args: object, **_kwargs: object) -> bool:
+            transport._reset_gate.clear()
+            transport._reset_until_epoch_ms = 999_999_999_999
+            return True
+
+        cast(Any, transport._limiter).try_acquire_async = acquire_then_close_gate
+
+        # Spawn the request — it should park on the second gate-wait.
+        request_task = asyncio.create_task(
+            transport.handle_async_request(_make_request())
+        )
+        await asyncio.sleep(0)  # let it reach the wait
+        await asyncio.sleep(0)
+        assert not request_task.done(), (
+            "request should be parked on the post-acquire gate re-check, "
+            "not have forwarded into an engaged-window"
+        )
+        assert mock_wrapped_transport.handle_async_request.call_count == 0, (
+            "wrapped transport must NOT have been called while the gate was closed"
+        )
+
+        # Reopen the gate — request should now complete.
+        transport._reset_until_epoch_ms = None
+        transport._reset_gate.set()
+        await request_task
+        assert request_task.done()
+        assert mock_wrapped_transport.handle_async_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_stale_release_callback_does_not_clear_fresh_task(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """A completed older release task must not clear a newer in-flight one.
+
+        Race scenario: timer A fires, spawns task A (stored as
+        ``_release_task``). Before task A completes, a later
+        ``_engage_reset_gate`` schedules timer B; timer B fires and
+        spawns task B, overwriting the reference. When task A finishes
+        (its deadline-mismatch no-op), its ``add_done_callback`` would
+        — without the identity check — clear the reference to the
+        still-running task B, defeating ``aclose()``'s cancel logic.
+
+        The identity check in ``_clear_release_task`` is the fix; this
+        test pins it.
+        """
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+
+        # Simulate task A finishing: build a fake task identity, store
+        # it, then call the done-callback as if a *different* task A
+        # finished. The identity check should leave the stored reference
+        # intact.
+        loop = asyncio.get_running_loop()
+
+        async def noop() -> None:
+            return None
+
+        task_a = loop.create_task(noop())
+        task_b = loop.create_task(noop())
+        await task_a  # finishes; we want this one to no-op the clear
+        await task_b  # finishes; pretend this is the fresher in-flight
+
+        transport._release_task = task_b
+        transport._clear_release_task(task_a)  # stale callback firing
+
+        assert transport._release_task is task_b, (
+            "stale done-callback must not clear a fresher in-flight task"
+        )
+
+        # Sanity: when the *current* task's callback fires, it should clear.
+        transport._clear_release_task(task_b)
+        assert transport._release_task is None
+
+    @pytest.mark.asyncio
+    async def test_aclose_cancels_pending_release_task(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """``aclose()`` must cancel both the timer AND any spawned release task.
+
+        If the ``loop.call_later`` callback fires *just before* shutdown,
+        it spawns ``_release_reset_gate`` as a task that may still be
+        running (waiting on ``self._lock``) when ``aclose()`` is called.
+        Without explicit cancel + await, asyncio emits "Task was destroyed
+        but it is pending" warnings, and the task can race with the
+        wrapped transport's own shutdown.
+        """
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+
+        # Manually drive the timer callback to spawn a release task,
+        # mirroring the path the real ``loop.call_later`` would trigger.
+        transport._reset_until_epoch_ms = 999_999_999_999
+        transport._reset_gate.clear()
+        transport._schedule_release(999_999_999_999)
+        release_task = transport._release_task
+        assert release_task is not None, "release task should have been spawned"
+
+        # Close before the task naturally completes.
+        await transport.aclose()
+
+        assert transport._release_task is None, (
+            "aclose should clear the release-task reference"
+        )
+        assert release_task.done() or release_task.cancelled(), (
+            "in-flight release task should be cancelled or completed by aclose"
+        )
+        mock_wrapped_transport.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_earlier_reset_does_not_shorten_active_gate(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """An out-of-order response with an earlier reset must not shorten the gate.
+
+        First response engages the gate to a far-future deadline (60s). A
+        subsequent stale response with an earlier reset (10s) must be
+        ignored — otherwise the gate would release early and let requests
+        through before the server's actual reset.
+        """
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+
+        # First response: large reset window engages the gate to ~60s out.
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=0, reset_offset_seconds=60
+        )
+        await transport.handle_async_request(_make_request())
+
+        far_deadline = transport._reset_until_epoch_ms
+        assert far_deadline is not None
+
+        # Force-open the limiter gate to allow a second request through;
+        # in production a request inside an active gate would block, but
+        # here we just want to verify the engagement-time logic doesn't
+        # shrink the deadline.
+        transport._reset_gate.set()
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            remaining=0,
+            reset_offset_seconds=10,  # earlier than the active gate
+        )
+        await transport.handle_async_request(_make_request())
+
+        assert transport._reset_until_epoch_ms == far_deadline, (
+            "an earlier reset must not replace a later active deadline"
+        )
+
+
+@pytest.mark.unit
+class TestRateLimitTransportHeaderAbsence:
+    """Auth/redirect endpoints often omit (or malform) X-Ratelimit-* — must no-op.
+
+    Either case skips header-driven sync; only the optimistic per-request
+    decrement applies. The reset gate stays open.
+    """
+
+    @pytest.mark.parametrize(
+        ("response_kwargs", "case"),
+        [
+            ({}, "absent"),
+            (
+                {
+                    "extra_headers": {
+                        "X-Ratelimit-Remaining": "not-a-number",
+                        "X-Ratelimit-Reset": "garbage",
+                    }
+                },
+                "malformed",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_no_header_driven_sync(
+        self,
+        mock_wrapped_transport: AsyncMock,
+        response_kwargs: dict[str, Any],
+        case: str,
+    ) -> None:
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            **response_kwargs
+        )
+
+        # Should not raise even on malformed headers.
+        await transport.handle_async_request(_make_request())
+
+        assert transport._estimated_remaining == 59, f"case={case}"
+        assert transport._reset_gate.is_set(), f"case={case}"
+
+
+@pytest.mark.unit
+class TestRateLimitTransport5xx:
+    """Server errors must not be misread as rate-limit signals."""
+
+    @pytest.mark.asyncio
+    async def test_5xx_without_rate_headers_does_not_engage(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+        mock_wrapped_transport.handle_async_request.return_value = _build_response(
+            status=502
+        )
+
+        await transport.handle_async_request(_make_request())
+
+        # No rate-limit headers ⇒ no header-driven sync regardless of status
+        # code. The optimistic per-request decrement still fires (it tracks
+        # what the server saw, independent of the response shape). Gate stays
+        # open since no remaining=0 signal arrived.
+        assert transport._estimated_remaining == 59
+        assert transport._reset_gate.is_set()
+
+
+@pytest.mark.unit
+class TestRateLimitTransportStreaming:
+    """A streaming response object should pass through the limiter unchanged."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_response_pass_through(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """The transport shouldn't read or consume the response body."""
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=60,
+        )
+
+        streaming_response = _build_response(remaining=50, reset_offset_seconds=30)
+        mock_wrapped_transport.handle_async_request.return_value = streaming_response
+
+        result = await transport.handle_async_request(_make_request())
+
+        # Same object returned — limiter only inspects headers, not body.
+        assert result is streaming_response
+
+
+def _chain_has_rate_limit(client: KatanaClient) -> bool:
+    """Walk the transport stack on ``client``'s underlying httpx client.
+
+    Returns True iff a ``RateLimitTransport`` is found anywhere in the chain.
+    Each transport class stores its inner transport under a different attr —
+    ``_wrapped_transport`` for our own layers, ``_async_transport`` for
+    httpx-retries' ``RetryTransport``.
+    """
+    async_client = client.get_async_httpx_client()
+    transport: object = async_client._transport
+    while transport is not None:
+        if isinstance(transport, RateLimitTransport):
+            return True
+        # Use getattr because pyright won't narrow on hasattr for private
+        # attrs; sentinel pattern keeps type-checker happy without casts.
+        sentinel = object()
+        next_transport = getattr(transport, "_wrapped_transport", sentinel)
+        if next_transport is sentinel:
+            next_transport = getattr(transport, "_async_transport", sentinel)
+        if next_transport is sentinel:
+            return False
+        transport = next_transport
+    return False
+
+
+@pytest.mark.unit
+class TestRateLimitTransportOptOut:
+    """``requests_per_minute=None`` on ``KatanaClient`` omits the layer entirely."""
+
+    def test_none_omits_layer(self) -> None:
+        """When opted out, the chain has no RateLimitTransport instance."""
+        client = KatanaClient(
+            api_key="test-key",
+            base_url="https://api.example.test",
+            requests_per_minute=None,
+        )
+
+        assert not _chain_has_rate_limit(client), (
+            "RateLimitTransport should not be in the chain when requests_per_minute=None"
+        )
+
+    def test_default_includes_layer(self) -> None:
+        """Default constructor (rpm=60) puts a RateLimitTransport in the chain."""
+        client = KatanaClient(
+            api_key="test-key",
+            base_url="https://api.example.test",
+        )
+        assert _chain_has_rate_limit(client), (
+            "RateLimitTransport should be in the default chain (rpm=60 default)"
+        )
+
+
+@pytest.mark.unit
+class TestRateLimitTransportComposition:
+    """RateLimit + Pagination compose cleanly (no retry — that's the integration test in test_rate_limit_retry.py)."""
+
+    @pytest.mark.asyncio
+    async def test_pagination_through_rate_limiter(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """Each paginated page acquires its own token from the limiter.
+
+        Builds the actual stack pattern (rate-limit innermost, pagination
+        outside), fires a paginated request, and verifies that pagination
+        triggered N HTTP calls — each of which went through the limiter.
+        """
+        rate_limit = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=600,  # 10/sec — plenty for a 2-page test
+        )
+        pagination = PaginationTransport(
+            wrapped_transport=rate_limit,
+            max_pages=10,
+        )
+
+        page1 = MagicMock(spec=httpx.Response)
+        page1.status_code = 200
+        page1.headers = {
+            "X-Ratelimit-Remaining": "59",
+            "X-Ratelimit-Reset": str(int((time.time() + 60) * 1000)),
+        }
+        page1.json.return_value = {
+            "data": [{"id": 1}, {"id": 2}],
+            "pagination": {"page": 1, "total_pages": 2},
+        }
+
+        async def aread1() -> None:
+            return None
+
+        page1.aread = aread1
+
+        page2 = MagicMock(spec=httpx.Response)
+        page2.status_code = 200
+        page2.headers = {
+            "X-Ratelimit-Remaining": "58",
+            "X-Ratelimit-Reset": str(int((time.time() + 60) * 1000)),
+        }
+        page2.json.return_value = {
+            "data": [{"id": 3}],
+            "pagination": {"page": 2, "total_pages": 2},
+        }
+
+        async def aread2() -> None:
+            return None
+
+        page2.aread = aread2
+
+        mock_wrapped_transport.handle_async_request.side_effect = [page1, page2]
+
+        await pagination.handle_async_request(
+            httpx.Request("GET", "https://api.example.test/items")
+        )
+
+        # Two HTTP calls (one per page), each acquired a token. The limiter's
+        # estimate should reflect the latest header (58 from page 2).
+        assert mock_wrapped_transport.handle_async_request.call_count == 2
+        assert rate_limit._estimated_remaining == 58
+
+
+@pytest.mark.unit
+class TestRateLimitTransportConcurrency:
+    """Concurrent observe_response calls are serialized by the lock."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_responses_use_lock(
+        self, mock_wrapped_transport: AsyncMock
+    ) -> None:
+        """Fire multiple requests concurrently; estimate stays bounded by lowest remaining.
+
+        Each request optimistically decrements the estimate (-1) and each
+        response can sync-down to a lower value, but neither path is allowed
+        to sync upward. The exact final value depends on async interleaving
+        (a request can decrement before *or* after another request's
+        sync-down completes), so the assertion is a *bound*: the final
+        estimate must be at most the lowest reported ``remaining`` value
+        (5 in this fixture). Going above 5 would prove the lock failed
+        and one update overwrote a fresher (lower) one.
+        """
+        transport = RateLimitTransport(
+            wrapped_transport=mock_wrapped_transport,
+            requests_per_minute=600,
+        )
+
+        responses = [
+            _build_response(remaining=10, reset_offset_seconds=60),
+            _build_response(remaining=5, reset_offset_seconds=60),
+            _build_response(remaining=8, reset_offset_seconds=60),
+        ]
+        mock_wrapped_transport.handle_async_request.side_effect = responses
+
+        await asyncio.gather(
+            transport.handle_async_request(_make_request()),
+            transport.handle_async_request(_make_request()),
+            transport.handle_async_request(_make_request()),
+        )
+
+        assert transport._estimated_remaining <= 5, (
+            "concurrent updates must respect the lowest reported remaining "
+            f"(got {transport._estimated_remaining}, expected ≤5)"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1314,6 +1314,7 @@ dependencies = [
     { name = "httpx" },
     { name = "httpx-retries" },
     { name = "pydantic" },
+    { name = "pyrate-limiter" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "sqlmodel" },
@@ -1327,6 +1328,7 @@ dev = [
     { name = "build" },
     { name = "datamodel-code-generator" },
     { name = "katana-mcp-server" },
+    { name = "looptime" },
     { name = "mdformat" },
     { name = "mdformat-gfm" },
     { name = "mdformat-tables" },
@@ -1377,6 +1379,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx-retries", specifier = ">=0.4.5" },
     { name = "katana-mcp-server", marker = "extra == 'dev'", editable = "katana_mcp_server" },
+    { name = "looptime", marker = "extra == 'dev'", specifier = ">=0.7" },
     { name = "mdformat", marker = "extra == 'dev'", specifier = ">=0.7.21" },
     { name = "mdformat-gfm", marker = "extra == 'dev'", specifier = ">=0.4.1" },
     { name = "mdformat-tables", marker = "extra == 'dev'", specifier = ">=1.0.0" },
@@ -1391,6 +1394,7 @@ requires-dist = [
     { name = "openapi-spec-validator", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.0" },
     { name = "pydantic", specifier = ">=2.12.0" },
+    { name = "pyrate-limiter", specifier = ">=3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -1471,6 +1475,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/ac/34cbfb433a10e28c7fd830f91c5a348462ba748413cbb950c7f259e67aa7/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0a83c6f7a6b2bfc11ef3ed67f8cbe99f8ff500b05655d8e7df9aab993a6abc95", size = 69529, upload-time = "2025-08-22T13:49:55.29Z" },
     { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload-time = "2025-08-22T13:49:56.35Z" },
     { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload-time = "2025-08-22T13:49:57.302Z" },
+]
+
+[[package]]
+name = "looptime"
+version = "0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/3e/74b54612606b87eedd21820517d206c370888fea8c66d93c05f1f4d4388e/looptime-0.7.tar.gz", hash = "sha256:6b32eab62d2f11af9d2322a0d120054a38b9eb9380383a427a68155cf34963c4", size = 38328, upload-time = "2026-01-03T13:06:26.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/3c/2bec447bf2486dfe8ed9c99d01892d57388b3620883d2374b975f36f1963/looptime-0.7-py3-none-any.whl", hash = "sha256:efb3916196dbbe943a7f2853d79647e4476a5dd149306ce2736607d814930327", size = 21890, upload-time = "2026-01-03T13:06:24.785Z" },
 ]
 
 [[package]]
@@ -2447,6 +2460,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pyrate-limiter"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/0c/6e78218e6ef726be35a4c0a5e2e281e36ddd940566800219e96d13de99ad/pyrate_limiter-4.1.0.tar.gz", hash = "sha256:be1ac413a263aa410b98757d1b01a880650948a1fc3a959512f15865eb58dbf3", size = 306136, upload-time = "2026-03-22T14:43:03.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/fd/57181fafae08385d00ea2702be246ab8035352a0a8e1f63391c2bcad74d4/pyrate_limiter-4.1.0-py3-none-any.whl", hash = "sha256:2696b4e4a6cffb3d40fc76662baccb766697893f0979e12bebbfc7d3b6b19603", size = 38197, upload-time = "2026-03-22T14:43:01.975Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `RateLimitTransport` to the resilient transport stack — proactively throttles every outgoing request against Katana's documented 60-req/min budget using `pyrate-limiter`.
- Adapts to `X-Ratelimit-Remaining` / `X-Ratelimit-Reset` response headers: drains the local bucket when the server reports fewer remaining tokens (other clients sharing the API key), and engages an `asyncio.Event` reset-gate when remaining hits 0.
- Closes the gap where `respect_retry_after_header=True` was configured but never exercised in tests — adds integration tests verifying both numeric and HTTP-date `Retry-After` formats are honored.
- Removes the now-redundant `_STOCK_FETCH_CONCURRENCY` semaphore in `reporting.py` (separate commit).

Closes #590. Foundational dep for #463 / #592.

## Behavior

- Default: 60 req/min budget, applied to every actual HTTP request (including retries and per-page paginated fetches — Katana counts each).
- Configurable via `KatanaClient(requests_per_minute=N)`.
- Opt out via `requests_per_minute=None`.
- Retry-After waiting stays in `RetryTransport` (urllib3.Retry) — no double-sleep from the rate-limit transport on 429s.

## Stack placement

```
RetryTransport            ← outermost, owns Retry-After waiting
  ↓
PaginationTransport
  ↓
ErrorLoggingTransport
  ↓
RateLimitTransport        ← NEW
  ↓
AsyncHTTPTransport        ← innermost actual HTTP
```

## Design notes

- Direct `pyrate-limiter` dep, not `httpx-limiter` — its `AbstractRateLimiterRepository` is for distributed Redis-backed scenarios and provides no hook for response-header observation, so we'd be wrapping it anyway.
- Sync-down only (never up) on header observation — out-of-order responses can't overwrite a fresher (lower) estimate.
- Reset-gate uses `asyncio.Event` because pyrate's bucket clock doesn't naturally align with Katana's window — the gate is the override that enforces "block until server's reset elapses."
- Defensive header parsing: missing/malformed values are no-ops (auth flows and redirect endpoints often omit them).
- Concurrent response handling serialized by an internal `asyncio.Lock`.

## Test plan

- [x] All 2,919 existing tests pass
- [x] 18 new tests in `tests/test_rate_limit_transport.py` — init validation, acquire-before-forward, sync-down, reset-gate, header absence, malformed headers, 5xx, streaming responses, opt-out, composition with `PaginationTransport`, concurrent-response serialization
- [x] 3 new integration tests in `tests/test_rate_limit_retry.py` — confirms `respect_retry_after_header=True` actually delays retries (numeric + HTTP-date formats + sanity check that absent header falls back to backoff)
- [x] `uv run --extra docs poe check` clean (lint + ty + format + tests)

## Out of scope (filed separately)

- #594 — TS-client parallel work (mirrors this design with `bottleneck`/`p-throttle`)
- #591 — bulk upsert in `_sync_one_locked`
- #592 — filtered write-through cache fetches (the cache-side win for #463)
- #593 — background cache warm-up at MCP lifespan startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)