### PR TITLE
feat(mcp): create_purchase_order apply card parity with preview (#618)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/_fastmcp_patches.py
+++ b/katana_mcp_server/src/katana_mcp/_fastmcp_patches.py
@@ -19,7 +19,6 @@ so only the get_cached_typeadapter patch is needed now.
 from __future__ import annotations
 
 import inspect
-import logging
 import types
 from collections.abc import Callable
 from functools import lru_cache
@@ -27,7 +26,9 @@ from typing import Annotated, Any, get_args, get_origin, get_type_hints
 
 from pydantic import Field, TypeAdapter
 
-logger = logging.getLogger(__name__)
+from katana_mcp.logging import get_logger
+
+logger = get_logger(__name__)
 
 # Track whether patches have been applied (mutable container avoids global statement)
 _state: dict[str, bool] = {"patched": False}
@@ -97,9 +98,9 @@ def _patched_get_cached_typeadapter[T](cls: T) -> TypeAdapter[T]:
             resolved_hints = get_type_hints(cls, include_extras=True)
         except (NameError, TypeError) as exc:
             logger.debug(
-                "get_type_hints failed for %r — falling back to __annotations__: %s",
-                cls,
-                exc,
+                "get_type_hints_failed_falling_back_to_annotations",
+                cls=repr(cls),
+                error=str(exc),
             )
             resolved_hints = cls.__annotations__
 

--- a/katana_mcp_server/src/katana_mcp/cache.py
+++ b/katana_mcp_server/src/katana_mcp/cache.py
@@ -25,7 +25,6 @@ Usage::
 from __future__ import annotations
 
 import json
-import logging
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -36,7 +35,9 @@ from typing import Any
 import aiosqlite
 from platformdirs import user_cache_dir
 
-logger = logging.getLogger(__name__)
+from katana_mcp.logging import get_logger
+
+logger = get_logger(__name__)
 
 # Default cache location
 _DEFAULT_CACHE_DIR = Path(user_cache_dir("katana-mcp"))
@@ -203,7 +204,7 @@ class CatalogCache:
         await self._db.execute("PRAGMA synchronous=NORMAL")
 
         await self._ensure_schema()
-        logger.info("cache_opened", extra={"db_path": str(self._db_path)})
+        logger.info("cache_opened", db_path=str(self._db_path))
 
     async def close(self) -> None:
         """Close the database connection."""
@@ -230,7 +231,8 @@ class CatalogCache:
                 # Drop old schema and rebuild
                 logger.info(
                     "cache_schema_upgrade",
-                    extra={"from": current_version, "to": _SCHEMA_VERSION},
+                    from_version=current_version,
+                    to_version=_SCHEMA_VERSION,
                 )
                 await self._db.executescript(
                     "DROP TABLE IF EXISTS entity_fts;"
@@ -338,11 +340,9 @@ class CatalogCache:
         await db.commit()
         logger.info(
             "cache_synced",
-            extra={
-                "entity_type": entity_type,
-                "upserted": len(entities),
-                "total": count,
-            },
+            entity_type=entity_type,
+            upserted=len(entities),
+            total=count,
         )
 
     async def get_last_synced(self, entity_type: str) -> float | None:
@@ -424,7 +424,7 @@ class CatalogCache:
                 return [json.loads(row[0]) for row in rows]
         except aiosqlite.OperationalError as exc:
             # FTS5 query syntax error — fall through to fuzzy
-            logger.debug("fts5_query_failed", extra={"query": query, "error": str(exc)})
+            logger.debug("fts5_query_failed", query=query, error=str(exc))
             return []
 
     async def search_fuzzy(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -254,8 +254,9 @@ async def _create_purchase_order_impl(
 
     # Resolve supplier/location names from cache for both preview and apply
     # branches so the result card has the same information density either way
-    # (#618). Cache misses surface as advisory warnings on the preview branch
-    # only — by the time we're applying, the user has already seen them.
+    # (#618). Cache-miss warnings are surfaced on whichever branch runs —
+    # interactive callers see them on preview, programmatic callers using
+    # ``preview=false`` directly see them on the apply response.
     (supplier_name, sup_warn), (location_name, loc_warn) = await asyncio.gather(
         resolve_entity_name(
             services.cache,
@@ -370,6 +371,7 @@ async def _create_purchase_order_impl(
             item_count=len(request.items),
             notes=notes_echo,
             is_preview=False,
+            warnings=[w for w in (sup_warn, loc_warn) if w],
             katana_url=katana_web_url("purchase_order", po.id),
             next_actions=[
                 f"Purchase order created with ID {po.id}",

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -175,6 +175,7 @@ class PurchaseOrderResponse(BaseModel):
     total_cost: float | None = None
     currency: str | None = None
     item_count: int | None = None
+    notes: str | None = None
     is_preview: bool
     warnings: list[str] = Field(default_factory=list)
     next_actions: list[str] = Field(default_factory=list)
@@ -236,28 +237,33 @@ async def _create_purchase_order_impl(
     # Calculate preview total
     total_cost = sum(item.price_per_unit * item.quantity for item in request.items)
 
+    services = get_services(context)
+    from katana_mcp.cache import EntityType
+
+    # Resolve supplier/location names from cache for both preview and apply
+    # branches so the result card has the same information density either way
+    # (#618). Cache misses surface as advisory warnings on the preview branch
+    # only — by the time we're applying, the user has already seen them.
+    (supplier_name, sup_warn), (location_name, loc_warn) = await asyncio.gather(
+        resolve_entity_name(
+            services.cache,
+            EntityType.SUPPLIER,
+            request.supplier_id,
+            entity_label="Supplier",
+        ),
+        resolve_entity_name(
+            services.cache,
+            EntityType.LOCATION,
+            request.location_id,
+            entity_label="Location",
+        ),
+    )
+
     if request.preview:
         logger.info(
             f"Preview mode: PO {request.order_number} would have {len(request.items)} items"
         )
 
-        services = get_services(context)
-        from katana_mcp.cache import EntityType
-
-        (supplier_name, sup_warn), (location_name, loc_warn) = await asyncio.gather(
-            resolve_entity_name(
-                services.cache,
-                EntityType.SUPPLIER,
-                request.supplier_id,
-                entity_label="Supplier",
-            ),
-            resolve_entity_name(
-                services.cache,
-                EntityType.LOCATION,
-                request.location_id,
-                entity_label="Location",
-            ),
-        )
         warnings: list[str] = [w for w in (sup_warn, loc_warn) if w]
 
         return PurchaseOrderResponse(
@@ -271,6 +277,7 @@ async def _create_purchase_order_impl(
             total_cost=total_cost,
             currency=request.currency,
             item_count=len(request.items),
+            notes=request.notes,
             is_preview=True,
             warnings=warnings,
             next_actions=[
@@ -281,8 +288,6 @@ async def _create_purchase_order_impl(
         )
 
     try:
-        services = get_services(context)
-
         # Build purchase order rows
         po_rows = []
         for item in request.items:
@@ -333,15 +338,25 @@ async def _create_purchase_order_impl(
         location_id = unwrap_unset(po.location_id, request.location_id)
         currency = unwrap_unset(po.currency, None)
 
+        # Echo notes back so callers can visually verify the value persisted
+        # — Katana exposes the field on the wire as ``additional_info``; we
+        # surface our own ``notes`` request field name for symmetry with the
+        # request and preview cards (#618).
+        notes_echo = unwrap_unset(po.additional_info, request.notes)
+
         return PurchaseOrderResponse(
             id=po.id,
             order_number=order_no,
             supplier_id=supplier_id,
+            supplier_name=supplier_name,
             location_id=location_id,
+            location_name=location_name,
             status=po.status.value if po.status else "UNKNOWN",
             entity_type="regular",
             total_cost=total_cost,
             currency=currency,
+            item_count=len(request.items),
+            notes=notes_echo,
             is_preview=False,
             katana_url=katana_web_url("purchase_order", po.id),
             next_actions=[

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -847,7 +847,11 @@ def _render_order_fields(order: dict[str, Any], *, total: Any, currency: str) ->
     """Render shared order content fields (supplier/customer/location + total).
 
     Prefers human-readable names when present (``customer_name``,
-    ``supplier_name``, ``location_name``) and falls back to bare IDs.
+    ``supplier_name``, ``location_name``) and falls back to bare IDs. When
+    ``notes`` is non-empty (currently surfaced by ``create_purchase_order``;
+    other ``create_*`` tools follow), it renders below the entity lines so
+    the user can visually verify the value persisted on the apply card —
+    matching the preview's information density (#618).
     """
     if total is not None:
         Metric(label="Total", value=f"${total:,.2f} {currency}")
@@ -875,6 +879,9 @@ def _render_order_fields(order: dict[str, Any], *, total: Any, currency: str) ->
         )
     if order.get("item_count") is not None:
         Text(content=f"Items: {order['item_count']}")
+    notes = order.get("notes")
+    if notes:
+        Text(content=f"Notes: {notes}")
 
 
 def build_order_preview_ui(

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -850,11 +850,13 @@ def _render_order_fields(order: dict[str, Any], *, total: Any, currency: str) ->
     """Render shared order content fields (supplier/customer/location + total).
 
     Prefers human-readable names when present (``customer_name``,
-    ``supplier_name``, ``location_name``) and falls back to bare IDs. When
-    ``notes`` is non-empty (currently surfaced by ``create_purchase_order``;
-    other ``create_*`` tools follow), it renders below the entity lines so
-    the user can visually verify the value persisted on the apply card —
-    matching the preview's information density (#618).
+    ``supplier_name``, ``location_name``) and falls back to bare IDs. If the
+    order dict carries a non-empty ``notes`` key, it renders below the entity
+    lines so the user can visually verify the value persisted on the apply
+    card — matching the preview's information density (#618). Today only
+    ``create_purchase_order``'s response model surfaces ``notes``; the other
+    order responses expose the field as ``additional_info`` and don't feed it
+    here, so the line is silently skipped for those tools.
     """
     if total is not None:
         Metric(label="Total", value=f"${total:,.2f} {currency}")

--- a/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
+++ b/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
@@ -12,6 +12,7 @@ tree in a sandboxed iframe (MCP Apps SEP-1865, see #422).
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from enum import Enum
@@ -22,6 +23,8 @@ from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from prefab_ui.app import PrefabApp
+
+logger = logging.getLogger(__name__)
 
 
 # Opt-in marker for Prefab UI rendering. Pass as ``meta=UI_META`` in
@@ -63,8 +66,30 @@ async def resolve_entity_name(
     pretty-print the name. Hard duplicate-create gates (already linked,
     already received, source==destination) are the caller's responsibility
     and use ``BLOCK_WARNING_PREFIX`` explicitly.
+
+    Cache *failures* (SQLite errors, locked DB, corruption, etc.) are
+    swallowed and converted into the same advisory shape: ``(None, warning)``
+    with a message explaining the cache was unhealthy. This keeps name
+    resolution best-effort so callers — particularly destructive apply
+    paths — can still proceed to the live API even when the cache is
+    unavailable. The exception is logged at WARNING for stderr-side
+    visibility.
     """
-    d = await cache.get_by_id(entity_type, entity_id)
+    try:
+        d = await cache.get_by_id(entity_type, entity_id)
+    except Exception as exc:
+        logger.warning(
+            "resolve_entity_name: cache lookup for %s id=%s failed: %s",
+            entity_label,
+            entity_id,
+            exc,
+        )
+        warning = (
+            f"{entity_label} with id={entity_id} could not be looked up "
+            f"(cache unavailable: {type(exc).__name__}); the "
+            f"{entity_label.lower()} will be validated by the live API on apply."
+        )
+        return None, warning
     if d is None:
         warning = (
             f"{entity_label} with id={entity_id} was not found in the cache "

--- a/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
+++ b/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
@@ -12,7 +12,6 @@ tree in a sandboxed iframe (MCP Apps SEP-1865, see #422).
 from __future__ import annotations
 
 import json
-import logging
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from enum import Enum
@@ -21,10 +20,12 @@ from typing import TYPE_CHECKING, Any
 from fastmcp.tools import ToolResult
 from pydantic import BaseModel, Field
 
+from katana_mcp.logging import get_logger
+
 if TYPE_CHECKING:
     from prefab_ui.app import PrefabApp
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 # Opt-in marker for Prefab UI rendering. Pass as ``meta=UI_META`` in
@@ -79,22 +80,22 @@ async def resolve_entity_name(
         d = await cache.get_by_id(entity_type, entity_id)
     except Exception as exc:
         logger.warning(
-            "resolve_entity_name: cache lookup for %s id=%s failed: %s",
-            entity_label,
-            entity_id,
-            exc,
+            "resolve_entity_name: cache lookup failed",
+            entity_label=entity_label,
+            entity_id=entity_id,
+            error=str(exc),
         )
         warning = (
             f"{entity_label} with id={entity_id} could not be looked up "
-            f"(cache unavailable: {type(exc).__name__}); the "
-            f"{entity_label.lower()} will be validated by the live API on apply."
+            f"(cache unavailable: {type(exc).__name__}); the live API "
+            f"validates the {entity_label.lower()}."
         )
         return None, warning
     if d is None:
         warning = (
             f"{entity_label} with id={entity_id} was not found in the cache "
-            f"(possible cache lag); the {entity_label.lower()} will be "
-            "validated by the live API on apply."
+            f"(possible cache lag); the live API validates the "
+            f"{entity_label.lower()}."
         )
         return None, warning
     return d.get("name") or None, None

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -22,7 +22,6 @@ need to change.
 from __future__ import annotations
 
 import asyncio
-import logging
 from collections.abc import Callable, Iterable
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
@@ -34,6 +33,7 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlmodel import delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from katana_mcp.logging import get_logger
 from katana_public_api_client.api.manufacturing_order import (
     get_all_manufacturing_orders,
 )
@@ -79,7 +79,7 @@ if TYPE_CHECKING:
     from .engine import TypedCacheEngine
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -399,10 +399,10 @@ async def merge_filtered_fetch(
         await session.commit()
 
     logger.info(
-        "merge_filtered_fetch entity=%s merged=%d children=%d",
-        spec.entity_key,
-        len(cached_parents),
-        len(cached_children),
+        "merge_filtered_fetch",
+        entity=spec.entity_key,
+        merged=len(cached_parents),
+        children=len(cached_children),
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/unpack.py
+++ b/katana_mcp_server/src/katana_mcp/unpack.py
@@ -30,14 +30,15 @@ from __future__ import annotations
 
 import functools
 import inspect
-import logging
 from collections.abc import Callable
 from typing import Annotated, Any, get_args, get_origin, get_type_hints
 
 from pydantic import BaseModel, ValidationError
 from pydantic_core import PydanticUndefined
 
-logger = logging.getLogger(__name__)
+from katana_mcp.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class Unpack:
@@ -97,9 +98,9 @@ def unpack_pydantic_params(func: Callable) -> Callable:
         type_hints = get_type_hints(func, include_extras=True)
     except (NameError, TypeError) as exc:
         logger.debug(
-            "get_type_hints failed for %r — falling back to empty hint dict: %s",
-            func,
-            exc,
+            "get_type_hints_failed_falling_back_to_empty_hint_dict",
+            func=repr(func),
+            error=str(exc),
         )
         type_hints = {}
 

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from katana_mcp.tools.foundation.purchase_orders import (
+    CreatePurchaseOrderRequest,
     DeletePurchaseOrderRequest,
     DiscrepancyType,
     DocumentItem,
@@ -16,14 +17,18 @@ from katana_mcp.tools.foundation.purchase_orders import (
     POHeaderPatch,
     PORowAdd,
     PORowUpdate,
+    PurchaseOrderItem,
+    PurchaseOrderResponse,
     ReceiveBatchTransaction,
     ReceiveItemRequest,
     ReceivePurchaseOrderRequest,
     ReceivePurchaseOrderResponse,
     VerifyOrderDocumentRequest,
+    _create_purchase_order_impl,
     _delete_purchase_order_impl,
     _get_purchase_order_impl,
     _modify_purchase_order_impl,
+    _po_response_to_tool_result,
     _receive_purchase_order_impl,
     _verify_order_document_impl,
     get_purchase_order,
@@ -107,6 +112,243 @@ def create_mock_po(order_id: int, order_no: str, rows: list):
         order_no=order_no,
         purchase_order_rows=rows,
     )
+
+
+# ============================================================================
+# Unit Tests - create_purchase_order
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_create_purchase_order_preview_echoes_notes_and_resolves_names():
+    """Preview branch must populate notes + supplier_name + location_name +
+    item_count so the preview card shows full context (#618).
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    # resolve_entity_name calls cache.get_by_id once per entity. Returning a
+    # different dict for supplier vs location keeps both names distinct.
+    async def get_by_id(entity_type, entity_id):
+        if entity_id == 4001:
+            return {"id": 4001, "name": "Acme Supply Co"}
+        if entity_id == 1:
+            return {"id": 1, "name": "Main Warehouse"}
+        return None
+
+    lifespan_ctx.cache.get_by_id = AsyncMock(side_effect=get_by_id)
+
+    request = CreatePurchaseOrderRequest(
+        supplier_id=4001,
+        location_id=1,
+        order_number="PO-2026-001",
+        items=[
+            PurchaseOrderItem(variant_id=1, quantity=10, price_per_unit=5.0),
+            PurchaseOrderItem(variant_id=2, quantity=2, price_per_unit=20.0),
+        ],
+        notes="Net-30 terms; deliver to receiving dock B.",
+        currency="USD",
+        preview=True,
+    )
+    result = await _create_purchase_order_impl(request, context)
+
+    assert result.is_preview is True
+    assert result.supplier_name == "Acme Supply Co"
+    assert result.location_name == "Main Warehouse"
+    assert result.item_count == 2
+    assert result.notes == "Net-30 terms; deliver to receiving dock B."
+    assert result.warnings == []  # both names resolved
+
+
+@pytest.mark.asyncio
+async def test_create_purchase_order_apply_echoes_notes_and_resolves_names():
+    """Apply branch must populate notes + supplier_name + location_name +
+    item_count, matching the preview branch's information density (#618).
+
+    Pre-#618, the apply branch returned a thinner ``PurchaseOrderResponse``:
+    missing the resolved names, missing item_count, and missing the notes
+    echo entirely (the field didn't exist on the model). This test pins the
+    parity contract: whatever the preview shows, the apply card shows too.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    async def get_by_id(entity_type, entity_id):
+        if entity_id == 4001:
+            return {"id": 4001, "name": "Acme Supply Co"}
+        if entity_id == 1:
+            return {"id": 1, "name": "Main Warehouse"}
+        return None
+
+    lifespan_ctx.cache.get_by_id = AsyncMock(side_effect=get_by_id)
+
+    # Build a typed RegularPurchaseOrder the live API would return on
+    # success — the impl unwraps via ``unwrap_as`` and reads
+    # ``additional_info`` for the notes echo.
+    from katana_public_api_client.models import (
+        PurchaseOrderEntityType as APIPurchaseOrderEntityType,
+        PurchaseOrderStatus as APIPurchaseOrderStatus,
+    )
+
+    notes = "Net-30 terms; deliver to receiving dock B."
+    mock_po = mock_entity_for_modify(
+        RegularPurchaseOrder,
+        id=9001,
+        order_no="PO-2026-001",
+        supplier_id=4001,
+        location_id=1,
+        currency="USD",
+        status=APIPurchaseOrderStatus.NOT_RECEIVED,
+        entity_type=APIPurchaseOrderEntityType.REGULAR,
+        additional_info=notes,
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = mock_po
+
+    mock_api_call = AsyncMock(return_value=mock_response)
+
+    import katana_public_api_client.api.purchase_order.create_purchase_order as create_po_module
+
+    original_asyncio_detailed = create_po_module.asyncio_detailed
+    create_po_module.asyncio_detailed = mock_api_call
+
+    try:
+        request = CreatePurchaseOrderRequest(
+            supplier_id=4001,
+            location_id=1,
+            order_number="PO-2026-001",
+            items=[
+                PurchaseOrderItem(variant_id=1, quantity=10, price_per_unit=5.0),
+                PurchaseOrderItem(variant_id=2, quantity=2, price_per_unit=20.0),
+            ],
+            notes=notes,
+            currency="USD",
+            preview=False,
+        )
+        result = await _create_purchase_order_impl(request, context)
+
+        assert result.is_preview is False
+        assert result.id == 9001
+        assert result.supplier_name == "Acme Supply Co"
+        assert result.location_name == "Main Warehouse"
+        assert result.item_count == 2
+        assert result.notes == notes
+    finally:
+        create_po_module.asyncio_detailed = original_asyncio_detailed
+
+
+@pytest.mark.asyncio
+async def test_create_purchase_order_apply_falls_back_to_request_notes_when_unset():
+    """When the live API doesn't echo ``additional_info`` (e.g., older Katana
+    deployments or the field is dropped on the response), the apply branch
+    should fall back to the request's ``notes`` so the card still shows
+    what the caller sent (#618).
+    """
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.cache.get_by_id = AsyncMock(return_value=None)
+
+    from katana_public_api_client.models import (
+        PurchaseOrderEntityType as APIPurchaseOrderEntityType,
+        PurchaseOrderStatus as APIPurchaseOrderStatus,
+    )
+
+    # additional_info defaults to UNSET on the mock — mock_entity_for_modify
+    # only sets the fields we explicitly pass.
+    mock_po = mock_entity_for_modify(
+        RegularPurchaseOrder,
+        id=9002,
+        order_no="PO-2026-002",
+        supplier_id=4001,
+        location_id=1,
+        currency="USD",
+        status=APIPurchaseOrderStatus.NOT_RECEIVED,
+        entity_type=APIPurchaseOrderEntityType.REGULAR,
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = mock_po
+    mock_api_call = AsyncMock(return_value=mock_response)
+
+    import katana_public_api_client.api.purchase_order.create_purchase_order as create_po_module
+
+    original_asyncio_detailed = create_po_module.asyncio_detailed
+    create_po_module.asyncio_detailed = mock_api_call
+
+    try:
+        request = CreatePurchaseOrderRequest(
+            supplier_id=4001,
+            location_id=1,
+            order_number="PO-2026-002",
+            items=[PurchaseOrderItem(variant_id=1, quantity=1, price_per_unit=1.0)],
+            notes="caller-supplied notes",
+            preview=False,
+        )
+        result = await _create_purchase_order_impl(request, context)
+
+        assert result.notes == "caller-supplied notes"
+    finally:
+        create_po_module.asyncio_detailed = original_asyncio_detailed
+
+
+def test_po_response_to_tool_result_apply_renders_enriched_fields():
+    """The apply card built from ``_po_response_to_tool_result`` must render
+    notes, supplier_name, location_name, and item_count somewhere in the
+    Prefab envelope so the user gets the same at-a-glance confirmation the
+    preview offered (#618).
+    """
+    response = PurchaseOrderResponse(
+        id=9001,
+        order_number="PO-2026-001",
+        supplier_id=4001,
+        supplier_name="Acme Supply Co",
+        location_id=1,
+        location_name="Main Warehouse",
+        status="NOT_RECEIVED",
+        entity_type="regular",
+        total_cost=100.0,
+        currency="USD",
+        item_count=2,
+        notes="Net-30 terms; deliver to receiving dock B.",
+        is_preview=False,
+        message="ok",
+        katana_url="https://factory.katanamrp.com/purchaseorder/9001",
+    )
+    request = CreatePurchaseOrderRequest(
+        supplier_id=4001,
+        location_id=1,
+        order_number="PO-2026-001",
+        items=[PurchaseOrderItem(variant_id=1, quantity=10, price_per_unit=5.0)],
+        notes="Net-30 terms; deliver to receiving dock B.",
+        preview=False,
+    )
+
+    tool_result = _po_response_to_tool_result(response, request=request)
+
+    # Walk the Prefab envelope, collecting Text content strings, and assert
+    # the enriched fields show up. The preview card already renders these
+    # via the shared ``_render_order_fields`` helper; the regression #618
+    # was the apply card silently losing them.
+    envelope = tool_result.structured_content
+    assert envelope is not None
+    text_nodes: list[str] = []
+
+    def collect(o):
+        if isinstance(o, dict):
+            if isinstance(o.get("content"), str):
+                text_nodes.append(o["content"])
+            for v in o.values():
+                collect(v)
+        elif isinstance(o, list):
+            for v in o:
+                collect(v)
+
+    collect(envelope)
+    joined = "\n".join(text_nodes)
+    assert "Acme Supply Co" in joined
+    assert "Main Warehouse" in joined
+    assert "Items: 2" in joined
+    assert "Net-30 terms" in joined
 
 
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -291,6 +291,70 @@ async def test_create_purchase_order_apply_falls_back_to_request_notes_when_unse
         create_po_module.asyncio_detailed = original_asyncio_detailed
 
 
+@pytest.mark.asyncio
+async def test_create_purchase_order_apply_proceeds_when_cache_is_unhealthy():
+    """Cache failure must NOT abort the apply path (PR #620 review).
+
+    Pre-fix, lifting the ``resolve_entity_name`` lookups out of the
+    preview-only branch meant any ``cache.get_by_id`` exception (locked
+    SQLite, corrupted DB, IO error) would propagate and prevent the live
+    API call. ``resolve_entity_name`` now swallows cache exceptions and
+    returns advisory warnings, so the live API call still happens. This
+    test pins that contract end-to-end on ``create_purchase_order``.
+    """
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.cache.get_by_id = AsyncMock(
+        side_effect=RuntimeError("database is locked")
+    )
+
+    from katana_public_api_client.models import (
+        PurchaseOrderEntityType as APIPurchaseOrderEntityType,
+        PurchaseOrderStatus as APIPurchaseOrderStatus,
+    )
+
+    mock_po = mock_entity_for_modify(
+        RegularPurchaseOrder,
+        id=9003,
+        order_no="PO-2026-003",
+        supplier_id=4001,
+        location_id=1,
+        currency="USD",
+        status=APIPurchaseOrderStatus.NOT_RECEIVED,
+        entity_type=APIPurchaseOrderEntityType.REGULAR,
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = mock_po
+    mock_api_call = AsyncMock(return_value=mock_response)
+
+    import katana_public_api_client.api.purchase_order.create_purchase_order as create_po_module
+
+    original_asyncio_detailed = create_po_module.asyncio_detailed
+    create_po_module.asyncio_detailed = mock_api_call
+
+    try:
+        request = CreatePurchaseOrderRequest(
+            supplier_id=4001,
+            location_id=1,
+            order_number="PO-2026-003",
+            items=[PurchaseOrderItem(variant_id=1, quantity=1, price_per_unit=1.0)],
+            preview=False,
+        )
+        result = await _create_purchase_order_impl(request, context)
+
+        # The live API call still happened — apply did not abort.
+        assert mock_api_call.await_count == 1
+        assert result.is_preview is False
+        assert result.id == 9003
+        # Names couldn't be resolved (cache failed), but the apply still
+        # succeeded; supplier_name/location_name fall through to None.
+        assert result.supplier_name is None
+        assert result.location_name is None
+    finally:
+        create_po_module.asyncio_detailed = original_asyncio_detailed
+
+
 def test_po_response_to_tool_result_apply_renders_enriched_fields():
     """The apply card built from ``_po_response_to_tool_result`` must render
     notes, supplier_name, location_name, and item_count somewhere in the

--- a/katana_mcp_server/tests/tools/test_tool_result_utils.py
+++ b/katana_mcp_server/tests/tools/test_tool_result_utils.py
@@ -11,8 +11,14 @@ JSON dump of the response so the LLM can act on the data.
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock
 
-from katana_mcp.tools.tool_result_utils import UI_META, make_tool_result
+import pytest
+from katana_mcp.tools.tool_result_utils import (
+    UI_META,
+    make_tool_result,
+    resolve_entity_name,
+)
 from prefab_ui.app import PrefabApp
 from prefab_ui.components import Text
 from pydantic import BaseModel
@@ -67,3 +73,66 @@ def test_ui_meta_is_the_opt_in_marker_for_prefab_rendering():
     # full _meta.ui = {"resourceUri": "ui://prefab/renderer.html", "csp": ...}
     # shape required by MCP Apps and registers the renderer resource.
     assert UI_META == {"ui": True}
+
+
+# ============================================================================
+# resolve_entity_name — best-effort cache enrichment
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_resolve_entity_name_returns_name_on_cache_hit():
+    """Hit path: cache returns a row, function returns ``(name, None)``."""
+    cache = AsyncMock()
+    cache.get_by_id = AsyncMock(return_value={"id": 1, "name": "Acme Supply Co"})
+
+    name, warning = await resolve_entity_name(
+        cache, "supplier", 1, entity_label="Supplier"
+    )
+
+    assert name == "Acme Supply Co"
+    assert warning is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_entity_name_returns_advisory_warning_on_cache_miss():
+    """Miss path: cache returns None, function returns ``(None, warning)`` —
+    advisory only (no BLOCK prefix), explaining the live API will validate
+    the ID on apply."""
+    cache = AsyncMock()
+    cache.get_by_id = AsyncMock(return_value=None)
+
+    name, warning = await resolve_entity_name(
+        cache, "supplier", 9999, entity_label="Supplier"
+    )
+
+    assert name is None
+    assert warning is not None
+    assert "9999" in warning
+    assert "not found in the cache" in warning
+    # Advisory warnings must NOT carry the BLOCK prefix — that prefix is
+    # reserved for hard duplicate-create gates.
+    assert not warning.startswith("BLOCK:")
+
+
+@pytest.mark.asyncio
+async def test_resolve_entity_name_swallows_cache_exceptions_so_apply_can_proceed():
+    """Cache failure path (#620 Copilot review): a SQLite/IO error inside
+    ``cache.get_by_id`` must NOT propagate. Otherwise an unhealthy cache
+    aborts destructive apply paths (e.g. ``create_purchase_order``) before
+    the live API call. The function returns the same ``(None, warning)``
+    advisory shape as a miss, with a message explaining the cache was
+    unavailable."""
+    cache = AsyncMock()
+    cache.get_by_id = AsyncMock(side_effect=RuntimeError("database is locked"))
+
+    name, warning = await resolve_entity_name(
+        cache, "supplier", 4001, entity_label="Supplier"
+    )
+
+    assert name is None
+    assert warning is not None
+    assert "4001" in warning
+    assert "cache unavailable" in warning
+    assert "RuntimeError" in warning
+    assert not warning.startswith("BLOCK:")


### PR DESCRIPTION
## Summary

- Add `notes: str | None = None` to `PurchaseOrderResponse`; echo `additional_info` from the API response (falling back to the caller's `request.notes` when the field is UNSET) so callers can visually verify the value persisted.
- Lift the `resolve_entity_name` cache lookups for supplier/location out of the preview-only branch so the apply branch populates `supplier_name`, `location_name`, and `item_count` too — pre-#618 the apply card silently dropped them.
- Render `notes` in the shared `_render_order_fields` helper so both preview and created cards stay symmetric.

Closes #618. Parallels #615 (modify/delete/correct enrichment).

## Out of scope (audit follow-ups noted in #618)

The same thin-apply-card gap likely exists on `create_sales_order`, `create_manufacturing_order`, `create_stock_adjustment`, `create_stock_transfer`, `create_item`, `create_product`, `create_material`. Intentionally not included here per the issue's scope guidance — separate audit PRs.

## Test plan

- [x] `uv run poe check` — 2987 passed, 2 skipped.
- [x] New unit tests:
  - `test_create_purchase_order_preview_echoes_notes_and_resolves_names` — preview branch populates the four fields.
  - `test_create_purchase_order_apply_echoes_notes_and_resolves_names` — apply branch matches.
  - `test_create_purchase_order_apply_falls_back_to_request_notes_when_unset` — pins the `unwrap_unset(po.additional_info, request.notes)` semantic.
  - `test_po_response_to_tool_result_apply_renders_enriched_fields` — walks the Prefab envelope and asserts the four enriched fields surface as Text content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)