### PR TITLE
fix(mcp): sync parent caches before lifting default_supplier onto variants

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -1575,7 +1575,12 @@ async def _fetch_variant_by_id(services: Any, variant_id: int) -> dict[str, Any]
     return variant_obj.to_dict()
 
 
-@cache_read(EntityType.VARIANT)
+@cache_read(
+    EntityType.VARIANT,
+    EntityType.PRODUCT,
+    EntityType.MATERIAL,
+    EntityType.SUPPLIER,
+)
 async def _get_variant_details_impl(
     request: GetVariantDetailsRequest, context: Context
 ) -> list[VariantDetailsResponse]:

--- a/katana_mcp_server/tests/integration/test_error_scenarios.py
+++ b/katana_mcp_server/tests/integration/test_error_scenarios.py
@@ -32,9 +32,29 @@ from tests.conftest import create_mock_context
 
 @pytest.fixture(autouse=True)
 def _patch_cache_sync():
-    """Patch cache sync for all error scenario tests."""
-    with patch("katana_mcp.cache_sync.ensure_variants_synced", new_callable=AsyncMock):
-        yield
+    """Patch cache sync for all error scenario tests.
+
+    ``get_variant_details`` syncs VARIANT plus PRODUCT, MATERIAL, and SUPPLIER
+    (parent-derived ``default_supplier_*`` fields are lifted from the parent
+    product/material), so all four are mocked here.
+    """
+    from katana_mcp.cache import EntityType
+    from katana_mcp.tools import decorators
+
+    original = decorators._sync_fns
+    decorators._sync_fns = {
+        EntityType.VARIANT: AsyncMock(),
+        EntityType.PRODUCT: AsyncMock(),
+        EntityType.MATERIAL: AsyncMock(),
+        EntityType.SUPPLIER: AsyncMock(),
+    }
+    try:
+        with patch(
+            "katana_mcp.cache_sync.ensure_variants_synced", new_callable=AsyncMock
+        ):
+            yield
+    finally:
+        decorators._sync_fns = original
 
 
 @pytest.mark.asyncio

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -58,13 +58,30 @@ def _content_text(result) -> str:
 
 @pytest.fixture(autouse=True)
 def _patch_cache_sync():
-    """Patch ensure_variants_synced for all unit tests.
+    """Patch entity syncs for all unit tests.
 
     The cache sync is tested separately; tool tests verify tool logic
-    with pre-populated cache mocks.
+    with pre-populated cache mocks. ``get_variant_details`` syncs VARIANT
+    plus PRODUCT, MATERIAL, and SUPPLIER (parent-derived ``default_supplier_*``
+    are lifted from the parent product/material), so all four are mocked.
     """
-    with patch("katana_mcp.cache_sync.ensure_variants_synced", new_callable=AsyncMock):
-        yield
+    from katana_mcp.cache import EntityType
+    from katana_mcp.tools import decorators
+
+    original = decorators._sync_fns
+    decorators._sync_fns = {
+        EntityType.VARIANT: AsyncMock(),
+        EntityType.PRODUCT: AsyncMock(),
+        EntityType.MATERIAL: AsyncMock(),
+        EntityType.SUPPLIER: AsyncMock(),
+    }
+    try:
+        with patch(
+            "katana_mcp.cache_sync.ensure_variants_synced", new_callable=AsyncMock
+        ):
+            yield
+    finally:
+        decorators._sync_fns = original
 
 
 _INVENTORY_API = "katana_public_api_client.api.inventory.get_all_inventory_point"

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -37,18 +37,27 @@ def _content_text(result) -> str:
 
 @pytest.fixture(autouse=True)
 def _patch_cache_sync():
-    """Patch variant sync for all unit tests.
+    """Patch entity syncs for all unit tests.
 
     The @cache_read decorator caches sync functions in a module-level dict on
     first call, so patching the cache_sync module alone is not enough — we
     also need to clear and re-mock the cached mapping in the decorators module.
+
+    ``get_variant_details`` syncs VARIANT plus PRODUCT, MATERIAL, and SUPPLIER
+    (so the parent-derived ``default_supplier_id`` / ``default_supplier_name``
+    can be lifted onto the variant response — see #613-followup), so all four
+    are mocked.
     """
     from katana_mcp.cache import EntityType
     from katana_mcp.tools import decorators
 
-    mock_sync = AsyncMock()
     original = decorators._sync_fns
-    decorators._sync_fns = {EntityType.VARIANT: mock_sync}
+    decorators._sync_fns = {
+        EntityType.VARIANT: AsyncMock(),
+        EntityType.PRODUCT: AsyncMock(),
+        EntityType.MATERIAL: AsyncMock(),
+        EntityType.SUPPLIER: AsyncMock(),
+    }
     try:
         with patch(
             "katana_mcp.cache_sync.ensure_variants_synced", new_callable=AsyncMock
@@ -149,6 +158,73 @@ async def test_get_variant_details_format_json_includes_deleted_at():
 
     data = json.loads(_content_text(result))
     assert data["variants"][0]["deleted_at"] == "2024-09-01T12:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_syncs_parent_entity_caches():
+    """get_variant_details lifts ``default_supplier_id`` / ``_name`` from the
+    parent product/material — so PRODUCT, MATERIAL, and SUPPLIER caches must
+    be synced alongside VARIANT before the lookup runs. Otherwise a fresh
+    install / cold cache yields ``default_supplier_id: null`` for variants
+    whose parent simply hasn't been cached yet.
+    """
+    from katana_mcp.cache import EntityType
+    from katana_mcp.tools import decorators
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.cache.get_by_sku = AsyncMock(return_value=dict(_FULL_VARIANT_DICT))
+
+    request = GetVariantDetailsRequest(sku="KNF-PRO-8PC-STL")
+    await _get_variant_details_impl(request, context)
+
+    sync_fns = decorators._sync_fns
+    assert sync_fns is not None  # set by the autouse fixture
+    for entity_type in (
+        EntityType.VARIANT,
+        EntityType.PRODUCT,
+        EntityType.MATERIAL,
+        EntityType.SUPPLIER,
+    ):
+        sync_fns[entity_type].assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_lifts_default_supplier_from_parent():
+    """When parent + supplier are present in the cache, ``default_supplier_id``
+    and ``default_supplier_name`` are lifted onto the variant response
+    (regression: cold-cache call previously returned ``null`` because
+    PRODUCT/SUPPLIER were never synced before the parent lookup).
+    """
+    context, lifespan_ctx = create_mock_context()
+    variant = dict(_FULL_VARIANT_DICT)
+    lifespan_ctx.cache.get_by_sku = AsyncMock(return_value=variant)
+
+    parent_product = {
+        "id": 101,
+        "uom": "set",
+        "default_supplier_id": 555,
+        "batch_tracked": False,
+    }
+    supplier = {"id": 555, "name": "Acme Cutlery Co"}
+
+    async def _get_many_by_ids(entity_type, ids):
+        from katana_mcp.cache import EntityType
+
+        if entity_type == EntityType.PRODUCT:
+            return {101: parent_product} if 101 in set(ids) else {}
+        if entity_type == EntityType.SUPPLIER:
+            return {555: supplier} if 555 in set(ids) else {}
+        return {}
+
+    lifespan_ctx.cache.get_many_by_ids = AsyncMock(side_effect=_get_many_by_ids)
+
+    request = GetVariantDetailsRequest(sku="KNF-PRO-8PC-STL")
+    [result] = await _get_variant_details_impl(request, context)
+
+    assert result.default_supplier_id == 555
+    assert result.default_supplier_name == "Acme Cutlery Co"
+    assert result.uom == "set"
+    assert result.is_batch_tracked is False
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`get_variant_details` was returning `default_supplier_id: null` for variants that did, in fact, have a supplier configured on the parent product/material. The supplier (and `default_supplier_name`, `uom`, `is_batch_tracked`) lives on the parent header, not on the variant — so the tool already lifts those fields from the parent during enrichment. The bug: the `@cache_read` decorator was only syncing `VARIANT`, so any variant whose parent or default-supplier row hadn't been cached on a prior call hit an empty parent dict and the lifted fields all came back null.

- Add `PRODUCT`, `MATERIAL`, and `SUPPLIER` to the `@cache_read` decorator on `_get_variant_details_impl` (matches the four-entity pattern already used by `_top_selling_variants_impl` in reporting).
- Extend the autouse `_patch_cache_sync` fixtures in `test_items.py`, `test_inventory.py`, and `test_error_scenarios.py` to mock all four sync functions — the previous fixtures only stubbed VARIANT, so the new sync calls would otherwise hit real `get_all_products` against a `MagicMock` httpx client.
- Add two regression tests:
  - `test_get_variant_details_syncs_parent_entity_caches` pins the four-entity sync set.
  - `test_get_variant_details_lifts_default_supplier_from_parent` exercises the parent-supplier lift end-to-end with pre-populated cache mocks.

## Test plan

- [x] `uv run poe check` (2983 passed, 2 skipped)
- [x] New tests cover the four-entity sync set and the parent-supplier lift
- [ ] Smoke-test `get_variant_details` against the production tenant — confirm `default_supplier_id` and `default_supplier_name` populate for a variant whose parent has a supplier set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)