### PR TITLE
perf(mcp): bulk-upsert cache rows in _sync_one_locked

### DIFF
--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -27,9 +27,12 @@ from collections.abc import Callable, Iterable
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from itertools import batched
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlmodel import delete
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from katana_public_api_client.api.manufacturing_order import (
     get_all_manufacturing_orders,
@@ -199,6 +202,43 @@ def _convert(spec: EntitySpec, attrs_obj: Any) -> tuple[Any, list[Any]]:
     return parent, children
 
 
+# SQLite caps each prepared statement at 999 bound parameters by default.
+# Headroom (900) keeps us safe on older / embedded builds without sacrificing
+# meaningful throughput. Wide schemas (``CachedSalesOrder`` at 33 cols) end up
+# at chunks of ~27; narrow ones (recipe rows at ~13 cols) get ~69 — both
+# orders of magnitude beyond the per-row ``session.merge`` round-trip.
+_SQLITE_PARAM_BUDGET = 900
+
+
+async def _bulk_upsert(session: AsyncSession, table_cls: type, rows: list[Any]) -> None:
+    """One ``INSERT ... ON CONFLICT(id) DO UPDATE`` per chunk; no-op on empty rows.
+
+    Replaces a per-row ``session.merge`` loop (SELECT-then-INSERT-or-UPDATE
+    each) with a chunked bulk upsert. Chunk size is derived from each cache
+    class's column count so we stay under SQLite's bound-parameter cap on
+    wide schemas; narrower tables get larger chunks for free.
+
+    The include-set is driven from ``__table__.columns`` rather than a
+    hardcoded exclude list, so adding a new ``Relationship`` field to a
+    cache class can never silently leak into the values payload.
+    """
+    if not rows:
+        return
+
+    column_names = {col.name for col in table_cls.__table__.columns}
+    chunk_size = max(1, _SQLITE_PARAM_BUDGET // len(column_names))
+
+    # ``model_dump`` per chunk (not eagerly across the whole batch) so a
+    # cold sync of thousands of rows doesn't double-buffer the cache rows
+    # *and* their dict projections in memory before the first INSERT.
+    for chunk in batched(rows, chunk_size):
+        values = [r.model_dump(include=column_names) for r in chunk]
+        stmt = sqlite_insert(table_cls).values(values)
+        update_cols = {c.name: c for c in stmt.excluded if c.name != "id"}
+        stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_cols)
+        await session.exec(stmt)
+
+
 async def _ensure_synced(
     client: KatanaClient, cache: TypedCacheEngine, spec: EntitySpec
 ) -> None:
@@ -293,10 +333,9 @@ async def _sync_one_locked(
 
     async with cache.session() as session:
         # Parents first so child FK constraints resolve on insert.
-        for parent in cached_parents:
-            await session.merge(parent)
-        for child in cached_children:
-            await session.merge(child)
+        await _bulk_upsert(session, spec.cache_cls, cached_parents)
+        if spec.child_cls is not None:
+            await _bulk_upsert(session, spec.child_cls, cached_children)
         # SQLite's DateTime column doesn't preserve tzinfo, so naive
         # UTC on the write side. ``row_count`` is the last-fetch size
         # (not a cumulative total, which would drift since a re-sync

--- a/katana_mcp_server/tests/test_typed_cache_invalidation.py
+++ b/katana_mcp_server/tests/test_typed_cache_invalidation.py
@@ -470,3 +470,180 @@ class TestMergeFilteredFetch:
         async with typed_cache_engine.session() as session:
             result = await session.exec(select(CachedManufacturingOrderRecipeRow))
             assert result.all() == []
+
+
+class TestBulkUpsert:
+    """``_sync_one_locked`` writes parents and children via a chunked bulk upsert
+    (``INSERT ... ON CONFLICT(id) DO UPDATE``) instead of per-row
+    ``session.merge``. These tests pin the contract: idempotency, incremental
+    column updates, no-op on empty fetches, and correctness when row count
+    drives the batch past SQLite's bound-parameter chunk boundary so that
+    multiple ``INSERT`` statements are emitted in one sync.
+    """
+
+    @pytest.mark.asyncio
+    async def test_idempotent_resync(self, typed_cache_engine):
+        """Running the same sync twice produces identical state, no errors."""
+        from sqlmodel import select
+
+        attrs = AttrsPurchaseOrder.from_dict(
+            {
+                "id": 7,
+                "order_no": "PO-IDEMPOTENT-7",
+                "entity_type": "regular",
+                "supplier_id": 1,
+                "currency": "USD",
+                "status": "NOT_RECEIVED",
+                "billing_status": "NOT_BILLED",
+            }
+        )
+        parsed = MagicMock()
+        parsed.data = [attrs]
+        response = MagicMock()
+        response.status_code = 200
+        response.parsed = parsed
+
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+                new=AsyncMock(return_value=response),
+            ),
+            _stub_po_row_sync(),
+        ):
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            result = await session.exec(select(CachedPurchaseOrder))
+            rows = result.all()
+        assert len(rows) == 1
+        assert rows[0].id == 7
+        assert rows[0].order_no == "PO-IDEMPOTENT-7"
+
+    @pytest.mark.asyncio
+    async def test_incremental_column_update(self, typed_cache_engine):
+        """A re-sync with the same id but a different column value updates the row.
+
+        Pins the ``ON CONFLICT DO UPDATE`` half: bulk upsert must overwrite
+        existing column values, not silently ignore the conflict.
+        """
+        async with typed_cache_engine.session() as session:
+            session.add(CachedPurchaseOrder(id=11, order_no="PO-OLD-NAME"))
+            await session.commit()
+
+        attrs = AttrsPurchaseOrder.from_dict(
+            {
+                "id": 11,
+                "order_no": "PO-NEW-NAME",
+                "entity_type": "regular",
+                "supplier_id": 1,
+                "currency": "USD",
+                "status": "NOT_RECEIVED",
+                "billing_status": "NOT_BILLED",
+            }
+        )
+        parsed = MagicMock()
+        parsed.data = [attrs]
+        response = MagicMock()
+        response.status_code = 200
+        response.parsed = parsed
+
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+                new=AsyncMock(return_value=response),
+            ),
+            _stub_po_row_sync(),
+        ):
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedPurchaseOrder, 11)
+            assert cached is not None
+            assert cached.order_no == "PO-NEW-NAME"
+
+    @pytest.mark.asyncio
+    async def test_empty_response_writes_no_rows_no_error(self, typed_cache_engine):
+        """Zero-row response advances ``SyncState`` without a SQL error.
+
+        Bulk insert with an empty values list raises ``CompileError``; the
+        helper's early return guards against that. Also verifies the
+        ``SyncState`` watermark still moves so the next sync is incremental.
+        """
+        from katana_mcp.typed_cache.sync_state import SyncState
+        from sqlmodel import select
+
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.find_purchase_orders.asyncio_detailed",
+                new=AsyncMock(return_value=_empty_response()),
+            ),
+            _stub_po_row_sync(),
+        ):
+            await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            po_rows = (await session.exec(select(CachedPurchaseOrder))).all()
+            state = await session.get(SyncState, "purchase_order")
+        assert po_rows == []
+        assert state is not None
+        assert state.last_synced is not None
+        assert state.row_count == 0
+
+    @pytest.mark.asyncio
+    async def test_bulk_upsert_past_chunking_boundary(self, typed_cache_engine):
+        """Sync 250 recipe rows in one shot — exercises multi-chunk bulk upsert.
+
+        Row count, not column count, drives this case past SQLite's 999
+        bound-parameter cap: ``CachedManufacturingOrderRecipeRow`` is a
+        narrow schema (~13 cols), but 250 rows at ~13 cols each = ~3250
+        params, well over the cap. Confirms the ``itertools.batched``
+        chunking emits multiple ``INSERT ... ON CONFLICT`` statements that
+        together cover the whole batch with no rows dropped.
+        """
+        from katana_mcp.typed_cache.sync import (
+            ensure_manufacturing_order_recipe_rows_synced,
+        )
+        from sqlmodel import func, select
+
+        from katana_public_api_client.models import (
+            ManufacturingOrderRecipeRow as AttrsRecipeRow,
+        )
+        from katana_public_api_client.models_pydantic._generated import (
+            CachedManufacturingOrderRecipeRow,
+        )
+
+        attrs_rows = [
+            AttrsRecipeRow.from_dict(
+                {
+                    "id": i,
+                    "manufacturing_order_id": 1,
+                    "variant_id": 100 + i,
+                    "planned_quantity_per_unit": 1.0,
+                    "total_actual_quantity": 0.0,
+                    "cost": 0.0,
+                }
+            )
+            for i in range(1, 251)
+        ]
+        parsed = MagicMock()
+        parsed.data = attrs_rows
+        response = MagicMock()
+        response.status_code = 200
+        response.parsed = parsed
+
+        with patch(
+            "katana_mcp.typed_cache.sync.get_all_manufacturing_order_recipe_rows.asyncio_detailed",
+            new=AsyncMock(return_value=response),
+        ):
+            await ensure_manufacturing_order_recipe_rows_synced(
+                MagicMock(), typed_cache_engine
+            )
+
+        async with typed_cache_engine.session() as session:
+            count = (
+                await session.exec(
+                    select(func.count()).select_from(CachedManufacturingOrderRecipeRow)
+                )
+            ).one()
+        assert count == 250


### PR DESCRIPTION
## Summary

Replaces the two per-row ``await session.merge(...)`` loops in
``_sync_one_locked`` with one chunked
``INSERT ... ON CONFLICT(id) DO UPDATE`` per table via
``sqlalchemy.dialects.sqlite.insert``. ``session.merge`` is
SELECT-then-INSERT-or-UPDATE per row; on a cold cache pulling
thousands of MO recipe rows that's thousands of round-trips inside
one transaction, dominating wall-time on the local-write side and
contributing directly to the cold-sync timeouts in #463.

Closes #591. Layered fix for #463 alongside the rate limiter (#590).

### Design

- **Module-private helper** ``_bulk_upsert(session, table_cls, rows)``
  in ``sync.py``. Early-returns on empty input (bulk insert with
  ``[]`` raises ``CompileError``).
- **Dynamic chunking** — ``_SQLITE_PARAM_BUDGET (900) // num_columns``
  per cache class, so wide schemas like ``CachedSalesOrder`` (33 cols
  → chunks of ~27) stay under SQLite's 999 bound-parameter cap while
  ``CachedManufacturingOrderRecipeRow`` (~13 cols → chunks of ~69)
  gets larger statements for free.
- **Include-set from ``__table__.columns``** — drives the
  ``model_dump(include=...)`` call. Adding a new ``Relationship``
  field to a cache class can never silently leak into the values
  payload because relationships aren't columns.
- **Parents first** — preserves FK ordering on insert.
- **``SyncState.merge`` left untouched** — single row, no win.
- **``itertools.batched``** — Python 3.12 stdlib, no new dep.

### Tests

New ``TestBulkUpsert`` class in
``test_typed_cache_invalidation.py`` (extends existing fixtures):

- ``test_idempotent_resync`` — same response twice → identical
  state, no errors.
- ``test_incremental_column_update`` — re-sync with the same id but
  a different ``order_no`` → row updated (proves the ``DO UPDATE``
  half).
- ``test_empty_response_writes_no_rows_no_error`` — empty
  ``data=[]`` → no ``CompileError``, ``SyncState`` still advances.
- ``test_bulk_upsert_past_chunking_boundary`` — 250 recipe rows
  (~3250 bound parameters) → all 250 land, exercising the
  multi-chunk path.

``force_resync`` calls ``_sync_one_locked`` after truncating, so it
inherits the speedup automatically — no changes needed there.

## Test plan

- [x] ``uv run poe check`` — 2943 passed, 2 unrelated skips
- [x] ``TestBulkUpsert`` — 4/4 pass
- [x] Existing ``test_typed_cache_invalidation.py`` — 23/23 still
      pass
- [ ] Local cold-sync wall-time captured against ``main`` and this
      branch on a representative dataset (issue claims ~20× on the
      SQLite-write side; verify and edit this PR description with
      the numbers before merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)