### PR TITLE
feat(mcp): direct-apply preview cards for every modification tool

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -31,7 +31,7 @@ from typing import Any, ClassVar
 from fastmcp.tools import ToolResult
 from pydantic import BaseModel, ConfigDict, Field
 
-from katana_mcp.tools.tool_result_utils import BLOCK_WARNING_PREFIX, make_simple_result
+from katana_mcp.tools.tool_result_utils import BLOCK_WARNING_PREFIX, make_tool_result
 from katana_public_api_client.client_types import UNSET, Unset
 from katana_public_api_client.domain.converters import unwrap_unset
 
@@ -425,9 +425,39 @@ def render_modification_md(response: ModificationResponse) -> str:
     return "\n".join(lines)
 
 
-def to_tool_result(response: ModificationResponse) -> ToolResult:
-    """Build a :class:`ToolResult` from a :class:`ModificationResponse`."""
-    return make_simple_result(
-        render_modification_md(response),
-        structured_data=response.model_dump(),
+def to_tool_result(
+    response: ModificationResponse,
+    *,
+    confirm_request: ConfirmableRequest,
+    confirm_tool: str,
+) -> ToolResult:
+    """Build a :class:`ToolResult` with a Prefab UI from a ModificationResponse.
+
+    Preview branch: emits ``build_modification_preview_ui`` with the
+    direct-apply rail (Confirm fires ``tools/call`` directly + iframe
+    pushes the structured result back via ``ui/update-model-context``).
+    Non-preview branch: emits ``build_modification_result_ui`` summarizing
+    each action's terminal status.
+
+    ``confirm_request`` is the original Pydantic request (its ``preview``
+    field flips to ``False`` when the iframe re-issues for apply);
+    ``confirm_tool`` is the registered MCP tool name to re-call. The
+    preview branch wires both into the Confirm-button CallTool; the
+    result branch uses ``confirm_tool`` to derive the title verb so a
+    delete reads "Product Delete" instead of "Product Modification".
+    """
+    from katana_mcp.tools.prefab_ui import (
+        build_modification_preview_ui,
+        build_modification_result_ui,
     )
+
+    response_dict = response.model_dump()
+    if response.is_preview:
+        ui = build_modification_preview_ui(
+            response_dict,
+            confirm_request=confirm_request,
+            confirm_tool=confirm_tool,
+        )
+    else:
+        ui = build_modification_result_ui(response_dict, tool_name=confirm_tool)
+    return make_tool_result(response, ui=ui)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
@@ -84,6 +84,7 @@ from katana_mcp.tools.foundation.sales_orders import (
     SOOperation,
     _fetch_sales_order_attrs,
 )
+from katana_mcp.tools.tool_result_utils import UI_META
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.api.manufacturing_order import (
@@ -747,7 +748,11 @@ async def correct_manufacturing_order(
     ``prior_state``.
     """
     response = await _correct_manufacturing_order_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(
+        response,
+        confirm_request=request,
+        confirm_tool="correct_manufacturing_order",
+    )
 
 
 # ============================================================================
@@ -1198,7 +1203,9 @@ async def correct_sales_order(
     SO in an intermediate state with a breadcrumb in ``prior_state``.
     """
     response = await _correct_sales_order_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(
+        response, confirm_request=request, confirm_tool="correct_sales_order"
+    )
 
 
 # ============================================================================
@@ -1648,7 +1655,9 @@ async def correct_purchase_order(
     directly — there's no close-state to preserve.
     """
     response = await _correct_purchase_order_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(
+        response, confirm_request=request, confirm_tool="correct_purchase_order"
+    )
 
 
 # ============================================================================
@@ -1674,16 +1683,22 @@ def register_tools(mcp: FastMCP) -> None:
         correct_manufacturing_order,
         tags={"orders", "manufacturing", "write", "correction"},
         annotations=_correct,
+        meta=UI_META,
+        direct=True,
     )
     register_preview_tool(
         mcp,
         correct_sales_order,
         tags={"orders", "sales", "write", "correction"},
         annotations=_correct,
+        meta=UI_META,
+        direct=True,
     )
     register_preview_tool(
         mcp,
         correct_purchase_order,
         tags={"orders", "purchasing", "write", "correction"},
         annotations=_correct,
+        meta=UI_META,
+        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -1288,7 +1288,7 @@ async def modify_item(
     error.
     """
     response = await _modify_item_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(response, confirm_request=request, confirm_tool="modify_item")
 
 
 # ============================================================================
@@ -1333,7 +1333,7 @@ async def delete_item(
     for manual revert.
     """
     response = await _delete_item_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(response, confirm_request=request, confirm_tool="delete_item")
 
 
 # ============================================================================
@@ -1762,12 +1762,16 @@ def register_tools(mcp: FastMCP) -> None:
         modify_item,
         tags={"catalog", "write"},
         annotations=_modify,
+        meta=UI_META,
+        direct=True,
     )
     register_preview_tool(
         mcp,
         delete_item,
         tags={"catalog", "write", "destructive"},
         annotations=_destructive,
+        meta=UI_META,
+        direct=True,
     )
     mcp.tool(tags={"catalog", "read"}, annotations=_read, meta=UI_META)(
         get_variant_details

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -3118,7 +3118,11 @@ async def modify_manufacturing_order(
     revert.
     """
     response = await _modify_manufacturing_order_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(
+        response,
+        confirm_request=request,
+        confirm_tool="modify_manufacturing_order",
+    )
 
 
 # ============================================================================
@@ -3155,7 +3159,11 @@ async def delete_manufacturing_order(
     The response carries a ``prior_state`` snapshot for manual revert.
     """
     response = await _delete_manufacturing_order_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(
+        response,
+        confirm_request=request,
+        confirm_tool="delete_manufacturing_order",
+    )
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -3215,10 +3223,14 @@ def register_tools(mcp: FastMCP) -> None:
         modify_manufacturing_order,
         tags={"orders", "manufacturing", "write"},
         annotations=_modify,
+        meta=UI_META,
+        direct=True,
     )
     register_preview_tool(
         mcp,
         delete_manufacturing_order,
         tags={"orders", "manufacturing", "write", "destructive"},
         annotations=_destructive_write,
+        meta=UI_META,
+        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -2707,7 +2707,9 @@ async def modify_purchase_order(
       pre-modification PO so callers can compose a revert call manually.
     """
     response = await _modify_purchase_order_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(
+        response, confirm_request=request, confirm_tool="modify_purchase_order"
+    )
 
 
 # ============================================================================
@@ -2744,7 +2746,9 @@ async def delete_purchase_order(
     snapshot of the pre-delete PO so callers can recreate it manually if needed.
     """
     response = await _delete_purchase_order_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(
+        response, confirm_request=request, confirm_tool="delete_purchase_order"
+    )
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -2811,10 +2815,14 @@ def register_tools(mcp: FastMCP) -> None:
         modify_purchase_order,
         tags={"orders", "purchasing", "write"},
         annotations=_modify,
+        meta=UI_META,
+        direct=True,
     )
     register_preview_tool(
         mcp,
         delete_purchase_order,
         tags={"orders", "purchasing", "write", "destructive"},
         annotations=_destructive,
+        meta=UI_META,
+        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -2108,7 +2108,9 @@ async def modify_sales_order(
     field as ``(prior unknown) → new``.
     """
     response = await _modify_sales_order_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(
+        response, confirm_request=request, confirm_tool="modify_sales_order"
+    )
 
 
 # ============================================================================
@@ -2144,7 +2146,9 @@ async def delete_sales_order(
     The response carries a ``prior_state`` snapshot for manual revert.
     """
     response = await _delete_sales_order_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(
+        response, confirm_request=request, confirm_tool="delete_sales_order"
+    )
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -2194,10 +2198,14 @@ def register_tools(mcp: FastMCP) -> None:
         modify_sales_order,
         tags={"orders", "sales", "write"},
         annotations=_modify,
+        meta=UI_META,
+        direct=True,
     )
     register_preview_tool(
         mcp,
         delete_sales_order,
         tags={"orders", "sales", "write", "destructive"},
         annotations=_destructive,
+        meta=UI_META,
+        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -41,6 +41,7 @@ from katana_mcp.tools._modification_dispatch import (
 )
 from katana_mcp.tools.tool_result_utils import (
     BLOCK_WARNING_PREFIX,
+    UI_META,
     PaginationMeta,
     apply_date_window_filters,
     enum_to_str,
@@ -964,7 +965,9 @@ async def modify_stock_transfer(
     so previews show every supplied field as ``(prior unknown) → new``.
     """
     response = await _modify_stock_transfer_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(
+        response, confirm_request=request, confirm_tool="modify_stock_transfer"
+    )
 
 
 # ============================================================================
@@ -1004,7 +1007,9 @@ async def delete_stock_transfer(
     with a snapshot for manual revert).
     """
     response = await _delete_stock_transfer_impl(request, context)
-    return to_tool_result(response)
+    return to_tool_result(
+        response, confirm_request=request, confirm_tool="delete_stock_transfer"
+    )
 
 
 # ============================================================================
@@ -1055,10 +1060,14 @@ def register_tools(mcp: FastMCP) -> None:
         modify_stock_transfer,
         tags={"inventory", "stock_transfer", "write"},
         annotations=_modify,
+        meta=UI_META,
+        direct=True,
     )
     register_preview_tool(
         mcp,
         delete_stock_transfer,
         tags={"inventory", "stock_transfer", "write", "destructive"},
         annotations=_destructive,
+        meta=UI_META,
+        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -28,6 +28,9 @@ from prefab_ui.actions.mcp import CallTool, SendMessage, UpdateContext
 from prefab_ui.app import PrefabApp
 from prefab_ui.components import (
     H3,
+    Alert,
+    AlertDescription,
+    AlertTitle,
     Badge,
     Button,
     Card,
@@ -1227,6 +1230,387 @@ def build_verification_ui(
                     on_click=SendMessage(
                         f"Receive items for purchase order {response.get('order_id', '')} "
                         "despite discrepancies"
+                    ),
+                )
+    return app
+
+
+# ============================================================================
+# Generic Modification Preview/Result UIs (modify_*/delete_*/correct_*)
+# ============================================================================
+
+
+def _format_field_value(value: Any) -> str:
+    """Render a FieldChange ``old`` / ``new`` value for the diff DataTable.
+
+    ``None`` collapses to ``(unset)`` so the cell isn't blank; lists are
+    comma-joined for compact display; everything else stringifies.
+    """
+    if value is None:
+        return "(unset)"
+    if isinstance(value, list):
+        return ", ".join(str(v) for v in value)
+    return str(value)
+
+
+def _change_to_diff_row(change: dict[str, Any]) -> dict[str, Any]:
+    """Convert a :class:`FieldChange` dict into a diff DataTable row.
+
+    Mirrors the markdown layout in
+    :func:`katana_mcp.tools._modification._render_changes_block`:
+
+    - ``is_unchanged`` — "(unchanged)" in the After column
+    - ``is_unknown_prior`` — "(prior unknown)" in the Before column
+    - ``is_added`` — "(unset)" in the Before column
+    - default — old → new
+    """
+    field = str(change.get("field", ""))
+    new = _format_field_value(change.get("new"))
+    if change.get("is_unchanged"):
+        return {
+            "field": field,
+            "before": _format_field_value(change.get("old")),
+            "after": "(unchanged)",
+        }
+    if change.get("is_unknown_prior"):
+        return {"field": field, "before": "(prior unknown)", "after": new}
+    if change.get("is_added"):
+        return {"field": field, "before": "(unset)", "after": new}
+    return {
+        "field": field,
+        "before": _format_field_value(change.get("old")),
+        "after": new,
+    }
+
+
+_DIFF_COLUMNS: list[DataTableColumn] = [
+    DataTableColumn(key="field", header="Field"),
+    DataTableColumn(key="before", header="Before"),
+    DataTableColumn(key="after", header="After"),
+]
+
+_LEGACY_DIFF_STATE_KEY = "legacy_diff_rows"
+
+# Display labels for the verb in modification card titles. The verb is
+# derived from the registered tool name (its first underscore-delimited
+# token), so ``modify_item`` → "Modify", ``delete_item`` → "Delete", etc.
+# Fallback for unrecognized verbs is "Modify" so the title still reads
+# sensibly even if a new tool prefix is introduced before this map is
+# updated.
+_VERB_DISPLAY: dict[str, str] = {
+    "modify": "Modify",
+    "delete": "Delete",
+    "correct": "Correct",
+    "update": "Update",
+}
+
+
+def _humanize_snake_case(raw: str) -> str:
+    """Convert a snake_case identifier to a Title Case display label."""
+    return raw.replace("_", " ").title()
+
+
+def _verb_label(tool_name: str | None) -> str:
+    """Pick the human-readable verb for the modification card title.
+
+    Used to render ``"Modify Product"`` / ``"Delete Product"`` /
+    ``"Correct Purchase Order"`` titles correctly across the modification
+    rail. ``None`` (or any unrecognized prefix) falls back to "Modify".
+    """
+    if not tool_name:
+        return "Modify"
+    return _VERB_DISPLAY.get(tool_name.split("_", 1)[0], "Modify")
+
+
+def _action_status_badge(
+    action: dict[str, Any],
+) -> tuple[str, Literal["default", "secondary", "outline", "destructive"]]:
+    """Pick a (label, variant) pair for an action's status badge.
+
+    ``succeeded is None`` means the action hasn't been executed (preview
+    or fail-fast skip), so we surface PLANNED. Mirrors the status string
+    in ``katana_mcp.tools._modification._render_action_block`` so the
+    Prefab card and the markdown fallback agree on how each action reads.
+    """
+    succeeded = action.get("succeeded")
+    if succeeded is None:
+        return "PLANNED", "secondary"
+    if succeeded is True:
+        verified = action.get("verified")
+        if verified is False:
+            return "APPLIED (verification mismatch)", "destructive"
+        if verified is None:
+            return "APPLIED", "default"
+        return "APPLIED (verified)", "default"
+    return "FAILED", "destructive"
+
+
+def _render_action_section(
+    idx: int,
+    action: dict[str, Any],
+    *,
+    rows_state_key: str | None,
+) -> None:
+    """Render one ActionResult as a Separator + heading + diff DataTable.
+
+    ``rows_state_key`` is the PrefabApp state slot holding the diff rows
+    for this action (or ``None`` when the action has no field changes —
+    e.g. a delete). DataTable binds rows by state-key string per the
+    file's convention.
+    """
+    Separator()
+    op_label = _humanize_snake_case(str(action.get("operation") or "")) or "Action"
+    target = action.get("target_id")
+    target_suffix = f" #{target}" if target is not None else ""
+    status_label, status_variant = _action_status_badge(action)
+    with Row(gap=2):
+        Text(content=f"{idx}. {op_label}{target_suffix}")
+        Badge(label=status_label, variant=status_variant)
+
+    if action.get("error"):
+        Muted(content=f"Error: {action['error']}")
+
+    if rows_state_key is not None:
+        DataTable(columns=_DIFF_COLUMNS, rows=rows_state_key)
+
+
+def _summarize_actions(
+    actions: list[dict[str, Any]],
+) -> tuple[dict[str, list[dict[str, Any]]], list[str | None], int, int]:
+    """One-pass action scan for the modification builders.
+
+    Returns ``(state_slots, per_action_keys, success_count, failed_count)``:
+
+    - ``state_slots`` maps slot name (``"diff_action_<idx>"``) to its row
+      list — fold this into the PrefabApp ``state`` dict.
+    - ``per_action_keys[i]`` is the slot name for action ``i``, or ``None``
+      if the action has no field changes (e.g. a delete).
+    - The two counts are used by the result builder for the aggregate
+      status badge; the preview builder ignores them (succeeded is always
+      ``None`` on preview-shaped actions).
+    """
+    state_slots: dict[str, list[dict[str, Any]]] = {}
+    per_action_keys: list[str | None] = []
+    success_count = failed_count = 0
+    for idx, action in enumerate(actions, start=1):
+        succeeded = action.get("succeeded")
+        if succeeded is True:
+            success_count += 1
+        elif succeeded is False:
+            failed_count += 1
+        rows = [_change_to_diff_row(c) for c in (action.get("changes") or [])]
+        if rows:
+            key = f"diff_action_{idx}"
+            state_slots[key] = rows
+            per_action_keys.append(key)
+        else:
+            per_action_keys.append(None)
+    return state_slots, per_action_keys, success_count, failed_count
+
+
+def build_modification_preview_ui(
+    response: dict[str, Any],
+    *,
+    confirm_request: BaseModel,
+    confirm_tool: str,
+) -> PrefabApp:
+    """Preview card for a :class:`ModificationResponse` with the direct-apply rail.
+
+    Used by every tool that returns a ``ModificationResponse`` from
+    ``_modification.py`` — ``modify_*``, ``delete_*``, ``correct_*``.
+    Confirm fires ``tools/call`` directly and the iframe pushes the
+    structured result to the agent via ``ui/update-model-context``
+    (ADR-0016 spike rail).
+
+    Renders one section per planned :class:`ActionResult` (operation header
+    + diff DataTable) plus a footer Confirm/Cancel pair that morphs in
+    place to applied / error / cancelled states.
+    """
+    apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    entity_type_raw = str(response.get("entity_type") or "entity")
+    entity_type_label = _humanize_snake_case(entity_type_raw)
+    verb_label = _verb_label(confirm_tool)
+    cancel_action = _build_cancel_action(
+        f"the {entity_type_raw.replace('_', ' ')} {verb_label.lower()}"
+    )
+
+    actions = response.get("actions") or []
+    legacy_changes = response.get("changes") or []
+    block_warnings, regular_warnings = _split_warnings(response.get("warnings"))
+    n_actions = len(actions) if actions else (1 if legacy_changes else 0)
+
+    action_row_slots, per_action_keys, _, _ = _summarize_actions(actions)
+    legacy_rows_key: str | None = None
+    if not actions and legacy_changes:
+        legacy_rows_key = _LEGACY_DIFF_STATE_KEY
+
+    state: dict[str, Any] = {
+        "pending": False,
+        "cancelled": False,
+        "applied": False,
+        "error": None,
+        **action_row_slots,
+    }
+    if legacy_rows_key is not None:
+        state[legacy_rows_key] = [_change_to_diff_row(c) for c in legacy_changes]
+
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
+        with CardHeader(), Row(gap=2):
+            title_suffix = f" — {n_actions} action(s)" if n_actions > 0 else ""
+            CardTitle(content=f"{verb_label} {entity_type_label}{title_suffix}")
+            entity_id = response.get("entity_id")
+            if entity_id is not None:
+                Badge(label=f"#{entity_id}", variant="outline")
+            Badge(label="PREVIEW", variant="secondary")
+
+        with CardContent(), Column(gap=3):
+            if response.get("message"):
+                Text(content=response["message"])
+
+            if actions:
+                for idx, action in enumerate(actions, start=1):
+                    _render_action_section(
+                        idx, action, rows_state_key=per_action_keys[idx - 1]
+                    )
+            elif legacy_rows_key is not None:
+                DataTable(columns=_DIFF_COLUMNS, rows=legacy_rows_key)
+
+            if block_warnings or regular_warnings:
+                Separator()
+                for warning in block_warnings:
+                    Badge(label=warning, variant="destructive")
+                for warning in regular_warnings:
+                    Badge(label=warning, variant="secondary")
+
+            with If("applied"):
+                Separator()
+                Text(content=f"{entity_type_label} {verb_label.lower()} applied.")
+                Muted(
+                    content=(
+                        "The structured result has been pushed to the "
+                        "assistant's context."
+                    )
+                )
+            with Elif("error"):
+                Separator()
+                with Alert(variant="destructive", icon="circle-alert"):
+                    AlertTitle(content="Apply failed")
+                    AlertDescription(content="{{ error }}")
+
+        with CardFooter():
+            if block_warnings:
+                Muted(
+                    content="Cannot proceed — see warnings above. No changes have been made."
+                )
+            else:
+                with If("applied"):
+                    Muted(content="Changes applied.")
+                with Elif("error"):
+                    Muted(content="Apply failed — see error above.")
+                with Elif("cancelled"):
+                    Muted(content="Cancelled. No changes were made.")
+                with Else():
+                    Muted(content="This is a preview. No changes have been made.")
+
+            confirm_label = (
+                f"Confirm {n_actions} action(s)" if n_actions > 1 else "Confirm Changes"
+            )
+            _render_apply_button_row(
+                confirm_label=confirm_label,
+                apply_action=apply_action,
+                cancel_action=cancel_action,
+                disabled=bool(block_warnings),
+                direct_apply=True,
+            )
+    return app
+
+
+def build_modification_result_ui(
+    response: dict[str, Any], *, tool_name: str | None = None
+) -> PrefabApp:
+    """Result card for an *applied* :class:`ModificationResponse`.
+
+    Mirrors :func:`build_modification_preview_ui` but without Confirm/Cancel
+    — every action carries its terminal status (APPLIED / APPLIED (verified) /
+    APPLIED (verification mismatch) / FAILED) and the card surfaces the
+    aggregate outcome plus a "View in Katana" button when a ``katana_url``
+    is present (deletes successfully applied null out the URL upstream).
+
+    ``tool_name`` is the registered MCP tool name (e.g. ``"delete_item"``) —
+    used to derive the title's verb so a successful delete reads "Product
+    Delete" rather than the misleading "Product Modification". Optional
+    for backwards compatibility with the legacy single-action shape, which
+    falls back to the response's top-level ``operation`` field.
+    """
+    entity_type_label = _humanize_snake_case(
+        str(response.get("entity_type") or "entity")
+    )
+    actions = response.get("actions") or []
+    legacy_changes = response.get("changes") or []
+    legacy_op = _humanize_snake_case(str(response.get("operation") or ""))
+
+    action_row_slots, per_action_keys, success_count, failed_count = _summarize_actions(
+        actions
+    )
+
+    overall_status: str
+    overall_variant: Literal["default", "secondary", "outline", "destructive"]
+    if failed_count > 0 and success_count > 0:
+        overall_status, overall_variant = "PARTIAL FAILURE", "destructive"
+    elif failed_count > 0:
+        overall_status, overall_variant = "FAILED", "destructive"
+    else:
+        overall_status, overall_variant = "APPLIED", "default"
+
+    legacy_rows_key: str | None = None
+    if not actions and legacy_changes:
+        legacy_rows_key = _LEGACY_DIFF_STATE_KEY
+
+    state: dict[str, Any] = dict(action_row_slots)
+    if legacy_rows_key is not None:
+        state[legacy_rows_key] = [_change_to_diff_row(c) for c in legacy_changes]
+
+    # Title verb: prefer the tool-derived verb (works for delete/correct
+    # tools); fall back to the legacy single-action ``operation`` field;
+    # finally to a neutral "Modification".
+    if tool_name:
+        title_op = _verb_label(tool_name)
+    else:
+        title_op = legacy_op or "Modification"
+
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
+        with CardHeader(), Row(gap=2):
+            CardTitle(content=f"{entity_type_label} {title_op}")
+            entity_id = response.get("entity_id")
+            if entity_id is not None:
+                Badge(label=f"#{entity_id}", variant="outline")
+            Badge(label=overall_status, variant=overall_variant)
+
+        with CardContent(), Column(gap=3):
+            if response.get("message"):
+                Text(content=response["message"])
+
+            if actions:
+                Muted(
+                    content=(
+                        f"{success_count} succeeded, {failed_count} failed "
+                        f"of {len(actions)}"
+                    )
+                )
+                for idx, action in enumerate(actions, start=1):
+                    _render_action_section(
+                        idx, action, rows_state_key=per_action_keys[idx - 1]
+                    )
+            elif legacy_rows_key is not None:
+                DataTable(columns=_DIFF_COLUMNS, rows=legacy_rows_key)
+
+        if response.get("katana_url"):
+            with CardFooter(), Row(gap=2):
+                Button(
+                    label="View in Katana",
+                    variant="outline",
+                    on_click=SendMessage(
+                        f"Open {response['katana_url']} in the Katana web UI"
                     ),
                 )
     return app

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -16,6 +16,8 @@ from katana_mcp.tools.prefab_ui import (
     build_item_detail_ui,
     build_item_mutation_ui,
     build_low_stock_ui,
+    build_modification_preview_ui,
+    build_modification_result_ui,
     build_order_created_ui,
     build_order_preview_ui,
     build_receipt_ui,
@@ -1556,4 +1558,472 @@ class TestBlockWarningSuppressesConfirm:
         )
         assert not diagnostic_label.startswith("BLOCK:"), (
             f"Badge label still has literal BLOCK: prefix: {diagnostic_label!r}"
+        )
+
+
+class _ModifyStubRequest(BaseModel):
+    """Stub for ``ConfirmableRequest`` used by modification-card tests.
+
+    Mirrors the load-bearing fields ``_build_apply_action_direct`` reads
+    (``id``, ``preview``) without pulling a real entity request shape into
+    these unit tests.
+    """
+
+    id: int = 1
+    preview: bool = True
+
+
+def _modification_preview_response(
+    *,
+    actions: list[dict] | None = None,
+    legacy_changes: list[dict] | None = None,
+    warnings: list[str] | None = None,
+    katana_url: str | None = None,
+) -> dict:
+    """Build a minimal preview-shaped ``ModificationResponse`` dict."""
+    return {
+        "entity_type": "product",
+        "entity_id": 17058420,
+        "is_preview": True,
+        "operation": "" if actions is not None else "update",
+        "changes": legacy_changes or [],
+        "actions": actions or [],
+        "prior_state": None,
+        "warnings": warnings or [],
+        "next_actions": ["Review the planned actions", "Set preview=false to apply"],
+        "katana_url": katana_url,
+        "message": "Preview: 2 action(s) planned",
+    }
+
+
+class TestBuildModificationPreviewUI:
+    """Preview card for ``modify_*`` / ``delete_*`` / ``correct_*`` tools.
+
+    The card must render a per-action diff DataTable and a Confirm button
+    on the direct-apply rail (Confirm fires ``tools/call`` directly + the
+    iframe pushes the result via ``ui/update-model-context``).
+    """
+
+    def test_basic_two_action_preview_renders_envelope(self):
+        response = _modification_preview_response(
+            actions=[
+                {
+                    "operation": "update_header",
+                    "target_id": 17058420,
+                    "changes": [
+                        {
+                            "field": "name",
+                            "old": "Old Name",
+                            "new": "New Name",
+                            "is_added": False,
+                            "is_unchanged": False,
+                            "is_unknown_prior": False,
+                        }
+                    ],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                },
+                {
+                    "operation": "update_variant",
+                    "target_id": 40371805,
+                    "changes": [
+                        {
+                            "field": "internal_barcode",
+                            "old": None,
+                            "new": "LD0739",
+                            "is_added": False,
+                            "is_unchanged": False,
+                            "is_unknown_prior": True,
+                        }
+                    ],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                },
+            ],
+        )
+        app = build_modification_preview_ui(
+            response,
+            confirm_request=_ModifyStubRequest(id=17058420, preview=True),
+            confirm_tool="modify_item",
+        )
+        _assert_valid_prefab(app)
+
+    def test_confirm_button_uses_direct_apply_call_tool(self):
+        """Confirm wires CallTool(modify_item, ..., preview=False)."""
+        response = _modification_preview_response(
+            actions=[
+                {
+                    "operation": "update_header",
+                    "target_id": 1,
+                    "changes": [
+                        {
+                            "field": "name",
+                            "old": "x",
+                            "new": "y",
+                            "is_added": False,
+                            "is_unchanged": False,
+                            "is_unknown_prior": False,
+                        }
+                    ],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                }
+            ],
+        )
+        app = build_modification_preview_ui(
+            response,
+            confirm_request=_ModifyStubRequest(id=1, preview=True),
+            confirm_tool="modify_item",
+        )
+        envelope = app.to_json()
+
+        # Find the CallTool action — it's nested under a Button's onClick.
+        def find_call_tool(tree: object) -> dict | None:
+            if isinstance(tree, dict):
+                if tree.get("action") == "toolCall":
+                    return tree
+                for v in tree.values():
+                    found = find_call_tool(v)
+                    if found is not None:
+                        return found
+            elif isinstance(tree, list):
+                for v in tree:
+                    found = find_call_tool(v)
+                    if found is not None:
+                        return found
+            return None
+
+        call_tool = find_call_tool(envelope)
+        assert call_tool is not None, "Confirm button must wire a CallTool action"
+        assert call_tool["tool"] == "modify_item"
+        assert call_tool["arguments"]["preview"] is False, (
+            "CallTool arguments must flip preview=False so the direct-apply "
+            "fires the apply branch."
+        )
+
+    def test_block_warning_suppresses_confirm_button(self):
+        """A ``BLOCK:``-prefixed warning must drop the Confirm button (only
+        Cancel remains), matching the shape used by the other preview cards.
+        """
+        response = _modification_preview_response(
+            actions=[
+                {
+                    "operation": "delete",
+                    "target_id": 1,
+                    "changes": [],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                }
+            ],
+            warnings=["BLOCK: cannot proceed — already deleted"],
+        )
+        app = build_modification_preview_ui(
+            response,
+            confirm_request=_ModifyStubRequest(),
+            confirm_tool="delete_item",
+        )
+        envelope = app.to_json()
+        confirm = _find_buttons_by_label(envelope, "Confirm Changes")
+        confirm_n = _find_buttons_by_label(envelope, "Confirm 1 action(s)")
+        assert len(confirm) + len(confirm_n) == 0, (
+            "Confirm button must be suppressed when a BLOCK: warning is set."
+        )
+        cancel = _find_buttons_by_label(envelope, "Cancel")
+        assert len(cancel) == 1, "Cancel button must remain on BLOCK warning."
+
+    def test_legacy_single_action_shape_renders_diff_table(self):
+        """Tools that still emit the legacy single-action shape (top-level
+        ``operation`` + ``changes``, empty ``actions``) must still get a
+        diff table rendered."""
+        response = _modification_preview_response(
+            actions=[],
+            legacy_changes=[
+                {
+                    "field": "status",
+                    "old": "DRAFT",
+                    "new": "RECEIVED",
+                    "is_added": False,
+                    "is_unchanged": False,
+                    "is_unknown_prior": False,
+                }
+            ],
+        )
+        app = build_modification_preview_ui(
+            response,
+            confirm_request=_ModifyStubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        envelope = app.to_json()
+        assert _has_node_of_type(envelope, "DataTable"), (
+            "Legacy single-action shape must still render a diff DataTable."
+        )
+
+    def test_title_verb_derives_from_tool_name(self):
+        """``modify_item`` → "Modify", ``delete_item`` → "Delete",
+        ``correct_purchase_order`` → "Correct" — closes Copilot review
+        finding that the title was hard-coded as "Modify".
+        """
+        response = _modification_preview_response(
+            actions=[
+                {
+                    "operation": "delete",
+                    "target_id": 1,
+                    "changes": [],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                }
+            ],
+        )
+        app = build_modification_preview_ui(
+            response,
+            confirm_request=_ModifyStubRequest(),
+            confirm_tool="delete_item",
+        )
+        envelope = app.to_json()
+        titles: list[str] = []
+
+        def collect_titles(o: object) -> None:
+            if isinstance(o, dict):
+                if o.get("type") == "CardTitle" and isinstance(o.get("content"), str):
+                    titles.append(o["content"])
+                for v in o.values():
+                    collect_titles(v)
+            elif isinstance(o, list):
+                for v in o:
+                    collect_titles(v)
+
+        collect_titles(envelope)
+        assert any(t.startswith("Delete ") for t in titles), (
+            f"delete_item card title must start with 'Delete'; got {titles!r}"
+        )
+
+    def test_title_action_count_suffix_uses_n_actions(self):
+        """The action-count suffix must be present whenever there's at
+        least one planned action, including the legacy single-action
+        shape (where ``actions`` is empty but ``changes`` is populated).
+        Closes Copilot review finding.
+        """
+        response = _modification_preview_response(
+            actions=[],
+            legacy_changes=[
+                {
+                    "field": "status",
+                    "old": "DRAFT",
+                    "new": "RECEIVED",
+                    "is_added": False,
+                    "is_unchanged": False,
+                    "is_unknown_prior": False,
+                }
+            ],
+        )
+        app = build_modification_preview_ui(
+            response,
+            confirm_request=_ModifyStubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        envelope = app.to_json()
+        titles: list[str] = []
+
+        def collect_titles(o: object) -> None:
+            if isinstance(o, dict):
+                if o.get("type") == "CardTitle" and isinstance(o.get("content"), str):
+                    titles.append(o["content"])
+                for v in o.values():
+                    collect_titles(v)
+            elif isinstance(o, list):
+                for v in o:
+                    collect_titles(v)
+
+        collect_titles(envelope)
+        assert any("1 action(s)" in t for t in titles), (
+            f"Legacy single-action title must include the count suffix; got {titles!r}"
+        )
+
+
+class TestBuildModificationResultUI:
+    """Result card for an applied (non-preview) ModificationResponse."""
+
+    def _response(self, actions: list[dict]) -> dict:
+        return {
+            "entity_type": "purchase_order",
+            "entity_id": 99,
+            "is_preview": False,
+            "operation": "",
+            "changes": [],
+            "actions": actions,
+            "prior_state": None,
+            "warnings": [],
+            "next_actions": [],
+            "katana_url": "https://factory.katanamrp.com/purchaseorder/99",
+            "message": "Applied 2 action(s)",
+        }
+
+    def test_all_succeeded_renders_applied_status(self):
+        response = self._response(
+            [
+                {
+                    "operation": "update_header",
+                    "target_id": 99,
+                    "changes": [
+                        {
+                            "field": "status",
+                            "old": "DRAFT",
+                            "new": "OPEN",
+                            "is_added": False,
+                            "is_unchanged": False,
+                            "is_unknown_prior": False,
+                        }
+                    ],
+                    "succeeded": True,
+                    "error": None,
+                    "verified": True,
+                    "actual_after": None,
+                }
+            ]
+        )
+        app = build_modification_result_ui(response)
+        envelope = app.to_json()
+        labels: list[str] = []
+
+        def collect_badges(o: object) -> None:
+            if isinstance(o, dict):
+                if o.get("type") == "Badge" and isinstance(o.get("label"), str):
+                    labels.append(o["label"])
+                for v in o.values():
+                    collect_badges(v)
+            elif isinstance(o, list):
+                for v in o:
+                    collect_badges(v)
+
+        collect_badges(envelope)
+        assert "APPLIED" in labels, (
+            f"Top-level status badge must read APPLIED on full success; got {labels!r}"
+        )
+
+    def test_partial_failure_marks_overall_partial_failure(self):
+        response = self._response(
+            [
+                {
+                    "operation": "update_header",
+                    "target_id": 99,
+                    "changes": [],
+                    "succeeded": True,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                },
+                {
+                    "operation": "update_row",
+                    "target_id": 1234,
+                    "changes": [],
+                    "succeeded": False,
+                    "error": "422 row already shipped",
+                    "verified": None,
+                    "actual_after": None,
+                },
+            ]
+        )
+        app = build_modification_result_ui(response)
+        envelope = app.to_json()
+        labels: list[str] = []
+
+        def collect_badges(o: object) -> None:
+            if isinstance(o, dict):
+                if o.get("type") == "Badge" and isinstance(o.get("label"), str):
+                    labels.append(o["label"])
+                for v in o.values():
+                    collect_badges(v)
+            elif isinstance(o, list):
+                for v in o:
+                    collect_badges(v)
+
+        collect_badges(envelope)
+        assert "PARTIAL FAILURE" in labels, (
+            f"Mixed succeed/fail must surface PARTIAL FAILURE; got {labels!r}"
+        )
+        # Per-action FAILED badge must also surface
+        assert "FAILED" in labels
+
+    def test_view_in_katana_button_present_when_url_set(self):
+        response = self._response(
+            [
+                {
+                    "operation": "update_header",
+                    "target_id": 99,
+                    "changes": [],
+                    "succeeded": True,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                }
+            ]
+        )
+        app = build_modification_result_ui(response)
+        envelope = app.to_json()
+        assert len(_find_buttons_by_label(envelope, "View in Katana")) == 1
+
+    def test_no_katana_url_drops_view_button(self):
+        response = self._response(
+            [
+                {
+                    "operation": "delete",
+                    "target_id": 99,
+                    "changes": [],
+                    "succeeded": True,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                }
+            ]
+        )
+        response["katana_url"] = None  # delete nulls it
+        app = build_modification_result_ui(response)
+        envelope = app.to_json()
+        assert len(_find_buttons_by_label(envelope, "View in Katana")) == 0
+
+    def test_title_verb_derives_from_tool_name(self):
+        """Result-card title verb mirrors the preview-card behavior —
+        ``delete_purchase_order`` reads "Purchase Order Delete" rather
+        than the misleading "Purchase Order Modification".
+        """
+        response = self._response(
+            [
+                {
+                    "operation": "delete",
+                    "target_id": 99,
+                    "changes": [],
+                    "succeeded": True,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                }
+            ]
+        )
+        app = build_modification_result_ui(response, tool_name="delete_purchase_order")
+        envelope = app.to_json()
+        titles: list[str] = []
+
+        def collect_titles(o: object) -> None:
+            if isinstance(o, dict):
+                if o.get("type") == "CardTitle" and isinstance(o.get("content"), str):
+                    titles.append(o["content"])
+                for v in o.values():
+                    collect_titles(v)
+            elif isinstance(o, list):
+                for v in o:
+                    collect_titles(v)
+
+        collect_titles(envelope)
+        assert any(t.endswith("Delete") for t in titles), (
+            f"delete_* result title must end with 'Delete'; got {titles!r}"
         )

--- a/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
+++ b/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
@@ -53,30 +53,33 @@ def registered_tools() -> dict[str, object]:
 # Tools currently using the direct-apply rail (per ADR-0016 spike).
 DIRECT_APPLY_TOOLS = [
     "create_purchase_order",
+    # Modification tools — every tool that returns a ModificationResponse
+    # via _modification.to_tool_result is on the direct-apply rail.
+    "modify_purchase_order",
+    "delete_purchase_order",
+    "modify_sales_order",
+    "delete_sales_order",
+    "modify_manufacturing_order",
+    "delete_manufacturing_order",
+    "modify_stock_transfer",
+    "delete_stock_transfer",
+    "modify_item",
+    "delete_item",
+    "correct_manufacturing_order",
+    "correct_sales_order",
+    "correct_purchase_order",
 ]
 
 # Tools using the SendMessage rail (default, per ADR-0015).
 SEND_MESSAGE_APPLY_TOOLS = [
-    "modify_purchase_order",
-    "delete_purchase_order",
     "receive_purchase_order",
     "create_sales_order",
-    "modify_sales_order",
-    "delete_sales_order",
     "create_manufacturing_order",
-    "modify_manufacturing_order",
-    "delete_manufacturing_order",
     "create_stock_transfer",
-    "modify_stock_transfer",
-    "delete_stock_transfer",
     "create_stock_adjustment",
     "update_stock_adjustment",
     "delete_stock_adjustment",
-    "modify_item",
-    "delete_item",
     "fulfill_order",
-    "correct_manufacturing_order",
-    "correct_sales_order",
 ]
 
 PREVIEW_BUTTON_TOOLS = DIRECT_APPLY_TOOLS + SEND_MESSAGE_APPLY_TOOLS

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -192,7 +192,19 @@ def test_render_modification_md_includes_parent_id_when_set():
     assert "**Parent ID**: 42" in md
 
 
-def test_to_tool_result_serializes_response_as_structured_data():
+def test_to_tool_result_emits_prefab_envelope_and_response_in_content():
+    """to_tool_result wires the Prefab modification card.
+
+    Per the MCP Apps spec (SEP-1865) and ``make_tool_result``: the
+    response JSON lives in ``content`` (model context — what the LLM
+    reads), and the Prefab envelope lives in ``structured_content`` (for
+    iframe rendering). The card shape itself is covered by
+    ``test_prefab_ui.py``; here we just verify the wiring.
+    """
+    import json as _json
+
+    from katana_mcp.tools._modification import ConfirmableRequest
+
     response = ModificationResponse(
         entity_type="purchase_order",
         entity_id=1,
@@ -200,12 +212,24 @@ def test_to_tool_result_serializes_response_as_structured_data():
         is_preview=False,
         message="ok",
     )
-    result = to_tool_result(response)
-    # The structured payload mirrors the response model — downstream callers
-    # rely on the shape via ``structured_content``.
+    confirm_request = ConfirmableRequest(id=1, preview=False)
+    result = to_tool_result(
+        response,
+        confirm_request=confirm_request,
+        confirm_tool="modify_purchase_order",
+    )
+
+    # content carries the response JSON for the LLM.
+    assert result.content
+    text = result.content[0].text  # type: ignore[union-attr]
+    payload = _json.loads(text)
+    assert payload["entity_type"] == "purchase_order"
+    assert payload["operation"] == "update"
+
+    # structured_content carries the Prefab envelope for the iframe.
     assert result.structured_content is not None
-    assert result.structured_content["entity_type"] == "purchase_order"
-    assert result.structured_content["operation"] == "update"
+    assert "$prefab" in result.structured_content
+    assert "view" in result.structured_content
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Adds `build_modification_preview_ui` and `build_modification_result_ui` to `katana_mcp/tools/prefab_ui.py`. Preview emits a Prefab card with a per-action diff DataTable (Field / Before / After) and direct-apply Confirm/Cancel that morphs in place to applied/error/cancelled. Result emits the same shape minus buttons plus an aggregate `APPLIED` / `PARTIAL FAILURE` / `FAILED` status badge.
- `_modification.to_tool_result(response)` is rewritten to take `confirm_request` + `confirm_tool` kwargs and route to the appropriate builder via `make_tool_result(response, ui=ui)`. All 13 wrapper call sites pass them through; matching `register_preview_tool` calls flip to `direct=True` + `meta=UI_META` so the agent receives `PREVIEW_APPLY_DIRECT_COACHING`.
- Uses the direct-apply rail spiked in #56a4ea58 (per ADR-0016): Confirm fires `tools/call` directly, iframe pushes the structured result back via `ui/update-model-context` (MCP Apps SEP-1865), so the agent gets the apply outcome on its next turn without re-issuing. Tools moved to direct-apply: `modify_purchase_order`, `delete_purchase_order`, `modify_sales_order`, `delete_sales_order`, `modify_manufacturing_order`, `delete_manufacturing_order`, `modify_stock_transfer`, `delete_stock_transfer`, `modify_item`, `delete_item`, `correct_manufacturing_order`, `correct_sales_order`, `correct_purchase_order`. The SendMessage rail still serves `receive_purchase_order`, `fulfill_order`, `update_stock_adjustment`, `delete_stock_adjustment`, and the `create_*` paths that don't go through `_modification.to_tool_result`.
- Two side fixes ported from a parallel session: the error block binds `{{ error }}` (bare state-key, matching `{{ pending }}` / `{{ applied }}`) instead of `{{ $state.error }}` which rendered literally; and renders as an `Alert` with `AlertTitle` + `AlertDescription` (destructive variant) so apply failures surface inline in the card even when toasts miss.
- `correct_purchase_order` was missing from the description-coaching test allowlist entirely; added.

## Why
The user's screenshot showed a `modify_item` call producing only a bare "Result" chip in claude.ai because the response had no `PrefabApp` attached — `_modification.to_tool_result` was emitting markdown via `make_simple_result(...)` and never plumbed a UI envelope. The shared `ModificationResponse` shape already carries everything a card needs (per-action diffs, warnings, katana_url) — it just wasn't being rendered.

## Test plan
- [ ] `uv run poe check` is green locally (2991 passed; format/lint/type/test all clean)
- [ ] 8 new tests in `test_prefab_ui.py` cover: rendered envelope, direct-apply CallTool wiring with `preview=False`, BLOCK warnings suppressing the Confirm button, the legacy single-action diff path, APPLIED / PARTIAL FAILURE / FAILED badges, and the View-in-Katana button drop on successful delete.
- [ ] Existing `test_modification.py::to_tool_result` test updated to assert the new content/structured_content split (response JSON in `content`, Prefab envelope in `structured_content`).
- [ ] `test_tool_descriptions_and_annotations.py` rail registry updated; description coaching matches each tool's actual rail.
- [ ] Manual smoke test: send a `modify_item` call from a Claude.ai conversation against the local server; the diff card should render with Confirm; Confirm should morph the card to "Applied" and the agent should receive the structured result on its next turn without re-issuing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)