### PR TITLE
fix(mcp): surface apply errors clearly + document every Field on foundation tools

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -166,10 +166,18 @@ class CreateManufacturingOrderRequest(BaseModel):
         description="Make-to-order only: also create MOs for subassemblies. Ignored for standalone MOs.",
     )
     order_created_date: datetime | None = Field(
-        default=None, description="Order creation date (standalone mode only)"
+        default=None,
+        description=(
+            "Order creation date (standalone mode only) — ISO 8601 date or "
+            "datetime (e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
     production_deadline_date: datetime | None = Field(
-        default=None, description="Production deadline date (standalone mode only)"
+        default=None,
+        description=(
+            "Production deadline date (standalone mode only) — ISO 8601 date "
+            "or datetime (e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
     additional_info: str | None = Field(
         default=None, description="Additional notes (standalone mode only)"
@@ -202,8 +210,14 @@ class ManufacturingOrderResponse(BaseModel):
     production_deadline_date: datetime | None = None
     additional_info: str | None = None
     is_preview: bool
-    warnings: list[str] = Field(default_factory=list)
-    next_actions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Operator-facing warnings raised during the operation.",
+    )
+    next_actions: list[str] = Field(
+        default_factory=list,
+        description="Suggested follow-up tools to call after this response.",
+    )
     message: str
     katana_url: str | None = None
 
@@ -625,7 +639,8 @@ class RecipeRowInfo(BaseModel):
     ingredient_availability: str | None = None
     ingredient_expected_date: str | None = None
     batch_transactions: list[RecipeRowBatchTransactionInfo] = Field(
-        default_factory=list
+        default_factory=list,
+        description="Batch allocations consumed for this recipe row.",
     )
     cost: float | None = None
     created_at: str | None = None
@@ -641,14 +656,24 @@ class OperationRowInfo(BaseModel):
     id: int
     manufacturing_order_id: int | None = None
     status: str | None = None
-    type_: str | None = Field(default=None, alias="type_")
+    type_: str | None = Field(
+        default=None,
+        alias="type_",
+        description="Operation type — one of fixed, perUnit, process, or setup.",
+    )
     rank: float | None = None
     operation_id: int | None = None
     operation_name: str | None = None
     resource_id: int | None = None
     resource_name: str | None = None
-    assigned_operators: list[AssignedOperatorInfo] = Field(default_factory=list)
-    completed_by_operators: list[AssignedOperatorInfo] = Field(default_factory=list)
+    assigned_operators: list[AssignedOperatorInfo] = Field(
+        default_factory=list,
+        description="Operators currently assigned to this operation.",
+    )
+    completed_by_operators: list[AssignedOperatorInfo] = Field(
+        default_factory=list,
+        description="Operators who logged completed time on this operation.",
+    )
     active_operator_id: float | None = None
     planned_time_per_unit: float | None = None
     planned_time_parameter: float | None = None
@@ -714,9 +739,18 @@ class ProductionInfo(BaseModel):
     factory_id: int | None = None
     quantity: float | None = None
     production_date: str | None = None
-    ingredients: list[ProductionIngredientInfo] = Field(default_factory=list)
-    operations: list[ProductionOperationInfo] = Field(default_factory=list)
-    serial_numbers: list[SerialNumberInfo] = Field(default_factory=list)
+    ingredients: list[ProductionIngredientInfo] = Field(
+        default_factory=list,
+        description="Ingredient consumption records for this production.",
+    )
+    operations: list[ProductionOperationInfo] = Field(
+        default_factory=list,
+        description="Operation time records for this production.",
+    )
+    serial_numbers: list[SerialNumberInfo] = Field(
+        default_factory=list,
+        description="Serial numbers issued for this production.",
+    )
     created_at: str | None = None
     updated_at: str | None = None
     deleted_at: str | None = None
@@ -755,14 +789,29 @@ class GetManufacturingOrderResponse(BaseModel):
     material_cost: float | None = None
     subassemblies_cost: float | None = None
     operations_cost: float | None = None
-    batch_transactions: list[BatchTransactionInfo] = Field(default_factory=list)
-    serial_numbers: list[SerialNumberInfo] = Field(default_factory=list)
+    batch_transactions: list[BatchTransactionInfo] = Field(
+        default_factory=list,
+        description="Batch allocations rolled up across all recipe rows.",
+    )
+    serial_numbers: list[SerialNumberInfo] = Field(
+        default_factory=list,
+        description="Serial numbers issued across all productions on this MO.",
+    )
     created_at: str | None = None
     updated_at: str | None = None
     deleted_at: str | None = None
-    recipe_rows: list[RecipeRowInfo] = Field(default_factory=list)
-    operation_rows: list[OperationRowInfo] = Field(default_factory=list)
-    productions: list[ProductionInfo] = Field(default_factory=list)
+    recipe_rows: list[RecipeRowInfo] = Field(
+        default_factory=list,
+        description="Recipe rows (ingredients) on the manufacturing order.",
+    )
+    operation_rows: list[OperationRowInfo] = Field(
+        default_factory=list,
+        description="Operation rows (production steps) on the manufacturing order.",
+    )
+    productions: list[ProductionInfo] = Field(
+        default_factory=list,
+        description="Production records (completion logs) on the manufacturing order.",
+    )
 
 
 def _recipe_row_info_from_attrs(row: Any, sku: str | None) -> RecipeRowInfo:
@@ -2580,8 +2629,14 @@ class MOHeaderPatch(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    order_no: str | None = Field(default=None)
-    variant_id: int | None = Field(default=None)
+    order_no: str | None = Field(default=None, description="New order number")
+    variant_id: int | None = Field(
+        default=None,
+        description=(
+            "New produced-variant ID (the SKU being manufactured). "
+            "Look up via `search_items`."
+        ),
+    )
     location_id: int | None = Field(
         default=None,
         description=("New production location ID. Look up via `list_locations`."),
@@ -2593,12 +2648,40 @@ class MOHeaderPatch(BaseModel):
             "PARTIALLY_COMPLETED. Katana validates transitions server-side."
         ),
     )
-    planned_quantity: float | None = Field(default=None, gt=0)
-    actual_quantity: float | None = Field(default=None, ge=0)
-    order_created_date: datetime | None = Field(default=None)
-    production_deadline_date: datetime | None = Field(default=None)
-    done_date: datetime | None = Field(default=None)
-    additional_info: str | None = Field(default=None)
+    planned_quantity: float | None = Field(
+        default=None,
+        gt=0,
+        description="New planned production quantity",
+    )
+    actual_quantity: float | None = Field(
+        default=None,
+        ge=0,
+        description="New actual produced quantity",
+    )
+    order_created_date: datetime | None = Field(
+        default=None,
+        description=(
+            "New order created date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
+    )
+    production_deadline_date: datetime | None = Field(
+        default=None,
+        description=(
+            "New production deadline — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
+    )
+    done_date: datetime | None = Field(
+        default=None,
+        description=(
+            "New completion timestamp (when MO was finished) — ISO 8601 date "
+            "or datetime (e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
+    )
+    additional_info: str | None = Field(
+        default=None, description="New notes / additional info"
+    )
 
 
 class RecipeRowBatchTransaction(BaseModel):
@@ -2623,8 +2706,16 @@ class MORecipeRowAdd(BaseModel):
 
     variant_id: int = Field(..., description="Variant ID of the ingredient")
     planned_quantity_per_unit: float = Field(..., description="Quantity per unit", gt=0)
-    notes: str | None = Field(default=None)
-    total_actual_quantity: float | None = Field(default=None, ge=0)
+    notes: str | None = Field(
+        default=None, description="Operator notes for this recipe row"
+    )
+    total_actual_quantity: float | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Total quantity actually consumed (for completion logging on the row)"
+        ),
+    )
     batch_transactions: list[RecipeRowBatchTransaction] | None = Field(
         default=None,
         description=(
@@ -2642,10 +2733,21 @@ class MORecipeRowUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Recipe row ID")
-    variant_id: int | None = Field(default=None)
-    planned_quantity_per_unit: float | None = Field(default=None, gt=0)
-    notes: str | None = Field(default=None)
-    total_actual_quantity: float | None = Field(default=None, ge=0)
+    variant_id: int | None = Field(
+        default=None,
+        description="New ingredient variant ID. Look up via `search_items`.",
+    )
+    planned_quantity_per_unit: float | None = Field(
+        default=None,
+        gt=0,
+        description="New planned consumption per produced unit",
+    )
+    notes: str | None = Field(default=None, description="New operator notes")
+    total_actual_quantity: float | None = Field(
+        default=None,
+        ge=0,
+        description="New total actual quantity consumed",
+    )
     batch_transactions: list[RecipeRowBatchTransaction] | None = Field(
         default=None,
         description=(
@@ -2665,17 +2767,51 @@ class MOOperationRowAdd(BaseModel):
     status: ManufacturingOperationStatusLiteral = Field(
         ..., description="Initial operation status"
     )
-    operation_id: int | None = Field(default=None)
-    type: ManufacturingOperationTypeLiteral | None = Field(
-        default=None, description="LINKED (template) or STANDARD"
+    operation_id: int | None = Field(
+        default=None,
+        description=(
+            "Operation template ID — links this row to a reusable operation "
+            "definition. Omit for ad-hoc operations not bound to a template."
+        ),
     )
-    operation_name: str | None = Field(default=None)
-    resource_id: int | None = Field(default=None)
-    resource_name: str | None = Field(default=None)
-    planned_time_parameter: float | None = Field(default=None)
-    planned_time_per_unit: float | None = Field(default=None)
-    cost_parameter: float | None = Field(default=None)
-    cost_per_hour: float | None = Field(default=None)
+    type: ManufacturingOperationTypeLiteral | None = Field(
+        default=None,
+        description="Operation cost-model type — one of fixed, perUnit, process, or setup.",
+    )
+    operation_name: str | None = Field(
+        default=None,
+        description="Free-text operation label (e.g., 'Cut to length')",
+    )
+    resource_id: int | None = Field(
+        default=None,
+        description=(
+            "Resource (work-station/machine) ID configured in Katana. "
+            "Distinct from operators — Katana doesn't expose a list-resources "
+            "MCP tool, so callers typically read this from an existing MO's "
+            "operation_rows or the Katana web UI."
+        ),
+    )
+    resource_name: str | None = Field(
+        default=None, description="Free-text resource name"
+    )
+    planned_time_parameter: float | None = Field(
+        default=None,
+        description=(
+            "Planned-time divisor for the operation cost model "
+            "(e.g., minutes-per-item denominator)"
+        ),
+    )
+    planned_time_per_unit: float | None = Field(
+        default=None,
+        description="Planned time per produced unit (in operation time units)",
+    )
+    cost_parameter: float | None = Field(
+        default=None,
+        description="Cost calculation parameter (e.g., per-hour rate divisor)",
+    )
+    cost_per_hour: float | None = Field(
+        default=None, description="Operation cost per hour"
+    )
 
 
 class MOOperationRowUpdate(BaseModel):
@@ -2684,17 +2820,51 @@ class MOOperationRowUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Operation row ID")
-    status: ManufacturingOperationStatusLiteral | None = Field(default=None)
-    operation_id: int | None = Field(default=None)
-    type: ManufacturingOperationTypeLiteral | None = Field(default=None)
-    operation_name: str | None = Field(default=None)
-    resource_id: int | None = Field(default=None)
-    resource_name: str | None = Field(default=None)
-    planned_time_parameter: float | None = Field(default=None)
-    planned_time_per_unit: float | None = Field(default=None)
-    total_actual_time: float | None = Field(default=None)
-    cost_parameter: float | None = Field(default=None)
-    cost_per_hour: float | None = Field(default=None)
+    status: ManufacturingOperationStatusLiteral | None = Field(
+        default=None,
+        description=(
+            "New operation status — NOT_STARTED / IN_PROGRESS / PAUSED / "
+            "BLOCKED / COMPLETED. Katana validates transitions server-side."
+        ),
+    )
+    operation_id: int | None = Field(
+        default=None, description="New operation template ID"
+    )
+    type: ManufacturingOperationTypeLiteral | None = Field(
+        default=None,
+        description="New operation cost-model type — fixed, perUnit, process, or setup.",
+    )
+    operation_name: str | None = Field(
+        default=None, description="New free-text operation label"
+    )
+    resource_id: int | None = Field(
+        default=None,
+        description=(
+            "New resource (work-station/machine) ID. Distinct from operators "
+            "— Katana doesn't expose a list-resources MCP tool, so callers "
+            "typically read this from an existing MO's operation_rows or the "
+            "Katana web UI."
+        ),
+    )
+    resource_name: str | None = Field(
+        default=None, description="New free-text resource name"
+    )
+    planned_time_parameter: float | None = Field(
+        default=None, description="New planned-time divisor"
+    )
+    planned_time_per_unit: float | None = Field(
+        default=None, description="New planned time per produced unit"
+    )
+    total_actual_time: float | None = Field(
+        default=None,
+        description="Total time actually spent on this operation (for completion logging)",
+    )
+    cost_parameter: float | None = Field(
+        default=None, description="New cost calculation parameter"
+    )
+    cost_per_hour: float | None = Field(
+        default=None, description="New operation cost per hour"
+    )
 
 
 class MOProductionAdd(BaseModel):
@@ -2705,7 +2875,13 @@ class MOProductionAdd(BaseModel):
     completed_quantity: float = Field(
         ..., description="Quantity produced in this production record", gt=0
     )
-    completed_date: datetime | None = Field(default=None)
+    completed_date: datetime | None = Field(
+        default=None,
+        description=(
+            "Completion timestamp (when production was finished) — ISO 8601 "
+            "date or datetime (e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
+    )
     is_final: bool | None = Field(
         default=None,
         description="When true, marks this as the final production record",
@@ -2721,7 +2897,13 @@ class MOProductionUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Production record ID")
-    production_date: datetime | None = Field(default=None)
+    production_date: datetime | None = Field(
+        default=None,
+        description=(
+            "When production happened — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
+    )
 
 
 class ModifyManufacturingOrderRequest(ConfirmableRequest):

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -129,7 +129,13 @@ class PurchaseOrderItem(BaseModel):
     purchase_uom_conversion_rate: float | None = Field(
         None, description="Conversion rate for purchase UOM"
     )
-    arrival_date: datetime | None = Field(None, description="Expected arrival date")
+    arrival_date: datetime | None = Field(
+        None,
+        description=(
+            "Expected arrival date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
+    )
 
 
 class CreatePurchaseOrderRequest(BaseModel):
@@ -176,8 +182,14 @@ class PurchaseOrderResponse(BaseModel):
     currency: str | None = None
     item_count: int | None = None
     is_preview: bool
-    warnings: list[str] = Field(default_factory=list)
-    next_actions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Operator-facing warnings raised during the operation.",
+    )
+    next_actions: list[str] = Field(
+        default_factory=list,
+        description="Suggested follow-up tools to call after this response.",
+    )
     message: str
     katana_url: str | None = None
 
@@ -463,8 +475,14 @@ class ReceivePurchaseOrderResponse(BaseModel):
     total_cost: float | None = None
     items_received: int = 0
     is_preview: bool = True
-    warnings: list[str] = Field(default_factory=list)
-    next_actions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Operator-facing warnings raised during the operation.",
+    )
+    next_actions: list[str] = Field(
+        default_factory=list,
+        description="Suggested follow-up tools to call after this response.",
+    )
     message: str
 
 
@@ -725,7 +743,10 @@ class PurchaseOrderRowInfo(BaseModel):
     purchase_order_id: int | None = None
     landed_cost: float | str | None = None
     group_id: int | None = None
-    batch_transactions: list[dict[str, Any]] = Field(default_factory=list)
+    batch_transactions: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Batch allocations for this row's received quantity.",
+    )
 
 
 class PurchaseOrderAdditionalCostRowInfo(BaseModel):
@@ -775,7 +796,10 @@ class SupplierInfo(BaseModel):
     currency: str | None = None
     comment: str | None = None
     default_address_id: int | None = None
-    addresses: list[dict[str, Any]] = Field(default_factory=list)
+    addresses: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Supplier address records (billing/shipping).",
+    )
     created_at: str | None = None
     updated_at: str | None = None
     deleted_at: str | None = None
@@ -809,12 +833,17 @@ class GetPurchaseOrderResponse(BaseModel):
     billing_status: str | None = None
     last_document_status: str | None = None
     tracking_location_id: int | None = None
-    purchase_order_rows: list[PurchaseOrderRowInfo] = Field(default_factory=list)
+    purchase_order_rows: list[PurchaseOrderRowInfo] = Field(
+        default_factory=list,
+        description="Line items on the purchase order.",
+    )
     additional_cost_rows: list[PurchaseOrderAdditionalCostRowInfo] = Field(
-        default_factory=list
+        default_factory=list,
+        description="Additional cost rows (shipping, duties, handling fees).",
     )
     accounting_metadata: list[PurchaseOrderAccountingMetadataInfo] = Field(
-        default_factory=list
+        default_factory=list,
+        description="Accounting integration metadata (bill IDs, integration type).",
     )
 
 
@@ -1461,9 +1490,18 @@ class VerifyOrderDocumentResponse(BaseModel):
 
     order_id: int
     purchase_order: GetPurchaseOrderResponse | None = None
-    matches: list[MatchResult] = Field(default_factory=list)
-    discrepancies: list[Discrepancy] = Field(default_factory=list)
-    suggested_actions: list[str] = Field(default_factory=list)
+    matches: list[MatchResult] = Field(
+        default_factory=list,
+        description="Line items where the document agrees with the PO.",
+    )
+    discrepancies: list[Discrepancy] = Field(
+        default_factory=list,
+        description="Differences detected between the document and the PO.",
+    )
+    suggested_actions: list[str] = Field(
+        default_factory=list,
+        description="Recommended follow-up tool calls to resolve discrepancies.",
+    )
     overall_status: str = Field(..., description="match, partial_match, or no_match")
     message: str
 
@@ -2272,10 +2310,18 @@ class POHeaderPatch(BaseModel):
         ),
     )
     expected_arrival_date: datetime | None = Field(
-        default=None, description="New expected arrival date"
+        default=None,
+        description=(
+            "New expected arrival date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
     order_created_date: datetime | None = Field(
-        default=None, description="New order created date"
+        default=None,
+        description=(
+            "New order created date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
     additional_info: str | None = Field(
         default=None, description="New notes / additional info"
@@ -2302,7 +2348,11 @@ class PORowAdd(BaseModel):
         default=None, description="UOM conversion rate"
     )
     arrival_date: datetime | None = Field(
-        default=None, description="Expected arrival date for this row"
+        default=None,
+        description=(
+            "Expected arrival date for this row — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
 
 
@@ -2326,10 +2376,18 @@ class PORowUpdate(BaseModel):
     )
     purchase_uom: str | None = Field(default=None, description="New purchase UOM")
     received_date: datetime | None = Field(
-        default=None, description="New received date"
+        default=None,
+        description=(
+            "New received date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
     arrival_date: datetime | None = Field(
-        default=None, description="New row-level arrival date"
+        default=None,
+        description=(
+            "New row-level arrival date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -189,7 +189,11 @@ class CreateSalesOrderRequest(BaseModel):
         ),
     )
     delivery_date: datetime | None = Field(
-        default=None, description="Requested delivery date (optional)"
+        default=None,
+        description=(
+            "Requested delivery date (optional) — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
     currency: str | None = Field(
         default=None,
@@ -222,8 +226,14 @@ class SalesOrderResponse(BaseModel):
     delivery_date: str | None = None
     item_count: int | None = None
     is_preview: bool
-    warnings: list[str] = Field(default_factory=list)
-    next_actions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Operator-facing warnings raised during the operation.",
+    )
+    next_actions: list[str] = Field(
+        default_factory=list,
+        description="Suggested follow-up tools to call after this response.",
+    )
     message: str
     katana_url: str | None = None
 
@@ -891,7 +901,10 @@ class SalesOrderRowDetail(BaseModel):
     linked_manufacturing_order_id: int | None = None
     conversion_rate: float | None = None
     conversion_date: str | None = None
-    serial_numbers: list[int] = Field(default_factory=list)
+    serial_numbers: list[int] = Field(
+        default_factory=list,
+        description="Serial number IDs allocated to this row.",
+    )
     created_at: str | None = None
     updated_at: str | None = None
     deleted_at: str | None = None
@@ -979,7 +992,10 @@ class GetSalesOrderResponse(BaseModel):
     # Addresses — both the ID pointers on the SO and the full resolved list
     billing_address_id: int | None = None
     shipping_address_id: int | None = None
-    addresses: list[SalesOrderAddressInfo] = Field(default_factory=list)
+    addresses: list[SalesOrderAddressInfo] = Field(
+        default_factory=list,
+        description="Sales order addresses (billing and shipping).",
+    )
 
     # Linked resources
     linked_manufacturing_order_id: int | None = None
@@ -996,7 +1012,10 @@ class GetSalesOrderResponse(BaseModel):
     deleted_at: str | None = None
 
     # Line items — exhaustive per-row detail
-    rows: list[SalesOrderRowDetail] = Field(default_factory=list)
+    rows: list[SalesOrderRowDetail] = Field(
+        default_factory=list,
+        description="Line items on the sales order.",
+    )
 
 
 def _shipping_fee_from_attrs(fee: Any) -> SalesOrderShippingFeeInfo | None:
@@ -1512,12 +1531,26 @@ class SOHeaderPatch(BaseModel):
         default=None, description="New conversion date (ISO-8601)"
     )
     order_created_date: datetime | None = Field(
-        default=None, description="New order created date"
+        default=None,
+        description=(
+            "New order created date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
     delivery_date: datetime | None = Field(
-        default=None, description="New delivery date"
+        default=None,
+        description=(
+            "New delivery date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
-    picked_date: datetime | None = Field(default=None, description="New picked date")
+    picked_date: datetime | None = Field(
+        default=None,
+        description=(
+            "New picked date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
+    )
     additional_info: str | None = Field(
         default=None, description="New notes / additional info"
     )
@@ -1573,14 +1606,17 @@ class SOAddressAdd(BaseModel):
     entity_type: AddressEntityTypeLiteral = Field(
         ..., description="Address kind — billing or shipping"
     )
-    first_name: str | None = Field(default=None)
-    last_name: str | None = Field(default=None)
-    company: str | None = Field(default=None)
-    city: str | None = Field(default=None)
-    state: str | None = Field(default=None)
-    zip: str | None = Field(default=None)
-    country: str | None = Field(default=None)
-    phone: str | None = Field(default=None)
+    first_name: str | None = Field(default=None, description="Recipient first name")
+    last_name: str | None = Field(default=None, description="Recipient last name")
+    company: str | None = Field(default=None, description="Company name")
+    city: str | None = Field(default=None, description="City")
+    state: str | None = Field(default=None, description="State or region")
+    zip: str | None = Field(default=None, description="Postal/ZIP code")
+    country: str | None = Field(
+        default=None,
+        description="Country (ISO 3166 name or two-letter code, e.g. 'US', 'United States')",
+    )
+    phone: str | None = Field(default=None, description="Contact phone number")
 
 
 class SOAddressUpdate(BaseModel):
@@ -1591,14 +1627,17 @@ class SOAddressUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Address ID to update")
-    first_name: str | None = Field(default=None)
-    last_name: str | None = Field(default=None)
-    company: str | None = Field(default=None)
-    city: str | None = Field(default=None)
-    state: str | None = Field(default=None)
-    zip: str | None = Field(default=None)
-    country: str | None = Field(default=None)
-    phone: str | None = Field(default=None)
+    first_name: str | None = Field(default=None, description="New recipient first name")
+    last_name: str | None = Field(default=None, description="New recipient last name")
+    company: str | None = Field(default=None, description="New company name")
+    city: str | None = Field(default=None, description="New city")
+    state: str | None = Field(default=None, description="New state or region")
+    zip: str | None = Field(default=None, description="New postal/ZIP code")
+    country: str | None = Field(
+        default=None,
+        description="New country (ISO 3166 name or two-letter code)",
+    )
+    phone: str | None = Field(default=None, description="New contact phone number")
 
 
 class SOFulfillmentRowInput(BaseModel):
@@ -1621,13 +1660,34 @@ class SOFulfillmentAdd(BaseModel):
     sales_order_fulfillment_rows: list[SOFulfillmentRowInput] = Field(
         ..., description="Rows being fulfilled (variant + quantity)", min_length=1
     )
-    picked_date: datetime | None = Field(default=None)
-    conversion_rate: float | None = Field(default=None)
-    conversion_date: datetime | None = Field(default=None)
-    tracking_number: str | None = Field(default=None)
-    tracking_url: str | None = Field(default=None)
-    tracking_carrier: str | None = Field(default=None)
-    tracking_method: str | None = Field(default=None)
+    picked_date: datetime | None = Field(
+        default=None,
+        description=(
+            "When items were picked — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
+    )
+    conversion_rate: float | None = Field(
+        default=None,
+        description="Currency conversion rate applied to the fulfillment",
+    )
+    conversion_date: datetime | None = Field(
+        default=None,
+        description=(
+            "Conversion-rate fix date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
+    )
+    tracking_number: str | None = Field(
+        default=None, description="Carrier tracking number"
+    )
+    tracking_url: str | None = Field(default=None, description="Carrier tracking URL")
+    tracking_carrier: str | None = Field(
+        default=None, description="Carrier name (e.g., UPS, FedEx, USPS)"
+    )
+    tracking_method: str | None = Field(
+        default=None, description="Shipping method (e.g., Ground, Express, 2-Day)"
+    )
 
 
 class SOFulfillmentUpdate(BaseModel):
@@ -1636,18 +1696,44 @@ class SOFulfillmentUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: int = Field(..., description="Fulfillment ID to update")
-    status: FulfillmentStatusLiteral | None = Field(default=None)
-    picked_date: datetime | None = Field(default=None)
+    status: FulfillmentStatusLiteral | None = Field(
+        default=None,
+        description="New fulfillment status — DELIVERED or PACKED",
+    )
+    picked_date: datetime | None = Field(
+        default=None,
+        description=(
+            "New picked date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
+    )
     packer_id: int | None = Field(
         default=None,
         description=("New packer (operator). Look up via `list_operators`."),
     )
-    conversion_rate: float | None = Field(default=None)
-    conversion_date: datetime | None = Field(default=None)
-    tracking_number: str | None = Field(default=None)
-    tracking_url: str | None = Field(default=None)
-    tracking_carrier: str | None = Field(default=None)
-    tracking_method: str | None = Field(default=None)
+    conversion_rate: float | None = Field(
+        default=None, description="New currency conversion rate"
+    )
+    conversion_date: datetime | None = Field(
+        default=None,
+        description=(
+            "New conversion-rate fix date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
+    )
+    tracking_number: str | None = Field(
+        default=None, description="New carrier tracking number"
+    )
+    tracking_url: str | None = Field(
+        default=None, description="New carrier tracking URL"
+    )
+    tracking_carrier: str | None = Field(
+        default=None, description="New carrier name (e.g., UPS, FedEx, USPS)"
+    )
+    tracking_method: str | None = Field(
+        default=None,
+        description="New shipping method (e.g., Ground, Express, 2-Day)",
+    )
 
 
 class SOShippingFeeAdd(BaseModel):
@@ -1656,7 +1742,10 @@ class SOShippingFeeAdd(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     amount: str = Field(..., description="Fee amount (decimal string)")
-    description: str | None = Field(default=None)
+    description: str | None = Field(
+        default=None,
+        description="Customer-facing fee label (e.g., 'Standard shipping')",
+    )
     tax_rate_id: int | None = Field(
         default=None,
         description=("Tax rate ID. Look up via `list_tax_rates`."),
@@ -1675,7 +1764,10 @@ class SOShippingFeeUpdate(BaseModel):
 
     id: int = Field(..., description="Shipping fee ID to update")
     amount: str = Field(..., description="Fee amount (required by API)")
-    description: str | None = Field(default=None)
+    description: str | None = Field(
+        default=None,
+        description="New customer-facing fee label",
+    )
     tax_rate_id: int | None = Field(
         default=None,
         description=("Tax rate ID. Look up via `list_tax_rates`."),

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -173,7 +173,11 @@ class CreateStockTransferRequest(BaseModel):
         ),
     )
     expected_arrival_date: datetime = Field(
-        ..., description="Expected arrival date at the destination location"
+        ...,
+        description=(
+            "Expected arrival date at the destination location — ISO 8601 date "
+            "or datetime (e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
     rows: list[StockTransferRowInput] = Field(
         ..., description="Line items to transfer", min_length=1
@@ -208,8 +212,14 @@ class StockTransferResponse(BaseModel):
     expected_arrival_date: str | None = None
     item_count: int | None = None
     is_preview: bool
-    warnings: list[str] = Field(default_factory=list)
-    next_actions: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Operator-facing warnings raised during the operation.",
+    )
+    next_actions: list[str] = Field(
+        default_factory=list,
+        description="Suggested follow-up tools to call after this response.",
+    )
     message: str
     katana_url: str | None = None
 
@@ -799,10 +809,18 @@ class StockTransferHeaderPatch(BaseModel):
         default=None, description="New stock transfer number"
     )
     transfer_date: datetime | None = Field(
-        default=None, description="New transfer date"
+        default=None,
+        description=(
+            "New transfer date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
     expected_arrival_date: datetime | None = Field(
-        default=None, description="New expected arrival date"
+        default=None,
+        description=(
+            "New expected arrival date — ISO 8601 date or datetime "
+            "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
+        ),
     )
     additional_info: str | None = Field(
         default=None, description="New additional info/notes"
@@ -839,8 +857,20 @@ class ModifyStockTransferRequest(ConfirmableRequest):
     """
 
     id: int = Field(..., description="Stock transfer ID")
-    update_header: StockTransferHeaderPatch | None = Field(default=None)
-    update_status: StockTransferStatusPatch | None = Field(default=None)
+    update_header: StockTransferHeaderPatch | None = Field(
+        default=None,
+        description=(
+            "Header-field patches: transfer number, transfer/expected-arrival "
+            "dates, additional info."
+        ),
+    )
+    update_status: StockTransferStatusPatch | None = Field(
+        default=None,
+        description=(
+            "Status transition (DRAFT → IN_TRANSIT → RECEIVED). Maps to the "
+            "dedicated status endpoint; runs after header updates."
+        ),
+    )
 
 
 class DeleteStockTransferRequest(ConfirmableRequest):

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -28,6 +28,9 @@ from prefab_ui.actions.mcp import CallTool, SendMessage, UpdateContext
 from prefab_ui.app import PrefabApp
 from prefab_ui.components import (
     H3,
+    Alert,
+    AlertDescription,
+    AlertTitle,
     Badge,
     Button,
     Card,
@@ -954,8 +957,9 @@ def build_order_preview_ui(
                     )
                 with Elif("error"):
                     Separator()
-                    Text(content="Apply failed.")
-                    Muted(content="{{ $state.error }}")
+                    with Alert(variant="destructive", icon="circle-alert"):
+                        AlertTitle(content="Apply failed")
+                        AlertDescription(content="{{ error }}")
 
         with CardFooter():
             if block_warnings:
@@ -1573,8 +1577,9 @@ def build_apply_error_ui(
             Badge(label="ERROR", variant="destructive")
 
         with CardContent(), Column(gap=2):
-            Text(content=error_message)
+            with Alert(variant="destructive", icon="circle-alert"):
+                AlertTitle(content="Error")
+                AlertDescription(content=error_message)
             if hint:
-                Separator()
                 Muted(content=hint)
     return app


### PR DESCRIPTION
## Summary

Two related improvements to the MCP server's create/modify-order tools.

### 1. Apply errors now surface clearly in the preview card

The direct-apply Confirm-button rail had a template-interpolation bug — `{{ $state.error }}` rendered literally because prefab_ui state keys are referenced bare (matching `{{ pending }}` / `{{ applied }}` / `{{ cancelled }}` already in the same envelope). When an apply failed, the user saw `{{ $state.error }}` in muted gray text instead of the actual Katana error.

Fixed the interpolation, and upgraded the in-card error rendering on both the direct-apply preview rail and `build_apply_error_ui` (the non-preview write path) to use a destructive `Alert` block — `AlertTitle` + `AlertDescription` with a `circle-alert` icon. Errors now stand out visually whether or not the toast is captured. The agent already receives the error via `UpdateContext` on the same on-error chain, so it can react on its next turn.

### 2. Every `Field()` on the four foundation tool modules now has a description

Sweep across `purchase_orders.py`, `sales_orders.py`, `manufacturing_orders.py`, and `stock_transfers.py` (~113 fields):

- **All `datetime | None` fields** now end with `— ISO 8601 date or datetime (e.g. '2026-05-08' or '2026-05-08T14:30:00Z')` so the agent knows what format to send. Pydantic already accepts bare dates *and* datetimes; the hint just makes the schema self-documenting.
- **All response-model collection fields** (`warnings`, `next_actions`, `rows`, `addresses`, `recipe_rows`, `operation_rows`, `productions`, …) get short purpose descriptions.
- **All input patch/row/add models** (`MOHeaderPatch`, `MORecipeRow*`, `MOOperationRow*`, `MOProduction*`, `SOAddress*`, `SOFulfillment*`, `SOShippingFee*`, `ModifyStockTransferRequest` patch slots) get per-field descriptions covering operator-facing semantics.
- **Fixed pre-existing stringly-typed lies** on `ManufacturingOperationTypeLiteral` (descriptions claimed `LINKED / STANDARD`; the actual literal is `fixed | perUnit | process | setup`) and added the missing `PAUSED` value in the `ManufacturingOperationStatusLiteral` description.

The motivating incident: an agent passed `arrival_date: "2026-05-08"` to `create_purchase_order`, the apply failed, and the broken error template hid the real Katana error string. The agent then *guessed* the cause was a missing time component (it wasn't — pydantic accepts bare dates) and retried with `T00:00:00`. The user wanted both the error rendering fixed *and* the field semantics documented so the next agent doesn't have to guess cold.

## Test plan

- [x] `uv run poe check` passes (2981 tests, lint, type-check, format).
- [x] All `test_prefab_ui.py` cases pass — the existing error-handling regression tests (`test_po_preview_direct_apply_handles_error`, `test_apply_error_surfaces_actual_error_message`) still cover the on-error chain shape.
- [x] AST scan confirms zero remaining undocumented `Field()` declarations across the four foundation modules.
- [ ] Spot-check an actual MCP `create_purchase_order` preview/apply against a sandbox account to confirm the destructive Alert renders and surfaces the real error string when one occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)