### PR TITLE
docs(KATANA_API_QUESTIONS): add §7 (stock_transfer/stock_adjustment immutability) + sweep stale entries

### DIFF
--- a/docs/KATANA_API_QUESTIONS.md
+++ b/docs/KATANA_API_QUESTIONS.md
@@ -365,6 +365,109 @@ Katana fixes the asymmetry, the echo becomes a no-op write.
 
 ______________________________________________________________________
 
+## 7. Stock Transfer & Stock Adjustment — Row Immutability + DELETE Behavior
+
+### 7.1 Stock-transfer / stock-adjustment rows are immutable post-creation
+
+**Status: CONFIRMED via 3-source spec agreement on 2026-05-07**
+
+`PATCH /stock_transfers/{id}` and `PATCH /stock_adjustments/{id}` both accept *header
+fields only* — neither schema includes a `stock_transfer_rows` / `stock_adjustment_rows`
+property, and both declare `additionalProperties: false`. There are also no row-level
+endpoints (`/stock_transfer_rows/{id}`, `/stock_adjustment_rows/{id}`) on any source we
+have. Confirmed across:
+
+- `docs/katana-openapi.yaml` (local)
+- `docs/upstream-specs/live-gateway.yaml` (Katana's API gateway)
+- `docs/upstream-specs/readme-portal.yaml` (Katana's public portal)
+
+**Practical implication:** Once a stock transfer or stock adjustment is created, its
+variant + quantity rows can't be edited. The only API-sanctioned correction paths are:
+
+1. Post compensating `create_stock_adjustment` call(s) that reverse or amend the prior
+   inventory delta. The shape depends on which entity got it wrong:
+
+   - **Stock adjustment** is already location-scoped, so a single compensating
+     adjustment at the same `location_id` undoes the original delta.
+   - **Stock transfer** moves inventory between two locations, so reversing it requires
+     **two** compensating adjustments — one at the source location to restore the
+     outflow, one at the target location to remove the inflow. (Both adjustments should
+     share matching `reason` text so the audit trail traces back to the same correction
+     event.)
+
+   The original record stays as the audit trail of what was *intended*; the compensating
+   adjustment(s) record what was *fixed*. This is the path the MCP `correct_*` family
+   deliberately does **not** cover for ST/SA — the reasoning is captured in #533 and the
+   (in-flight) help-resource update tracked under #602.
+
+1. `DELETE` the record and re-create with corrected rows — see open question §7.2.
+
+**Why this is asymmetric with PO/SO/MO:** Purchase orders, sales orders, and
+manufacturing orders all expose row-level PATCH endpoints (`/purchase_order_rows/{id}`,
+`/sales_order_rows/{id}`, `/manufacturing_order_recipe_rows/{id}`), which is what makes
+the reopen → modify → restore pattern work for them (`correct_manufacturing_order` /
+`correct_sales_order` / `correct_purchase_order` shipped in PR #536, #546, #595). Stock
+transfer and stock adjustment have no equivalent surface, so the same pattern can't
+apply.
+
+**Asks:**
+
+1. Confirm whether row-level CRUD is intentionally absent from the API surface for
+   stock_transfer and stock_adjustment, or if it's an oversight.
+1. If a future DTO change will add `stock_transfer_rows` / `stock_adjustment_rows` to
+   the PATCH body (or expose row-level endpoints), please flag it — our spec + tools
+   would track that change.
+
+### 7.2 DELETE behavior on already-applied stock_transfer / stock_adjustment is unverified
+
+**Status: OPEN — needs live-API verification**
+
+Both `DELETE /stock_transfers/{id}` and `DELETE /stock_adjustments/{id}` are documented
+on every spec source, but the **response code disagrees across sources**:
+
+- `docs/katana-openapi.yaml` (local) → `204`
+- `docs/upstream-specs/readme-portal.yaml` (Katana's public portal) → `204`
+- `docs/upstream-specs/live-gateway.yaml` (Katana's API gateway) → `200`
+
+The two upstream sources disagree, so we don't actually know what the live API returns
+on success. Worth resolving as part of the live-API check below — most likely `204`
+(matching the public portal and what our spec already declares), with the gateway spec
+out of sync, but worth confirming. (If it's `200`, the spec needs to declare a body
+schema for the DELETE response, since `204` means no content.)
+
+What's also unclear is the inventory-effect side of the delete:
+
+1. **Stock transfers in `received` status** have already moved inventory from source →
+   target location. Does DELETE reverse the inventory move, leave it in place, or
+   422-refuse?
+1. **Stock adjustments** apply their inventory delta on creation. Does DELETE reverse
+   the delta?
+1. **Audit-trail preservation:** Even if DELETE 204s, do the historical
+   `inventory_movements` rows associated with the deleted record stay queryable, or are
+   they removed too?
+
+**Why it matters:** A `correct_stock_transfer` or `correct_stock_adjustment` tool
+implemented via "delete + recreate with corrected rows" depends on these behaviors.
+Without confirmation, we don't know if the workaround is safe to expose or whether it'd
+silently corrupt inventory. If reversal is automatic, delete-and-recreate becomes a
+viable correction pattern; if not, the compensating-adjustment pattern (§7.1) remains
+the only safe option.
+
+**Asks:**
+
+1. Confirm the canonical DELETE success status code (`200` or `204`) so the spec sources
+   can be reconciled.
+1. Document the DELETE side-effects on each entity per status (where applicable):
+   - Does DELETE on a `received` stock_transfer reverse the inventory move?
+   - Does DELETE on any stock_adjustment reverse the inventory delta?
+   - Are historical `inventory_movements` rows preserved or removed when their parent is
+     deleted?
+1. If reversal is *not* automatic, document that explicitly so we can warn operators in
+   the MCP wrapper before they delete a record assuming the inventory effect will roll
+   back.
+
+______________________________________________________________________
+
 ## Resolved Issues (FYI)
 
 Issues discovered and fixed during P1-P4 alignment, documented here for reference:

--- a/docs/KATANA_API_QUESTIONS.md
+++ b/docs/KATANA_API_QUESTIONS.md
@@ -1,8 +1,14 @@
 # Katana API Questions
 
 Questions and inconsistencies discovered during P1-P4 OpenAPI spec alignment (Katana
-spec dated 2026-01-20, 104 paths). Each was investigated against the live API on
-2026-02-07.
+spec dated 2026-01-20, 104 paths). Each was originally investigated against the live API
+on 2026-02-07.
+
+**Doc state:** swept 2026-05-07 — entries cross-checked against the current local spec
+plus `docs/upstream-specs/live-gateway.yaml` and
+`docs/upstream-specs/readme-portal.yaml`. "Last verified" lines on each still-open entry
+note the date and method (spec-only vs live-API). Resolved entries moved to the Resolved
+Issues table at the bottom.
 
 ______________________________________________________________________
 
@@ -24,67 +30,50 @@ read-only on materials, despite being writable on products.
 correct as-is. This may be a product-line decision (materials inherit these properties
 from the products they're consumed by), but it's worth confirming with Katana.
 
+**Last verified:** 2026-05-07 (spec-only — `MaterialUpdateDto` in
+`docs/upstream-specs/live-gateway.yaml` still excludes both fields; live-API
+re-verification not re-run).
+
 ### 1.2 `MaterialConfig` schema requires `id` and `material_id` on CREATE
 
-**Status: CONFIRMED - spec error, API does not require them**
+**Status: CONFIRMED — spec error; needs follow-up in our local spec**
 
 `CreateMaterialRequest.configs` references the `MaterialConfig` schema, which has `id`
 and `material_id` as required fields. These values don't exist yet when creating a new
 material.
 
-**Investigation:** Created a material with configs containing only `name` and `values`
-(no `id` or `material_id`). The API accepted it (200 OK) and returned the created
-configs with server-generated `id` and `product_id` values.
+**Investigation (2026-02-07):** Created a material with configs containing only `name`
+and `values` (no `id` or `material_id`). The API accepted it (200 OK) and returned the
+created configs with server-generated identifier fields populated. (The original note
+recorded `product_id` as the parent-ID field name on the response — possibly a typo,
+possibly accurate if Katana's wire shape uses `product_id` even on a material's configs.
+Worth confirming on the next live-API sweep tracked under #603.)
 
-**Conclusion:** Confirmed spec error. The Katana API spec's `MaterialConfig` schema
-over-specifies the create case. Our spec already uses the simplified inline schema for
-create, which matches reality.
+**Live spec (2026-05-07 cross-check):** `live-gateway.yaml` uses an inline
+`ItemVariantConfigDto` (only `values` is required; `id` and `name` are optional).
+
+**Status of fix in our local spec:** This entry's earlier conclusion claimed *"Our spec
+already uses the simplified inline schema for create, which matches reality."* That's
+not currently true: `docs/katana-openapi.yaml` `CreateMaterialRequest.configs` still
+$refs the over-specified `MaterialConfig` schema. The reality and the upstream spec
+agree on the simplified shape; our local spec hasn't been updated yet. **Action:**
+follow-up spec PR to switch to the inline shape (or define a sibling
+`MaterialConfigCreate` and ref it from `CreateMaterialRequest`).
+
+**Last verified:** 2026-05-07 (spec-only).
 
 ### 1.3 Manufacturing Order cannot be linked to Sales Order via create/update
 
-**Status: RESOLVED - use `/manufacturing_order_make_to_order`**
-
-The Manufacturing Order response includes `sales_order_id`, `sales_order_row_id`, and
-`sales_order_delivery_deadline`, but none of these fields appear in the Create or Update
-request schemas.
-
-**Investigation:**
-
-- `PATCH /manufacturing_orders/{id}` with `sales_order_id` returns 422
-  `additionalProperties` - the field is truly not settable via update.
-- `POST /manufacturing_order_make_to_order` exists and accepts
-  `{"sales_order_row_id": <id>, "create_subassemblies": <bool>}`. This is the linking
-  mechanism - it creates a new MO already linked to a sales order row.
-- `POST /manufacturing_order_unlink` exists and accepts `{"sales_order_row_id": <id>}`
-  to break the link.
-- There is no way to link an *existing* unlinked MO to a sales order. The flow is:
-  create-linked (make_to_order) or create-unlinked (regular create), then optionally
-  unlink.
-
-**Conclusion:** The API design is intentional. Linking is one-way at creation time via
-`/manufacturing_order_make_to_order`. Our spec already documents both endpoints
-correctly. The original question about a missing "link" endpoint is answered: linking
-only happens at MO creation, not post-hoc.
+*Moved to the Resolved Issues table — `/manufacturing_order_make_to_order` is the
+linking endpoint. Linking only happens at MO creation; there is no post-hoc link
+endpoint by design.*
 
 ### 1.4 Purchase Order `status` in CREATE only accepts one value
 
-**Status: CONFIRMED - only `NOT_RECEIVED` allowed, field is optional**
-
-`CreatePurchaseOrderRequest` includes a `status` field, but the only valid value is
-`NOT_RECEIVED`.
-
-**Investigation:**
-
-- `POST /purchase_orders` without a `status` field succeeds (200 OK), and the created PO
-  has `status: "NOT_RECEIVED"` automatically.
-- `POST /purchase_orders` with `status: "NOT_RECEIVED"` also succeeds identically.
-- `POST /purchase_orders` with `status: "PARTIALLY_RECEIVED"` returns 422 with
-  `allowedValues: ["NOT_RECEIVED"]`.
-
-**Conclusion:** The field is optional and defaults to `NOT_RECEIVED`. Including it is
-harmless but pointless. This appears to be a Katana API design choice (consistent schema
-shape between create/update) rather than a bug. Our spec correctly documents the enum
-constraint.
+*Moved to the Resolved Issues table — Katana now accepts `DRAFT` and `NOT_RECEIVED` on
+`POST /purchase_orders`. The 2026-02-07 finding (only `NOT_RECEIVED`) is no longer
+current; both `live-gateway.yaml` and our local `CreatePurchaseOrderInitialStatus` enum
+list `[DRAFT, NOT_RECEIVED]` as of 2026-05-07.*
 
 ______________________________________________________________________
 
@@ -104,6 +93,13 @@ wrapped in `{"data": [...]}` like other list endpoints.
 **Conclusion:** Cannot verify field naming with no data. The raw-array response format
 is another non-standard pattern worth noting. If bin locations are ever configured in
 the test account, this should be re-investigated.
+
+**Cross-reference:** The raw-array response shape (no `{"data": [...]}` wrapper) is now
+tracked separately as #575
+(`bug(client): /bin_locations returns bare array, not StorageBinListResponse wrapper`).
+The `name` vs `bin_name` portion of this question remains open.
+
+**Last verified:** 2026-05-07 (spec-only — no live data to test against).
 
 ### 2.2 `ProductOperationRow` uses `product_operation_row_id` instead of `id`
 
@@ -126,6 +122,10 @@ The `ProductOperationRow` fields are: `product_operation_row_id`, `product_id`,
 **Conclusion:** This is confirmed as a real inconsistency in the Katana API - not a spec
 error on our side. The product operation row is the only resource that uses a
 non-standard primary key naming convention.
+
+**Last verified:** 2026-05-07 (spec-only — `product_operation_row_id` still appears as
+the key field in our local `ProductOperationRow` schema and as a query parameter in
+`live-gateway.yaml`).
 
 ______________________________________________________________________
 
@@ -154,26 +154,22 @@ ______________________________________________________________________
 system presets. Factory settings and operators are UI-managed. Our spec correctly
 documents them as GET-only.
 
+**MCP exposure update (2026-05-07):** PR #589 added `list_locations`, `list_suppliers`,
+`list_tax_rates`, `list_operators`, and `list_additional_costs` MCP tools (read-only
+wrappers around the existing `katana://...` resources). This doesn't change the API
+surface — these endpoints remain GET-only on the Katana side; the new MCP tools just
+make the read surface more discoverable to LLM agents.
+
+**Last verified:** 2026-05-07 (spec-only — `live-gateway.yaml` shows only `get` for
+`/factory`, `/operators`, and `/additional_costs`).
+
 ______________________________________________________________________
 
 ## 4. Nullable Field Semantics
 
-### 4.1 Variant `lead_time` and `minimum_order_quantity` null semantics
-
-**Status: CLARIFIED - null means "not set"**
-
-**Investigation:**
-
-- Out of 250 variants sampled, 249 had `lead_time: null` and all 250 had
-  `minimum_order_quantity: null`. Only one variant had `lead_time: 10`.
-- `PATCH /variants/{id}` with `lead_time: 0` succeeds - the response shows
-  `lead_time: 0` (integer zero, distinct from null).
-- `PATCH /variants/{id}` with `lead_time: null` succeeds - the response shows
-  `lead_time: null`.
-
-**Conclusion:** `null` means "not configured / no value set" rather than a meaningful
-zero or "N/A". The API correctly distinguishes between `0` (explicit zero) and `null`
-(not set). This is consistent with standard nullable semantics. No spec change needed.
+*Section retired — only entry (§4.1 Variant `lead_time` / `minimum_order_quantity` null
+semantics) was clarified during the original 2026-02-07 investigation; moved to the
+Resolved Issues table.*
 
 ______________________________________________________________________
 
@@ -201,6 +197,9 @@ combination. The POST "creates" forecast overrides for specific periods, and DEL
 "clears" overrides for specific periods. This design makes sense when understood as a
 calculation API rather than a REST resource. No spec change needed, but worth
 documenting the different mental model.
+
+**Last verified:** 2026-05-07 (spec-only — `live-gateway.yaml` shows the same
+non-standard shape; no live-API re-test).
 
 ______________________________________________________________________
 
@@ -322,14 +321,18 @@ Each was verified by:
 Test records used (all deleted post-verification): Material 17042013, Product 17042018,
 MO 16647058, StockAdjustment 2394711.
 
-Two other candidates couldn't be tested in this round and remain unverified:
+Two other candidates couldn't be tested in the original round and were noted as blocked.
+Both blockers have since shipped — these are now testable, follow-up verification
+pending:
 
-- **SalesOrder** — blocked by a separate spec bug (`SalesOrderStatus` enum is missing
-  `PENDING`); newly-created SOs can't be ingested through our cache. Test SO created on
-  Katana but ID unobservable; needs manual cleanup. (Filed as a separate spec issue.)
-- **StockTransfer** — blocked by `create_stock_transfer` returning an opaque 422 on the
-  execute path (preview accepts the same payload). Same shape as `create_purchase_order`
-  requires `status` (#499). Filed as a separate issue.
+- **SalesOrder** — was blocked by missing `PENDING` in `SalesOrderStatus`. Fixed in PR
+  #524 (closed #516). Ready for re-test against the wipe-on-PATCH question.
+- **StockTransfer** — was blocked by `create_stock_transfer` returning opaque 422 on the
+  execute path (#499 / #517). The 422 opacity was fixed in PR #578 (rewrote
+  `ValidationErrorDetail` to match Katana's Ajv-style wire shape). Ready for re-test.
+
+A live-API re-run that extends the §6.2 wipe table to cover SO and ST should be paired
+with the broader doc sweep tracked under #603.
 
 **Conclusion:** This is a platform-wide PATCH-merge bug, not a one-off on PurchaseOrder.
 Whatever is treating omitted `additional_info` as a null-write is doing so consistently
@@ -472,12 +475,15 @@ ______________________________________________________________________
 
 Issues discovered and fixed during P1-P4 alignment, documented here for reference:
 
-| Issue                                                                              | Resolution                                               |
-| ---------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| PurchaseOrderAccountingMetadata used camelCase field names                         | Fixed to snake_case to match actual API responses        |
-| StockAdjustment field renames (`adjustment_date` -> `stock_adjustment_date`, etc.) | Updated spec to match actual field names                 |
-| SalesOrderFulfillment schema overhaul                                              | ~8 fields removed, ~10 added to match actual API         |
-| SalesReturnRow field corrections                                                   | Updated to match actual response structure               |
-| 7 schemas incorrectly used UpdatableEntity                                         | Upgraded to DeletableEntity where DELETE endpoints exist |
-| PriceList phantom fields (`currency`, `end_date`, etc.)                            | Removed fields not present in actual API responses       |
-| StockTransfer/StockAdjustment had status enums                                     | Removed - these resources use free-form status strings   |
+| Issue                                                                              | Resolution                                                                                                                                                               |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| PurchaseOrderAccountingMetadata used camelCase field names                         | Fixed to snake_case to match actual API responses                                                                                                                        |
+| StockAdjustment field renames (`adjustment_date` -> `stock_adjustment_date`, etc.) | Updated spec to match actual field names                                                                                                                                 |
+| SalesOrderFulfillment schema overhaul                                              | ~8 fields removed, ~10 added to match actual API                                                                                                                         |
+| SalesReturnRow field corrections                                                   | Updated to match actual response structure                                                                                                                               |
+| 7 schemas incorrectly used UpdatableEntity                                         | Upgraded to DeletableEntity where DELETE endpoints exist                                                                                                                 |
+| PriceList phantom fields (`currency`, `end_date`, etc.)                            | Removed fields not present in actual API responses                                                                                                                       |
+| StockTransfer/StockAdjustment had status enums                                     | Removed - these resources use free-form status strings                                                                                                                   |
+| §1.3 — MO ↔ SO linking via PATCH                                                   | API design: linking is one-way at MO creation via `POST /manufacturing_order_make_to_order`. No post-hoc link endpoint exists by design.                                 |
+| §1.4 — PO CREATE `status` only accepted `NOT_RECEIVED` (2026-02-07)                | Katana now accepts both `DRAFT` and `NOT_RECEIVED` (verified spec-only against `live-gateway.yaml` and our local `CreatePurchaseOrderInitialStatus` enum on 2026-05-07). |
+| §4.1 — Variant `lead_time` / `minimum_order_quantity` null semantics               | Clarified — `null` means "not set" (distinct from `0`). API correctly distinguishes.                                                                                     |


### PR DESCRIPTION
## Summary

Two related doc updates to `docs/KATANA_API_QUESTIONS.md`:

### 1. Added §7 — stock_transfer/stock_adjustment row immutability + DELETE open question

3-source confirmation (local + `live-gateway.yaml` + `readme-portal.yaml`) that `PATCH /stock_transfers/{id}` and `PATCH /stock_adjustments/{id}` accept header fields only, and no row-level CRUD endpoints exist anywhere. Documents *why* the `correct_*` family deliberately excludes ST/SA. §7.2 surfaces the open question of whether DELETE reverses already-applied inventory effects — the answer determines whether a future "delete + recreate with corrected rows" pattern is viable.

### 2. Swept the existing entries (§1–§6) against the upstream specs

Cross-checked each entry against `live-gateway.yaml` + `readme-portal.yaml` and the current local spec on 2026-05-07. Findings:

**Moved to Resolved Issues table:**
- §1.3 — MO ↔ SO linking (confirmed by-design via `/manufacturing_order_make_to_order`).
- §1.4 — PO CREATE status: the 2026-02-07 finding ("only `NOT_RECEIVED` allowed") is **stale**. Both `live-gateway.yaml` and our local `CreatePurchaseOrderInitialStatus` enum now list `[DRAFT, NOT_RECEIVED]`.
- §4.1 — Variant null semantics (clarified — `null` means "not set", distinct from `0`).
- §4 section retired (only entry was §4.1).

**Updated:**
- §1.2 — corrected the prior "our spec is fixed" claim. `CreateMaterialRequest.configs` **still** $refs the over-specified `MaterialConfig` schema; the upstream uses an inline `ItemVariantConfigDto` requiring only `values`. Real follow-up needed.
- §2.1 — cross-referenced #575 for the raw-array bin_locations response.
- §3 — noted PR #589 added `list_*` MCP tools for read-side discovery (no API surface change).
- §6.2 — updated the SalesOrder + StockTransfer "blocked" footnotes; both blockers shipped today (PR #524 fixed `SalesOrderStatus`; PR #578 fixed `create_stock_transfer` 422 opacity). These rows are now testable.

**Added** "Last verified: 2026-05-07 (spec-only)" lines on all still-open entries. Live-API re-verification of behavioral entries (§6.1, §6.2 wipe table extension, §7.2 DELETE side-effects) is the remaining tail and stays open under #603.

## Why bundled

The §7 addition came out of investigating "is correct_stock_transfer really off the table?" The sweep came out of "while we're here, let's not leave 4-month-old findings in place." Both touch the same file and have the same audience.

## Related

- #523 — WS-H umbrella (closed when this PR merges; the family is complete with MO/SO/PO + the documented ST/SA non-coverage).
- #533 — assess `correct_stock_transfer` (closed Done).
- #602 — follow-up to surface the ST/SA non-coverage in `help.py` + tool docstrings.
- #603 — general doc review umbrella (this PR closes the spec-cross-check pass; live-API re-verification remains).
- #604 — this PR.

## Test plan

- [x] `uv run poe agent-check` — clean (mdformat + ruff + ty + pytest all green)
- Doc-only change. No code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)