### PR TITLE
fix(mcp): get_variant_details batch returns partial results on misses

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -550,8 +550,9 @@ exposes on the Variant record is surfaced — no follow-up lookups needed
 for pricing, barcodes, supplier codes, config attributes, custom fields,
 or timestamps (including `deleted_at`).
 
-For multiple variants at once, pass `skus=[...]` or `variant_ids=[...]` —
-batching N lookups in one call beats N separate invocations.
+For multiple variants at once, pass `{"skus": [...]}` or
+`{"variant_ids": [...]}` — batching N lookups in one call beats N separate
+invocations.
 
 **Parameters (at least one of the first four is required):**
 - `sku` (optional): Single SKU to look up (exact case-insensitive match)
@@ -578,6 +579,17 @@ labels use the canonical Pydantic field names (e.g.
 rendered in explicit bracket syntax so LLM consumers can't misread a value
 as a differently-labeled field. List form returned when a batch is
 requested.
+
+**Partial results on batch misses:** Singular requests
+(`{"sku": "..."}` / `{"variant_id": ...}`) raise an error if the variant
+isn't found. Batch requests (`{"skus": [...]}` / `{"variant_ids": [...]}`,
+or any mixed form) never short-circuit — the response carries every variant
+that resolved plus a `not_found` list of the missing identifiers. JSON
+payloads expose this as
+`{"variants": [...], "not_found": [{"sku": ...}, ...]}`; markdown appends
+a `**Not found (n):** ...` section after the table when there are
+misses. This makes batching safe for receiving-flow lookups where one
+bad SKU on a packing slip shouldn't lose the rest of the batch.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from katana_mcp.cache import EntityType
 from katana_mcp.logging import get_logger, observe_tool
@@ -1435,6 +1435,47 @@ class VariantDetailsResponse(BaseModel):
     deleted_at: str | None = None
 
 
+class VariantNotFound(BaseModel):
+    """Identifier for a variant that was requested but couldn't be resolved.
+
+    Exactly one of ``sku`` / ``variant_id`` is set, matching the form the
+    caller used in the request. Surfaced from
+    :func:`_get_variant_details_impl` so batch callers can see the gaps
+    without parsing exception text. The XOR is enforced at validation
+    time so invalid shapes (both set, both unset) can't leak into the
+    JSON / markdown rendering paths — e.g., the markdown miss line
+    formats ``#{variant_id}`` whenever ``sku is None``, so a both-None
+    instance would render ``#None``.
+    """
+
+    sku: str | None = None
+    variant_id: int | None = None
+
+    @model_validator(mode="after")
+    def _check_exactly_one_identifier(self) -> VariantNotFound:
+        if (self.sku is None) == (self.variant_id is None):
+            raise ValueError(
+                "VariantNotFound requires exactly one of 'sku' or 'variant_id'; "
+                f"got sku={self.sku!r}, variant_id={self.variant_id!r}"
+            )
+        return self
+
+
+class GetVariantDetailsResult(BaseModel):
+    """Partial-result envelope for variant lookups.
+
+    Splits hits from misses so a batch with one bad SKU still returns the
+    rest of the batch. The singular convenience path (a request with a
+    single ``sku=`` / ``variant_id=``) keeps raising ``ValueError`` for a
+    clean "that one variant doesn't exist" UX — only the batch path
+    (``skus=[...]`` / ``variant_ids=[...]`` or any mixed form) lands here
+    and never short-circuits. See issue #617.
+    """
+
+    found: list[VariantDetailsResponse] = Field(default_factory=list)
+    not_found: list[VariantNotFound] = Field(default_factory=list)
+
+
 def _variant_details_to_tool_result(response: VariantDetailsResponse) -> ToolResult:
     """Convert VariantDetailsResponse to ToolResult.
 
@@ -1575,19 +1616,12 @@ async def _fetch_variant_by_id(services: Any, variant_id: int) -> dict[str, Any]
     return variant_obj.to_dict()
 
 
-@cache_read(
-    EntityType.VARIANT,
-    EntityType.PRODUCT,
-    EntityType.MATERIAL,
-    EntityType.SUPPLIER,
-)
-async def _get_variant_details_impl(
-    request: GetVariantDetailsRequest, context: Context
-) -> list[VariantDetailsResponse]:
-    """Look up one or more variants by SKU(s) or variant ID(s).
-
-    Returns a list of matching variants. Raises ValueError if any are not found.
-    """
+def _collect_variant_identifiers(
+    request: GetVariantDetailsRequest,
+) -> tuple[list[str], list[int]]:
+    """Flatten the request's singular + plural identifier fields into
+    a single ``(skus, variant_ids)`` pair, validating that at least one
+    identifier was provided and that no SKU is blank."""
     skus: list[str] = []
     variant_ids: list[int] = []
 
@@ -1608,12 +1642,79 @@ async def _get_variant_details_impl(
             "Must provide at least one of: sku, variant_id, skus, variant_ids"
         )
 
-    services = get_services(context)
-
-    # Validate SKUs aren't blank before dispatching
     sku_cleaned = [s.strip() for s in skus]
     if any(not clean for clean in sku_cleaned):
         raise ValueError("SKU cannot be empty")
+
+    return sku_cleaned, variant_ids
+
+
+def _is_singular_request(request: GetVariantDetailsRequest) -> bool:
+    """True when the request carries exactly one identifier via the
+    scalar ``sku=`` / ``variant_id=`` field, with no plural list. The
+    singular path raises on a miss; the batch path returns it in
+    ``not_found``."""
+    return (
+        not request.skus
+        and not request.variant_ids
+        and (request.sku is not None) ^ (request.variant_id is not None)
+    )
+
+
+def _partition_variant_lookups(
+    *,
+    sku_cleaned: list[str],
+    sku_variants: list[dict[str, Any] | None],
+    variant_ids: list[int],
+    id_variants: list[dict[str, Any] | None],
+    is_singular_request: bool,
+) -> tuple[list[dict[str, Any]], list[VariantNotFound]]:
+    """Split parallel-lookup results into hits and misses. In singular
+    mode, the first miss raises; in batch mode, misses accumulate into
+    ``not_found`` and processing continues."""
+    hits: list[dict[str, Any]] = []
+    not_found: list[VariantNotFound] = []
+    for sku, v in zip(sku_cleaned, sku_variants, strict=True):
+        if not v:
+            if is_singular_request:
+                raise ValueError(f"Variant with SKU '{sku}' not found")
+            not_found.append(VariantNotFound(sku=sku))
+            continue
+        hits.append(v)
+    for variant_id, v in zip(variant_ids, id_variants, strict=True):
+        if v is None:
+            if is_singular_request:
+                raise ValueError(f"Variant ID {variant_id} not found")
+            not_found.append(VariantNotFound(variant_id=variant_id))
+            continue
+        hits.append(v)
+    return hits, not_found
+
+
+@cache_read(
+    EntityType.VARIANT,
+    EntityType.PRODUCT,
+    EntityType.MATERIAL,
+    EntityType.SUPPLIER,
+)
+async def _get_variant_details_impl(
+    request: GetVariantDetailsRequest, context: Context
+) -> GetVariantDetailsResult:
+    """Look up one or more variants by SKU(s) or variant ID(s).
+
+    Returns a :class:`GetVariantDetailsResult` with hits in ``found`` and
+    misses in ``not_found``. The singular convenience path (the request
+    carries exactly one identifier via ``sku=`` or ``variant_id=``, with
+    no plural list) keeps raising ``ValueError`` on a miss so the
+    "that one variant doesn't exist" UX stays clean. The batch path —
+    ``skus=[...]`` / ``variant_ids=[...]`` or any mixed form — never
+    short-circuits, so a single bad SKU can't kill an otherwise-good
+    batch (#617).
+    """
+    sku_cleaned, variant_ids = _collect_variant_identifiers(request)
+    is_singular_request = _is_singular_request(request)
+
+    services = get_services(context)
 
     # Parallelize both groups of lookups
     sku_variants, id_variants = await asyncio.gather(
@@ -1621,24 +1722,22 @@ async def _get_variant_details_impl(
         asyncio.gather(*(_fetch_variant_by_id(services, v) for v in variant_ids)),
     )
 
-    found: list[dict[str, Any]] = []
-    for sku, v in zip(sku_cleaned, sku_variants, strict=True):
-        if not v:
-            raise ValueError(f"Variant with SKU '{sku}' not found")
-        found.append(v)
-    for variant_id, v in zip(variant_ids, id_variants, strict=True):
-        if v is None:
-            raise ValueError(f"Variant ID {variant_id} not found")
-        found.append(v)
+    hits, not_found = _partition_variant_lookups(
+        sku_cleaned=sku_cleaned,
+        sku_variants=list(sku_variants),
+        variant_ids=variant_ids,
+        id_variants=list(id_variants),
+        is_singular_request=is_singular_request,
+    )
 
     # Bulk-fetch parents + suppliers once for the whole batch so the
     # response includes UoM, default supplier name, and batch-tracked
     # status without a per-variant follow-up call (#538).
     products, materials, supplier_by_id = await _enrich_variants_with_parent(
-        services, found
+        services, hits
     )
-    results: list[VariantDetailsResponse] = []
-    for v in found:
+    found: list[VariantDetailsResponse] = []
+    for v in hits:
         # Pick the parent map by which ID the variant carries — product
         # and material IDs may collide, so a merged map would mis-attach.
         if v.get("product_id"):
@@ -1649,9 +1748,9 @@ async def _get_variant_details_impl(
             parent = None
         sup_id = (parent or {}).get("default_supplier_id")
         supplier = supplier_by_id.get(sup_id) if sup_id else None
-        results.append(_dict_to_variant_details(v, parent=parent, supplier=supplier))
+        found.append(_dict_to_variant_details(v, parent=parent, supplier=supplier))
 
-    return results
+    return GetVariantDetailsResult(found=found, not_found=not_found)
 
 
 @observe_tool
@@ -1662,9 +1761,10 @@ async def get_variant_details(
     """Get comprehensive variant details by SKU(s) or variant ID(s).
 
     Pass one or more values via ``skus`` / ``variant_ids`` (or the singular
-    ``sku`` / ``variant_id``). A single item returns a rich detail card; multiple
-    items return a summary table. Batching N lookups in one call beats N
-    separate invocations.
+    ``sku`` / ``variant_id``). When exactly one variant resolves and there are
+    no misses, the response is a rich detail card; otherwise it's a summary
+    table (and a ``Not found`` section is appended when the batch had misses).
+    Batching N lookups in one call beats N separate invocations.
 
     Returns pricing, barcodes, supplier codes, and more.
 
@@ -1672,12 +1772,21 @@ async def get_variant_details(
     items, MO recipe rows) to resolve them to SKUs and full details.
 
     Tries the cache first; falls back to the API for variant IDs not in cache.
-    Raises ValueError if any requested variant is not found.
+    For a singular request (one ``sku=`` or ``variant_id=``), raises
+    ``ValueError`` if the variant isn't found. For a batch request
+    (``skus=[...]`` / ``variant_ids=[...]`` or mixed), returns the variants
+    that resolved plus a ``not_found`` list of the misses — a single bad
+    identifier never kills the whole batch (#617).
     """
-    responses = await _get_variant_details_impl(request, context)
+    result = await _get_variant_details_impl(request, context)
+    found = result.found
+    not_found = result.not_found
 
     if request.format == "json":
-        payload = {"variants": [r.model_dump() for r in responses]}
+        payload = {
+            "variants": [r.model_dump() for r in found],
+            "not_found": [n.model_dump(exclude_none=True) for n in not_found],
+        }
         import json as _json
 
         return ToolResult(
@@ -1687,35 +1796,58 @@ async def get_variant_details(
 
     # If a single-variant request, return the single-variant markdown + UI.
     # Treat a single-element batch list (skus=[X] or variant_ids=[X]) the same
-    # as the singular form to honor the docstring's "single item" promise.
-    is_single = len(responses) == 1 and (
-        request.sku is not None
-        or request.variant_id is not None
-        or len(request.skus or []) == 1
-        or len(request.variant_ids or []) == 1
+    # as the singular form to honor the docstring's "single item" promise —
+    # but only when there are no misses; with misses we fall through to the
+    # batch renderer so the "Not found" section still surfaces.
+    is_single = (
+        len(found) == 1
+        and not not_found
+        and (
+            request.sku is not None
+            or request.variant_id is not None
+            or len(request.skus or []) == 1
+            or len(request.variant_ids or []) == 1
+        )
     )
     if is_single:
-        return _variant_details_to_tool_result(responses[0])
+        return _variant_details_to_tool_result(found[0])
 
-    # Batch response: summary + table
-    table = format_md_table(
-        headers=["ID", "SKU", "Name", "Sales Price", "Purchase Price"],
-        rows=[
-            [
-                v.id,
-                v.sku,
-                v.name,
-                f"${v.sales_price:,.2f}" if v.sales_price is not None else "N/A",
-                f"${v.purchase_price:,.2f}" if v.purchase_price is not None else "N/A",
-            ]
-            for v in responses
-        ],
-    )
-    markdown = f"## Variant Details ({len(responses)} variants)\n\n{table}"
+    # Batch response: summary + table (+ a "Not found" section when the
+    # batch had misses, so callers see the gaps at a glance without
+    # reaching into structured_content).
+    if found:
+        table = format_md_table(
+            headers=["ID", "SKU", "Name", "Sales Price", "Purchase Price"],
+            rows=[
+                [
+                    v.id,
+                    v.sku,
+                    v.name,
+                    f"${v.sales_price:,.2f}" if v.sales_price is not None else "N/A",
+                    f"${v.purchase_price:,.2f}"
+                    if v.purchase_price is not None
+                    else "N/A",
+                ]
+                for v in found
+            ],
+        )
+        markdown = f"## Variant Details ({len(found)} variants)\n\n{table}"
+    else:
+        markdown = "## Variant Details (0 variants)\n\nNo variants resolved."
+
+    if not_found:
+        misses = ", ".join(
+            f"`{n.sku}`" if n.sku is not None else f"`#{n.variant_id}`"
+            for n in not_found
+        )
+        markdown += f"\n\n**Not found ({len(not_found)}):** {misses}"
 
     return make_simple_result(
         markdown,
-        structured_data={"variants": [v.model_dump() for v in responses]},
+        structured_data={
+            "variants": [v.model_dump() for v in found],
+            "not_found": [n.model_dump(exclude_none=True) for n in not_found],
+        },
     )
 
 

--- a/katana_mcp_server/tests/integration/test_inventory_workflow.py
+++ b/katana_mcp_server/tests/integration/test_inventory_workflow.py
@@ -66,7 +66,7 @@ class TestInventorySearchWorkflow:
             _var_results = await _get_variant_details_impl(
                 details_request, integration_context
             )
-            details = _var_results[0]
+            details = _var_results.found[0]
         except ValueError as e:
             # SKU might have been deleted between search and details call
             if "not found" in str(e).lower():
@@ -149,7 +149,7 @@ class TestInventorySearchWorkflow:
                 _var_results = await _get_variant_details_impl(
                     details_request, integration_context
                 )
-                details = _var_results[0]
+                details = _var_results.found[0]
                 details_results.append(details)
             except ValueError:
                 # Item not found - skip it
@@ -288,7 +288,7 @@ class TestInventoryDataConsistency:
                 _var_results = await _get_variant_details_impl(
                     details_request, integration_context
                 )
-                details = _var_results[0]
+                details = _var_results.found[0]
 
                 # IDs should match
                 assert details.id == item.id, (

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -910,7 +910,7 @@ async def test_get_variant_details():
 
     request = GetVariantDetailsRequest(sku="WIDGET-001")
     _var_results = await _get_variant_details_impl(request, context)
-    result = _var_results[0]
+    result = _var_results.found[0]
 
     assert result.id == 123
     assert result.sku == "WIDGET-001"
@@ -950,7 +950,7 @@ async def test_get_variant_details_case_insensitive():
     # Search with lowercase SKU
     request = GetVariantDetailsRequest(sku="widget-001")
     _var_results = await _get_variant_details_impl(request, context)
-    result = _var_results[0]
+    result = _var_results.found[0]
 
     assert result.id == 123
     assert result.sku == "WIDGET-001"
@@ -1015,7 +1015,7 @@ async def test_get_variant_details_minimal_fields():
 
     request = GetVariantDetailsRequest(sku="MIN-001")
     _var_results = await _get_variant_details_impl(request, context)
-    result = _var_results[0]
+    result = _var_results.found[0]
 
     assert result.id == 123
     assert result.sku == "MIN-001"
@@ -1051,7 +1051,7 @@ async def test_get_variant_details_with_timestamps():
 
     request = GetVariantDetailsRequest(sku="TIME-001")
     _var_results = await _get_variant_details_impl(request, context)
-    result = _var_results[0]
+    result = _var_results.found[0]
 
     assert result.created_at == "2024-01-01T12:00:00+00:00"
     assert result.updated_at == "2024-06-01T14:30:00+00:00"
@@ -1775,7 +1775,7 @@ async def test_get_variant_details_integration(katana_context):
 
     try:
         _var_results = await _get_variant_details_impl(request, katana_context)
-        result = _var_results[0]
+        result = _var_results.found[0]
 
         # Verify response structure
         assert isinstance(result.id, int)
@@ -2018,19 +2018,25 @@ async def test_get_variant_details_format_json_returns_json():
         "katana_mcp.tools.foundation.items._get_variant_details_impl",
         new_callable=AsyncMock,
     ) as mock_impl:
-        from katana_mcp.tools.foundation.items import VariantDetailsResponse
+        from katana_mcp.tools.foundation.items import (
+            GetVariantDetailsResult,
+            VariantDetailsResponse,
+        )
 
-        mock_impl.return_value = [
-            VariantDetailsResponse(
-                id=42,
-                sku="VAR-42",
-                name="Test Variant",
-                item_id=100,
-                item_type="product",
-                sales_price=10.0,
-                purchase_price=5.0,
-            )
-        ]
+        mock_impl.return_value = GetVariantDetailsResult(
+            found=[
+                VariantDetailsResponse(
+                    id=42,
+                    sku="VAR-42",
+                    name="Test Variant",
+                    product_id=100,
+                    type="product",
+                    sales_price=10.0,
+                    purchase_price=5.0,
+                )
+            ],
+            not_found=[],
+        )
 
         result = await get_variant_details(
             variant_id=42, format="json", context=context

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -16,11 +16,13 @@ from katana_mcp.tools.foundation.items import (
     GetItemRequest,
     GetVariantDetailsRequest,
     ItemType,
+    VariantNotFound,
     _get_item_impl,
     _get_variant_details_impl,
     get_item,
     get_variant_details,
 )
+from pydantic import ValidationError
 
 from tests.conftest import create_mock_context
 
@@ -114,8 +116,8 @@ async def test_get_variant_details_surfaces_every_variant_field():
     lifespan_ctx.cache.get_by_sku = AsyncMock(return_value=variant_dict)
 
     request = GetVariantDetailsRequest(sku="KNF-PRO-8PC-STL")
-    results = await _get_variant_details_impl(request, context)
-    result = results[0]
+    result_envelope = await _get_variant_details_impl(request, context)
+    result = result_envelope.found[0]
 
     # Core fields
     assert result.id == 3001
@@ -219,12 +221,215 @@ async def test_get_variant_details_lifts_default_supplier_from_parent():
     lifespan_ctx.cache.get_many_by_ids = AsyncMock(side_effect=_get_many_by_ids)
 
     request = GetVariantDetailsRequest(sku="KNF-PRO-8PC-STL")
-    [result] = await _get_variant_details_impl(request, context)
+    [result] = (await _get_variant_details_impl(request, context)).found
 
     assert result.default_supplier_id == 555
     assert result.default_supplier_name == "Acme Cutlery Co"
     assert result.uom == "set"
     assert result.is_batch_tracked is False
+
+
+# ============================================================================
+# get_variant_details — partial-result batching (#617)
+# ============================================================================
+#
+# Pre-#617 the impl raised on the first cache miss inside a batch, killing
+# any other hits in the same call. The contract is now:
+#
+# - Singular convenience path (one ``sku=`` or ``variant_id=`` and no plural
+#   list) — keep raising ``ValueError`` so the "that one variant doesn't
+#   exist" UX stays clean.
+# - Batch path (``skus=[...]`` / ``variant_ids=[...]`` or any mixed form) —
+#   never short-circuit; return the hits in ``found`` and the misses in
+#   ``not_found``.
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_batch_all_hits_returns_all_no_misses():
+    """All-hits batch behaves identically to the pre-#617 path: every
+    requested variant lands in ``found`` and ``not_found`` is empty."""
+    context, lifespan_ctx = create_mock_context()
+    by_sku = {
+        "WIDGET-A": {"id": 1, "sku": "WIDGET-A", "display_name": "Widget A"},
+        "WIDGET-B": {"id": 2, "sku": "WIDGET-B", "display_name": "Widget B"},
+    }
+    lifespan_ctx.cache.get_by_sku = AsyncMock(side_effect=by_sku.get)
+
+    request = GetVariantDetailsRequest(skus=["WIDGET-A", "WIDGET-B"])
+    result = await _get_variant_details_impl(request, context)
+
+    assert [v.sku for v in result.found] == ["WIDGET-A", "WIDGET-B"]
+    assert result.not_found == []
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_batch_partial_hits_returns_hits_and_misses():
+    """A batch with one miss + one hit returns the hit in ``found`` and
+    the missing identifier in ``not_found`` — no raise. This is the
+    canonical receiving-flow case from #617."""
+    context, lifespan_ctx = create_mock_context()
+    by_sku = {
+        "WIDGET-B": {"id": 2, "sku": "WIDGET-B", "display_name": "Widget B"},
+    }
+    lifespan_ctx.cache.get_by_sku = AsyncMock(side_effect=by_sku.get)
+
+    request = GetVariantDetailsRequest(skus=["MISSING-A", "WIDGET-B"])
+    result = await _get_variant_details_impl(request, context)
+
+    assert [v.sku for v in result.found] == ["WIDGET-B"]
+    assert len(result.not_found) == 1
+    assert result.not_found[0].sku == "MISSING-A"
+    assert result.not_found[0].variant_id is None
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_batch_all_misses_returns_empty_found():
+    """An all-misses batch returns an empty ``found`` list and a
+    populated ``not_found`` — no raise even though nothing resolved."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.cache.get_by_sku = AsyncMock(return_value=None)
+
+    request = GetVariantDetailsRequest(skus=["MISSING-A", "MISSING-B"])
+    result = await _get_variant_details_impl(request, context)
+
+    assert result.found == []
+    assert [n.sku for n in result.not_found] == ["MISSING-A", "MISSING-B"]
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_singular_sku_miss_still_raises():
+    """The singular convenience path (one ``sku=``) keeps raising
+    ``ValueError`` on a miss — the partial-result contract only applies
+    to the batch path."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.cache.get_by_sku = AsyncMock(return_value=None)
+
+    request = GetVariantDetailsRequest(sku="MISSING-SOLO")
+    with pytest.raises(ValueError, match="Variant with SKU 'MISSING-SOLO' not found"):
+        await _get_variant_details_impl(request, context)
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_singular_variant_id_miss_still_raises():
+    """Singular ``variant_id=`` miss raises identically to singular
+    ``sku=`` miss."""
+    context, _lifespan_ctx = create_mock_context()
+
+    with patch(
+        "katana_mcp.tools.foundation.items._fetch_variant_by_id",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        request = GetVariantDetailsRequest(variant_id=99999)
+        with pytest.raises(ValueError, match="Variant ID 99999 not found"):
+            await _get_variant_details_impl(request, context)
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_mixed_skus_and_variant_ids_partial():
+    """Mixed ``skus`` + ``variant_ids`` follows the batch contract — the
+    caller is treating it as a batch, so misses on either side land in
+    ``not_found`` rather than raising."""
+    context, lifespan_ctx = create_mock_context()
+    by_sku = {
+        "WIDGET-OK": {"id": 1, "sku": "WIDGET-OK", "display_name": "Widget OK"},
+    }
+    lifespan_ctx.cache.get_by_sku = AsyncMock(side_effect=by_sku.get)
+
+    by_id = {
+        2: {"id": 2, "sku": "VAR-OK", "display_name": "Variant OK"},
+    }
+
+    async def _fetch(_services, vid):
+        return by_id.get(vid)
+
+    with patch(
+        "katana_mcp.tools.foundation.items._fetch_variant_by_id",
+        side_effect=_fetch,
+    ):
+        request = GetVariantDetailsRequest(
+            skus=["WIDGET-OK", "MISSING-X"],
+            variant_ids=[2, 99999],
+        )
+        result = await _get_variant_details_impl(request, context)
+
+    assert sorted(v.sku for v in result.found) == ["VAR-OK", "WIDGET-OK"]
+    assert {(n.sku, n.variant_id) for n in result.not_found} == {
+        ("MISSING-X", None),
+        (None, 99999),
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_batch_markdown_lists_not_found_section():
+    """Public tool's markdown rendering surfaces a ``Not found`` section
+    when a batch had misses, so callers see the gaps without parsing the
+    structured payload."""
+    context, lifespan_ctx = create_mock_context()
+    by_sku = {
+        "WIDGET-B": {"id": 2, "sku": "WIDGET-B", "display_name": "Widget B"},
+    }
+    lifespan_ctx.cache.get_by_sku = AsyncMock(side_effect=by_sku.get)
+
+    result = await get_variant_details(skus=["MISSING-A", "WIDGET-B"], context=context)
+
+    text = _content_text(result)
+    assert "WIDGET-B" in text
+    assert "Not found" in text
+    assert "MISSING-A" in text
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_batch_json_includes_not_found():
+    """Public tool's JSON rendering carries a ``not_found`` array next to
+    ``variants`` so programmatic consumers can branch on it."""
+    context, lifespan_ctx = create_mock_context()
+    by_sku = {
+        "WIDGET-B": {"id": 2, "sku": "WIDGET-B", "display_name": "Widget B"},
+    }
+    lifespan_ctx.cache.get_by_sku = AsyncMock(side_effect=by_sku.get)
+
+    result = await get_variant_details(
+        skus=["MISSING-A", "WIDGET-B"], format="json", context=context
+    )
+
+    payload = json.loads(_content_text(result))
+    assert [v["sku"] for v in payload["variants"]] == ["WIDGET-B"]
+    assert payload["not_found"] == [{"sku": "MISSING-A"}]
+
+
+# ============================================================================
+# VariantNotFound — XOR invariant on identifier shape
+# ============================================================================
+
+
+def test_variant_not_found_accepts_sku_only():
+    """The canonical SKU-miss shape is valid."""
+    miss = VariantNotFound(sku="MISSING-A")
+    assert miss.sku == "MISSING-A"
+    assert miss.variant_id is None
+
+
+def test_variant_not_found_accepts_variant_id_only():
+    """The canonical variant-id-miss shape is valid."""
+    miss = VariantNotFound(variant_id=99999)
+    assert miss.sku is None
+    assert miss.variant_id == 99999
+
+
+def test_variant_not_found_rejects_both_set():
+    """Both identifiers set is invalid — would render an ambiguous miss
+    line in markdown / leak both fields in JSON."""
+    with pytest.raises(ValidationError, match="exactly one of 'sku' or 'variant_id'"):
+        VariantNotFound(sku="MISSING-A", variant_id=99999)
+
+
+def test_variant_not_found_rejects_both_none():
+    """Both identifiers unset is invalid — markdown would render
+    ``#None`` because the formatter falls back to ``variant_id`` when
+    ``sku`` is None."""
+    with pytest.raises(ValidationError, match="exactly one of 'sku' or 'variant_id'"):
+        VariantNotFound()
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- `get_variant_details(skus=[...])` no longer raises on the first cache miss — batch lookups now return what resolved plus a `not_found` list of the missing identifiers, so one bad SKU on a packing slip can't lose the rest of the batch (#617).
- Singular convenience path (`sku=...` or `variant_id=...`) keeps raising `ValueError` for a clean "that one variant doesn't exist" UX. Mixed forms (singular + plural in one call) follow the batch contract since the caller is treating it as a batch.
- New `GetVariantDetailsResult` envelope: `found: list[VariantDetailsResponse]` + `not_found: list[VariantNotFound]`. JSON payloads expose `{"variants": [...], "not_found": [{"sku": ...}, ...]}`; markdown appends a `**Not found (n):** ...` section after the table when there are misses.
- Help resource and tool docstring updated to document the partial-result contract.

## Test plan

- [x] `uv run poe check` — 2994 passed, 2 skipped
- [x] New unit tests in `test_items.py` cover: all-hits batch, partial-hits batch, all-misses batch, singular-sku miss raises, singular-variant_id miss raises, mixed `skus`+`variant_ids` partial, markdown lists not_found section, JSON includes not_found
- [x] Existing tests in `test_inventory.py`, `test_error_scenarios.py`, `test_inventory_workflow.py` updated to consume `.found` from the new envelope

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)