### PR TITLE
feat(mcp): direct-apply Confirm-button rail spike on create_purchase_order

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -188,9 +188,10 @@ def _po_response_to_tool_result(
 ) -> ToolResult:
     """Convert PurchaseOrderResponse to ToolResult with the appropriate Prefab UI.
 
-    On the preview branch, the rendered UI's "Confirm & Create" button
-    invokes ``create_purchase_order`` directly via ``CallTool`` with the
-    original args + ``preview=False``.
+    On the preview branch, the rendered UI uses the direct-apply rail
+    (Confirm fires ``tools/call`` directly + iframe pushes the structured
+    result to the agent via ``ui/update-model-context``). This is the spike
+    for the rail described in ADR-0016 (forthcoming, supersedes ADR-0015).
     """
     from katana_mcp.tools.prefab_ui import (
         build_order_created_ui,
@@ -204,6 +205,7 @@ def _po_response_to_tool_result(
             "Purchase Order",
             confirm_request=request,
             confirm_tool="create_purchase_order",
+            direct_apply=True,
         )
     else:
         ui = build_order_created_ui(order_dict, "Purchase Order")
@@ -2784,6 +2786,7 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "purchasing", "write"},
         annotations=_create,
         meta=UI_META,
+        direct=True,
     )
     register_preview_tool(
         mcp,

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from prefab_ui.actions import Action, SetState, ShowToast
-from prefab_ui.actions.mcp import CallTool, SendMessage
+from prefab_ui.actions.mcp import CallTool, SendMessage, UpdateContext
 from prefab_ui.app import PrefabApp
 from prefab_ui.components import (
     H3,
@@ -44,7 +44,7 @@ from prefab_ui.components import (
     Separator,
     Text,
 )
-from prefab_ui.components.control_flow import Elif, ForEach, If
+from prefab_ui.components.control_flow import Elif, Else, ForEach, If
 from prefab_ui.components.slot import Slot
 from prefab_ui.rx import RESULT, Rx
 from pydantic import BaseModel
@@ -90,21 +90,50 @@ PREVIEW_APPLY_COACHING = (
 )
 
 
-def with_preview_coaching(fn: Any) -> str:
+# Coaching text for tools using the direct-apply rail (Confirm button fires
+# ``tools/call`` directly + iframe pushes the structured result back via
+# ``ui/update-model-context``). The agent does not re-issue the call — it
+# receives the apply result automatically on its next turn. See
+# ``docs/adr/0016-direct-apply-confirm-button-rail.md`` (forthcoming).
+PREVIEW_APPLY_DIRECT_COACHING = (
+    "Preview→apply: when ``preview=True`` (default) AND the host renders "
+    "MCP Apps iframes (Claude Desktop, Claude.ai, Cowork, etc.), returns a "
+    "Prefab card with Confirm/Cancel buttons. Do NOT re-narrate the card or "
+    "ask for confirmation in chat — the buttons handle that. End your turn "
+    "after the preview response.\n\n"
+    "When the user clicks Confirm in the iframe, the iframe fires the apply "
+    "call directly and morphs in place to a result card. The structured "
+    "apply response (id, status, etc.) arrives in your context on your next "
+    "turn via ``ui/update-model-context``. Treat it as you would any "
+    "tool-call result — acknowledge completion, suggest next steps. Do NOT "
+    "re-issue the call after the iframe already applied.\n\n"
+    "Non-iframe-host fallback: if the host does not render Prefab cards "
+    "(no iframe was shown to the user), there are no buttons. Ask the user "
+    "for confirmation in chat, then re-issue with ``preview=False`` "
+    "yourself.\n\n"
+    "If you receive a chat message starting with ``Cancel: do not apply ...``, "
+    "the user opted out — acknowledge briefly without re-issuing."
+)
+
+
+def with_preview_coaching(fn: Any, *, direct: bool = False) -> str:
     """Build a FastMCP tool description by appending preview→apply coaching
     to the function's docstring.
 
-    The constant ``PREVIEW_APPLY_COACHING`` is the single source of truth
-    for this text — update there to update every tool's description at
-    once. Tools without a ``preview`` parameter do not receive the
-    coaching (their tool description should not lie about the flow they
-    actually expose).
+    Two coaching variants:
+
+    - ``direct=False`` (default): tools using the SendMessage rail. Confirm
+      fires a ``Apply: call <tool>(...)`` chat message; agent re-issues.
+    - ``direct=True``: tools using the direct-apply rail. Confirm fires
+      ``tools/call`` directly and pushes the result via
+      ``ui/update-model-context``; agent does not re-issue.
 
     Most callers should use :func:`register_preview_tool` rather than
     calling this directly.
     """
+    coaching = PREVIEW_APPLY_DIRECT_COACHING if direct else PREVIEW_APPLY_COACHING
     base = (fn.__doc__ or "").strip()
-    return f"{base}\n\n{PREVIEW_APPLY_COACHING}" if base else PREVIEW_APPLY_COACHING
+    return f"{base}\n\n{coaching}" if base else coaching
 
 
 def register_preview_tool(
@@ -114,26 +143,18 @@ def register_preview_tool(
     tags: set[str],
     annotations: Any,
     meta: Any = None,
+    direct: bool = False,
 ) -> None:
     """Register a preview-mode write tool with standard coaching applied.
 
-    Equivalent to::
-
-        mcp.tool(
-            description=with_preview_coaching(fn),
-            tags=tags,
-            annotations=annotations,
-            meta=meta,
-        )(fn)
-
-    Every tool whose request model has a ``preview`` field and emits a
-    Prefab preview card with Confirm/Cancel buttons should register via
-    this helper — that's how the audit test in
-    ``tests/test_tool_descriptions_and_annotations.py`` knows the agent
-    contract is wired up.
+    Set ``direct=True`` for tools whose preview UI uses the direct-apply
+    rail (Confirm button fires ``tools/call`` directly and pushes the
+    structured result back via ``ui/update-model-context``). Default
+    ``direct=False`` uses the SendMessage rail (Confirm fires a chat
+    ``Apply: call ...`` for the agent to re-issue).
     """
     mcp.tool(
-        description=with_preview_coaching(fn),
+        description=with_preview_coaching(fn, direct=direct),
         tags=tags,
         annotations=annotations,
         meta=meta,
@@ -212,6 +233,76 @@ def _build_apply_action(
     ]
 
 
+def _build_apply_action_direct(
+    confirm_tool: str | None,
+    confirm_request: BaseModel | None,
+) -> list[Action] | None:
+    """Construct the direct-apply Confirm-button click action chain.
+
+    The chain is ``[SetState(pending, True), CallTool(...)]``. Setting
+    ``pending=True`` synchronously before the call fires is the spam guard:
+    the buttons bind ``disabled=Rx("pending") | ...`` so a second click
+    while the call is in flight is dropped (no duplicate POs). The
+    ``on_success`` / ``on_error`` chains clear ``pending`` and flip
+    ``applied`` / ``error`` for the in-place morph.
+
+    On success the iframe pushes the structured result back to the agent's
+    model context via ``ui/update-model-context`` (MCP Apps spec,
+    SEP-1865, 2026-01-26). The agent sees the result on its next turn —
+    no re-issue needed.
+
+    On error the iframe shows the error inline and pushes the error
+    reason into model context so the agent can react on its next turn.
+
+    The ``UpdateContext.content`` field (text channel) is the spec-correct
+    one for agent-visible context: per the MCP Apps spec, ``content``
+    reaches the model; ``structuredContent`` is for UI rendering and is
+    not guaranteed in model context.
+
+    See ``docs/adr/0016-direct-apply-confirm-button-rail.md`` (forthcoming)
+    for the architectural rationale; supersedes ADR-0015 for tools that
+    opt into this rail.
+
+    ``confirm_tool`` and ``confirm_request`` must be both set or both
+    ``None`` (the latter for builders that render their non-preview branch).
+    """
+    if confirm_tool is None and confirm_request is None:
+        return None
+    if confirm_tool is None or confirm_request is None:
+        raise ValueError(
+            "confirm_tool and confirm_request must be set together (or both None)"
+        )
+    args = confirm_request.model_dump(mode="json")
+    if "preview" not in args:
+        raise ValueError(
+            f"_build_apply_action_direct requires a request model with a "
+            f"`preview` field; {type(confirm_request).__name__} has none."
+        )
+    args["preview"] = False
+    return [
+        # Click guard — disables the button immediately so a double-click
+        # in the iframe can't fire two applies (which would create
+        # duplicate POs etc.). Cleared in on_success/on_error.
+        SetState("pending", True),
+        CallTool(
+            tool=confirm_tool,
+            arguments=args,
+            on_success=[
+                SetState("pending", False),
+                SetState("applied", True),
+                SetState("result", RESULT),
+                UpdateContext(content=RESULT),
+            ],
+            on_error=[
+                SetState("pending", False),
+                SetState("error", "{{ $error }}"),
+                ShowToast("{{ $error }}", variant="error"),
+                UpdateContext(content="Apply failed: {{ $error }}"),
+            ],
+        ),
+    ]
+
+
 def _build_cancel_action(operation_label: str) -> list[Action]:
     """Construct the Cancel-button click action.
 
@@ -236,14 +327,24 @@ def _render_apply_button_row(
     apply_action: list[Action] | None,
     cancel_action: list[Action],
     disabled: bool = False,
+    direct_apply: bool = False,
 ) -> None:
     """Render the preview-card button row with state-aware visuals.
 
-    Three visual states, all driven by iframe state (`pending`, `cancelled`):
+    States driven by iframe state:
 
     - **Default** — Confirm + Cancel buttons enabled.
-    - **Pending…** — pill rendered, both buttons disabled, after Confirm
-      click. The agent is now expected to re-issue the apply tool call.
+    - **Pending…** — pill rendered, both buttons disabled. Set on click for
+      both rails: SendMessage rail uses it as the re-issue handoff signal;
+      direct-apply rail uses it as the in-flight click guard so a
+      double-click cannot fire two applies. Cleared in on_success /
+      on_error for direct rail; persists for SendMessage rail (the agent
+      re-issue replaces the card).
+    - **Applied** — pill rendered, both buttons disabled. Direct-apply rail
+      only (``direct_apply=True``); apply succeeded and the iframe morphed.
+    - **Error** — pill rendered, both buttons disabled. Direct-apply rail
+      only; apply failed. The error reason is in iframe state and was
+      pushed to the agent via ``ui/update-model-context``.
     - **Cancelled** — pill rendered, both buttons disabled, after Cancel
       click.
 
@@ -264,12 +365,28 @@ def _render_apply_button_row(
             )
         return
 
-    locked = Rx("pending") | Rx("cancelled")
+    if direct_apply:
+        # `pending` is the in-flight guard — set on click before CallTool
+        # fires, cleared in on_success/on_error. Including it in `locked`
+        # is what prevents double-click from firing two applies.
+        locked = Rx("pending") | Rx("applied") | Rx("error") | Rx("cancelled")
+    else:
+        locked = Rx("pending") | Rx("cancelled")
     with Row(gap=2):
-        with If("pending"):
-            Badge(label="Pending…", variant="secondary")
-        with Elif("cancelled"):
-            Badge(label="Cancelled", variant="secondary")
+        if direct_apply:
+            with If("pending"):
+                Badge(label="Applying…", variant="secondary")
+            with Elif("applied"):
+                Badge(label="Applied", variant="default")
+            with Elif("error"):
+                Badge(label="Error", variant="destructive")
+            with Elif("cancelled"):
+                Badge(label="Cancelled", variant="secondary")
+        else:
+            with If("pending"):
+                Badge(label="Pending…", variant="secondary")
+            with Elif("cancelled"):
+                Badge(label="Cancelled", variant="secondary")
         Button(
             label=confirm_label,
             variant="default",
@@ -766,17 +883,36 @@ def build_order_preview_ui(
     *,
     confirm_request: BaseModel,
     confirm_tool: str,
+    direct_apply: bool = False,
 ) -> PrefabApp:
     """Build an order preview card with confirm/cancel buttons.
 
     Pass the original Pydantic ``confirm_request`` and matching
-    ``confirm_tool`` name; the Confirm button is wired via
-    :func:`_build_apply_action`.
+    ``confirm_tool`` name. Two apply rails:
+
+    - ``direct_apply=False`` (default) — Confirm fires a SendMessage chat
+      hint and the agent re-issues the call. See ADR-0015.
+    - ``direct_apply=True`` — Confirm fires ``tools/call`` directly, the
+      iframe morphs in place to a result view, and the structured response
+      is pushed to the agent via ``ui/update-model-context``. See ADR-0016
+      (forthcoming). Currently opted into by ``create_purchase_order``;
+      rolling out across the rest of the write tools after Cowork
+      verification.
     """
     fields = _extract_order_fields(order)
-    apply_action = _build_apply_action(confirm_tool, confirm_request)
+    apply_action: list[Action] | CallTool | None
+    if direct_apply:
+        apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    else:
+        apply_action = _build_apply_action(confirm_tool, confirm_request)
     cancel_action = _build_cancel_action(f"that {order_type.lower()}")
     state: dict[str, Any] = {"order": order, "pending": False, "cancelled": False}
+    if direct_apply:
+        # Initial state for the morph; on apply success the iframe sets
+        # `applied=True` and stashes the structured response in `result`.
+        state["applied"] = False
+        state["error"] = None
+        state["result"] = None
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
@@ -801,11 +937,43 @@ def build_order_preview_ui(
                 for warning in regular_warnings:
                     Badge(label=warning, variant="secondary")
 
+            if direct_apply:
+                # Direct-apply morph: success/error blocks render in place
+                # of the preview footer messaging when the iframe state
+                # flips. The agent has already received the structured
+                # result via ui/update-model-context — these blocks are
+                # for the user, not the agent.
+                with If("applied"):
+                    Separator()
+                    Text(content=f"{order_type} created.")
+                    Muted(
+                        content=(
+                            "The structured result has been pushed to the "
+                            "assistant's context."
+                        )
+                    )
+                with Elif("error"):
+                    Separator()
+                    Text(content="Apply failed.")
+                    Muted(content="{{ $state.error }}")
+
         with CardFooter():
             if block_warnings:
                 Muted(
                     content="Cannot proceed — see warnings above. No changes have been made."
                 )
+            elif direct_apply:
+                # Footer message tracks the iframe state — once applied or
+                # errored, "This is a preview" is no longer true and would
+                # confuse the user.
+                with If("applied"):
+                    Muted(content=f"{order_type} created.")
+                with Elif("error"):
+                    Muted(content="Apply failed — see error above.")
+                with Elif("cancelled"):
+                    Muted(content="Cancelled. No changes were made.")
+                with Else():
+                    Muted(content="This is a preview. No changes have been made.")
             else:
                 Muted(content="This is a preview. No changes have been made.")
 
@@ -814,6 +982,7 @@ def build_order_preview_ui(
                 apply_action=apply_action,
                 cancel_action=cancel_action,
                 disabled=bool(block_warnings),
+                direct_apply=direct_apply,
             )
     return app
 

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -792,6 +792,276 @@ class TestConfirmButtonEmitsApplyMessage:
         assert "preview=False" in msg["content"]
 
 
+class TestConfirmButtonDirectApplyRail:
+    """Direct-apply rail (ADR-0016, supersedes ADR-0015 for opted-in tools):
+
+    The Confirm button fires ``tools/call`` directly from the iframe with
+    the original args + ``preview=False``, and on success pushes the
+    structured result back to the agent's model context via
+    ``ui/update-model-context``. The agent does NOT re-issue the call.
+
+    Currently opted into by ``create_purchase_order``; rolling out to other
+    write tools after Cowork verification.
+    """
+
+    @staticmethod
+    def _confirm_action(envelope: dict, label: str) -> dict:
+        """Return the inner ``toolCall`` action for the direct-apply rail.
+
+        The direct rail's onClick is a list:
+        ``[setState("pending", True), toolCall(...)]``. The leading
+        ``setState`` is the in-flight click guard (so a double-click can't
+        fire two applies); the toolCall is what we return for assertions.
+        """
+        buttons = _find_buttons_by_label(envelope, label)
+        assert len(buttons) == 1, (
+            f"Expected exactly one Button with label {label!r}; found {len(buttons)}."
+        )
+        on_click = buttons[0].get("onClick") or buttons[0].get("on_click")
+        assert isinstance(on_click, list), (
+            f"Direct-apply rail onClick should be a [SetState, CallTool] list; "
+            f"got {type(on_click).__name__}: {on_click!r}"
+        )
+        # Click guard must come first: SetState(pending=True) before the
+        # CallTool so the button binds locked the moment the click fires.
+        assert on_click[0].get("action") == "setState", (
+            f"First action must be the pending guard; got {on_click[0]!r}"
+        )
+        assert on_click[0].get("key") == "pending"
+        assert on_click[0].get("value") is True, (
+            f"pending guard must set pending=True; got {on_click[0]!r}"
+        )
+        tool_calls = [a for a in on_click if a.get("action") == "toolCall"]
+        assert len(tool_calls) == 1, (
+            f"Expected exactly one toolCall in onClick; got {tool_calls!r}"
+        )
+        return tool_calls[0]
+
+    def test_po_preview_direct_apply_fires_call_tool(self):
+        from katana_mcp.tools.foundation.purchase_orders import (
+            CreatePurchaseOrderRequest,
+            PurchaseOrderItem,
+        )
+
+        request = CreatePurchaseOrderRequest(
+            supplier_id=2,
+            location_id=3,
+            order_number="PO-1",
+            items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
+        )
+        app = build_order_preview_ui(
+            {
+                "id": 1,
+                "order_number": "PO-1",
+                "supplier_id": 2,
+                "location_id": 3,
+                "status": "NOT_RECEIVED",
+                "warnings": [],
+            },
+            "Purchase Order",
+            confirm_request=request,
+            confirm_tool="create_purchase_order",
+            direct_apply=True,
+        )
+        envelope = app.to_json()
+        on_click = self._confirm_action(envelope, "Confirm & Create Purchase Order")
+
+        # The direct rail fires CallTool with the apply args (preview=False).
+        assert on_click.get("tool") == "create_purchase_order"
+        args = on_click.get("arguments") or {}
+        assert args.get("preview") is False, (
+            f"Direct rail must override preview=False; got {args!r}"
+        )
+        assert args.get("supplier_id") == 2
+        assert args.get("location_id") == 3
+        assert args.get("order_number") == "PO-1"
+
+    def test_po_preview_direct_apply_pushes_result_via_update_context(self):
+        """on_success chain must include UpdateContext(content=$result).
+
+        This is the load-bearing primitive: the iframe pushes the apply
+        result into the agent's context for its next turn, replacing the
+        SendMessage round-trip.
+        """
+        from katana_mcp.tools.foundation.purchase_orders import (
+            CreatePurchaseOrderRequest,
+            PurchaseOrderItem,
+        )
+
+        request = CreatePurchaseOrderRequest(
+            supplier_id=2,
+            location_id=3,
+            order_number="PO-1",
+            items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
+        )
+        app = build_order_preview_ui(
+            {
+                "id": 1,
+                "order_number": "PO-1",
+                "supplier_id": 2,
+                "location_id": 3,
+                "status": "NOT_RECEIVED",
+                "warnings": [],
+            },
+            "Purchase Order",
+            confirm_request=request,
+            confirm_tool="create_purchase_order",
+            direct_apply=True,
+        )
+        envelope = app.to_json()
+        on_click = self._confirm_action(envelope, "Confirm & Create Purchase Order")
+
+        on_success = on_click.get("onSuccess")
+        assert isinstance(on_success, list), (
+            f"Expected onSuccess to be a list; got {on_success!r}"
+        )
+        update_contexts = [a for a in on_success if a.get("action") == "updateContext"]
+        assert len(update_contexts) == 1, (
+            f"Expected exactly one updateContext action; got {update_contexts!r}"
+        )
+        assert update_contexts[0].get("content") == "{{ $result }}", (
+            f"updateContext.content must carry $result reactive ref so the "
+            f"agent receives the structured apply response on its next turn; "
+            f"got {update_contexts[0]!r}"
+        )
+
+        # State morph: applied=True so the iframe flips to a result view in
+        # place. result=$result so any inline Rx refs to state.result work.
+        set_states = [a for a in on_success if a.get("action") == "setState"]
+        keys = {s.get("key") for s in set_states}
+        assert "applied" in keys and "result" in keys, (
+            f"Expected applied/result state morph; got keys {keys!r}"
+        )
+
+    def test_po_preview_direct_apply_handles_error(self):
+        """on_error chain must include UpdateContext with the error reason
+        plus a toast and an 'error' state morph.
+        """
+        from katana_mcp.tools.foundation.purchase_orders import (
+            CreatePurchaseOrderRequest,
+            PurchaseOrderItem,
+        )
+
+        request = CreatePurchaseOrderRequest(
+            supplier_id=2,
+            location_id=3,
+            order_number="PO-1",
+            items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
+        )
+        app = build_order_preview_ui(
+            {
+                "id": 1,
+                "order_number": "PO-1",
+                "supplier_id": 2,
+                "location_id": 3,
+                "status": "NOT_RECEIVED",
+                "warnings": [],
+            },
+            "Purchase Order",
+            confirm_request=request,
+            confirm_tool="create_purchase_order",
+            direct_apply=True,
+        )
+        envelope = app.to_json()
+        on_click = self._confirm_action(envelope, "Confirm & Create Purchase Order")
+
+        on_error = on_click.get("onError")
+        assert isinstance(on_error, list), (
+            f"Expected onError to be a list; got {on_error!r}"
+        )
+        update_contexts = [a for a in on_error if a.get("action") == "updateContext"]
+        assert len(update_contexts) == 1, (
+            f"Expected exactly one updateContext on error; got {update_contexts!r}"
+        )
+        assert "$error" in update_contexts[0].get("content", ""), (
+            f"updateContext on error must include the error reason; "
+            f"got {update_contexts[0]!r}"
+        )
+        toasts = [a for a in on_error if a.get("action") == "showToast"]
+        assert len(toasts) == 1, f"Expected one error toast; got {toasts!r}"
+
+    def test_po_preview_direct_apply_double_click_is_guarded(self):
+        """Confirm button binds ``pending`` so a double-click cannot fire
+        two applies. Ensures (1) on_click sets pending=True before
+        CallTool, (2) on_success/on_error clear pending=False, and (3) the
+        button's disabled expression includes ``pending`` (so the second
+        click is dropped while the first is in flight).
+
+        Without this guard a fast double-click on ``create_purchase_order``
+        would fire two CallTool requests in parallel and create duplicate
+        POs in Katana — there's no idempotency on the API side.
+        """
+        from katana_mcp.tools.foundation.purchase_orders import (
+            CreatePurchaseOrderRequest,
+            PurchaseOrderItem,
+        )
+
+        request = CreatePurchaseOrderRequest(
+            supplier_id=2,
+            location_id=3,
+            order_number="PO-1",
+            items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
+        )
+        app = build_order_preview_ui(
+            {
+                "id": 1,
+                "order_number": "PO-1",
+                "supplier_id": 2,
+                "location_id": 3,
+                "status": "NOT_RECEIVED",
+                "warnings": [],
+            },
+            "Purchase Order",
+            confirm_request=request,
+            confirm_tool="create_purchase_order",
+            direct_apply=True,
+        )
+        envelope = app.to_json()
+
+        buttons = _find_buttons_by_label(envelope, "Confirm & Create Purchase Order")
+        on_click = buttons[0].get("onClick") or buttons[0].get("on_click")
+        # Click chain: [SetState(pending, True), CallTool(...)].
+        assert on_click[0].get("action") == "setState"
+        assert on_click[0].get("key") == "pending"
+        assert on_click[0].get("value") is True
+
+        # Inner CallTool clears pending in both on_success and on_error.
+        tool_call = next(a for a in on_click if a.get("action") == "toolCall")
+        for chain_name in ("onSuccess", "onError"):
+            chain = tool_call.get(chain_name) or []
+            pending_clears = [
+                a
+                for a in chain
+                if a.get("action") == "setState"
+                and a.get("key") == "pending"
+                and a.get("value") is False
+            ]
+            assert len(pending_clears) == 1, (
+                f"{chain_name} must clear pending=False so the buttons unlock "
+                f"after the call resolves; got {chain!r}"
+            )
+
+        # The button's `disabled` field carries the reactive lockout
+        # expression. Assert against that specific field — searching the
+        # whole button payload would false-positive because the guard
+        # names also appear inside `onClick` actions (e.g.,
+        # `setState(key="applied")` in on_success).
+        disabled = buttons[0].get("disabled")
+        assert isinstance(disabled, str), (
+            f"Expected disabled to be a reactive template string; got "
+            f"{disabled!r}. Lockout-contract pin lives there."
+        )
+        # Both the click guard (pending) and the morph guards (applied,
+        # error, cancelled) must be in the disabled expression so the
+        # button locks the moment any of those states flips.
+        for guard in ("pending", "applied", "error", "cancelled"):
+            assert guard in disabled, (
+                f"Confirm button's `disabled` expression must reference "
+                f"state '{guard}' so the button locks when it flips; "
+                f"got disabled={disabled!r}"
+            )
+
+
 class TestCancelButtonEmitsCancelMessage:
     """The Cancel button must fire ``setState("cancelled", True)`` plus a
     ``sendMessage("Cancel: do not apply ...")`` so the agent recognizes the

--- a/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
+++ b/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
@@ -37,13 +37,26 @@ def registered_tools() -> dict[str, object]:
 # Tools whose request model has a ``preview: bool`` field AND emit a Prefab
 # preview card with Confirm/Cancel buttons. These must include the coaching
 # block (``with_preview_coaching``) in their description so the agent
-# recognizes the iframe SendMessage round-trip.
+# recognizes the iframe round-trip.
+#
+# Two rails:
+#   - SendMessage rail (default) — Confirm fires a ``Apply: call`` chat hint
+#     and the agent re-issues. Coaching: ``PREVIEW_APPLY_COACHING``.
+#   - Direct-apply rail (``register_preview_tool(direct=True)``) — Confirm
+#     fires ``tools/call`` directly and pushes the structured result back via
+#     ``ui/update-model-context``. Coaching: ``PREVIEW_APPLY_DIRECT_COACHING``.
 #
 # ``rebuild_cache`` has a ``preview`` field but renders markdown text rather
 # than a Prefab card, so it does not need coaching about button-driven
 # Apply: messages.
-PREVIEW_BUTTON_TOOLS = [
+
+# Tools currently using the direct-apply rail (per ADR-0016 spike).
+DIRECT_APPLY_TOOLS = [
     "create_purchase_order",
+]
+
+# Tools using the SendMessage rail (default, per ADR-0015).
+SEND_MESSAGE_APPLY_TOOLS = [
     "modify_purchase_order",
     "delete_purchase_order",
     "receive_purchase_order",
@@ -66,14 +79,15 @@ PREVIEW_BUTTON_TOOLS = [
     "correct_sales_order",
 ]
 
+PREVIEW_BUTTON_TOOLS = DIRECT_APPLY_TOOLS + SEND_MESSAGE_APPLY_TOOLS
+
 
 @pytest.mark.parametrize("tool_name", PREVIEW_BUTTON_TOOLS)
-def test_preview_button_tool_has_apply_coaching(
+def test_preview_button_tool_has_no_renarrate_coaching(
     registered_tools: dict[str, object], tool_name: str
 ) -> None:
-    """Every preview-button tool's description must include both coaching
-    paragraphs from ``PREVIEW_APPLY_COACHING``: the "do not re-narrate"
-    guidance (closes #544) and the ``Apply:`` re-issue instruction.
+    """Every preview-button tool's description must include the
+    "do not re-narrate" coaching (closes #544). Required for both rails.
     """
     tool = registered_tools[tool_name]
     description = tool.description or ""
@@ -82,10 +96,42 @@ def test_preview_button_tool_has_apply_coaching(
         f"re-narrate the preview card and ask for confirmation in chat. "
         f"Wire via with_preview_coaching() in register_tools."
     )
+
+
+@pytest.mark.parametrize("tool_name", SEND_MESSAGE_APPLY_TOOLS)
+def test_send_message_apply_tool_has_apply_call_coaching(
+    registered_tools: dict[str, object], tool_name: str
+) -> None:
+    """SendMessage-rail tools must coach the agent to recognize the
+    ``Apply: call <tool>(...)`` chat hint and re-issue.
+    """
+    tool = registered_tools[tool_name]
+    description = tool.description or ""
     assert "Apply: call" in description, (
         f"{tool_name}: missing 'Apply: call' coaching — agent will not "
         f"recognize the Confirm-button SendMessage and re-issue the call. "
-        f"Wire via with_preview_coaching() in register_tools."
+        f"Wire via with_preview_coaching() (direct=False) in register_tools."
+    )
+
+
+@pytest.mark.parametrize("tool_name", DIRECT_APPLY_TOOLS)
+def test_direct_apply_tool_has_update_model_context_coaching(
+    registered_tools: dict[str, object], tool_name: str
+) -> None:
+    """Direct-apply-rail tools must coach the agent that the apply result
+    arrives via ``ui/update-model-context``, not via re-issue.
+    """
+    tool = registered_tools[tool_name]
+    description = tool.description or ""
+    assert "ui/update-model-context" in description, (
+        f"{tool_name}: missing 'ui/update-model-context' coaching — agent "
+        f"won't know to expect the apply result via the iframe context push. "
+        f"Wire via with_preview_coaching(direct=True) in register_tools."
+    )
+    assert "Do NOT re-issue" in description, (
+        f"{tool_name}: missing 'Do NOT re-issue' coaching — agent may "
+        f"incorrectly re-issue after the iframe already applied. "
+        f"Wire via with_preview_coaching(direct=True) in register_tools."
     )
 
 
@@ -125,6 +171,11 @@ def test_read_only_tools_do_not_have_coaching(
         description = registered_tools[name].description or ""
         assert "Apply: call" not in description, (
             f"{name}: read-only tool unexpectedly carries the preview→apply "
+            f"coaching. The coaching should only be on tools that emit a "
+            f"Prefab preview card with Confirm/Cancel buttons."
+        )
+        assert "ui/update-model-context" not in description, (
+            f"{name}: read-only tool unexpectedly carries the direct-apply "
             f"coaching. The coaching should only be on tools that emit a "
             f"Prefab preview card with Confirm/Cancel buttons."
         )


### PR DESCRIPTION
## Summary

Spike of a new write-tool confirmation rail on a single tool
(`create_purchase_order`). Confirm button fires `tools/call` directly
from the iframe + pushes the structured apply result back to the agent
via `ui/update-model-context` (MCP Apps SEP-1865, merged 2026-01-28).
The agent receives the apply outcome on its next turn without
re-issuing the call — collapsing the SendMessage round-trip from
ADR-0015.

ADR-0015's premise that "iframe-fired tools/call results never reach
the agent" missed the `ui/update-model-context` primitive shipped in
the Jan 2026 MCP Apps spec. With it, the iframe can capture `$result`
from a `CallTool` and push it into the agent's model context — giving
us button-click apply + iframe morph + agent-visible result, the full
UX we wanted from day one.

## What changed

- **`_build_apply_action_direct`** (new) — fires `CallTool` with
  `on_success: [SetState(applied), SetState(result, $result), UpdateContext(content=$result)]`
  and `on_error: [SetState(error), ShowToast, UpdateContext(error reason)]`
- **`build_order_preview_ui` gains `direct_apply: bool = False`** —
  default keeps existing SendMessage rail untouched. When `True`,
  renders `applied`/`error` morph blocks in place of the preview
  footer; the result card replaces the preview card without a separate
  render.
- **`register_preview_tool` gains `direct: bool = False`** — selects
  `PREVIEW_APPLY_DIRECT_COACHING` (vs the existing
  `PREVIEW_APPLY_COACHING`). The new coaching covers both the
  iframe-host happy path (apply result arrives via
  update-model-context, do not re-issue) and the **non-iframe-host
  fallback** (ask the user in chat, re-issue with `preview=False`
  yourself), so agents degrade cleanly on hosts that don't render
  Prefab cards.
- **`create_purchase_order` opts in** — only tool wired up for the
  spike. Remaining write tools stay on the SendMessage rail until
  Cowork honor of `update-model-context` is verified in production.

## Why a spike, not a full rollout

The decision rests on whether **Cowork** honors `ui/update-model-context`
for live-rendered iframes. Anthropic's published `mcp-server-dev` skill
documents `app.updateModelContext` as the canonical silent-context API,
and the MCP Apps spec is universally implemented across hosts that
ship MCP Apps support (Claude Desktop, Claude.ai web, VS Code Copilot,
Goose, Postman, MCPJam). Cowork shares Anthropic's plugin
infrastructure (per claude.com/plugins) so by parity it's almost
certainly supported — but no public confirmation exists, and ChatGPT
has a known unfixed bug (community.openai.com/t/.../1379700,
2026-04-24) where live-rendered iframes silently drop
`update-model-context`. ChatGPT is out of scope.

If the spike works (iframe morphs in place AND agent's next response
references the new PO's id/number/katana_url without re-issuing the
tool), Phase 2 rolls out to all preview-mode write tools and Phase 3
removes the SendMessage rail dead code + writes ADR-0016 to supersede
ADR-0015.

If the spike fails (Cowork drops `update-model-context`), revert is
small — one helper, ~10 lines.

## Test plan

- [x] `uv run poe check` passes (2980 tests)
- [x] New `TestConfirmButtonDirectApplyRail` class in
  `test_prefab_ui.py` pins:
  - `CallTool` action shape (`tool: "create_purchase_order"`,
    `arguments.preview: false`, all original args carried)
  - `on_success` chain includes `UpdateContext(content="{{ $result }}")`
    plus `SetState(applied)` / `SetState(result)` morph
  - `on_error` chain includes `UpdateContext` with the error reason,
    a toast, and `SetState(error)` morph
- [x] `test_tool_descriptions_and_annotations.py` splits
  `PREVIEW_BUTTON_TOOLS` into `DIRECT_APPLY_TOOLS` (just
  `create_purchase_order` for now) and `SEND_MESSAGE_APPLY_TOOLS`
  (everything else); separate parametrized tests pin each rail's
  coaching shape
- [x] Existing SendMessage-rail tests untouched — they continue to
  exercise the default rail across all other write tools
- [ ] **Manual smoke on Cowork** — open a `create_purchase_order`
  preview, click Confirm, verify (a) the iframe morphs in place to a
  result view AND (b) the agent's next response references the new
  PO's `id`, `order_no`, and `katana_url` *without having re-issued
  the tool*. Step (b) proves `update-model-context` actually delivered
  the structured result.

## References

- ADR-0015 (the rail this supersedes for opted-in tools):
  `docs/adr/0015-confirmation-pattern-for-write-tools.md`
- MCP Apps spec (SEP-1865, 2026-01-26):
  https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx
- Anthropic skill doc (`app.updateModelContext`):
  https://github.com/anthropics/claude-plugins-official/blob/main/plugins/mcp-server-dev/skills/build-mcp-app/SKILL.md
- Plan file (local): `swift-waddling-sutton.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)