### PR TITLE
fix(mcp): repair Prefab card rendering across the board + add browser-render test harness (#629, #630)

### DIFF
--- a/.devcontainer/oncreate.sh
+++ b/.devcontainer/oncreate.sh
@@ -21,4 +21,11 @@ echo "🪝 Installing pre-commit hooks..."
 uv run pre-commit install
 uv run pre-commit install-hooks
 
+# Install Chromium for Playwright (needed by `poe test-browser`).
+# ``--with-deps`` pulls in apt system libs Chromium needs at launch
+# time. ~250MB; cached in the Codespaces prebuild so spinning up a
+# fresh codespace is instant.
+echo "🎭 Installing Chromium for Playwright (browser-render tests)..."
+uv run playwright install --with-deps chromium
+
 echo "✅ onCreate setup complete - dependencies cached for fast startup!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,57 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: false
 
+  # Headless-browser render tests for Prefab UI cards. Runs `poe
+  # test-browser`, which spins up `fastmcp dev apps` against a minimal
+  # MCP server in `katana_mcp_server/tests/browser/render_test_server.py`
+  # and drives the iframe via Playwright + Chromium. Catches the
+  # blank-iframe / "valid wire envelope but unrenderable" bug class
+  # that the Python-side unit tests can't see.
+  #
+  # Single Python version (3.14) — the JS renderer doesn't care which
+  # Python launched it, and re-running across the matrix would burn
+  # ~5 minutes for no signal.
+  browser-test:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip for docs-only changes
+        if: needs.changes.outputs.code == 'false'
+        run: echo "Skipping browser tests for documentation-only changes"
+
+      - name: Checkout code
+        if: needs.changes.outputs.code == 'true'
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        if: needs.changes.outputs.code == 'true'
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.14"
+
+      - name: Install dependencies
+        if: needs.changes.outputs.code == 'true'
+        run: uv sync --all-extras
+
+      - name: Cache Playwright browsers
+        if: needs.changes.outputs.code == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          # Bust the cache when the playwright pin changes — the
+          # browser build is pinned to the SDK version.
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+
+      - name: Install Chromium for Playwright
+        if: needs.changes.outputs.code == 'true'
+        run: uv run playwright install --with-deps chromium
+
+      - name: Run browser-render tests
+        if: needs.changes.outputs.code == 'true'
+        run: uv run poe test-browser
+
   quality:
     needs: changes
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,6 +280,22 @@ Common mistakes to avoid:
   PAT-based pushes); tightening that bypass is tracked in #429 (GitHub App migration).
   Until #429 lands, the local hook is the only mechanical guardrail.
 
+- **Prefab `DataTable.rows` requires mustache `{{ key }}` for state binding, not bare
+  string** - The Python pydantic field type accepts `rows: str` either way, but the JS
+  renderer crashes the entire iframe with `t.some is not a function` if it sees a bare
+  state-key string — it treats the string as the rows array itself, calls `.some()` on a
+  string, and the React tree never mounts. Use mustache form everywhere:
+  `rows="{{ items }}"`, `rows="{{ stock.by_location }}"` (dotted paths supported).
+  `_assert_state_bindings_resolve` in `katana_mcp_server/tests/test_prefab_ui.py`
+  enforces this on every state-bound DataTable. The browser-render harness in
+  `katana_mcp_server/tests/browser/` proves cards actually render in headless Chromium —
+  the prior unit-test contract (`to_json()` returns a dict with `$prefab`) was
+  insufficient because the wire envelope can be "valid but unrenderable." Discovered
+  while investigating #629; bit every state-bound DataTable in the repo (search,
+  inventory, verification, batch_recipe, modification card). Run
+  `uv run poe test-browser` to exercise the JS renderer locally; needs one-time
+  `uv run playwright install chromium`.
+
 ## Using the LSP tool
 
 Both Python (pyright) and TypeScript (typescript-language-server) LSPs are configured

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,9 +5,10 @@ Guidance for Claude Code working with this repository.
 ## Quick Start
 
 ```bash
-uv sync --all-extras         # Install dependencies
-uv run pre-commit install    # Setup hooks (installs both pre-commit AND pre-push)
-cp .env.example .env         # Add KATANA_API_KEY
+uv sync --all-extras                # Install dependencies
+uv run pre-commit install           # Setup hooks (installs both pre-commit AND pre-push)
+uv run playwright install chromium  # Headless browser for Prefab UI render tests
+cp .env.example .env                # Add KATANA_API_KEY
 ```
 
 **Worktrees: re-run `uv run pre-commit install` after `git worktree add`** — pre-commit
@@ -17,14 +18,15 @@ worktree's `.git/hooks/`.
 
 ## Essential Commands
 
-| Command                  | Time   | When to Use              |
-| ------------------------ | ------ | ------------------------ |
-| `uv run poe quick-check` | ~5-10s | During development       |
-| `uv run poe agent-check` | ~8-12s | Before committing        |
-| `uv run poe check`       | ~30s   | **Before opening PR**    |
-| `uv run poe full-check`  | ~40s   | Before requesting review |
-| `uv run poe fix`         | ~5s    | Auto-fix lint issues     |
-| `uv run poe test`        | ~16s   | Run tests (4 workers)    |
+| Command                   | Time   | When to Use                          |
+| ------------------------- | ------ | ------------------------------------ |
+| `uv run poe quick-check`  | ~5-10s | During development                   |
+| `uv run poe agent-check`  | ~8-12s | Before committing                    |
+| `uv run poe check`        | ~75s   | **Before opening PR** (incl browser) |
+| `uv run poe full-check`   | ~85s   | Before requesting review             |
+| `uv run poe fix`          | ~5s    | Auto-fix lint issues                 |
+| `uv run poe test`         | ~16s   | Run tests (4 workers, no browser)    |
+| `uv run poe test-browser` | ~60s   | Headless Prefab UI render tests      |
 
 **NEVER CANCEL** long-running commands - they may appear to hang but are processing.
 

--- a/katana_mcp_server/pyproject.toml
+++ b/katana_mcp_server/pyproject.toml
@@ -79,6 +79,7 @@ asyncio_mode = "strict"
 markers = [
     "unit: Unit tests with mocks",
     "integration: Integration tests requiring API key",
+    "browser: Browser-render tests via Playwright + fastmcp dev-apps (slow, needs `playwright install chromium`)",
 ]
 
 [tool.semantic_release]

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -158,17 +158,37 @@ class ActionResult(BaseModel):
     # Derived display fields — computed from succeeded/verified/changes/operation
     # so client renderers (Prefab cards) bind directly without recomputing.
     # Travels with every preview AND apply response, so the live-tick path
-    # (SetState("plan_actions", RESULT.actions) on Confirm) preserves shape.
+    # (SetState("plan_actions", RESULT.actions) on Confirm) preserves the
+    # exact same row shape between preview-time and apply-time. ``index`` is
+    # set by the dispatcher (it's the position in the plan, 1-based).
+    index: int = 0
+    operation_label: str = ""
+    target_label: str = ""
     status_label: str = ""
     summary: str = ""
 
     @model_validator(mode="after")
     def _populate_derived(self) -> ActionResult:
+        if not self.operation_label:
+            self.operation_label = _derive_operation_label(self)
+        if not self.target_label:
+            self.target_label = _derive_target_label(self)
         if not self.status_label:
             self.status_label = _derive_status_label(self)
         if not self.summary:
             self.summary = _derive_summary(self)
         return self
+
+
+def _derive_operation_label(action: ActionResult) -> str:
+    """Humanize the snake_case operation for the display column."""
+    raw = (action.operation or "").replace("_", " ").title()
+    return raw or "Action"
+
+
+def _derive_target_label(action: ActionResult) -> str:
+    """``#<id>`` when the action has a target, em-dash otherwise."""
+    return f"#{action.target_id}" if action.target_id is not None else "—"
 
 
 def _derive_status_label(action: ActionResult) -> str:

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -29,7 +29,7 @@ from enum import Enum
 from typing import Any, ClassVar
 
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from katana_mcp.tools.tool_result_utils import BLOCK_WARNING_PREFIX, make_tool_result
 from katana_public_api_client.client_types import UNSET, Unset
@@ -154,6 +154,53 @@ class ActionResult(BaseModel):
     error: str | None = None
     verified: bool | None = None
     actual_after: dict[str, Any] | None = None
+
+    # Derived display fields — computed from succeeded/verified/changes/operation
+    # so client renderers (Prefab cards) bind directly without recomputing.
+    # Travels with every preview AND apply response, so the live-tick path
+    # (SetState("plan_actions", RESULT.actions) on Confirm) preserves shape.
+    status_label: str = ""
+    summary: str = ""
+
+    @model_validator(mode="after")
+    def _populate_derived(self) -> ActionResult:
+        if not self.status_label:
+            self.status_label = _derive_status_label(self)
+        if not self.summary:
+            self.summary = _derive_summary(self)
+        return self
+
+
+def _derive_status_label(action: ActionResult) -> str:
+    """Compute a status label string for an ActionResult.
+
+    Mirrors ``katana_mcp.tools.prefab_ui._action_status_badge`` (which we
+    delete in this change) so client + server agree without coordination.
+    """
+    if action.succeeded is None:
+        return "PLANNED"
+    if action.succeeded is True:
+        if action.verified is False:
+            return "APPLIED (verification mismatch)"
+        if action.verified is True:
+            return "APPLIED (verified)"
+        return "APPLIED"
+    return "FAILED"
+
+
+def _derive_summary(action: ActionResult) -> str:
+    """One-line description of what an action does, for the Changes column."""
+    op = action.operation.lower()
+    if op.startswith("delete"):
+        return "deleted"
+    if op.startswith("add") or op.startswith("create"):
+        n = len(action.changes)
+        return f"{n} field(s) set"
+    # update_*, modify_*, correct_*, etc.
+    n = sum(1 for c in action.changes if not c.is_unchanged)
+    if n == 0 and action.changes:
+        return f"{len(action.changes)} field(s) — no change"
+    return f"{n} field(s) changed"
 
 
 class ModificationResponse(BaseModel):

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -102,9 +102,15 @@ class ActionSpec:
     apply: ApplyCallable | None = None
     verify: VerifyCallable | None = None
 
-    def to_planned_result(self) -> ActionResult:
-        """Build an ActionResult for the preview branch (action not yet run)."""
+    def to_planned_result(self, index: int = 0) -> ActionResult:
+        """Build an ActionResult for the preview branch (action not yet run).
+
+        ``index`` is the 1-based position in the plan — used by the Prefab
+        card's ``#`` column. The dispatcher passes a real index when
+        constructing the list; default 0 is for direct unit-test calls.
+        """
         return ActionResult(
+            index=index,
             operation=self.operation,
             target_id=self.target_id,
             changes=list(self.diff),
@@ -129,7 +135,7 @@ async def execute_plan(plan: list[ActionSpec]) -> list[ActionResult]:
     """
     results: list[ActionResult] = []
 
-    for spec in plan:
+    for idx, spec in enumerate(plan, start=1):
         if spec.apply is None:
             raise RuntimeError(
                 f"ActionSpec for {spec.operation} (target {spec.target_id}) "
@@ -145,6 +151,7 @@ async def execute_plan(plan: list[ActionSpec]) -> list[ActionResult]:
             )
             results.append(
                 ActionResult(
+                    index=idx,
                     operation=spec.operation,
                     target_id=spec.target_id,
                     changes=list(spec.diff),
@@ -169,6 +176,7 @@ async def execute_plan(plan: list[ActionSpec]) -> list[ActionResult]:
 
         results.append(
             ActionResult(
+                index=idx,
                 operation=spec.operation,
                 target_id=spec.target_id,
                 changes=list(spec.diff),
@@ -188,7 +196,7 @@ def plan_to_preview_results(plan: list[ActionSpec]) -> list[ActionResult]:
     Each ActionResult carries the operation/target/diff but
     ``succeeded=None`` to signal "planned, not yet executed".
     """
-    return [spec.to_planned_result() for spec in plan]
+    return [spec.to_planned_result(index=idx) for idx, spec in enumerate(plan, start=1)]
 
 
 def unset_dict(

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -472,7 +472,7 @@ def build_search_results_ui(
                     sortable=True,
                 ),
             ],
-            rows="items",
+            rows="{{ items }}",
             search=True,
             paginated=True,
             pageSize=20,
@@ -749,7 +749,7 @@ def build_inventory_check_ui(
                         DataTableColumn(key="available", header="Available"),
                         DataTableColumn(key="expected", header="Expected"),
                     ],
-                    rows="stock.by_location",
+                    rows="{{ stock.by_location }}",
                 )
 
         with CardFooter(), Row(gap=2):
@@ -820,7 +820,7 @@ def build_low_stock_ui(
                     align="right",
                 ),
             ],
-            rows="items",
+            rows="{{ items }}",
             search=True,
             paginated=True,
         )
@@ -1217,7 +1217,7 @@ def build_verification_ui(
                     DataTableColumn(key="unit_price", header="Price", align="right"),
                     DataTableColumn(key="status", header="Status"),
                 ],
-                rows="matches",
+                rows="{{ matches }}",
             )
 
         # Discrepancies table
@@ -1229,7 +1229,7 @@ def build_verification_ui(
                     DataTableColumn(key="type", header="Type"),
                     DataTableColumn(key="message", header="Details"),
                 ],
-                rows="discrepancies",
+                rows="{{ discrepancies }}",
             )
 
         # Action buttons
@@ -1303,6 +1303,13 @@ _ACTION_COLUMNS: list[DataTableColumn] = [
 ]
 
 _PLAN_ACTIONS_KEY = "plan_actions"
+# DataTable.rows requires the mustache template form (``{{ key }}``) for
+# state-bound rows — the JS renderer interprets bare strings as the rows
+# array itself and crashes with ``t.some is not a function``. Discovered
+# via headless apps_dev render tests after #634; the Python pydantic
+# field type accepts bare strings, but the wire format only resolves
+# mustache references.
+_PLAN_ACTIONS_REF = f"{{{{ {_PLAN_ACTIONS_KEY} }}}}"
 
 
 def _derive_status_label(action: dict[str, Any]) -> str:
@@ -1357,15 +1364,14 @@ def _action_to_row(idx: int, action: dict[str, Any]) -> dict[str, Any]:
     absent (legacy single-action shape, older response generators, tests).
     """
     target = action.get("target_id")
-    status_label = action.get("status_label") or _derive_status_label(action)
-    summary = action.get("summary") or _derive_summary(action)
     return {
-        "index": idx,
-        "operation_label": _humanize_snake_case(str(action.get("operation") or ""))
-        or "Action",
-        "target_label": f"#{target}" if target is not None else "—",
-        "summary": summary,
-        "status_label": status_label,
+        "index": action.get("index") or idx,
+        "operation_label": action.get("operation_label")
+        or (_humanize_snake_case(str(action.get("operation") or "")) or "Action"),
+        "target_label": action.get("target_label")
+        or (f"#{target}" if target is not None else "—"),
+        "summary": action.get("summary") or _derive_summary(action),
+        "status_label": action.get("status_label") or _derive_status_label(action),
         # Pass through the underlying fields so RESULT.actions replacement
         # preserves shape (the server's ActionResults carry these too).
         "operation": action.get("operation"),
@@ -1480,7 +1486,7 @@ def build_modification_preview_ui(
                 Text(content=response["message"])
 
             if n_actions > 0:
-                DataTable(columns=_ACTION_COLUMNS, rows=_PLAN_ACTIONS_KEY)
+                DataTable(columns=_ACTION_COLUMNS, rows=_PLAN_ACTIONS_REF)
 
             if block_warnings or regular_warnings:
                 Separator()
@@ -1592,7 +1598,7 @@ def build_modification_result_ui(
                         f"of {len(actions)}"
                     )
                 )
-                DataTable(columns=_ACTION_COLUMNS, rows=_PLAN_ACTIONS_KEY)
+                DataTable(columns=_ACTION_COLUMNS, rows=_PLAN_ACTIONS_REF)
 
         if response.get("katana_url"):
             with CardFooter(), Row(gap=2):
@@ -1846,7 +1852,7 @@ def build_batch_recipe_update_ui(
                 DataTableColumn(key="status", header="Status", sortable=True),
                 DataTableColumn(key="error", header="Error"),
             ],
-            rows="rows",
+            rows="{{ rows }}",
             search=True,
             paginated=True,
             pageSize=25,

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -239,6 +239,8 @@ def _build_apply_action(
 def _build_apply_action_direct(
     confirm_tool: str | None,
     confirm_request: BaseModel | None,
+    *,
+    extra_on_success: list[Action] | None = None,
 ) -> list[Action] | None:
     """Construct the direct-apply Confirm-button click action chain.
 
@@ -282,6 +284,18 @@ def _build_apply_action_direct(
             f"`preview` field; {type(confirm_request).__name__} has none."
         )
     args["preview"] = False
+    # The on_success chain runs the caller's extras BEFORE the generic
+    # flags so a builder that pushes RESULT.actions into a state slot (e.g.
+    # the modification card binding ``state.plan_actions`` for live-tick row
+    # updates) sees its row data land before the iframe morphs to its
+    # ``applied=True`` rendering.
+    on_success: list[Action] = [
+        *(extra_on_success or []),
+        SetState("pending", False),
+        SetState("applied", True),
+        SetState("result", RESULT),
+        UpdateContext(content=RESULT),
+    ]
     return [
         # Click guard — disables the button immediately so a double-click
         # in the iframe can't fire two applies (which would create
@@ -290,12 +304,7 @@ def _build_apply_action_direct(
         CallTool(
             tool=confirm_tool,
             arguments=args,
-            on_success=[
-                SetState("pending", False),
-                SetState("applied", True),
-                SetState("result", RESULT),
-                UpdateContext(content=RESULT),
-            ],
+            on_success=on_success,
             on_error=[
                 SetState("pending", False),
                 SetState("error", "{{ $error }}"),
@@ -1250,57 +1259,6 @@ def build_verification_ui(
 # ============================================================================
 
 
-def _format_field_value(value: Any) -> str:
-    """Render a FieldChange ``old`` / ``new`` value for the diff DataTable.
-
-    ``None`` collapses to ``(unset)`` so the cell isn't blank; lists are
-    comma-joined for compact display; everything else stringifies.
-    """
-    if value is None:
-        return "(unset)"
-    if isinstance(value, list):
-        return ", ".join(str(v) for v in value)
-    return str(value)
-
-
-def _change_to_diff_row(change: dict[str, Any]) -> dict[str, Any]:
-    """Convert a :class:`FieldChange` dict into a diff DataTable row.
-
-    Mirrors the markdown layout in
-    :func:`katana_mcp.tools._modification._render_changes_block`:
-
-    - ``is_unchanged`` — "(unchanged)" in the After column
-    - ``is_unknown_prior`` — "(prior unknown)" in the Before column
-    - ``is_added`` — "(unset)" in the Before column
-    - default — old → new
-    """
-    field = str(change.get("field", ""))
-    new = _format_field_value(change.get("new"))
-    if change.get("is_unchanged"):
-        return {
-            "field": field,
-            "before": _format_field_value(change.get("old")),
-            "after": "(unchanged)",
-        }
-    if change.get("is_unknown_prior"):
-        return {"field": field, "before": "(prior unknown)", "after": new}
-    if change.get("is_added"):
-        return {"field": field, "before": "(unset)", "after": new}
-    return {
-        "field": field,
-        "before": _format_field_value(change.get("old")),
-        "after": new,
-    }
-
-
-_DIFF_COLUMNS: list[DataTableColumn] = [
-    DataTableColumn(key="field", header="Field"),
-    DataTableColumn(key="before", header="Before"),
-    DataTableColumn(key="after", header="After"),
-]
-
-_LEGACY_DIFF_STATE_KEY = "legacy_diff_rows"
-
 # Display labels for the verb in modification card titles. The verb is
 # derived from the registered tool name (its first underscore-delimited
 # token), so ``modify_item`` → "Modify", ``delete_item`` → "Delete", etc.
@@ -1332,90 +1290,127 @@ def _verb_label(tool_name: str | None) -> str:
     return _VERB_DISPLAY.get(tool_name.split("_", 1)[0], "Modify")
 
 
-def _action_status_badge(
-    action: dict[str, Any],
-) -> tuple[str, Literal["default", "secondary", "outline", "destructive"]]:
-    """Pick a (label, variant) pair for an action's status badge.
+# Single column set used by both preview and result modification cards.
+# One row per planned action — server-derived ``status_label`` and
+# ``summary`` fields land directly here so the apply path's
+# ``SetState("plan_actions", RESULT.actions)`` swap preserves shape.
+_ACTION_COLUMNS: list[DataTableColumn] = [
+    DataTableColumn(key="index", header="#", width="3rem"),
+    DataTableColumn(key="operation_label", header="Operation"),
+    DataTableColumn(key="target_label", header="Target"),
+    DataTableColumn(key="summary", header="Changes"),
+    DataTableColumn(key="status_label", header="Status"),
+]
 
-    ``succeeded is None`` means the action hasn't been executed (preview
-    or fail-fast skip), so we surface PLANNED. Mirrors the status string
-    in ``katana_mcp.tools._modification._render_action_block`` so the
-    Prefab card and the markdown fallback agree on how each action reads.
+_PLAN_ACTIONS_KEY = "plan_actions"
+
+
+def _derive_status_label(action: dict[str, Any]) -> str:
+    """Compute a status label from raw ``succeeded`` / ``verified`` fields.
+
+    Used as a fallback for action dicts that don't already carry the
+    server-derived ``status_label`` (legacy responses, older clients,
+    test fixtures). Mirrors
+    :func:`katana_mcp.tools._modification._derive_status_label`.
     """
     succeeded = action.get("succeeded")
     if succeeded is None:
-        return "PLANNED", "secondary"
+        return "PLANNED"
     if succeeded is True:
         verified = action.get("verified")
         if verified is False:
-            return "APPLIED (verification mismatch)", "destructive"
-        if verified is None:
-            return "APPLIED", "default"
-        return "APPLIED (verified)", "default"
-    return "FAILED", "destructive"
+            return "APPLIED (verification mismatch)"
+        if verified is True:
+            return "APPLIED (verified)"
+        return "APPLIED"
+    return "FAILED"
 
 
-def _render_action_section(
-    idx: int,
-    action: dict[str, Any],
-    *,
-    rows_state_key: str | None,
-) -> None:
-    """Render one ActionResult as a Separator + heading + diff DataTable.
+def _derive_summary(action: dict[str, Any]) -> str:
+    """Fallback summary derivation when the action lacks a server-supplied one."""
+    op = str(action.get("operation") or "").lower()
+    changes = action.get("changes") or []
+    if op.startswith("delete"):
+        return "deleted"
+    if op.startswith("add") or op.startswith("create"):
+        return f"{len(changes)} field(s) set"
+    n_changed = sum(
+        1 for c in changes if isinstance(c, dict) and not c.get("is_unchanged")
+    )
+    if n_changed == 0 and changes:
+        return f"{len(changes)} field(s) — no change"
+    return f"{n_changed} field(s) changed"
 
-    ``rows_state_key`` is the PrefabApp state slot holding the diff rows
-    for this action (or ``None`` when the action has no field changes —
-    e.g. a delete). DataTable binds rows by state-key string per the
-    file's convention.
+
+def _action_to_row(idx: int, action: dict[str, Any]) -> dict[str, Any]:
+    """Project one ActionResult dict into a DataTable row.
+
+    Returns a dict that carries display-only derived fields (``index``,
+    ``operation_label``, ``target_label``) on top of the underlying
+    ActionResult fields. Pre-populating the same shape both at preview-
+    build time and on the apply RESULT means the on_success
+    ``SetState("plan_actions", RESULT.actions)`` swap doesn't need any
+    transformation — the server's ``status_label``/``summary`` already
+    travel on every ActionResult.
+
+    Falls back to local derivation when ``status_label``/``summary`` are
+    absent (legacy single-action shape, older response generators, tests).
     """
-    Separator()
-    op_label = _humanize_snake_case(str(action.get("operation") or "")) or "Action"
     target = action.get("target_id")
-    target_suffix = f" #{target}" if target is not None else ""
-    status_label, status_variant = _action_status_badge(action)
-    with Row(gap=2):
-        Text(content=f"{idx}. {op_label}{target_suffix}")
-        Badge(label=status_label, variant=status_variant)
+    status_label = action.get("status_label") or _derive_status_label(action)
+    summary = action.get("summary") or _derive_summary(action)
+    return {
+        "index": idx,
+        "operation_label": _humanize_snake_case(str(action.get("operation") or ""))
+        or "Action",
+        "target_label": f"#{target}" if target is not None else "—",
+        "summary": summary,
+        "status_label": status_label,
+        # Pass through the underlying fields so RESULT.actions replacement
+        # preserves shape (the server's ActionResults carry these too).
+        "operation": action.get("operation"),
+        "target_id": target,
+        "succeeded": action.get("succeeded"),
+        "verified": action.get("verified"),
+        "error": action.get("error"),
+    }
 
-    if action.get("error"):
-        Muted(content=f"Error: {action['error']}")
 
-    if rows_state_key is not None:
-        DataTable(columns=_DIFF_COLUMNS, rows=rows_state_key)
+def _legacy_action(response: dict[str, Any]) -> dict[str, Any] | None:
+    """Synthesize a single ActionResult-shaped dict from the legacy shape.
 
-
-def _summarize_actions(
-    actions: list[dict[str, Any]],
-) -> tuple[dict[str, list[dict[str, Any]]], list[str | None], int, int]:
-    """One-pass action scan for the modification builders.
-
-    Returns ``(state_slots, per_action_keys, success_count, failed_count)``:
-
-    - ``state_slots`` maps slot name (``"diff_action_<idx>"``) to its row
-      list — fold this into the PrefabApp ``state`` dict.
-    - ``per_action_keys[i]`` is the slot name for action ``i``, or ``None``
-      if the action has no field changes (e.g. a delete).
-    - The two counts are used by the result builder for the aggregate
-      status badge; the preview builder ignores them (succeeded is always
-      ``None`` on preview-shaped actions).
+    The legacy single-action response carries top-level ``operation`` +
+    ``changes`` (instead of an ``actions`` list). Wrap it as one synthetic
+    action so both card builders flow through the same row builder.
     """
-    state_slots: dict[str, list[dict[str, Any]]] = {}
-    per_action_keys: list[str | None] = []
-    success_count = failed_count = 0
-    for idx, action in enumerate(actions, start=1):
-        succeeded = action.get("succeeded")
-        if succeeded is True:
-            success_count += 1
-        elif succeeded is False:
-            failed_count += 1
-        rows = [_change_to_diff_row(c) for c in (action.get("changes") or [])]
-        if rows:
-            key = f"diff_action_{idx}"
-            state_slots[key] = rows
-            per_action_keys.append(key)
-        else:
-            per_action_keys.append(None)
-    return state_slots, per_action_keys, success_count, failed_count
+    legacy_changes = response.get("changes") or []
+    legacy_op = response.get("operation") or ""
+    if not legacy_op and not legacy_changes:
+        return None
+    is_preview = bool(response.get("is_preview"))
+    n = len(legacy_changes)
+    return {
+        "operation": legacy_op,
+        "target_id": response.get("entity_id"),
+        "changes": legacy_changes,
+        "succeeded": None if is_preview else True,
+        "verified": None,
+        "error": None,
+        "status_label": "PLANNED" if is_preview else "APPLIED",
+        "summary": f"{n} field(s) changed" if n else "—",
+    }
+
+
+def _actions_to_rows(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Map ActionResult dicts to DataTable rows for ``state.plan_actions``."""
+    return [_action_to_row(idx, action) for idx, action in enumerate(actions, start=1)]
+
+
+def _count_outcomes(actions: list[dict[str, Any]]) -> tuple[int, int]:
+    """Tally ``(succeeded, failed)`` across an action list."""
+    s = sum(1 for a in actions if a.get("succeeded") is True)
+    f = sum(1 for a in actions if a.get("succeeded") is False)
+    return s, f
 
 
 def build_modification_preview_ui(
@@ -1428,15 +1423,31 @@ def build_modification_preview_ui(
 
     Used by every tool that returns a ``ModificationResponse`` from
     ``_modification.py`` — ``modify_*``, ``delete_*``, ``correct_*``.
-    Confirm fires ``tools/call`` directly and the iframe pushes the
-    structured result to the agent via ``ui/update-model-context``
-    (ADR-0016 spike rail).
 
-    Renders one section per planned :class:`ActionResult` (operation header
-    + diff DataTable) plus a footer Confirm/Cancel pair that morphs in
-    place to applied / error / cancelled states.
+    The card renders **one DataTable** bound to ``state.plan_actions``
+    (one row per planned action: # / Operation / Target / Changes / Status).
+    Confirm fires ``tools/call`` directly; the on_success chain pushes
+    ``RESULT.actions`` into ``state.plan_actions`` so each row's status
+    cell ticks PLANNED → APPLIED/FAILED in place without re-rendering
+    the iframe (ADR-0016 direct-apply rail). The iframe also pushes the
+    structured result to the agent via ``ui/update-model-context``.
     """
-    apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    actions = response.get("actions") or []
+    if not actions:
+        legacy = _legacy_action(response)
+        if legacy is not None:
+            actions = [legacy]
+
+    apply_action = _build_apply_action_direct(
+        confirm_tool,
+        confirm_request,
+        # Live-tick: replace the planned rows with the apply RESULT's actions
+        # before the generic ``applied=True`` flag flips. Each row's
+        # ``status_label`` updates from PLANNED to its terminal value
+        # (APPLIED / APPLIED (verified) / FAILED) and the DataTable
+        # re-renders rows in place — no iframe morph.
+        extra_on_success=[SetState(_PLAN_ACTIONS_KEY, RESULT.actions)],
+    )
     entity_type_raw = str(response.get("entity_type") or "entity")
     entity_type_label = _humanize_snake_case(entity_type_raw)
     verb_label = _verb_label(confirm_tool)
@@ -1444,25 +1455,16 @@ def build_modification_preview_ui(
         f"the {entity_type_raw.replace('_', ' ')} {verb_label.lower()}"
     )
 
-    actions = response.get("actions") or []
-    legacy_changes = response.get("changes") or []
     block_warnings, regular_warnings = _split_warnings(response.get("warnings"))
-    n_actions = len(actions) if actions else (1 if legacy_changes else 0)
-
-    action_row_slots, per_action_keys, _, _ = _summarize_actions(actions)
-    legacy_rows_key: str | None = None
-    if not actions and legacy_changes:
-        legacy_rows_key = _LEGACY_DIFF_STATE_KEY
+    n_actions = len(actions)
 
     state: dict[str, Any] = {
         "pending": False,
         "cancelled": False,
         "applied": False,
         "error": None,
-        **action_row_slots,
+        _PLAN_ACTIONS_KEY: _actions_to_rows(actions),
     }
-    if legacy_rows_key is not None:
-        state[legacy_rows_key] = [_change_to_diff_row(c) for c in legacy_changes]
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
@@ -1477,13 +1479,8 @@ def build_modification_preview_ui(
             if response.get("message"):
                 Text(content=response["message"])
 
-            if actions:
-                for idx, action in enumerate(actions, start=1):
-                    _render_action_section(
-                        idx, action, rows_state_key=per_action_keys[idx - 1]
-                    )
-            elif legacy_rows_key is not None:
-                DataTable(columns=_DIFF_COLUMNS, rows=legacy_rows_key)
+            if n_actions > 0:
+                DataTable(columns=_ACTION_COLUMNS, rows=_PLAN_ACTIONS_KEY)
 
             if block_warnings or regular_warnings:
                 Separator()
@@ -1492,16 +1489,7 @@ def build_modification_preview_ui(
                 for warning in regular_warnings:
                     Badge(label=warning, variant="secondary")
 
-            with If("applied"):
-                Separator()
-                Text(content=f"{entity_type_label} {verb_label.lower()} applied.")
-                Muted(
-                    content=(
-                        "The structured result has been pushed to the "
-                        "assistant's context."
-                    )
-                )
-            with Elif("error"):
+            with If("error"):
                 Separator()
                 with Alert(variant="destructive", icon="circle-alert"):
                     AlertTitle(content="Apply failed")
@@ -1514,7 +1502,9 @@ def build_modification_preview_ui(
                 )
             else:
                 with If("applied"):
-                    Muted(content="Changes applied.")
+                    Muted(
+                        content="Changes applied — see status column for per-action outcome."
+                    )
                 with Elif("error"):
                     Muted(content="Apply failed — see error above.")
                 with Elif("cancelled"):
@@ -1556,12 +1546,13 @@ def build_modification_result_ui(
         str(response.get("entity_type") or "entity")
     )
     actions = response.get("actions") or []
-    legacy_changes = response.get("changes") or []
     legacy_op = _humanize_snake_case(str(response.get("operation") or ""))
+    if not actions:
+        legacy = _legacy_action(response)
+        if legacy is not None:
+            actions = [legacy]
 
-    action_row_slots, per_action_keys, success_count, failed_count = _summarize_actions(
-        actions
-    )
+    success_count, failed_count = _count_outcomes(actions)
 
     overall_status: str
     overall_variant: Literal["default", "secondary", "outline", "destructive"]
@@ -1572,13 +1563,7 @@ def build_modification_result_ui(
     else:
         overall_status, overall_variant = "APPLIED", "default"
 
-    legacy_rows_key: str | None = None
-    if not actions and legacy_changes:
-        legacy_rows_key = _LEGACY_DIFF_STATE_KEY
-
-    state: dict[str, Any] = dict(action_row_slots)
-    if legacy_rows_key is not None:
-        state[legacy_rows_key] = [_change_to_diff_row(c) for c in legacy_changes]
+    state: dict[str, Any] = {_PLAN_ACTIONS_KEY: _actions_to_rows(actions)}
 
     # Title verb: prefer the tool-derived verb (works for delete/correct
     # tools); fall back to the legacy single-action ``operation`` field;
@@ -1607,12 +1592,7 @@ def build_modification_result_ui(
                         f"of {len(actions)}"
                     )
                 )
-                for idx, action in enumerate(actions, start=1):
-                    _render_action_section(
-                        idx, action, rows_state_key=per_action_keys[idx - 1]
-                    )
-            elif legacy_rows_key is not None:
-                DataTable(columns=_DIFF_COLUMNS, rows=legacy_rows_key)
+                DataTable(columns=_ACTION_COLUMNS, rows=_PLAN_ACTIONS_KEY)
 
         if response.get("katana_url"):
             with CardFooter(), Row(gap=2):

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -1444,16 +1444,17 @@ def build_modification_preview_ui(
         if legacy is not None:
             actions = [legacy]
 
-    apply_action = _build_apply_action_direct(
-        confirm_tool,
-        confirm_request,
-        # Live-tick: replace the planned rows with the apply RESULT's actions
-        # before the generic ``applied=True`` flag flips. Each row's
-        # ``status_label`` updates from PLANNED to its terminal value
-        # (APPLIED / APPLIED (verified) / FAILED) and the DataTable
-        # re-renders rows in place — no iframe morph.
-        extra_on_success=[SetState(_PLAN_ACTIONS_KEY, RESULT.actions)],
-    )
+    apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    # NOTE: A live-tick design (rows ticking PLANNED -> APPLIED in place via
+    # ``SetState("plan_actions", RESULT.actions)``) was attempted in #634 but
+    # turned out to be broken: ``$result`` in the on_success Rx context
+    # resolves to the apply tool's ``structured_content`` (a PrefabApp wire
+    # envelope from ``make_tool_result``), not to the raw
+    # ``ModificationResponse``. ``$result.actions`` therefore doesn't
+    # resolve and the SetState was a no-op in production. Caught by Copilot
+    # review; verified by the browser harness when its stub was switched to
+    # match production shape. Tracked as a follow-up — until then the
+    # apply path morphs the card via the existing ``applied=True`` flag.
     entity_type_raw = str(response.get("entity_type") or "entity")
     entity_type_label = _humanize_snake_case(entity_type_raw)
     verb_label = _verb_label(confirm_tool)

--- a/katana_mcp_server/tests/browser/__init__.py
+++ b/katana_mcp_server/tests/browser/__init__.py
@@ -1,0 +1,14 @@
+"""Browser-based render tests for Katana MCP Prefab UI cards.
+
+These tests spin up a minimal FastMCP server and fastmcp's ``apps_dev``
+preview UI, then drive the rendered iframe via Playwright. They catch
+runtime JS rendering failures in the Prefab renderer that the Python-side
+unit tests cannot — specifically the failure mode that produced #629
+(blank iframe on multi-state-bound DataTables).
+
+Run with:
+    uv run poe test-browser
+
+First run requires::
+    uv run playwright install chromium
+"""

--- a/katana_mcp_server/tests/browser/conftest.py
+++ b/katana_mcp_server/tests/browser/conftest.py
@@ -1,0 +1,174 @@
+"""Pytest fixtures for browser-based render tests.
+
+Spins up ``fastmcp dev apps`` against the local ``render_test_server`` and
+provides a Playwright ``page`` for the test, plus a helper to navigate to
+named card scenarios. Skips automatically when Playwright isn't installed
+or the bundled Chromium isn't available.
+
+Uses the raw ``playwright`` sync API rather than pytest-playwright to
+avoid pytest-base-url's ``base_url`` fixture colliding with our
+integration tests' same-name fixture.
+
+Setup (one-time per dev):
+    uv run playwright install chromium
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from urllib.parse import quote
+
+import httpx
+import pytest
+
+pytest.importorskip("playwright", reason="playwright package not installed")
+pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import (
+    Browser,
+    Error as PlaywrightError,
+    Page,
+    sync_playwright,
+)
+
+_SERVER_FILE = Path(__file__).parent / "render_test_server.py"
+_DEV_PORT = 18876
+_MCP_PORT = 18877
+
+
+def _port_free(port: int) -> bool:
+    """Probe if a TCP port is free on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+    return True
+
+
+def _wait_http_ok(url: str, timeout: float = 30.0) -> bool:
+    """Poll an URL until it responds (any non-connection-error response)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            httpx.get(url, timeout=1.0)
+            return True
+        except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.TimeoutException):
+            time.sleep(0.5)
+    return False
+
+
+@pytest.fixture(scope="session")
+def apps_dev_server() -> Iterator[str]:
+    """Start the fastmcp ``apps_dev`` preview server (and the underlying user
+    MCP server) in a subprocess, yielding the dev URL.
+
+    Session-scoped so all browser tests share one server. The first call
+    pays the spin-up cost (~10s including app-bridge.js fetch from npm);
+    subsequent tests are immediate.
+    """
+    if not _port_free(_DEV_PORT) or not _port_free(_MCP_PORT):
+        pytest.skip(
+            f"Ports {_DEV_PORT}/{_MCP_PORT} not free — likely an apps_dev "
+            f"server already running. Stop it before running browser tests."
+        )
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "fastmcp.cli",
+            "dev",
+            "apps",
+            f"{_SERVER_FILE}:mcp",
+            "--mcp-port",
+            str(_MCP_PORT),
+            "--dev-port",
+            str(_DEV_PORT),
+            "--no-reload",
+        ],
+        env={**os.environ, "FASTMCP_LOG_LEVEL": "WARNING"},
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=sys.platform != "win32",
+    )
+
+    dev_url = f"http://127.0.0.1:{_DEV_PORT}"
+    try:
+        if not _wait_http_ok(dev_url, timeout=30.0):
+            pytest.fail(
+                f"apps_dev server did not start on {dev_url} within 30s. "
+                f"Check that ``uv run fastmcp dev apps`` works manually."
+            )
+        yield dev_url
+    finally:
+        # Kill the entire process group — apps_dev spawns child processes
+        # for the user MCP server, and killing only the top-level would
+        # leak ports.
+        if proc.poll() is None:
+            try:
+                if sys.platform != "win32":
+                    os.killpg(os.getpgid(proc.pid), 15)
+                else:
+                    proc.kill()
+            except (ProcessLookupError, PermissionError):
+                proc.kill()
+            try:
+                proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+@pytest.fixture(scope="session")
+def playwright_browser() -> Iterator[Browser]:
+    """Launch a single headless Chromium for the entire test session.
+
+    Skips the test if Chromium isn't installed locally — the browser
+    suite is opt-in and only runs after ``playwright install chromium``.
+    """
+    with sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except PlaywrightError as exc:
+            pytest.skip(
+                f"Chromium not available — run `uv run playwright install "
+                f"chromium` first ({exc})"
+            )
+            return  # pytest.skip raises; this is unreachable but appeases the type checker
+        try:
+            yield browser
+        finally:
+            browser.close()
+
+
+@pytest.fixture
+def page(playwright_browser: Browser) -> Iterator[Page]:
+    """Per-test Playwright page."""
+    page = playwright_browser.new_page()
+    yield page
+    page.close()
+
+
+@pytest.fixture
+def render_scenario(apps_dev_server: str, page: Page):
+    """Helper that navigates to ``/launch?tool=render_scenario&args=...`` and
+    returns the iframe FrameLocator after waiting for it to render.
+    """
+
+    def _go(scenario_name: str, *, wait_ms: int = 8000):
+        url = f"{apps_dev_server}/launch?tool=render_scenario&args=" + quote(
+            json.dumps({"name": scenario_name})
+        )
+        page.goto(url, wait_until="domcontentloaded", timeout=30000)
+        # The iframe needs time for app-bridge handshake + renderer mount +
+        # tool-result push. 8s is comfortable in CI.
+        page.wait_for_timeout(wait_ms)
+        return page.frame_locator("#app-frame")
+
+    return _go

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -17,7 +17,11 @@ from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.tools import ToolResult
-from katana_mcp.tools._modification import ActionResult, FieldChange
+from katana_mcp.tools._modification import (
+    ActionResult,
+    FieldChange,
+    ModificationResponse,
+)
 from katana_mcp.tools.prefab_ui import (
     build_batch_recipe_update_ui,
     build_inventory_check_ui,
@@ -26,6 +30,7 @@ from katana_mcp.tools.prefab_ui import (
     build_search_results_ui,
     build_verification_ui,
 )
+from katana_mcp.tools.tool_result_utils import make_tool_result
 from prefab_ui.app import PrefabApp
 from pydantic import BaseModel
 
@@ -391,7 +396,14 @@ async def modify_manufacturing_order(
     Sub-payload args mirror :class:`ModifyManufacturingOrderRequest` so
     FastMCP's signature validator accepts the full Confirm-button payload.
     All values are ignored — the stub always returns the same canned
-    envelope, since we just need ``RESULT.actions`` to land in state.
+    envelope.
+
+    Uses ``make_tool_result`` (same helper real modification tools use) so
+    the wire shape matches production exactly: ``content`` carries the
+    response JSON, ``structured_content`` carries the apply result card's
+    Prefab envelope. This pins the contract that ``RESULT.actions`` in
+    the on_success Rx expression resolves the same way against the stub
+    as it does against the real tool.
     """
     del (
         id,
@@ -406,13 +418,14 @@ async def modify_manufacturing_order(
         update_productions,
         delete_production_ids,
     )  # unused — canned response
-    response = _twelve_action_response(
+    response_dict = _twelve_action_response(
         is_preview=preview, succeeded=None if preview else True
     )
-    return ToolResult(
-        content="ok",
-        structured_content=response,
+    response = ModificationResponse.model_validate(response_dict)
+    ui = build_modification_result_ui(
+        response_dict, tool_name="modify_manufacturing_order"
     )
+    return make_tool_result(response, ui=ui)
 
 
 if __name__ == "__main__":

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -19,8 +19,12 @@ from fastmcp import FastMCP
 from fastmcp.tools import ToolResult
 from katana_mcp.tools._modification import ActionResult, FieldChange
 from katana_mcp.tools.prefab_ui import (
+    build_batch_recipe_update_ui,
+    build_inventory_check_ui,
     build_modification_preview_ui,
     build_modification_result_ui,
+    build_search_results_ui,
+    build_verification_ui,
 )
 from prefab_ui.app import PrefabApp
 from pydantic import BaseModel
@@ -186,6 +190,113 @@ def _datatable_state_template_app() -> PrefabApp:
     return app
 
 
+# ---------------------------------------------------------------------------
+# Audit scenarios: cover the other state-bound DataTable cards that share
+# the bare-string-vs-mustache risk class. Verifies the mustache fix
+# actually renders, not just passes the assertion.
+# ---------------------------------------------------------------------------
+
+
+def _search_results_app() -> PrefabApp:
+    """build_search_results_ui with 50 items — exercises rows='{{ items }}'."""
+    items = [
+        {
+            "id": 10000 + i,
+            "sku": f"SKU-{i:04d}",
+            "name": f"Test Item {i}",
+            "item_type": "product" if i % 2 == 0 else "material",
+            "is_archived": False,
+            "is_sellable": True,
+        }
+        for i in range(50)
+    ]
+    return build_search_results_ui(items, query="Test", total_count=50)
+
+
+def _inventory_check_app() -> PrefabApp:
+    """build_inventory_check_ui with multi-location stock — exercises
+    rows='{{ stock.by_location }}' (path expression)."""
+    stock = {
+        "sku": "SKU-WIDGET",
+        "product_name": "Widget",
+        "in_stock": 42,
+        "available_stock": 35,
+        "committed": 7,
+        "expected": 100,
+        "by_location": [
+            {
+                "location_name": "Main Warehouse",
+                "location_id": 1,
+                "in_stock": 30,
+                "committed": 5,
+                "available": 25,
+                "expected": 60,
+            },
+            {
+                "location_name": "Brooklyn",
+                "location_id": 2,
+                "in_stock": 12,
+                "committed": 2,
+                "available": 10,
+                "expected": 40,
+            },
+        ],
+    }
+    return build_inventory_check_ui(stock)
+
+
+def _verification_app() -> PrefabApp:
+    """build_verification_ui with matches + discrepancies — exercises both
+    rows='{{ matches }}' and rows='{{ discrepancies }}'."""
+    response = {
+        "order_id": 123,
+        "overall_status": "partial_match",
+        "matches": [
+            {
+                "sku": "SKU-A",
+                "quantity": 5,
+                "unit_price": 10.50,
+                "status": "matched",
+            },
+            {
+                "sku": "SKU-B",
+                "quantity": 3,
+                "unit_price": 7.25,
+                "status": "matched",
+            },
+        ],
+        "discrepancies": [
+            {
+                "sku": "SKU-C",
+                "type": "qty_mismatch",
+                "message": "Expected 5, received 3",
+            },
+        ],
+    }
+    return build_verification_ui(response)
+
+
+def _batch_recipe_update_app() -> PrefabApp:
+    """build_batch_recipe_update_ui with 5 sub-ops — exercises rows='{{ rows }}'."""
+    response = {
+        "is_preview": True,
+        "message": "5 sub-ops planned",
+        "warnings": [],
+        "results": [
+            {
+                "group_label": "Replace bolt with nut",
+                "sub_op": "delete",
+                "sku": f"SKU-OLD-{i}",
+                "qty": 1,
+                "status": "PENDING",
+                "error": None,
+            }
+            for i in range(5)
+        ],
+    }
+    return build_batch_recipe_update_ui(response)
+
+
 SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
     # The bug-repro: 12 mixed actions on the preview card. Pre-fix this
     # rendered as a blank iframe; post-fix it renders one DataTable with 12
@@ -208,6 +319,12 @@ SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
     "datatable_inline": _datatable_inline_app,
     "datatable_state": _datatable_state_app,
     "datatable_state_template": _datatable_state_template_app,
+    # Audit coverage: post-mustache-fix render checks for every other
+    # state-bound DataTable card.
+    "search_results": _search_results_app,
+    "inventory_check": _inventory_check_app,
+    "verification": _verification_app,
+    "batch_recipe_update": _batch_recipe_update_app,
     "modify_item_single_preview": lambda: build_modification_preview_ui(
         {
             "entity_type": "product",

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -1,0 +1,302 @@
+"""Minimal FastMCP server exercising the Prefab card builders for browser tests.
+
+Exposes a single tool, ``render_scenario``, that takes a scenario name and
+returns a canned ``PrefabApp`` built by the real card builders. Browser tests
+navigate the fastmcp ``apps_dev`` ``/launch`` URL with ``tool=render_scenario``
++ ``args={"name": "<scenario>"}`` and assert the rendered DOM.
+
+Plus a stub ``modify_manufacturing_order`` that returns a canned apply
+``ModificationResponse`` — used by the Confirm-button click-through tests
+to exercise the live-tick path without hitting the real Katana API.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.tools import ToolResult
+from katana_mcp.tools._modification import ActionResult, FieldChange
+from katana_mcp.tools.prefab_ui import (
+    build_modification_preview_ui,
+    build_modification_result_ui,
+)
+from prefab_ui.app import PrefabApp
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Scenarios — each builds a PrefabApp via the real card builders.
+# ---------------------------------------------------------------------------
+
+
+class _StubRequest(BaseModel):
+    """Matches what a modify_manufacturing_order request looks like for the
+    Confirm-button payload (the iframe re-issues with these args).
+    """
+
+    id: int = 16467730
+    preview: bool = True
+
+
+def _twelve_action_response(*, is_preview: bool, succeeded: bool | None) -> dict:
+    """Build a 12-action mixed (6 add + 6 delete) response dict."""
+    actions: list[dict] = []
+    for i in range(6):
+        action = ActionResult(
+            index=i + 1,
+            operation="add_recipe_row",
+            target_id=None,
+            changes=[
+                FieldChange(
+                    field="variant_id", old=None, new=40000000 + i, is_added=True
+                ),
+                FieldChange(
+                    field="planned_quantity_per_unit", old=None, new=1, is_added=True
+                ),
+                FieldChange(
+                    field="notes",
+                    old=None,
+                    new=f"AM swap {i}: example note with (parens)",
+                    is_added=True,
+                ),
+            ],
+            succeeded=succeeded,
+            verified=True if succeeded else None,
+        )
+        actions.append(action.model_dump())
+    for i in range(6):
+        action = ActionResult(
+            index=7 + i,
+            operation="delete_recipe_row",
+            target_id=97411400 + i,
+            changes=[],
+            succeeded=succeeded,
+        )
+        actions.append(action.model_dump())
+    return {
+        "entity_type": "manufacturing_order",
+        "entity_id": 16467730,
+        "is_preview": is_preview,
+        "operation": "",
+        "changes": [],
+        "actions": actions,
+        "prior_state": None,
+        "warnings": [],
+        "next_actions": [],
+        "katana_url": "https://factory.katanamrp.com/manufacturingorder/16467730",
+        "message": (
+            "Preview: 12 action(s) planned" if is_preview else "Applied 12 action(s)"
+        ),
+    }
+
+
+def _trivial_text_app() -> PrefabApp:
+    """Minimal hello-world card to isolate render-pipeline issues."""
+    from prefab_ui.components import Card, CardContent, CardTitle, Text
+
+    with PrefabApp(state={}, css_class="p-4") as app, Card():
+        CardTitle(content="Trivial Test")
+        with CardContent():
+            Text(content="If you can read this the iframe is rendering.")
+    return app
+
+
+def _datatable_inline_app() -> PrefabApp:
+    """DataTable with inline rows (no state binding) — isolation test."""
+    from prefab_ui.components import (
+        Card,
+        CardContent,
+        CardTitle,
+        DataTable,
+        DataTableColumn,
+    )
+
+    with PrefabApp(state={}, css_class="p-4") as app, Card():
+        CardTitle(content="DataTable Inline Test")
+        with CardContent():
+            DataTable(
+                columns=[
+                    DataTableColumn(key="a", header="A"),
+                    DataTableColumn(key="b", header="B"),
+                ],
+                rows=[
+                    {"a": "1", "b": "one"},
+                    {"a": "2", "b": "two"},
+                ],
+            )
+    return app
+
+
+def _datatable_state_app() -> PrefabApp:
+    """DataTable with state-bound rows (bare string) — known broken."""
+    from prefab_ui.components import (
+        Card,
+        CardContent,
+        CardTitle,
+        DataTable,
+        DataTableColumn,
+    )
+
+    with (
+        PrefabApp(
+            state={"my_rows": [{"a": "1", "b": "one"}, {"a": "2", "b": "two"}]},
+            css_class="p-4",
+        ) as app,
+        Card(),
+    ):
+        CardTitle(content="DataTable State Bare Test")
+        with CardContent():
+            DataTable(
+                columns=[
+                    DataTableColumn(key="a", header="A"),
+                    DataTableColumn(key="b", header="B"),
+                ],
+                rows="my_rows",
+            )
+    return app
+
+
+def _datatable_state_template_app() -> PrefabApp:
+    """DataTable with state-bound rows using {{ template }} mustache form."""
+    from prefab_ui.components import (
+        Card,
+        CardContent,
+        CardTitle,
+        DataTable,
+        DataTableColumn,
+    )
+
+    with (
+        PrefabApp(
+            state={"my_rows": [{"a": "1", "b": "one"}, {"a": "2", "b": "two"}]},
+            css_class="p-4",
+        ) as app,
+        Card(),
+    ):
+        CardTitle(content="DataTable State Template Test")
+        with CardContent():
+            DataTable(
+                columns=[
+                    DataTableColumn(key="a", header="A"),
+                    DataTableColumn(key="b", header="B"),
+                ],
+                rows="{{ my_rows }}",
+            )
+    return app
+
+
+SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
+    # The bug-repro: 12 mixed actions on the preview card. Pre-fix this
+    # rendered as a blank iframe; post-fix it renders one DataTable with 12
+    # rows.
+    "modify_mo_12_actions_preview": lambda: build_modification_preview_ui(
+        _twelve_action_response(is_preview=True, succeeded=None),
+        confirm_request=_StubRequest(),
+        confirm_tool="modify_manufacturing_order",
+    ),
+    # Same 12-action plan after apply — every action APPLIED.
+    "modify_mo_12_actions_applied": lambda: build_modification_result_ui(
+        _twelve_action_response(is_preview=False, succeeded=True),
+        tool_name="modify_manufacturing_order",
+    ),
+    # Single-action smoke.
+    # Trivial sanity card — minimal Prefab tree with no DataTable. Used to
+    # isolate whether the iframe pipeline works at all vs. a card-specific
+    # rendering bug.
+    "trivial_text": _trivial_text_app,
+    "datatable_inline": _datatable_inline_app,
+    "datatable_state": _datatable_state_app,
+    "datatable_state_template": _datatable_state_template_app,
+    "modify_item_single_preview": lambda: build_modification_preview_ui(
+        {
+            "entity_type": "product",
+            "entity_id": 1,
+            "is_preview": True,
+            "operation": "",
+            "changes": [],
+            "actions": [
+                ActionResult(
+                    operation="update_header",
+                    target_id=1,
+                    changes=[FieldChange(field="name", old="x", new="y")],
+                    succeeded=None,
+                ).model_dump()
+            ],
+            "prior_state": None,
+            "warnings": [],
+            "next_actions": [],
+            "katana_url": None,
+            "message": "Preview: 1 action(s) planned",
+        },
+        confirm_request=_StubRequest(),
+        confirm_tool="modify_item",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# FastMCP server
+# ---------------------------------------------------------------------------
+
+
+mcp: FastMCP = FastMCP(name="katana-render-test")
+
+
+@mcp.tool(meta={"ui": True})
+async def render_scenario(name: str) -> PrefabApp:
+    """Render a named card-builder scenario for browser tests."""
+    builder = SCENARIOS.get(name)
+    if builder is None:
+        raise ValueError(f"Unknown scenario {name!r}. Available: {sorted(SCENARIOS)}")
+    return builder()
+
+
+@mcp.tool(meta={"ui": True})
+async def modify_manufacturing_order(
+    id: int,
+    preview: bool = True,
+    update_header: Any = None,
+    add_recipe_rows: Any = None,
+    update_recipe_rows: Any = None,
+    delete_recipe_row_ids: Any = None,
+    add_operation_rows: Any = None,
+    update_operation_rows: Any = None,
+    delete_operation_row_ids: Any = None,
+    add_productions: Any = None,
+    update_productions: Any = None,
+    delete_production_ids: Any = None,
+) -> ToolResult:
+    """Stub for the click-through test — when the Confirm button on the
+    preview card fires, the iframe calls this with ``preview=False`` and we
+    return a canned apply response so the live-tick SetState fires.
+
+    Sub-payload args mirror :class:`ModifyManufacturingOrderRequest` so
+    FastMCP's signature validator accepts the full Confirm-button payload.
+    All values are ignored — the stub always returns the same canned
+    envelope, since we just need ``RESULT.actions`` to land in state.
+    """
+    del (
+        id,
+        update_header,
+        add_recipe_rows,
+        update_recipe_rows,
+        delete_recipe_row_ids,
+        add_operation_rows,
+        update_operation_rows,
+        delete_operation_row_ids,
+        add_productions,
+        update_productions,
+        delete_production_ids,
+    )  # unused — canned response
+    response = _twelve_action_response(
+        is_preview=preview, succeeded=None if preview else True
+    )
+    return ToolResult(
+        content="ok",
+        structured_content=response,
+    )
+
+
+if __name__ == "__main__":
+    mcp.run(transport="http", port=8765)

--- a/katana_mcp_server/tests/browser/test_modification_render.py
+++ b/katana_mcp_server/tests/browser/test_modification_render.py
@@ -1,0 +1,109 @@
+"""Browser render tests for the modification card.
+
+These run the actual Prefab JS renderer against our card builders and
+assert the rendered DOM. Catches the bug class that #629 surfaced —
+runtime JS errors that the Python-side unit tests cannot detect.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+class TestModificationCardRender:
+    """Verify the modification card builders render correctly in a real browser."""
+
+    def test_trivial_card_renders(self, render_scenario):
+        """Sanity: a minimal Card+Text app renders. If this fails the
+        whole harness is broken — fix that before debugging anything else.
+        """
+        frame = render_scenario("trivial_text")
+        assert frame.locator("text=Trivial Test").count() == 1, (
+            "trivial card baseline broken — apps_dev pipeline not working"
+        )
+
+    def test_state_bound_datatable_requires_mustache(self, render_scenario):
+        """Pin the bare-string-vs-mustache contract. Bare-string state
+        references crash the renderer; mustache form works. The card
+        builders in :mod:`prefab_ui` must always emit mustache form.
+        """
+        bare = render_scenario("datatable_state")
+        # Bare-string ref triggers ``t.some is not a function`` — body is empty.
+        assert bare.locator("table").count() == 0, (
+            "bare-string state ref unexpectedly rendered — renderer "
+            "behavior changed; revisit the assertion in "
+            "_assert_state_bindings_resolve."
+        )
+
+        templated = render_scenario("datatable_state_template")
+        assert templated.locator("table").count() == 1
+        assert templated.locator("td").count() >= 4  # 2 rows x 2 cells
+
+    def test_modify_single_action_preview_renders(self, render_scenario):
+        """Single-action modify card: 1 action row, Confirm button visible."""
+        frame = render_scenario("modify_item_single_preview")
+        assert frame.locator("table").count() == 1
+        # Header + 1 action row.
+        assert frame.locator("table tr").count() == 2
+        assert frame.locator("text=PLANNED").count() >= 1
+        assert frame.locator("button").filter(has_text="Confirm").count() == 1
+
+    def test_modify_twelve_actions_preview_renders(self, render_scenario):
+        """Reproduces #629: 12-action mixed plan must render all rows.
+
+        Pre-fix this rendered as a blank iframe. With the mustache fix
+        and one-DataTable design, all 12 rows show with PLANNED status.
+        """
+        frame = render_scenario("modify_mo_12_actions_preview")
+        assert frame.locator("table").count() == 1
+        # Header + 12 action rows.
+        assert frame.locator("table tr").count() == 13
+        # Every action shows PLANNED (none have been applied yet).
+        assert frame.locator("td").filter(has_text="PLANNED").count() == 12
+
+    def test_modify_twelve_actions_applied_renders(self, render_scenario):
+        """Result card after a successful apply: all 12 rows APPLIED."""
+        frame = render_scenario("modify_mo_12_actions_applied")
+        assert frame.locator("table").count() == 1
+        assert frame.locator("table tr").count() == 13
+        # Every action shows APPLIED (verified).
+        assert frame.locator("td").filter(has_text="APPLIED").count() == 12
+
+    def test_apply_button_ticks_rows_live(self, render_scenario):
+        """Click-through live-tick: Confirm fires the apply call, the
+        on_success chain pushes RESULT.actions into state.plan_actions,
+        and rows transition from PLANNED to APPLIED in place.
+
+        The stub ``modify_manufacturing_order`` tool in
+        ``render_test_server.py`` returns a canned applied response.
+
+        Waits on the observable post-state condition (12 APPLIED cells
+        present) rather than a fixed timeout — fast on warm CI, robust
+        on slow CI, deterministic-fail if the live-tick path breaks.
+        """
+        frame = render_scenario("modify_mo_12_actions_preview")
+
+        # Pre-state: 12 PLANNED, 0 APPLIED.
+        assert frame.locator("td").filter(has_text="PLANNED").count() == 12
+        assert frame.locator("td").filter(has_text="APPLIED").count() == 0
+
+        # Fire the Confirm button.
+        frame.locator("button").filter(has_text="Confirm").first.click()
+
+        # Wait for the live-tick to land — first APPLIED cell to become
+        # visible. ``wait_for`` polls with a 30s default timeout, so this
+        # completes ~immediately when the apply round-trip succeeds and
+        # fails deterministically if the on_success chain is broken.
+        frame.locator("td").filter(has_text="APPLIED").first.wait_for(
+            state="visible", timeout=30000
+        )
+
+        # Post-state: 0 PLANNED, 12 APPLIED.
+        assert frame.locator("td").filter(has_text="PLANNED").count() == 0, (
+            "Live-tick failed — Confirm click did not push RESULT.actions "
+            "into state.plan_actions, so rows stayed PLANNED. Check the "
+            "on_success chain in _build_apply_action_direct."
+        )
+        assert frame.locator("td").filter(has_text="APPLIED").count() == 12

--- a/katana_mcp_server/tests/browser/test_modification_render.py
+++ b/katana_mcp_server/tests/browser/test_modification_render.py
@@ -71,39 +71,40 @@ class TestModificationCardRender:
         # Every action shows APPLIED (verified).
         assert frame.locator("td").filter(has_text="APPLIED").count() == 12
 
-    def test_apply_button_ticks_rows_live(self, render_scenario):
-        """Click-through live-tick: Confirm fires the apply call, the
-        on_success chain pushes RESULT.actions into state.plan_actions,
-        and rows transition from PLANNED to APPLIED in place.
+    def test_apply_button_morphs_card_to_applied_state(self, render_scenario):
+        """Click-through: Confirm fires the apply call, the on_success
+        chain flips ``state.applied=True``, and the footer/badge row
+        morphs to its applied state.
+
+        The pinned-here behavior is the conservative apply UX — the row
+        cells stay PLANNED because ``$result.actions`` doesn't resolve
+        in the on_success Rx context (see in-code comment in
+        ``build_modification_preview_ui``). A live-tick UX where rows
+        transition PLANNED → APPLIED in place is tracked as a follow-up
+        once the right Rx path is identified.
 
         The stub ``modify_manufacturing_order`` tool in
-        ``render_test_server.py`` returns a canned applied response.
-
-        Waits on the observable post-state condition (12 APPLIED cells
-        present) rather than a fixed timeout — fast on warm CI, robust
-        on slow CI, deterministic-fail if the live-tick path breaks.
+        ``render_test_server.py`` matches production wire shape via
+        ``make_tool_result``, so this test fails the same way production
+        would if the apply path regresses.
         """
         frame = render_scenario("modify_mo_12_actions_preview")
 
-        # Pre-state: 12 PLANNED, 0 APPLIED.
+        # Pre-state: 12 PLANNED, 0 APPLIED, "Applying..." badge absent,
+        # "Applied" footer pill absent.
         assert frame.locator("td").filter(has_text="PLANNED").count() == 12
-        assert frame.locator("td").filter(has_text="APPLIED").count() == 0
+        assert frame.locator("text=Applied").count() == 0
 
         # Fire the Confirm button.
         frame.locator("button").filter(has_text="Confirm").first.click()
 
-        # Wait for the live-tick to land — first APPLIED cell to become
-        # visible. ``wait_for`` polls with a 30s default timeout, so this
-        # completes ~immediately when the apply round-trip succeeds and
+        # Wait for the applied-state morph: the "Applied" pill in the
+        # button row appears once on_success fires. ``wait_for`` polls
+        # with a 30s timeout — completes fast when the apply succeeds,
         # fails deterministically if the on_success chain is broken.
-        frame.locator("td").filter(has_text="APPLIED").first.wait_for(
-            state="visible", timeout=30000
-        )
+        frame.locator("text=Applied").first.wait_for(state="visible", timeout=30000)
 
-        # Post-state: 0 PLANNED, 12 APPLIED.
-        assert frame.locator("td").filter(has_text="PLANNED").count() == 0, (
-            "Live-tick failed — Confirm click did not push RESULT.actions "
-            "into state.plan_actions, so rows stayed PLANNED. Check the "
-            "on_success chain in _build_apply_action_direct."
-        )
-        assert frame.locator("td").filter(has_text="APPLIED").count() == 12
+        # The Confirm button is now disabled (state.applied gates it via
+        # the ``locked`` Rx in ``_render_apply_button_row``).
+        confirm = frame.locator("button").filter(has_text="Confirm").first
+        assert confirm.is_disabled()

--- a/katana_mcp_server/tests/browser/test_other_cards_render.py
+++ b/katana_mcp_server/tests/browser/test_other_cards_render.py
@@ -1,0 +1,86 @@
+"""Browser render tests for state-bound DataTable cards beyond the
+modification surface.
+
+After #629 surfaced ``rows="bare-string"`` as broken, all 5 state-bound
+DataTable callsites in ``prefab_ui.py`` were mustache-wrapped. The
+modification card got dedicated coverage in
+``test_modification_render.py``; this file pins the other 4 — symmetric
+proof that the audit fix actually renders, not just passes the
+``_assert_state_bindings_resolve`` contract check.
+
+If any of these break, the failure mode is the same as #629: the iframe
+loads but the body stays empty (zero ``table`` elements). Each test
+asserts a positive count of rendered rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+class TestOtherCardsRender:
+    """Verify state-bound DataTables outside the modification surface
+    actually render. Catches regressions in the audit fix from #634."""
+
+    def test_search_results_renders(self, render_scenario):
+        """``build_search_results_ui`` — rows='{{ items }}' with 50 entries.
+
+        Pre-mustache-fix this rendered as a blank iframe; post-fix it
+        renders the table with all 50 items (paginated, so the visible
+        count depends on page_size=20).
+        """
+        frame = render_scenario("search_results")
+        assert frame.locator("table").count() == 1, (
+            "search_results card failed to render — DataTable missing"
+        )
+        # First page: header + 20 items (pageSize=20).
+        # Just assert there's a positive row count — the exact number
+        # depends on pagination + which page renders first.
+        assert frame.locator("table tr").count() >= 5
+        # SKUs from the test fixture should be visible.
+        assert frame.locator("text=SKU-0000").count() >= 1
+
+    def test_inventory_check_renders(self, render_scenario):
+        """``build_inventory_check_ui`` — rows='{{ stock.by_location }}'.
+
+        Path-expression form (``stock.by_location``) — the mustache
+        wrapper must support dot-notation. Renders a Metrics row plus a
+        per-location DataTable.
+        """
+        frame = render_scenario("inventory_check")
+        # Multi-location split → DataTable plus the Metric tiles.
+        assert frame.locator("table").count() == 1
+        # 2 locations + header.
+        assert frame.locator("table tr").count() >= 3
+        assert frame.locator("text=Main Warehouse").count() >= 1
+        assert frame.locator("text=Brooklyn").count() >= 1
+
+    def test_verification_renders(self, render_scenario):
+        """``build_verification_ui`` — two state-bound DataTables in one
+        card (rows='{{ matches }}' and rows='{{ discrepancies }}').
+
+        Both must render. Pre-fix this would fail on the first one and
+        leave the body empty; post-fix both should populate.
+        """
+        frame = render_scenario("verification")
+        # 2 DataTables (matches + discrepancies).
+        assert frame.locator("table").count() == 2
+        # Match rows visible.
+        assert frame.locator("text=SKU-A").count() >= 1
+        assert frame.locator("text=SKU-B").count() >= 1
+        # Discrepancy row visible.
+        assert frame.locator("text=SKU-C").count() >= 1
+        assert frame.locator("text=qty_mismatch").count() >= 1
+
+    def test_batch_recipe_update_renders(self, render_scenario):
+        """``build_batch_recipe_update_ui`` — rows='{{ rows }}' over 5
+        sub-ops grouped by ``group_label``.
+        """
+        frame = render_scenario("batch_recipe_update")
+        assert frame.locator("table").count() == 1
+        # 5 sub-ops + header.
+        assert frame.locator("table tr").count() >= 6
+        # SKU strings from the test fixture.
+        assert frame.locator("text=SKU-OLD-0").count() >= 1

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -7,6 +7,9 @@ valid PrefabApp instances. This catches constructor signature mismatches
 
 from __future__ import annotations
 
+import json
+from typing import Any
+
 import pytest
 from katana_mcp.tools.prefab_ui import (
     build_batch_recipe_update_ui,
@@ -38,11 +41,59 @@ class _StubRequest(BaseModel):
     preview: bool = True
 
 
+def _walk_view_tree(node: object) -> list[dict[str, Any]]:
+    """Yield every Component dict in a view tree (for test traversal)."""
+    found: list[dict[str, Any]] = []
+
+    def visit(o: object) -> None:
+        if isinstance(o, dict):
+            if "type" in o:
+                found.append(o)
+            for v in o.values():
+                visit(v)
+        elif isinstance(o, list):
+            for v in o:
+                visit(v)
+
+    visit(node)
+    return found
+
+
+def _assert_state_bindings_resolve(envelope: dict[str, Any]) -> None:
+    """Every DataTable rendering rows by state-key reference must point to
+    a slot that exists in ``state``. Catches typos and broken refactors
+    where a state slot is renamed but the binding isn't updated.
+    """
+    state = envelope.get("state") or {}
+    for component in _walk_view_tree(envelope.get("view")):
+        if component.get("type") != "DataTable":
+            continue
+        rows = component.get("rows")
+        if not isinstance(rows, str):
+            continue
+        # Bare key (e.g. "plan_actions") or templated ref ("{{ x }}").
+        if rows.startswith("{{"):
+            continue
+        assert rows in state, (
+            f"DataTable.rows='{rows}' references missing state slot. "
+            f"Available: {sorted(state)}"
+        )
+
+
 def _assert_valid_prefab(app: PrefabApp) -> None:
-    """Assert that a PrefabApp serializes to valid JSON."""
+    """Assert that a PrefabApp serializes to valid JSON.
+
+    Beyond the basic shape check, also rounds-trips through ``json.dumps``
+    (catches non-serializable values that ``to_json`` may have skipped) and
+    verifies that every state-bound DataTable references a present slot.
+    """
     result = app.to_json()
     assert isinstance(result, dict)
     assert "$prefab" in result
+    # Full JSON serialization roundtrip — catches anything ``to_json``
+    # produced that pydantic_core wouldn't accept downstream.
+    json.dumps(result)
+    _assert_state_bindings_resolve(result)
 
 
 class TestBuildSearchResultsUI:
@@ -1849,6 +1900,164 @@ class TestBuildModificationPreviewUI:
             f"Legacy single-action title must include the count suffix; got {titles!r}"
         )
 
+    def test_twelve_action_mixed_plan_renders_single_state_bound_table(self):
+        """Reproduces #629: 12-action mixed plans (6 adds + 6 deletes)
+        previously emitted N separate state-bound DataTables, blowing the
+        renderer. The fix is one DataTable bound to ``state.plan_actions``.
+        """
+        actions = []
+        for i in range(6):
+            actions.append(
+                {
+                    "operation": "add_recipe_row",
+                    "target_id": None,
+                    "changes": [
+                        {
+                            "field": "variant_id",
+                            "old": None,
+                            "new": 40000000 + i,
+                            "is_added": True,
+                            "is_unchanged": False,
+                            "is_unknown_prior": False,
+                        },
+                        {
+                            "field": "planned_quantity_per_unit",
+                            "old": None,
+                            "new": 1,
+                            "is_added": True,
+                            "is_unchanged": False,
+                            "is_unknown_prior": False,
+                        },
+                        {
+                            "field": "notes",
+                            "old": None,
+                            "new": f"AM swap {i}: notes with (parens) and #{i}",
+                            "is_added": True,
+                            "is_unchanged": False,
+                            "is_unknown_prior": False,
+                        },
+                    ],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                }
+            )
+        for i in range(6):
+            actions.append(
+                {
+                    "operation": "delete_recipe_row",
+                    "target_id": 97411400 + i,
+                    "changes": [],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                }
+            )
+        response = _modification_preview_response(actions=actions)
+        app = build_modification_preview_ui(
+            response,
+            confirm_request=_ModifyStubRequest(id=16467730, preview=True),
+            confirm_tool="modify_manufacturing_order",
+        )
+        envelope = app.to_json()
+
+        # Sanity: full envelope serializes and bindings resolve.
+        _assert_valid_prefab(app)
+
+        # Exactly one DataTable, bound to plan_actions.
+        tables = [
+            n
+            for n in _walk_view_tree(envelope.get("view"))
+            if n.get("type") == "DataTable"
+        ]
+        assert len(tables) == 1, f"expected 1 DataTable, got {len(tables)}"
+        assert tables[0]["rows"] == "plan_actions"
+
+        # plan_actions has 12 rows, all PLANNED.
+        plan_rows = envelope["state"]["plan_actions"]
+        assert len(plan_rows) == 12
+        assert [r["index"] for r in plan_rows] == list(range(1, 13))
+        assert all(r["status_label"] == "PLANNED" for r in plan_rows)
+
+        # Adds have target_label "—", deletes have "#<id>".
+        for r in plan_rows[:6]:
+            assert r["target_label"] == "—"
+            assert "field(s) set" in r["summary"]
+        for r in plan_rows[6:]:
+            assert r["target_label"].startswith("#")
+            assert r["summary"] == "deleted"
+
+    def test_apply_button_pushes_result_actions_into_state(self):
+        """The Confirm button's CallTool on_success chain must SetState
+        ``plan_actions`` to ``$result.actions`` so each row's status_label
+        ticks live from PLANNED → APPLIED/FAILED on apply.
+        """
+        response = _modification_preview_response(
+            actions=[
+                {
+                    "operation": "update_header",
+                    "target_id": 1,
+                    "changes": [],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                }
+            ],
+        )
+        app = build_modification_preview_ui(
+            response,
+            confirm_request=_ModifyStubRequest(),
+            confirm_tool="modify_item",
+        )
+        envelope = app.to_json()
+
+        # Find the CallTool action and inspect its on_success chain.
+        # toolCall actions are nested under Button.on_click (not Component
+        # children), so search the full envelope tree.
+        def find_action(o: object, action_name: str) -> dict[str, Any] | None:
+            if isinstance(o, dict):
+                if o.get("action") == action_name:
+                    return o
+                for v in o.values():
+                    found = find_action(v, action_name)
+                    if found is not None:
+                        return found
+            elif isinstance(o, list):
+                for v in o:
+                    found = find_action(v, action_name)
+                    if found is not None:
+                        return found
+            return None
+
+        call_tool = find_action(envelope, "toolCall")
+        assert call_tool is not None
+        # The wire field is camelCase via Pydantic alias="onSuccess".
+        on_success = call_tool.get("onSuccess") or call_tool.get("on_success") or []
+        # Must include a setState targeting plan_actions with $result.actions.
+        plan_action_set = next(
+            (
+                a
+                for a in on_success
+                if isinstance(a, dict)
+                and a.get("action") == "setState"
+                and a.get("key") == "plan_actions"
+            ),
+            None,
+        )
+        assert plan_action_set is not None, (
+            f"on_success must SetState('plan_actions', RESULT.actions) for "
+            f"live-tick; got {on_success!r}"
+        )
+        # The value should be an Rx reference resolving to $result.actions.
+        # Rx serializes via str() to "{{ key }}".
+        value = plan_action_set.get("value")
+        assert isinstance(value, str) and "$result.actions" in value, (
+            f"plan_actions value must reference $result.actions; got {value!r}"
+        )
+
 
 class TestBuildModificationResultUI:
     """Result card for an applied (non-preview) ModificationResponse."""
@@ -1951,8 +2160,13 @@ class TestBuildModificationResultUI:
         assert "PARTIAL FAILURE" in labels, (
             f"Mixed succeed/fail must surface PARTIAL FAILURE; got {labels!r}"
         )
-        # Per-action FAILED badge must also surface
-        assert "FAILED" in labels
+        # Per-action FAILED status must surface in the row data (status_label
+        # column of the plan_actions DataTable). After the live-tick redesign
+        # (#629), per-action status lives in the table cells, not in Badges.
+        plan_rows = envelope["state"]["plan_actions"]
+        statuses = [r["status_label"] for r in plan_rows]
+        assert "APPLIED" in statuses, f"expected APPLIED in {statuses!r}"
+        assert "FAILED" in statuses, f"expected FAILED in {statuses!r}"
 
     def test_view_in_katana_button_present_when_url_set(self):
         response = self._response(

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -8,6 +8,7 @@ valid PrefabApp instances. This catches constructor signature mismatches
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 import pytest
@@ -59,10 +60,14 @@ def _walk_view_tree(node: object) -> list[dict[str, Any]]:
     return found
 
 
+_MUSTACHE_RE = re.compile(r"^\s*\{\{\s*([^}\s]+)\s*\}\}\s*$")
+
+
 def _assert_state_bindings_resolve(envelope: dict[str, Any]) -> None:
     """Every DataTable rendering rows by state-key reference must point to
-    a slot that exists in ``state``. Catches typos and broken refactors
-    where a state slot is renamed but the binding isn't updated.
+    a slot that exists in ``state``, AND must use the mustache template
+    form ``{{ key }}``. Bare strings crash the JS renderer with
+    ``t.some is not a function`` — discovered via headless render tests.
     """
     state = envelope.get("state") or {}
     for component in _walk_view_tree(envelope.get("view")):
@@ -71,12 +76,18 @@ def _assert_state_bindings_resolve(envelope: dict[str, Any]) -> None:
         rows = component.get("rows")
         if not isinstance(rows, str):
             continue
-        # Bare key (e.g. "plan_actions") or templated ref ("{{ x }}").
-        if rows.startswith("{{"):
-            continue
-        assert rows in state, (
-            f"DataTable.rows='{rows}' references missing state slot. "
-            f"Available: {sorted(state)}"
+        m = _MUSTACHE_RE.match(rows)
+        assert m is not None, (
+            f"DataTable.rows={rows!r} is a bare string. State-bound rows "
+            f"must use the mustache template form '{{{{ key }}}}' — bare "
+            f"strings crash the JS renderer."
+        )
+        # The mustache content can be a path expression like "stock.by_location"
+        # — only the first segment must exist in state.
+        first_segment = m.group(1).split(".", 1)[0]
+        assert first_segment in state, (
+            f"DataTable.rows={rows!r} references missing state slot "
+            f"{first_segment!r}. Available: {sorted(state)}"
         )
 
 
@@ -1966,14 +1977,16 @@ class TestBuildModificationPreviewUI:
         # Sanity: full envelope serializes and bindings resolve.
         _assert_valid_prefab(app)
 
-        # Exactly one DataTable, bound to plan_actions.
+        # Exactly one DataTable, bound to plan_actions via mustache template.
+        # Bare-string state references crash the JS renderer with
+        # "t.some is not a function" — discovered via headless apps_dev tests.
         tables = [
             n
             for n in _walk_view_tree(envelope.get("view"))
             if n.get("type") == "DataTable"
         ]
         assert len(tables) == 1, f"expected 1 DataTable, got {len(tables)}"
-        assert tables[0]["rows"] == "plan_actions"
+        assert tables[0]["rows"] == "{{ plan_actions }}"
 
         # plan_actions has 12 rows, all PLANNED.
         plan_rows = envelope["state"]["plan_actions"]

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -2002,10 +2002,17 @@ class TestBuildModificationPreviewUI:
             assert r["target_label"].startswith("#")
             assert r["summary"] == "deleted"
 
-    def test_apply_button_pushes_result_actions_into_state(self):
-        """The Confirm button's CallTool on_success chain must SetState
-        ``plan_actions`` to ``$result.actions`` so each row's status_label
-        ticks live from PLANNED → APPLIED/FAILED on apply.
+    def test_apply_button_does_not_set_state_plan_actions(self):
+        """Pin: the live-tick design (``SetState("plan_actions", RESULT.actions)``)
+        was attempted in #634 but turned out to be broken — ``$result`` in
+        the on_success Rx context resolves to the apply tool's
+        ``structured_content`` (a PrefabApp wire envelope), not to the raw
+        ``ModificationResponse``. The SetState was a no-op in production.
+
+        Until the right Rx path is identified (tracked as a follow-up), the
+        on_success chain MUST NOT include a SetState targeting plan_actions
+        — a no-op SetState is misleading. The apply path morphs the card via
+        the existing ``applied=True`` flag instead.
         """
         response = _modification_preview_response(
             actions=[
@@ -2027,9 +2034,6 @@ class TestBuildModificationPreviewUI:
         )
         envelope = app.to_json()
 
-        # Find the CallTool action and inspect its on_success chain.
-        # toolCall actions are nested under Button.on_click (not Component
-        # children), so search the full envelope tree.
         def find_action(o: object, action_name: str) -> dict[str, Any] | None:
             if isinstance(o, dict):
                 if o.get("action") == action_name:
@@ -2047,9 +2051,7 @@ class TestBuildModificationPreviewUI:
 
         call_tool = find_action(envelope, "toolCall")
         assert call_tool is not None
-        # The wire field is camelCase via Pydantic alias="onSuccess".
         on_success = call_tool.get("onSuccess") or call_tool.get("on_success") or []
-        # Must include a setState targeting plan_actions with $result.actions.
         plan_action_set = next(
             (
                 a
@@ -2060,15 +2062,10 @@ class TestBuildModificationPreviewUI:
             ),
             None,
         )
-        assert plan_action_set is not None, (
-            f"on_success must SetState('plan_actions', RESULT.actions) for "
-            f"live-tick; got {on_success!r}"
-        )
-        # The value should be an Rx reference resolving to $result.actions.
-        # Rx serializes via str() to "{{ key }}".
-        value = plan_action_set.get("value")
-        assert isinstance(value, str) and "$result.actions" in value, (
-            f"plan_actions value must reference $result.actions; got {value!r}"
+        assert plan_action_set is None, (
+            f"on_success must NOT SetState('plan_actions', ...) — it would "
+            f"be a no-op until the live-tick Rx path is fixed. Found: "
+            f"{plan_action_set!r}"
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,12 @@ dev = [
   # Lets ``asyncio.sleep(5)`` and ``loop.call_later(5, ...)`` fire instantly
   # in real time while the loop perceives 5 seconds elapsed.
   "looptime>=0.7",
+  # Headless browser testing for Prefab UI cards via fastmcp dev-apps.
+  # We use the raw ``playwright`` sync API (not pytest-playwright fixtures)
+  # to avoid pytest-base-url's ``base_url`` fixture colliding with our
+  # integration tests' same-name fixture. Requires a one-time
+  # ``uv run playwright install chromium`` to fetch Chromium (~250MB).
+  "playwright>=1.59.0",
   "tox>=4.25.0",
   # Code quality and linting
   "ruff>=0.14.0",
@@ -233,6 +239,7 @@ markers = [
   "docs: marks tests as documentation tests (slow, only run in CI docs jobs)",
   "schema_validation: marks tests that validate OpenAPI schema quality (run with pytest-xdist disabled)",
   "looptime: marks tests that use the looptime fake-clock asyncio loop (the looptime plugin auto-registers this marker; explicit registration here keeps the suite robust under --strict-markers if plugin autoload is ever disabled)",
+  "browser: marks tests that drive a headless browser via Playwright against the fastmcp dev-apps preview server (slower, needs `playwright install chromium`)",
 ]
 
 [tool.coverage.run]
@@ -562,17 +569,21 @@ lint = ["lint-ruff", "typecheck", "lint-yaml"]
 # Performance: sequential 25s → parallel 16s = 36% faster
 # Note: Optimal count may vary by system (4+ cores recommended for best results)
 # Note: Integration tests excluded by default (hit real API, may be rate limited)
-test = "pytest -n 4 -m 'not docs and not schema_validation and not integration'"  # Parallel execution with pytest-xdist
-test-sequential = "pytest -m 'not docs and not schema_validation and not integration'"  # Sequential execution (if parallel has issues)
-test-verbose = "pytest -n 4 -v -m 'not docs and not schema_validation and not integration'"
-test-coverage = "pytest -n 4 --cov=katana_public_api_client --cov-report=term-missing -m 'not docs and not schema_validation and not integration'"
-test-coverage-html = "pytest -n 4 --cov=katana_public_api_client --cov-report=html -m 'not docs and not schema_validation and not integration'"
+test = "pytest -n 4 -m 'not docs and not schema_validation and not integration and not browser'"  # Parallel execution with pytest-xdist
+test-sequential = "pytest -m 'not docs and not schema_validation and not integration and not browser'"  # Sequential execution (if parallel has issues)
+test-verbose = "pytest -n 4 -v -m 'not docs and not schema_validation and not integration and not browser'"
+test-coverage = "pytest -n 4 --cov=katana_public_api_client --cov-report=term-missing -m 'not docs and not schema_validation and not integration and not browser'"
+test-coverage-html = "pytest -n 4 --cov=katana_public_api_client --cov-report=html -m 'not docs and not schema_validation and not integration and not browser'"
 test-unit = "pytest -n 4 -m 'unit and not schema_validation'"
 test-integration = "pytest -n 4 -m 'integration and not schema_validation'"
 test-docs = { shell = "CI_DOCS_BUILD=true pytest -m docs -v --timeout=600" }  # 10 minute timeout for docs
-test-no-docs = "pytest -n 4 -m 'not docs and not schema_validation and not integration'"
-test-all = "pytest -n 4 -m 'not schema_validation and not integration'"  # Run everything except schema_validation and integration (parallel-incompatible, API rate limits)
+test-no-docs = "pytest -n 4 -m 'not docs and not schema_validation and not integration and not browser'"
+test-all = "pytest -n 4 -m 'not schema_validation and not integration and not browser'"  # Run everything except schema_validation, integration, and browser (each parallel-incompatible or stateful)
 test-schema = "pytest -m schema_validation"  # Run schema validation tests only (sequential, may be slow)
+# Browser-render tests for Prefab UI cards. Runs sequentially because the
+# fastmcp dev-apps server holds a single MCP-port pair. First run requires
+# ``uv run playwright install chromium`` (~250MB).
+test-browser = { shell = "pytest -m browser --timeout=120 katana_mcp_server/tests/browser/" }
 
 # -----------------------------------------------------------------------------
 # OpenAPI and Code Generation Tasks
@@ -617,8 +628,8 @@ pre-commit-update = "pre-commit autoupdate"
 # Validation Tiers (for agent workflows)
 quick-check = ["format-check", "lint-ruff"]                              # Tier 1: Fast feedback (~5-10s)
 agent-check = ["format-check", "lint-ruff", "typecheck"]                # Tier 2: Pre-commit (~10-15s)
-check = ["format-check", "lint", "test"]                                 # Tier 3: PR validation (~40s)
-full-check = ["format-check", "lint", "test", "docs-build"]             # Tier 4: Final validation (~50s)
+check = ["format-check", "lint", "test", "test-browser"]                 # Tier 3: PR validation (~60s including browser render tests)
+full-check = ["format-check", "lint", "test", "test-browser", "docs-build"]             # Tier 4: Final validation (~70s)
 
 # Other combined workflows
 fix = ["format", "lint-ruff-fix"]

--- a/uv.lock
+++ b/uv.lock
@@ -1335,6 +1335,7 @@ dev = [
     { name = "mdformat-toc" },
     { name = "openapi-python-client" },
     { name = "openapi-spec-validator" },
+    { name = "playwright" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1392,6 +1393,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.29.0" },
     { name = "openapi-python-client", marker = "extra == 'dev'", specifier = ">=0.25.2" },
     { name = "openapi-spec-validator", marker = "extra == 'dev'", specifier = ">=0.7.0" },
+    { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.59.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.0" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pyrate-limiter", specifier = ">=3.0.0" },
@@ -2095,6 +2097,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.59.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/48/abab23f40643b4de8f2665816f0a1bf0994eeecda39d6d62f0f292b2ad01/playwright-1.59.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bfc6940100b57423175c819ce2422ec5880d55fa2769987f62ab7a1f5fe6783e", size = 43156922, upload-time = "2026-04-29T08:11:08.921Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/5e4d98b2ce3641b4343623c6450ff33b9de1c979d12a957505e392338b07/playwright-1.59.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:af068143a0c045ec11608b67d6c42e58db7e9cf65a742dd21fddedc1a9802c47", size = 41947177, upload-time = "2026-04-29T08:11:12.867Z" },
+    { url = "https://files.pythonhosted.org/packages/80/91/fd219aa78ca03d37e93aaedaed4e224131e3090a9264f9bb773c8271d67e/playwright-1.59.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:4a4a2d4842b0e4120de3fa48636e4b69085a05b81d8a35ad4353f530ade72ed6", size = 43156922, upload-time = "2026-04-29T08:11:16.595Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/1e513d37c5be07d12829ebce93dbfe7baee230084cb66966c423432799c4/playwright-1.59.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c5792aad9e22b91a09264b9edbc18553cf05ea5a39404d65dc19a012c6b2e51d", size = 47151793, upload-time = "2026-04-29T08:11:19.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2d/15f72288cb65d690134e18fefb9483cc4976f7579b580648c45e494481a7/playwright-1.59.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c881a19377d2b900af855fb525b5f22a27bf3cfbecba6d1edb36766d56cb100", size = 46877615, upload-time = "2026-04-29T08:11:23.863Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a1/717ac5bc99f387c0f60def91271ea4262125c0815d764a5d1776a272275c/playwright-1.59.0-py3-none-win32.whl", hash = "sha256:6989c476be2b9cd3e24a18cc9dcf202e266fb3d91e3e5395cd668c54ea54b119", size = 37713698, upload-time = "2026-04-29T08:11:27.251Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a5/4e630ee05d8b46b840f943268e86d6063703e8dadb2d3eb405c7b9b2e48c/playwright-1.59.0-py3-none-win_amd64.whl", hash = "sha256:d5a5cc064b82ca92996080025710844e417f44df8fda9001102c28f44174171c", size = 37713704, upload-time = "2026-04-29T08:11:30.41Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0c/3ece41761ba13c8321009aefcaec7a016eb42799c42eef5e03ace7f2de5b/playwright-1.59.0-py3-none-win_arm64.whl", hash = "sha256:93581ad515728cadc8af39b288a5633ba6d36e7d72048e79d890ce01ea2156f9", size = 33956745, upload-time = "2026-04-29T08:11:34.738Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2394,6 +2415,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The original report (#629) was that `modify_manufacturing_order` rendered as a blank iframe on 12-action plans. Investigation revealed **the bug class is much broader**: every state-bound `DataTable` in the codebase used `rows="bare-string"`, which the JS renderer crashes on with `t.some is not a function`. None of those cards were rendering correctly. This PR fixes all of them and adds a browser-render test harness — wired into CI and the devcontainer prebuild — so the bug class can never silently ship again.

## What's broken (and now fixed)

1. **Bare-string state binding crashes the JS renderer.** Pydantic accepts `rows: str` but the renderer requires the mustache template form `rows="{{ key }}"`. Bare strings get treated as the rows array itself, calling `.some()` on a string. **All 5 state-bound DataTable callsites were using bare strings**:
   - `build_modification_preview_ui` / `build_modification_result_ui`
   - `build_search_results_ui`
   - `build_inventory_check_ui`
   - `build_verification_ui`
   - `build_batch_recipe_update_ui`

   Fix: mustache-wrap every state reference. The strengthened `_assert_state_bindings_resolve` test enforces the contract — bare strings fail unit tests.

2. **Modification cards emitted N separate state-bound DataTables**, one per action with field changes. The cost of state binding (template indirection, multi-slot wire payload) was paid without delivering the benefit — the apply path morphed to a fresh `applied=True` state instead of updating planned rows in place. Fix: collapse to **one DataTable bound to `state.plan_actions`**, with server-derived display fields on `ActionResult` (`index`, `operation_label`, `target_label`, `status_label`, `summary`) so preview and result-card row shapes match.

## Live-tick UX status: **deferred to #645**

The PR initially attempted a live-tick UX (rows transitioning PLANNED → APPLIED in place via `SetState("plan_actions", RESULT.actions)` in the Confirm-button on_success). Copilot review caught that this was a no-op in production: `$result` in the on_success Rx context resolves to the apply tool's `structured_content` (a PrefabApp wire envelope from `make_tool_result`), not the raw `ModificationResponse`. `$result.actions` never resolves. The browser harness only passed because the stub had the wrong-but-convenient wire shape.

Resolution in c794914f: dropped the broken `SetState`, switched the harness stub to `make_tool_result` matching production exactly, and pinned the conservative apply UX (rows stay PLANNED; footer/badge flip to applied state) with an in-code comment + follow-up issue. Apply path is back to the same UX the codebase had before this PR — no functional regression.

Tracked as **#645** for proper investigation (right Rx path, or restructured apply path).

## Browser-render test harness — the biggest win

`katana_mcp_server/tests/browser/`:

- Spins up `fastmcp dev apps` against a minimal `render_test_server` (subprocess) and drives the iframe via headless Chromium (raw `playwright.sync_api`).
- Catches the bug class the prior unit tests cannot — runtime JS errors that produce a "loaded-but-empty" iframe.
- 10 tests covering the modification card surface (incl. the 12-action repro from #629 and the conservative apply-state morph) and the 4 other state-bound DataTable cards.
- Stub `modify_manufacturing_order` mirrors production wire shape via `make_tool_result` so the click-through test fails the same way production would.

The harness immediately surfaced both bugs above (the bare-string crash and, on the second pass, the broken live-tick), neither of which the 75 unit tests caught.

## CI + devcontainer

So the harness actually runs everywhere it needs to:

- **`.github/workflows/ci.yml`** — new `browser-test` job (single Python 3.14, caches Chromium build keyed by `uv.lock` hash). Browser tests now run on every PR.
- **`.devcontainer/oncreate.sh`** — appends `playwright install --with-deps chromium` to the Codespaces prebuild. Codespace users skip the manual install step.
- **`CLAUDE.md`** — documents the mustache state-binding pitfall in Known Pitfalls so future sessions know without rediscovering it.

## Closes / addresses

- **Closes #629** (modification card blank-iframe bug)
- **Closes #630** (audit other state-bound DataTables) — addressed inline rather than deferred
- **Stays open**: #631 (ExpandableRow follow-up), #632 (separate `list_manufacturing_orders` cache datetime bug), **#645** (live-tick UX)

## Test plan

- [x] All 3078 MCP unit tests pass (`uv run poe test`)
- [x] All 10 browser-render tests pass (`uv run poe test-browser`, ~100s)
- [x] Full `uv run poe check` green (lint + format + ty + tests + browser)
- [x] Browser tests reproduce the original 12-action blank-iframe bug and confirm the fix
- [x] CI `browser-test` job runs `poe test-browser` on every PR
- [x] All Copilot review comments addressed (9 total across two rounds — 5 fixed, 4 already-fixed)
- [ ] **Live smoke (recommended before merge):** call `modify_manufacturing_order` against the production Katana via Claude Desktop / Cowork to confirm the card renders in the real host's renderer

## Setup notes for reviewers

```bash
uv run playwright install chromium
```

Or use the devcontainer (now pre-installs Chromium in the prebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)