### PR TITLE
fix(mcp): make typed cache safe for concurrent MCP server processes

### DIFF
--- a/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
@@ -9,10 +9,12 @@ fetch).
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from collections import defaultdict
 from pathlib import Path
 
 from platformdirs import user_cache_dir
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel
@@ -38,6 +40,25 @@ assert _manufacturing_mod is not None
 assert _purchase_orders_mod is not None
 
 _DEFAULT_DB_PATH = Path(user_cache_dir("katana-mcp")) / "typed_cache.db"
+
+
+def _apply_sqlite_pragmas(dbapi_conn: sqlite3.Connection, _record: object) -> None:
+    """Per-connection PRAGMAs for the file-backed typed cache.
+
+    Multiple MCP server processes (Claude Desktop + worktrees) share the
+    same SQLite file. WAL lets concurrent readers coexist with a writer;
+    ``busy_timeout`` makes a contended writer wait instead of failing
+    immediately with ``database is locked``; ``synchronous=NORMAL`` is
+    the standard pairing with WAL. Registered via ``event.listen`` on
+    the file-backed engine so every checked-out connection has them.
+    """
+    cursor = dbapi_conn.cursor()
+    try:
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA busy_timeout=5000")
+        cursor.execute("PRAGMA synchronous=NORMAL")
+    finally:
+        cursor.close()
 
 
 class TypedCacheEngine:
@@ -118,6 +139,8 @@ class TypedCacheEngine:
             self._engine = create_async_engine(
                 f"sqlite+aiosqlite:///{db_path}",
             )
+            event.listen(self._engine.sync_engine, "connect", _apply_sqlite_pragmas)
+
         async with self._engine.begin() as conn:
             await conn.run_sync(SQLModel.metadata.create_all)
 

--- a/katana_mcp_server/tests/test_typed_cache.py
+++ b/katana_mcp_server/tests/test_typed_cache.py
@@ -72,6 +72,33 @@ class TestLifecycle:
         # Second close must not raise.
         await engine.close()
 
+    @pytest.mark.asyncio
+    async def test_file_backed_engine_uses_wal_and_busy_timeout(self, tmp_path: Path):
+        """File-backed engines apply WAL + busy_timeout PRAGMAs.
+
+        Multiple MCP server processes (Claude Desktop + worktrees) share
+        ``typed_cache.db``. Without WAL, a long-running reader blocks
+        every writer; without ``busy_timeout`` the loser of a write
+        contention raises ``database is locked`` immediately. Both must
+        be applied on every checked-out connection.
+        """
+        from sqlalchemy import text
+
+        engine = TypedCacheEngine(db_path=tmp_path / "test.db")
+        await engine.open()
+        try:
+            async with engine.session() as session:
+                conn = await session.connection()
+                journal = (await conn.execute(text("PRAGMA journal_mode"))).scalar()
+                busy = (await conn.execute(text("PRAGMA busy_timeout"))).scalar()
+                synchronous = (await conn.execute(text("PRAGMA synchronous"))).scalar()
+            assert journal == "wal"
+            assert busy == 5000
+            # synchronous=NORMAL is enum value 1.
+            assert synchronous == 1
+        finally:
+            await engine.close()
+
 
 class TestSyncState:
     """SyncState upsert / read roundtrip."""


### PR DESCRIPTION
## Summary

Multiple MCP server processes share `~/Library/Caches/katana-mcp/typed_cache.db` — Claude Desktop's MCP plus one per Claude Code worktree. I observed five `python` processes holding the file simultaneously today.

The legacy `cache.db` (`katana_mcp/cache.py`) already enables `journal_mode=WAL` + `synchronous=NORMAL`, but `typed_cache.db` (`typed_cache/engine.py`) fell back to SQLite defaults: rollback journal mode and `busy_timeout=0`. Under those defaults:

- A long-running reader holds SHARED and blocks every writer
- A blocked writer raises `database is locked` immediately, with no retry

So a `rebuild_cache` from one process can race a `list_manufacturing_orders` from another and lose. The per-process `asyncio.Lock` in `TypedCacheEngine.lock_for()` only serializes within a single process — it's invisible to other MCP instances.

## Changes

- `katana_mcp_server/src/katana_mcp/typed_cache/engine.py`: register a SQLAlchemy `connect` event listener on the file-backed engine that applies `journal_mode=WAL`, `busy_timeout=5000`, and `synchronous=NORMAL` on every checked-out connection. In-memory engines used by tests are unaffected.
- `katana_mcp_server/tests/test_typed_cache.py`: regression test that opens a real file-backed engine and reads back the three PRAGMAs through a session, so a future refactor can't silently revert.

## Test plan

- [x] `uv run poe check` — 2885 passed, 2 skipped
- [x] New regression test `test_file_backed_engine_uses_wal_and_busy_timeout` passes
- [x] All existing typed_cache tests (22) still pass
- [ ] Post-merge: re-check `~/Library/Caches/katana-mcp/typed_cache.db` PRAGMAs via `sqlite3 typed_cache.db 'PRAGMA journal_mode; PRAGMA busy_timeout;'` after the next MCP server start, expect `wal` and `5000`

## Out of scope

The deeper architectural question — N MCP processes each independently syncing against Katana, wasting API quota and dueling on `rebuild_cache` — remains. Worth a follow-up issue (per-worktree cache files, or worktree MCPs connecting to the Desktop instance instead of spawning their own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)