### PR TITLE
fix(mcp)!: parse list_locations address as nested object

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1604,16 +1604,18 @@ from flooding agent context.
 
 ### list_locations
 List or fuzzy-search warehouses and facilities by name. Returns id, name,
-address, city/country, and the is_primary flag. Use the `id` value when
-creating orders or filtering inventory queries.
+the is_primary flag, and a nested `address` object (line_1, line_2, city,
+state, zip, country) when one is on file. Use the `id` value when creating
+orders or filtering inventory queries.
 
 **Parameters:**
 - `query` (optional): Fuzzy match by name.
 - `limit` (optional, default 50, max 250): Cap on rows returned.
 - `format` (optional, default "markdown"): "markdown" | "json".
 
-**Returns:** `ListLocationsResponse` with `locations: [{id, name, address,
-city, country, is_primary}]`, `total_count`, `query`.
+**Returns:** `ListLocationsResponse` with `locations: [{id, name,
+address: {line_1, line_2, city, state, zip, country} | null,
+is_primary}]`, `total_count`, `query`.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
@@ -325,12 +325,19 @@ class ListLocationsRequest(BaseModel):
     format: Literal["markdown", "json"] = Field(default="markdown")
 
 
+class AddressInfo(BaseModel):
+    line_1: str | None = None
+    line_2: str | None = None
+    city: str | None = None
+    state: str | None = None
+    zip: str | None = None
+    country: str | None = None
+
+
 class LocationInfo(BaseModel):
     id: int
     name: str
-    address: str | None = None
-    city: str | None = None
-    country: str | None = None
+    address: AddressInfo | None = None
     is_primary: bool | None = None
 
 
@@ -340,13 +347,38 @@ class ListLocationsResponse(BaseModel):
     query: str | None = None
 
 
+def _address_from_dict(d: dict[str, Any] | None) -> AddressInfo | None:
+    if not d:
+        return None
+
+    def _clean(value: Any) -> str | None:
+        # Katana sometimes returns blank address parts as "" (notably line_2)
+        # rather than omitting them — treat whitespace-only as missing so the
+        # all-empty case below collapses to None instead of an AddressInfo
+        # full of empty strings.
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
+    info = AddressInfo(
+        line_1=_clean(d.get("line_1")),
+        line_2=_clean(d.get("line_2")),
+        city=_clean(d.get("city")),
+        state=_clean(d.get("state")),
+        zip=_clean(d.get("zip")),
+        country=_clean(d.get("country")),
+    )
+    return info if info.model_dump(exclude_none=True) else None
+
+
 def _location_from_dict(d: dict[str, Any]) -> LocationInfo:
+    raw_address = d.get("address")
+    address = _address_from_dict(raw_address) if isinstance(raw_address, dict) else None
     return LocationInfo(
         id=d.get("id") or 0,
         name=d.get("name") or "",
-        address=d.get("address"),
-        city=d.get("city"),
-        country=d.get("country"),
+        address=address,
         is_primary=d.get("is_primary"),
     )
 
@@ -367,10 +399,17 @@ async def _list_locations_impl(
 def _render_location_md(response: ListLocationsResponse) -> str:
     if not response.locations:
         return _empty_message("locations", response.query)
+
+    def _city_country(loc: LocationInfo) -> str:
+        if not loc.address:
+            return ""
+        parts = [p for p in (loc.address.city, loc.address.country) if p]
+        return f" — {', '.join(parts)}" if parts else ""
+
     lines = [
         f"- **{loc.name}** (ID: {loc.id})"
         + (" [primary]" if loc.is_primary else "")
-        + (f" — {loc.city}, {loc.country}" if loc.city or loc.country else "")
+        + _city_country(loc)
         for loc in response.locations
     ]
     header = _list_header(
@@ -384,9 +423,11 @@ def _render_location_md(response: ListLocationsResponse) -> str:
 async def list_locations(
     request: Annotated[ListLocationsRequest, Unpack()], context: Context
 ) -> ToolResult:
-    """List or search warehouses and facilities. Returns id, name, address,
-    city/country, and the is_primary flag. Use the ``id`` value when
-    creating orders or filtering inventory queries.
+    """List or search warehouses and facilities. Returns id, name, the
+    is_primary flag, and a nested ``address`` object
+    (``line_1``, ``line_2``, ``city``, ``state``, ``zip``, ``country``) when
+    one is on file. Use the ``id`` value when creating orders or filtering
+    inventory queries.
 
     Pass ``query`` to fuzzy-match by name; omit to browse. Default limit
     caps output at 50 rows.

--- a/katana_mcp_server/tests/tools/test_reference.py
+++ b/katana_mcp_server/tests/tools/test_reference.py
@@ -309,8 +309,15 @@ class TestListLocations:
                 {
                     "id": 100,
                     "name": "Main Warehouse",
-                    "city": "Portland",
-                    "country": "US",
+                    "address": {
+                        "id": 9,
+                        "line_1": "1 Industrial Way",
+                        "line_2": "Suite 4",
+                        "city": "Portland",
+                        "state": "OR",
+                        "zip": "97201",
+                        "country": "US",
+                    },
                     "is_primary": True,
                 }
             ]
@@ -320,7 +327,94 @@ class TestListLocations:
         )
         lifespan_ctx.cache.smart_search.assert_awaited_once()
         payload = json.loads(_extract_text(result))
-        assert payload["locations"][0]["is_primary"] is True
+        loc = payload["locations"][0]
+        assert loc["is_primary"] is True
+        assert loc["address"] == {
+            "line_1": "1 Industrial Way",
+            "line_2": "Suite 4",
+            "city": "Portland",
+            "state": "OR",
+            "zip": "97201",
+            "country": "US",
+        }
+
+    @pytest.mark.asyncio
+    async def test_markdown_renders_city_country_from_nested_address(self):
+        context, _ = _make_context(
+            get_all=[
+                {
+                    "id": 24141,
+                    "name": "Goleta DC",
+                    "address": {"city": "Goleta", "country": "US"},
+                }
+            ]
+        )
+        result = await list_locations(
+            query=None, limit=50, format="markdown", context=context
+        )
+        text = _extract_text(result)
+        assert "Goleta DC" in text
+        assert "Goleta, US" in text
+
+    @pytest.mark.asyncio
+    async def test_missing_address_yields_none(self):
+        context, _ = _make_context(get_all=[{"id": 1, "name": "No-address site"}])
+        result = await list_locations(
+            query=None, limit=50, format="json", context=context
+        )
+        payload = json.loads(_extract_text(result))
+        assert payload["locations"][0]["address"] is None
+
+    @pytest.mark.asyncio
+    async def test_blank_string_address_parts_collapse_to_none(self):
+        """Katana sometimes returns blank address parts as ``""`` rather than
+        omitting them — the all-empty case must still collapse to
+        ``address: null`` instead of an AddressInfo full of empty strings.
+        Also pins that a non-blank line_1 alongside blank-only siblings
+        still yields a populated address with the empties normalized away.
+        """
+        context, _ = _make_context(
+            get_all=[
+                {
+                    "id": 1,
+                    "name": "All-blank address",
+                    "address": {
+                        "id": 9,
+                        "line_1": "",
+                        "line_2": "   ",
+                        "city": "",
+                        "state": "",
+                        "zip": "",
+                        "country": "",
+                    },
+                },
+                {
+                    "id": 2,
+                    "name": "Partially-populated address",
+                    "address": {
+                        "line_1": "1 Main St",
+                        "line_2": "",
+                        "city": "Goleta",
+                        "state": "  ",
+                        "zip": None,
+                        "country": "US",
+                    },
+                },
+            ]
+        )
+        result = await list_locations(
+            query=None, limit=50, format="json", context=context
+        )
+        payload = json.loads(_extract_text(result))
+        assert payload["locations"][0]["address"] is None
+        assert payload["locations"][1]["address"] == {
+            "line_1": "1 Main St",
+            "line_2": None,
+            "city": "Goleta",
+            "state": None,
+            "zip": None,
+            "country": "US",
+        }
 
     @pytest.mark.asyncio
     async def test_no_query_filters_deleted(self):


### PR DESCRIPTION
## Summary

`list_locations` was returning a Pydantic validation error and no rows because `LocationInfo.address` was declared as `str | None`, but Katana's wire schema returns `Location.address` as a nested `LocationAddress` object (`line_1`, `line_2`, `city`, `state`, `zip`, `country`). The dict was passed straight through to Pydantic, which rejected it. Tests masked the bug by mocking a flat shape that doesn't match the API.

- Replace the flat `address: str` (plus top-level `city`/`country`) on `LocationInfo` with a structured `AddressInfo` sub-model: `address: AddressInfo | None`.
- Parse the nested wire shape in `_address_from_dict`; collapse all-empty addresses to `None`.
- Read `city`/`country` from the nested object in the markdown renderer (markdown output unchanged).
- Sync the `list_locations` docstring and the `help.py` reference — caught by the help-resource drift rule in CLAUDE.md.
- Update test fixtures to use realistic nested-address payloads, and add regression coverage for the nested case, the missing-address case, and markdown rendering.

## BREAKING CHANGE

JSON consumers of `list_locations` that read `loc["address"]` as a string, or top-level `loc["city"]` / `loc["country"]`, must switch to `loc["address"]["city"]`, `loc["address"]["line_1"]`, etc. The new shape is fully optional — `loc["address"]` may be `null` for locations without one on file. Markdown output is unchanged.

## Test plan

- [x] `uv run poe check` (2983 passed, 2 skipped)
- [x] New tests cover: nested address full payload, `address: null`, markdown rendering of nested city/country
- [ ] Smoke-test live `list_locations` against the production tenant once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)