### PR TITLE
chore(client)!: emit Mapped[T] on Cached* classes (drop col()/cast() ergonomics tax)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import time
 from datetime import datetime
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
@@ -1192,7 +1192,7 @@ def _apply_stock_adjustment_filters(
     this function lets the paginated path avoid re-parsing on the COUNT
     query.
     """
-    from sqlmodel import col, exists, select
+    from sqlmodel import exists, select
 
     from katana_public_api_client.models_pydantic._generated import (
         CachedStockAdjustment,
@@ -1202,14 +1202,14 @@ def _apply_stock_adjustment_filters(
     if request.location_id is not None:
         stmt = stmt.where(CachedStockAdjustment.location_id == request.location_id)
     if request.ids is not None:
-        stmt = stmt.where(col(CachedStockAdjustment.id).in_(request.ids))
+        stmt = stmt.where(CachedStockAdjustment.id.in_(request.ids))
     if request.stock_adjustment_number is not None:
         stmt = stmt.where(
             CachedStockAdjustment.stock_adjustment_number
             == request.stock_adjustment_number
         )
     if not request.include_deleted:
-        stmt = stmt.where(col(CachedStockAdjustment.deleted_at).is_(None))
+        stmt = stmt.where(CachedStockAdjustment.deleted_at.is_(None))
 
     # ``variant_id`` is a row-level field — EXISTS subquery scans the
     # indexed FK directly so a match on any row of any adjustment is
@@ -1229,7 +1229,7 @@ def _apply_stock_adjustment_filters(
     if request.reason is not None:
         needle = request.reason.strip()
         if needle:
-            stmt = stmt.where(col(CachedStockAdjustment.reason).ilike(f"%{needle}%"))
+            stmt = stmt.where(CachedStockAdjustment.reason.ilike(f"%{needle}%"))
 
     return apply_date_window_filters(
         stmt,
@@ -1256,8 +1256,8 @@ async def _list_stock_adjustments_impl(
     subquery against the row table so a match on any row is found
     regardless of how many adjustments precede it. See ADR-0018.
     """
-    from sqlalchemy.orm import QueryableAttribute, selectinload
-    from sqlmodel import col, func, select
+    from sqlalchemy.orm import selectinload
+    from sqlmodel import func, select
 
     from katana_mcp.typed_cache import ensure_stock_adjustments_synced
     from katana_public_api_client.models_pydantic._generated import (
@@ -1276,16 +1276,11 @@ async def _list_stock_adjustments_impl(
     # materialization time and we skip the correlated COUNT subquery.
     if request.include_rows:
         stmt = select(CachedStockAdjustment).options(
-            selectinload(
-                cast(
-                    "QueryableAttribute[Any]",
-                    CachedStockAdjustment.stock_adjustment_rows,
-                )
-            )
+            selectinload(CachedStockAdjustment.stock_adjustment_rows)
         )
     else:
         row_count_subq = (
-            select(func.count(col(CachedStockAdjustmentRow.id)))
+            select(func.count(CachedStockAdjustmentRow.id))
             .where(
                 CachedStockAdjustmentRow.stock_adjustment_id == CachedStockAdjustment.id
             )
@@ -1296,8 +1291,8 @@ async def _list_stock_adjustments_impl(
         stmt = select(CachedStockAdjustment, row_count_subq)
     stmt = _apply_stock_adjustment_filters(stmt, request, parsed_dates)
     stmt = stmt.order_by(
-        col(CachedStockAdjustment.created_at).desc(),
-        col(CachedStockAdjustment.id).desc(),
+        CachedStockAdjustment.created_at.desc(),
+        CachedStockAdjustment.id.desc(),
     )
     if request.page is not None:
         stmt = stmt.offset((request.page - 1) * request.limit).limit(request.limit)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -1776,14 +1776,13 @@ def _apply_manufacturing_order_filters(
     reflect exactly the same filter set as the data rows. ``parsed_dates``
     must come from :func:`parse_request_dates`.
     """
-    from sqlmodel import col
 
     from katana_public_api_client.models_pydantic._generated import (
         CachedManufacturingOrder,
     )
 
     if request.ids is not None:
-        stmt = stmt.where(col(CachedManufacturingOrder.id).in_(request.ids))
+        stmt = stmt.where(CachedManufacturingOrder.id.in_(request.ids))
     if request.order_no is not None:
         stmt = stmt.where(CachedManufacturingOrder.order_no == request.order_no)
     if request.status is not None:
@@ -1791,12 +1790,10 @@ def _apply_manufacturing_order_filters(
     if request.location_id is not None:
         stmt = stmt.where(CachedManufacturingOrder.location_id == request.location_id)
     if request.variant_ids is not None:
-        stmt = stmt.where(
-            col(CachedManufacturingOrder.variant_id).in_(request.variant_ids)
-        )
+        stmt = stmt.where(CachedManufacturingOrder.variant_id.in_(request.variant_ids))
     if request.sales_order_ids is not None:
         stmt = stmt.where(
-            col(CachedManufacturingOrder.sales_order_id).in_(request.sales_order_ids)
+            CachedManufacturingOrder.sales_order_id.in_(request.sales_order_ids)
         )
     if request.ingredient_availability is not None:
         stmt = stmt.where(
@@ -1813,7 +1810,7 @@ def _apply_manufacturing_order_filters(
             == request.is_linked_to_sales_order
         )
     if not request.include_deleted:
-        stmt = stmt.where(col(CachedManufacturingOrder.deleted_at).is_(None))
+        stmt = stmt.where(CachedManufacturingOrder.deleted_at.is_(None))
 
     return apply_date_window_filters(
         stmt,
@@ -1841,7 +1838,7 @@ async def _list_manufacturing_orders_impl(
     Filters (including ``production_deadline_*``) translate to indexed
     SQL. See ADR-0018.
     """
-    from sqlmodel import col, func, select
+    from sqlmodel import func, select
 
     from katana_mcp.typed_cache import ensure_manufacturing_orders_synced
     from katana_public_api_client.models_pydantic._generated import (
@@ -1857,8 +1854,8 @@ async def _list_manufacturing_orders_impl(
     stmt = select(CachedManufacturingOrder)
     stmt = _apply_manufacturing_order_filters(stmt, request, parsed_dates)
     stmt = stmt.order_by(
-        col(CachedManufacturingOrder.created_at).desc(),
-        col(CachedManufacturingOrder.id).desc(),
+        CachedManufacturingOrder.created_at.desc(),
+        CachedManufacturingOrder.id.desc(),
     )
     if request.page is not None:
         stmt = stmt.offset((request.page - 1) * request.limit).limit(request.limit)
@@ -2181,7 +2178,7 @@ async def _list_blocking_ingredients_impl(
     hasn't run for, which would otherwise surface as a false-positive
     blocking entry.
     """
-    from sqlmodel import col, select
+    from sqlmodel import select
 
     from katana_mcp.typed_cache import (
         MANUFACTURING_ORDER_RECIPE_ROW_SPEC,
@@ -2263,24 +2260,22 @@ async def _list_blocking_ingredients_impl(
         select(CachedManufacturingOrderRecipeRow, CachedManufacturingOrder)
         .join(
             CachedManufacturingOrder,
-            col(CachedManufacturingOrder.id)
+            CachedManufacturingOrder.id
             == CachedManufacturingOrderRecipeRow.manufacturing_order_id,
         )
-        .where(col(CachedManufacturingOrder.deleted_at).is_(None))
-        .where(col(CachedManufacturingOrderRecipeRow.deleted_at).is_(None))
-        .where(col(CachedManufacturingOrder.status).in_(statuses))
+        .where(CachedManufacturingOrder.deleted_at.is_(None))
+        .where(CachedManufacturingOrderRecipeRow.deleted_at.is_(None))
+        .where(CachedManufacturingOrder.status.in_(statuses))
         .where(
-            col(CachedManufacturingOrderRecipeRow.ingredient_availability).in_(
+            CachedManufacturingOrderRecipeRow.ingredient_availability.in_(
                 list(_BLOCKING_AVAILABILITY)
             )
         )
     )
     if request.mo_ids is not None:
-        stmt = stmt.where(col(CachedManufacturingOrder.id).in_(request.mo_ids))
+        stmt = stmt.where(CachedManufacturingOrder.id.in_(request.mo_ids))
     if request.mo_order_nos is not None:
-        stmt = stmt.where(
-            col(CachedManufacturingOrder.order_no).in_(request.mo_order_nos)
-        )
+        stmt = stmt.where(CachedManufacturingOrder.order_no.in_(request.mo_order_nos))
     if request.location_id is not None:
         stmt = stmt.where(CachedManufacturingOrder.location_id == request.location_id)
     stmt = apply_date_window_filters(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
@@ -2013,7 +2013,6 @@ def _apply_purchase_order_filters(
     Shared by the data SELECT and the COUNT SELECT so pagination totals
     reflect exactly the same filter set as the data rows.
     """
-    from sqlmodel import col
 
     from katana_public_api_client.models_pydantic._generated import (
         CachedPurchaseOrder,
@@ -2023,7 +2022,7 @@ def _apply_purchase_order_filters(
     )
 
     if request.ids is not None:
-        stmt = stmt.where(col(CachedPurchaseOrder.id).in_(request.ids))
+        stmt = stmt.where(CachedPurchaseOrder.id.in_(request.ids))
     if request.order_no is not None:
         stmt = stmt.where(CachedPurchaseOrder.order_no == request.order_no)
     if request.entity_type is not None:
@@ -2056,7 +2055,7 @@ def _apply_purchase_order_filters(
     if request.supplier_id is not None:
         stmt = stmt.where(CachedPurchaseOrder.supplier_id == request.supplier_id)
     if not request.include_deleted:
-        stmt = stmt.where(col(CachedPurchaseOrder.deleted_at).is_(None))
+        stmt = stmt.where(CachedPurchaseOrder.deleted_at.is_(None))
 
     return apply_date_window_filters(
         stmt,
@@ -2085,8 +2084,8 @@ async def _list_purchase_orders_impl(
     outsourced-only ``tracking_location_id``) translate to indexed SQL.
     See ADR-0018.
     """
-    from sqlalchemy.orm import QueryableAttribute, selectinload
-    from sqlmodel import col, func, select
+    from sqlalchemy.orm import selectinload
+    from sqlmodel import func, select
 
     from katana_mcp.typed_cache import ensure_purchase_orders_synced
     from katana_public_api_client.models_pydantic._generated import (
@@ -2105,16 +2104,11 @@ async def _list_purchase_orders_impl(
     # time and we skip the correlated COUNT subquery.
     if request.include_rows:
         stmt = select(CachedPurchaseOrder).options(
-            selectinload(
-                cast(
-                    "QueryableAttribute[Any]",
-                    CachedPurchaseOrder.purchase_order_rows,
-                )
-            )
+            selectinload(CachedPurchaseOrder.purchase_order_rows)
         )
     else:
         row_count_subq = (
-            select(func.count(col(CachedPurchaseOrderRow.id)))
+            select(func.count(CachedPurchaseOrderRow.id))
             .where(CachedPurchaseOrderRow.purchase_order_id == CachedPurchaseOrder.id)
             .correlate(CachedPurchaseOrder)
             .scalar_subquery()
@@ -2123,8 +2117,8 @@ async def _list_purchase_orders_impl(
         stmt = select(CachedPurchaseOrder, row_count_subq)
     stmt = _apply_purchase_order_filters(stmt, request, parsed_dates)
     stmt = stmt.order_by(
-        col(CachedPurchaseOrder.created_at).desc(),
-        col(CachedPurchaseOrder.id).desc(),
+        CachedPurchaseOrder.created_at.desc(),
+        CachedPurchaseOrder.id.desc(),
     )
     if request.page is not None:
         stmt = stmt.offset((request.page - 1) * request.limit).limit(request.limit)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -793,7 +793,7 @@ async def _fetch_completed_mo_recipe_rows_in_window(
     window datetimes must also be naive UTC — callers are responsible for
     stripping tzinfo before passing.
     """
-    from sqlmodel import col, select
+    from sqlmodel import select
 
     from katana_mcp.typed_cache import ensure_manufacturing_orders_synced
     from katana_public_api_client.models_pydantic._generated import (
@@ -815,13 +815,13 @@ async def _fetch_completed_mo_recipe_rows_in_window(
             select(CachedManufacturingOrderRecipeRow)
             .join(
                 CachedManufacturingOrder,
-                col(CachedManufacturingOrder.id)
+                CachedManufacturingOrder.id
                 == CachedManufacturingOrderRecipeRow.manufacturing_order_id,
             )
             .where(CachedManufacturingOrder.status == ManufacturingOrderStatus.done)
-            .where(col(CachedManufacturingOrder.done_date).is_not(None))
-            .where(col(CachedManufacturingOrder.deleted_at).is_(None))
-            .where(col(CachedManufacturingOrderRecipeRow.deleted_at).is_(None))
+            .where(CachedManufacturingOrder.done_date.is_not(None))
+            .where(CachedManufacturingOrder.deleted_at.is_(None))
+            .where(CachedManufacturingOrderRecipeRow.deleted_at.is_(None))
         )
         row_stmt = apply_date_window_filters(
             row_stmt,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
@@ -729,7 +729,6 @@ def _apply_sales_order_filters(
     this function lets the paginated path avoid re-parsing on the COUNT
     query.
     """
-    from sqlmodel import col
 
     from katana_public_api_client.models_pydantic._generated import (
         CachedSalesOrder,
@@ -744,7 +743,7 @@ def _apply_sales_order_filters(
     if request.order_no is not None:
         stmt = stmt.where(CachedSalesOrder.order_no == request.order_no)
     if request.ids is not None:
-        stmt = stmt.where(col(CachedSalesOrder.id).in_(request.ids))
+        stmt = stmt.where(CachedSalesOrder.id.in_(request.ids))
     if request.customer_id is not None:
         stmt = stmt.where(CachedSalesOrder.customer_id == request.customer_id)
     if request.location_id is not None:
@@ -766,7 +765,7 @@ def _apply_sales_order_filters(
     if request.currency is not None:
         stmt = stmt.where(CachedSalesOrder.currency == request.currency)
     if not request.include_deleted:
-        stmt = stmt.where(col(CachedSalesOrder.deleted_at).is_(None))
+        stmt = stmt.where(CachedSalesOrder.deleted_at.is_(None))
 
     return apply_date_window_filters(
         stmt,
@@ -794,8 +793,8 @@ async def _list_sales_orders_impl(
     translates request filters into indexed SQL and returns results
     directly. See ADR-0018.
     """
-    from sqlalchemy.orm import QueryableAttribute, selectinload
-    from sqlmodel import col, func, select
+    from sqlalchemy.orm import selectinload
+    from sqlmodel import func, select
 
     from katana_mcp.typed_cache import ensure_sales_orders_synced
     from katana_public_api_client.models_pydantic._generated import (
@@ -814,13 +813,11 @@ async def _list_sales_orders_impl(
     # time and we skip the correlated COUNT subquery entirely.
     if request.include_rows:
         stmt = select(CachedSalesOrder).options(
-            selectinload(
-                cast("QueryableAttribute[Any]", CachedSalesOrder.sales_order_rows)
-            )
+            selectinload(CachedSalesOrder.sales_order_rows)
         )
     else:
         row_count_subq = (
-            select(func.count(col(CachedSalesOrderRow.id)))
+            select(func.count(CachedSalesOrderRow.id))
             .where(CachedSalesOrderRow.sales_order_id == CachedSalesOrder.id)
             .correlate(CachedSalesOrder)
             .scalar_subquery()
@@ -828,9 +825,7 @@ async def _list_sales_orders_impl(
         )
         stmt = select(CachedSalesOrder, row_count_subq)
     stmt = _apply_sales_order_filters(stmt, request, parsed_dates)
-    stmt = stmt.order_by(
-        col(CachedSalesOrder.created_at).desc(), col(CachedSalesOrder.id).desc()
-    )
+    stmt = stmt.order_by(CachedSalesOrder.created_at.desc(), CachedSalesOrder.id.desc())
     if request.page is not None:
         stmt = stmt.offset((request.page - 1) * request.limit).limit(request.limit)
     else:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -16,7 +16,7 @@ import asyncio
 import datetime as _datetime
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
@@ -596,7 +596,6 @@ def _apply_stock_transfer_filters(
     (``draft``, ``inTransit`` (camelCase!), ``received``) which is what the
     cache column stores.
     """
-    from sqlmodel import col
 
     from katana_public_api_client.models_pydantic._generated import (
         CachedStockTransfer,
@@ -617,7 +616,7 @@ def _apply_stock_transfer_filters(
         stmt = stmt.where(
             CachedStockTransfer.stock_transfer_number == request.stock_transfer_number
         )
-    stmt = stmt.where(col(CachedStockTransfer.deleted_at).is_(None))
+    stmt = stmt.where(CachedStockTransfer.deleted_at.is_(None))
 
     return apply_date_window_filters(
         stmt,
@@ -637,8 +636,8 @@ async def _list_stock_transfers_impl(
     Filters (including ``status``, which Katana doesn't expose as a
     server-side filter) translate to indexed SQL. See ADR-0018.
     """
-    from sqlalchemy.orm import QueryableAttribute, selectinload
-    from sqlmodel import col, func, select
+    from sqlalchemy.orm import selectinload
+    from sqlmodel import func, select
 
     from katana_mcp.typed_cache import ensure_stock_transfers_synced
     from katana_public_api_client.models_pydantic._generated import (
@@ -657,16 +656,11 @@ async def _list_stock_transfers_impl(
     # materialization time and we skip the correlated COUNT subquery.
     if request.include_rows:
         stmt = select(CachedStockTransfer).options(
-            selectinload(
-                cast(
-                    "QueryableAttribute[Any]",
-                    CachedStockTransfer.stock_transfer_rows,
-                )
-            )
+            selectinload(CachedStockTransfer.stock_transfer_rows)
         )
     else:
         row_count_subq = (
-            select(func.count(col(CachedStockTransferRow.id)))
+            select(func.count(CachedStockTransferRow.id))
             .where(CachedStockTransferRow.stock_transfer_id == CachedStockTransfer.id)
             .correlate(CachedStockTransfer)
             .scalar_subquery()
@@ -675,8 +669,8 @@ async def _list_stock_transfers_impl(
         stmt = select(CachedStockTransfer, row_count_subq)
     stmt = _apply_stock_transfer_filters(stmt, request, parsed_dates)
     stmt = stmt.order_by(
-        col(CachedStockTransfer.created_at).desc(),
-        col(CachedStockTransfer.id).desc(),
+        CachedStockTransfer.created_at.desc(),
+        CachedStockTransfer.id.desc(),
     )
     if request.page is not None:
         stmt = stmt.offset((request.page - 1) * request.limit).limit(request.limit)

--- a/katana_public_api_client/models_pydantic/_generated/base.py
+++ b/katana_public_api_client/models_pydantic/_generated/base.py
@@ -14,65 +14,66 @@ from typing import Annotated
 from pydantic import ConfigDict, Field
 
 from katana_public_api_client.models_pydantic._base import KatanaPydanticBase
+from katana_public_api_client.models_pydantic._mapped_shim import Mapped
 
 
 class BaseEntity(KatanaPydanticBase):
     model_config = ConfigDict(extra="ignore")
 
-    id: Annotated[int, Field(description="Unique identifier")]
+    id: Annotated[Mapped[int], Field(description="Unique identifier")]
 
 
 class UpdatableEntity(BaseEntity):
     created_at: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Timestamp when the entity was first created"),
     ] = None
     updated_at: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Timestamp when the entity was last updated"),
     ] = None
 
 
 class ArchivableEntity(BaseEntity):
     created_at: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Timestamp when the entity was first created"),
     ] = None
     updated_at: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Timestamp when the entity was last updated"),
     ] = None
     archived_at: Annotated[
-        datetime | None, Field(description="Nullable archive timestamp")
+        Mapped[datetime | None], Field(description="Nullable archive timestamp")
     ] = None
 
 
 class DeletableEntity(BaseEntity):
     created_at: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Timestamp when the entity was first created"),
     ] = None
     updated_at: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Timestamp when the entity was last updated"),
     ] = None
     deleted_at: Annotated[
-        datetime | None, Field(description="Nullable deletion timestamp")
+        Mapped[datetime | None], Field(description="Nullable deletion timestamp")
     ] = None
 
 
 class ArchivableDeletableEntity(BaseEntity):
     created_at: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Timestamp when the entity was first created"),
     ] = None
     updated_at: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Timestamp when the entity was last updated"),
     ] = None
     archived_at: Annotated[
-        datetime | None, Field(description="Nullable archive timestamp")
+        Mapped[datetime | None], Field(description="Nullable archive timestamp")
     ] = None
     deleted_at: Annotated[
-        datetime | None, Field(description="Nullable deletion timestamp")
+        Mapped[datetime | None], Field(description="Nullable deletion timestamp")
     ] = None

--- a/katana_public_api_client/models_pydantic/_generated/manufacturing.py
+++ b/katana_public_api_client/models_pydantic/_generated/manufacturing.py
@@ -19,6 +19,7 @@ from sqlmodel import (
 )
 
 from katana_public_api_client.models_pydantic._base import KatanaPydanticBase
+from katana_public_api_client.models_pydantic._mapped_shim import Mapped
 from katana_public_api_client.models_pydantic._pydantic_json import PydanticJSON
 
 from .base import DeletableEntity
@@ -974,65 +975,67 @@ class CachedManufacturingOrderRecipeRow(DeletableEntity, table=True):
     __tablename__ = "manufacturing_order_recipe_row"
     model_config = ConfigDict(frozen=False)
 
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+    id: Annotated[
+        Mapped[int], SQLField(primary_key=True, description="Unique identifier")
+    ]
 
     manufacturing_order_id: Annotated[
-        int | None,
+        Mapped[int | None],
         SQLField(
             foreign_key="manufacturing_order.id",
             description="ID of the manufacturing order this recipe row belongs to",
         ),
     ] = None
     variant_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(description="ID of the ingredient variant required for production"),
     ] = None
     notes: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(
             description="Additional notes about this ingredient or special handling instructions"
         ),
     ] = None
     planned_quantity_per_unit: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="Planned quantity of this ingredient needed per unit produced"
         ),
     ] = None
     total_actual_quantity: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(description="Total actual quantity of this ingredient consumed"),
     ] = None
     ingredient_availability: Annotated[
-        OutsourcedPurchaseOrderIngredientAvailability | None,
+        Mapped[OutsourcedPurchaseOrderIngredientAvailability | None],
         Field(description="Current availability status of this ingredient"),
     ] = None
     ingredient_expected_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(
             description="Expected date when ingredient will be available if currently unavailable"
         ),
     ] = None
     batch_transactions: Annotated[
-        list[BatchTransaction3] | None,
+        Mapped[list[BatchTransaction3] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Batch tracking transactions for this ingredient consumption",
         ),
     ] = None
     cost: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(description="Total cost of this ingredient for the manufacturing order"),
     ] = None
     total_consumed_quantity: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(description="Total quantity consumed so far from this ingredient"),
     ] = None
     total_remaining_quantity: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(description="Remaining quantity needed from this ingredient"),
     ] = None
-    manufacturing_order: Optional["CachedManufacturingOrder"] = Relationship(
+    manufacturing_order: Mapped[Optional["CachedManufacturingOrder"]] = Relationship(
         back_populates="recipe_rows"
     )
 
@@ -1041,123 +1044,130 @@ class CachedManufacturingOrder(DeletableEntity, table=True):
     __tablename__ = "manufacturing_order"
     model_config = ConfigDict(frozen=False)
 
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+    id: Annotated[
+        Mapped[int], SQLField(primary_key=True, description="Unique identifier")
+    ]
 
     status: Annotated[
-        ManufacturingOrderStatus | None,
+        Mapped[ManufacturingOrderStatus | None],
         Field(description="Current production status of the manufacturing order"),
     ] = None
     order_no: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(
             description="Unique manufacturing order number for tracking and reference"
         ),
     ] = None
     variant_id: Annotated[
-        int | None, Field(description="ID of the product variant being manufactured")
+        Mapped[int | None],
+        Field(description="ID of the product variant being manufactured"),
     ] = None
     planned_quantity: Annotated[
-        float | None, Field(description="Originally planned quantity to produce")
+        Mapped[float | None],
+        Field(description="Originally planned quantity to produce"),
     ] = None
     actual_quantity: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(description="Actual quantity produced, null if production not completed"),
     ] = None
     completed_quantity: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="Total quantity completed so far (including partial completions)"
         ),
     ] = None
     remaining_quantity: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(description="Remaining quantity to produce (planned - completed)"),
     ] = None
     includes_partial_completions: Annotated[
-        bool | None,
+        Mapped[bool | None],
         Field(description="Whether this order has been partially completed"),
     ] = None
     batch_transactions: Annotated[
-        list[BatchTransaction] | None,
+        Mapped[list[BatchTransaction] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Batch transactions for produced items, typically one transaction per manufacturing order",
         ),
     ] = None
     location_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(description="ID of the factory location where production takes place"),
     ] = None
     order_created_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Date and time when the manufacturing order was created"),
     ] = None
     production_deadline_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Target deadline for completing production"),
     ] = None
     done_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Timestamp when the manufacturing order was completed"),
     ] = None
     additional_info: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(description="Optional notes or additional information about the order"),
     ] = None
     is_linked_to_sales_order: Annotated[
-        bool | None,
+        Mapped[bool | None],
         Field(
             description="Whether this manufacturing order is linked to a sales order"
         ),
     ] = None
     ingredient_availability: Annotated[
-        OutsourcedPurchaseOrderIngredientAvailability | None,
+        Mapped[OutsourcedPurchaseOrderIngredientAvailability | None],
         Field(
             description="Status of material ingredient availability for production",
         ),
     ] = None
     total_cost: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="Total cost of the manufacturing order including all materials and operations"
         ),
     ] = None
     total_actual_time: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(description="Total actual time spent on production operations"),
     ] = None
     total_planned_time: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(description="Total planned time for all production operations"),
     ] = None
     sales_order_id: Annotated[
-        int | None, Field(description="ID of the linked sales order, if applicable")
+        Mapped[int | None],
+        Field(description="ID of the linked sales order, if applicable"),
     ] = None
     sales_order_row_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(description="ID of the specific sales order row, if applicable"),
     ] = None
     sales_order_delivery_deadline: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Delivery deadline from the linked sales order"),
     ] = None
     material_cost: Annotated[
-        float | None, Field(description="Total cost of materials used in production")
+        Mapped[float | None],
+        Field(description="Total cost of materials used in production"),
     ] = None
     subassemblies_cost: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(description="Total cost of subassemblies used in production"),
     ] = None
     operations_cost: Annotated[
-        float | None, Field(description="Total cost of production operations and labor")
+        Mapped[float | None],
+        Field(description="Total cost of production operations and labor"),
     ] = None
     serial_numbers: Annotated[
-        list[SerialNumber] | None,
+        Mapped[list[SerialNumber] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Serial numbers assigned to produced items",
         ),
     ] = None
-    recipe_rows: list["CachedManufacturingOrderRecipeRow"] = Relationship(
+    recipe_rows: Mapped[list["CachedManufacturingOrderRecipeRow"]] = Relationship(
         back_populates="manufacturing_order"
     )

--- a/katana_public_api_client/models_pydantic/_generated/purchase_orders.py
+++ b/katana_public_api_client/models_pydantic/_generated/purchase_orders.py
@@ -18,6 +18,7 @@ from sqlmodel import (
 )
 
 from katana_public_api_client.models_pydantic._base import KatanaPydanticBase
+from katana_public_api_client.models_pydantic._mapped_shim import Mapped
 from katana_public_api_client.models_pydantic._pydantic_json import PydanticJSON
 
 from .base import DeletableEntity
@@ -872,100 +873,107 @@ class CachedPurchaseOrderRow(DeletableEntity, table=True):
     __tablename__ = "purchase_order_row"
     model_config = ConfigDict(frozen=False)
 
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+    id: Annotated[
+        Mapped[int], SQLField(primary_key=True, description="Unique identifier")
+    ]
 
     quantity: Annotated[
-        float | None, Field(description="The quantity of items for the order line.")
+        Mapped[float | None],
+        Field(description="The quantity of items for the order line."),
     ] = None
     variant_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(description="ID of product or material variant added to the order line."),
     ] = None
     tax_rate_id: Annotated[
-        int | None, Field(description="ID of tax added to price per unit.")
+        Mapped[int | None], Field(description="ID of tax added to price per unit.")
     ] = None
     price_per_unit: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="The sales price of one unit (excluding taxes) in sales order currency."
         ),
     ] = None
     price_per_unit_in_base_currency: Annotated[
-        float | None, Field(description="Unit price converted to the base currency")
+        Mapped[float | None],
+        Field(description="Unit price converted to the base currency"),
     ] = None
     purchase_uom_conversion_rate: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="The conversion rate between the purchase and stock tracking UoMs."
         ),
     ] = None
     purchase_uom: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(
             description="The unit used to measure the quantity of the items (e.g. pcs, kg, m) you purchase. It can be different\nfrom the unit used to track stock.\n"
         ),
     ] = None
     currency: Annotated[
-        str | None, Field(description="Currency used for this line item pricing")
+        Mapped[str | None],
+        Field(description="Currency used for this line item pricing"),
     ] = None
     conversion_rate: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="Currency rate used to convert from purchase order currency into factory base currency."
         ),
     ] = None
     total: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="The total value of the purchase order row (excluding taxes) in purchase order currency."
         ),
     ] = None
     total_in_base_currency: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="The total value of the purchase order row (excluding taxes) in base currency."
         ),
     ] = None
     conversion_date: Annotated[
-        datetime | None, Field(description="The date of the conversion rate used.")
+        Mapped[datetime | None],
+        Field(description="The date of the conversion rate used."),
     ] = None
     received_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(
             description="The date when the items on the purchase order row were received to your stock."
         ),
     ] = None
     arrival_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(
             description="The timestamp when the item on the row is expected to arrive (in full) in your warehouse. ISO 8601\nformat with time and timezone must be used.\n"
         ),
     ] = None
     batch_transactions: Annotated[
-        list[BatchTransaction4] | None,
+        Mapped[list[BatchTransaction4] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="An array of batch transactions and their quantities. You can receive stock for the same item in multiple\nbatches.\n",
         ),
     ] = None
     purchase_order_id: Annotated[
-        int | None,
+        Mapped[int | None],
         SQLField(
             foreign_key="purchase_order.id",
             description="Unique identifier of the parent purchase order",
         ),
     ] = None
     landed_cost: Annotated[
-        str | float | None,
+        Mapped[str | float | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Total landed cost including shipping, duties, and other charges",
         ),
     ] = None
     group_id: Annotated[
-        int | None, Field(description="Grouping identifier for organizational purposes")
+        Mapped[int | None],
+        Field(description="Grouping identifier for organizational purposes"),
     ] = None
-    purchase_order: Optional["CachedPurchaseOrder"] = Relationship(
+    purchase_order: Mapped[Optional["CachedPurchaseOrder"]] = Relationship(
         back_populates="purchase_order_rows"
     )
 
@@ -974,90 +982,93 @@ class CachedPurchaseOrder(DeletableEntity, table=True):
     __tablename__ = "purchase_order"
     model_config = ConfigDict(frozen=False)
 
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+    id: Annotated[
+        Mapped[int], SQLField(primary_key=True, description="Unique identifier")
+    ]
 
     status: Annotated[
-        PurchaseOrderStatus | None, Field(description="Status of the order.")
+        Mapped[PurchaseOrderStatus | None], Field(description="Status of the order.")
     ] = None
     order_no: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(
             description="A unique, identifying string used in the UI and controlled by the user."
         ),
     ] = None
     entity_type: Annotated[
-        PurchaseOrderEntityType | None,
+        Mapped[PurchaseOrderEntityType | None],
         Field(
             description='Either "regular" or "outsourced", depending on the purchase order type.'
         ),
     ] = None
     default_group_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(description="Default grouping identifier for organizational purposes"),
     ] = None
     supplier_id: Annotated[
-        int | None, Field(description="ID of the supplier who this order belongs to.")
+        Mapped[int | None],
+        Field(description="ID of the supplier who this order belongs to."),
     ] = None
     currency: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(
             description="Currency of the purchase order. Filled with supplier currency by default."
         ),
     ] = None
     expected_arrival_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(
             description="The timestamp when the items are expected to arrive (in full) in your warehouse."
         ),
     ] = None
     order_created_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="The timestamp of creating the document."),
     ] = None
     additional_info: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(
             description="A string attached to the object to add any internal comments, links to external files, additional\ninstructions, etc.\n"
         ),
     ] = None
     location_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(description="The ID of the location to which items are received."),
     ] = None
     total: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="The total value of the order (including taxes) in purchase order currency."
         ),
     ] = None
     total_in_base_currency: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="The total value of the order (including taxes) in base currency."
         ),
     ] = None
     billing_status: Annotated[
-        PurchaseOrderBillingStatus | None,
+        Mapped[PurchaseOrderBillingStatus | None],
         Field(
             description='Indicating the status of generating the bill through accounting integration to either Xero or QuickBooks\nOnline. "PARTIALLY_BILLED" does not apply to Xero integration.\n'
         ),
     ] = None
     last_document_status: Annotated[
-        DocumentSendStatus | None,
+        Mapped[DocumentSendStatus | None],
         Field(description="Status of the last e-mail sent from (O)PO card."),
     ] = None
-    purchase_order_rows: list["CachedPurchaseOrderRow"] = Relationship(
+    purchase_order_rows: Mapped[list["CachedPurchaseOrderRow"]] = Relationship(
         back_populates="purchase_order"
     )
     supplier: Annotated[
-        Supplier | None,
+        Mapped[Supplier | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Complete supplier information for this purchase order",
         ),
     ] = None
     tracking_location_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(
             description="(cache-only) Hoisted from OutsourcedPurchaseOrder so the single ``purchase_order`` cache table can filter by tracking location without a UNION across regular/outsourced rows."
         ),

--- a/katana_public_api_client/models_pydantic/_generated/sales_orders.py
+++ b/katana_public_api_client/models_pydantic/_generated/sales_orders.py
@@ -18,6 +18,7 @@ from sqlmodel import (
 )
 
 from katana_public_api_client.models_pydantic._base import KatanaPydanticBase
+from katana_public_api_client.models_pydantic._mapped_shim import Mapped
 from katana_public_api_client.models_pydantic._pydantic_json import PydanticJSON
 
 from .base import DeletableEntity, UpdatableEntity
@@ -1279,103 +1280,111 @@ class CachedSalesOrderRow(DeletableEntity, table=True):
     __tablename__ = "sales_order_row"
     model_config = ConfigDict(frozen=False)
 
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+    id: Annotated[
+        Mapped[int], SQLField(primary_key=True, description="Unique identifier")
+    ]
 
     sales_order_id: Annotated[
-        int | None,
+        Mapped[int | None],
         SQLField(
             foreign_key="sales_order.id",
             description="ID of the sales order this row belongs to",
         ),
     ] = None
     quantity: Annotated[
-        float, Field(description="Ordered quantity of the product variant")
+        Mapped[float], Field(description="Ordered quantity of the product variant")
     ]
     variant_id: Annotated[
-        int, Field(description="ID of the product variant being ordered")
+        Mapped[int], Field(description="ID of the product variant being ordered")
     ]
     tax_rate_id: Annotated[
-        int | None, Field(description="ID of the tax rate applied to this line item")
+        Mapped[int | None],
+        Field(description="ID of the tax rate applied to this line item"),
     ] = None
     tax_rate: Annotated[
-        float | None, Field(description="Tax rate percentage applied to this line item")
+        Mapped[float | None],
+        Field(description="Tax rate percentage applied to this line item"),
     ] = None
     location_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(description="Location where the product should be picked from"),
     ] = None
     product_availability: Annotated[
-        ProductAvailability | None,
+        Mapped[ProductAvailability | None],
         Field(
             description="Current availability status of the product for this order row",
         ),
     ] = None
     product_expected_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(
             description="Expected date when the product will be available if not currently in stock"
         ),
     ] = None
     price_per_unit: Annotated[
-        float | None, Field(description="Selling price per unit in the order currency")
+        Mapped[float | None],
+        Field(description="Selling price per unit in the order currency"),
     ] = None
     price_per_unit_in_base_currency: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="Selling price per unit converted to the base company currency"
         ),
     ] = None
     total: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="Total line amount (quantity * price_per_unit) in order currency"
         ),
     ] = None
     total_in_base_currency: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(description="Total line amount converted to the base company currency"),
     ] = None
     total_discount: Annotated[
-        str | None, Field(description="Discount amount applied to this line item")
+        Mapped[str | None],
+        Field(description="Discount amount applied to this line item"),
     ] = None
     cogs_value: Annotated[
-        float | None, Field(description="Cost of goods sold value for this line item")
+        Mapped[float | None],
+        Field(description="Cost of goods sold value for this line item"),
     ] = None
     attributes: Annotated[
-        list[Attribute] | None,
+        Mapped[list[Attribute] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Custom attributes associated with this sales order row",
         ),
     ] = None
     batch_transactions: Annotated[
-        list[BatchTransaction6] | None,
+        Mapped[list[BatchTransaction6] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Batch allocations for this order row when using batch tracking",
         ),
     ] = None
     serial_numbers: Annotated[
-        list[int] | None,
+        Mapped[list[int] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Serial numbers allocated to this order row for serialized products",
         ),
     ] = None
     linked_manufacturing_order_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(
             description="ID of the manufacturing order linked to this sales order row for make-to-order items"
         ),
     ] = None
     conversion_rate: Annotated[
-        float | None, Field(description="Currency conversion rate used for this row")
+        Mapped[float | None],
+        Field(description="Currency conversion rate used for this row"),
     ] = None
     conversion_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Date when the currency conversion rate was applied"),
     ] = None
-    sales_order: Optional["CachedSalesOrder"] = Relationship(
+    sales_order: Mapped[Optional["CachedSalesOrder"]] = Relationship(
         back_populates="sales_order_rows"
     )
 
@@ -1384,156 +1393,160 @@ class CachedSalesOrder(DeletableEntity, table=True):
     __tablename__ = "sales_order"
     model_config = ConfigDict(frozen=False)
 
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+    id: Annotated[
+        Mapped[int], SQLField(primary_key=True, description="Unique identifier")
+    ]
 
     customer_id: Annotated[
-        int, Field(description="Unique identifier of the customer placing the order")
+        Mapped[int],
+        Field(description="Unique identifier of the customer placing the order"),
     ]
     order_no: Annotated[
-        str,
+        Mapped[str],
         Field(description="Unique order number for tracking and reference purposes"),
     ]
     source: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(
             description="Source system or channel where the order originated (e.g., Shopify, manual entry)"
         ),
     ] = None
     order_created_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(
             description="Date and time when the sales order was created in the system"
         ),
     ] = None
     delivery_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Requested or promised delivery date for the order"),
     ] = None
     picked_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Date when items were picked from inventory for shipment"),
     ] = None
     location_id: Annotated[
-        int,
+        Mapped[int],
         Field(
             description="Unique identifier of the fulfillment location for this order"
         ),
     ]
     status: Annotated[
-        SalesOrderStatus,
+        Mapped[SalesOrderStatus],
         Field(description="Current fulfillment status of the sales order"),
     ]
     currency: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(
             description="Currency code for the order pricing (ISO 4217 format)",
             pattern="^[A-Z]{3}$",
         ),
     ] = None
     conversion_rate: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="Exchange rate used to convert order currency to base company currency"
         ),
     ] = None
     conversion_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Date when the currency conversion rate was applied"),
     ] = None
     invoicing_status: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(description="Current invoicing status indicating billing progress"),
     ] = None
     total: Annotated[
-        float | None, Field(description="Total order amount in the order currency")
+        Mapped[float | None],
+        Field(description="Total order amount in the order currency"),
     ] = None
     total_in_base_currency: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="Total order amount converted to the company's base currency"
         ),
     ] = None
     additional_info: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(description="Additional notes or instructions for the sales order"),
     ] = None
     customer_ref: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(description="Customer's reference number or purchase order number"),
     ] = None
-    sales_order_rows: list["CachedSalesOrderRow"] = Relationship(
+    sales_order_rows: Mapped[list["CachedSalesOrderRow"]] = Relationship(
         back_populates="sales_order"
     )
     ecommerce_order_type: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(
             description="Type of ecommerce order when imported from external platforms"
         ),
     ] = None
     ecommerce_store_name: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(
             description="Name of the ecommerce store when order originated from external platforms"
         ),
     ] = None
     ecommerce_order_id: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(description="Original order ID from the external ecommerce platform"),
     ] = None
-    product_availability: Annotated[ProductAvailability | None, Field()] = None
+    product_availability: Annotated[Mapped[ProductAvailability | None], Field()] = None
     product_expected_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(
             description="Expected date when products will be available for fulfillment"
         ),
     ] = None
     ingredient_availability: Annotated[
-        OutsourcedPurchaseOrderIngredientAvailability | None,
+        Mapped[OutsourcedPurchaseOrderIngredientAvailability | None],
         Field(),
     ] = None
     ingredient_expected_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(
             description="Expected date when ingredients will be available for production"
         ),
     ] = None
     production_status: Annotated[
-        SalesOrderProductionStatus | None,
+        Mapped[SalesOrderProductionStatus | None],
         Field(
             description="Current status of production for items in this order",
         ),
     ] = None
     tracking_number: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(description="Shipping carrier tracking number for package tracking"),
     ] = None
     tracking_number_url: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(description="URL link to track the shipment on carrier website"),
     ] = None
     billing_address_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(description="Reference to the customer address used for billing"),
     ] = None
     shipping_address_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(description="Reference to the customer address used for shipping"),
     ] = None
     linked_manufacturing_order_id: Annotated[
-        int | None,
+        Mapped[int | None],
         Field(
             description="ID of the linked manufacturing order if this sales order has associated production"
         ),
     ] = None
     shipping_fee: Annotated[
-        SalesOrderShippingFee | None,
+        Mapped[SalesOrderShippingFee | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Shipping fee details for this sales order",
         ),
     ] = None
     addresses: Annotated[
-        list[SalesOrderAddress] | None,
+        Mapped[list[SalesOrderAddress] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Complete address information for billing and shipping",

--- a/katana_public_api_client/models_pydantic/_generated/stock.py
+++ b/katana_public_api_client/models_pydantic/_generated/stock.py
@@ -18,6 +18,7 @@ from sqlmodel import (
 )
 
 from katana_public_api_client.models_pydantic._base import KatanaPydanticBase
+from katana_public_api_client.models_pydantic._mapped_shim import Mapped
 from katana_public_api_client.models_pydantic._pydantic_json import PydanticJSON
 
 from .base import DeletableEntity, UpdatableEntity
@@ -929,35 +930,38 @@ class CachedStockAdjustmentRow(KatanaPydanticBase, table=True):
     model_config = ConfigDict(frozen=False)
 
     stock_adjustment_id: Annotated[
-        int | None,
+        Mapped[int | None],
         SQLField(
             foreign_key="stock_adjustment.id",
             description="(cache-only) ID of the parent row, populated by SQLAlchemy on insert.",
         ),
     ] = None
 
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+    id: Annotated[
+        Mapped[int], SQLField(primary_key=True, description="Unique identifier")
+    ]
 
     variant_id: Annotated[
-        int, Field(description="ID of the product or material variant being adjusted")
+        Mapped[int],
+        Field(description="ID of the product or material variant being adjusted"),
     ]
     quantity: Annotated[
-        float, Field(description="Quantity to adjust (positive or negative)")
+        Mapped[float], Field(description="Quantity to adjust (positive or negative)")
     ]
     cost_per_unit: Annotated[
-        float | None,
+        Mapped[float | None],
         Field(
             description="Cost per unit for this adjustment (defaults to current average cost if not specified)"
         ),
     ] = None
     batch_transactions: Annotated[
-        list[StockAdjustmentBatchTransaction] | None,
+        Mapped[list[StockAdjustmentBatchTransaction] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Optional batch-specific adjustments for tracked inventory",
         ),
     ] = None
-    stock_adjustment: Optional["CachedStockAdjustment"] = Relationship(
+    stock_adjustment: Mapped[Optional["CachedStockAdjustment"]] = Relationship(
         back_populates="stock_adjustment_rows"
     )
 
@@ -966,30 +970,32 @@ class CachedStockAdjustment(DeletableEntity, table=True):
     __tablename__ = "stock_adjustment"
     model_config = ConfigDict(frozen=False)
 
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+    id: Annotated[
+        Mapped[int], SQLField(primary_key=True, description="Unique identifier")
+    ]
 
     stock_adjustment_number: Annotated[
-        str,
+        Mapped[str],
         Field(
             description="Human-readable reference number for tracking and audit purposes"
         ),
     ]
     stock_adjustment_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Date and time when the adjustment was performed"),
     ] = None
     location_id: Annotated[
-        int,
+        Mapped[int],
         Field(description="ID of the location where the stock adjustment is performed"),
     ]
     reason: Annotated[
-        str | None, Field(description="Reason for the stock adjustment")
+        Mapped[str | None], Field(description="Reason for the stock adjustment")
     ] = None
     additional_info: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(description="Optional notes or comments about the adjustment reason"),
     ] = None
-    stock_adjustment_rows: list["CachedStockAdjustmentRow"] = Relationship(
+    stock_adjustment_rows: Mapped[list["CachedStockAdjustmentRow"]] = Relationship(
         back_populates="stock_adjustment"
     )
 
@@ -999,37 +1005,40 @@ class CachedStockTransferRow(KatanaPydanticBase, table=True):
     model_config = ConfigDict(frozen=False)
 
     stock_transfer_id: Annotated[
-        int | None,
+        Mapped[int | None],
         SQLField(
             foreign_key="stock_transfer.id",
             description="(cache-only) ID of the parent row, populated by SQLAlchemy on insert.",
         ),
     ] = None
 
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+    id: Annotated[
+        Mapped[int], SQLField(primary_key=True, description="Unique identifier")
+    ]
 
     variant_id: Annotated[
-        int,
+        Mapped[int],
         Field(description="ID of the product or material variant being transferred"),
     ]
     quantity: Annotated[
-        float, Field(description="Quantity of the variant being transferred")
+        Mapped[float], Field(description="Quantity of the variant being transferred")
     ]
     cost_per_unit: Annotated[
-        float | None, Field(description="Cost per unit for the transferred variant")
+        Mapped[float | None],
+        Field(description="Cost per unit for the transferred variant"),
     ] = None
     batch_transactions: Annotated[
-        list[BatchTransaction7] | None,
+        Mapped[list[BatchTransaction7] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Batch transaction details for batch-tracked items",
         ),
     ] = None
     deleted_at: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Nullable deletion timestamp for the row"),
     ] = None
-    stock_transfer: Optional["CachedStockTransfer"] = Relationship(
+    stock_transfer: Mapped[Optional["CachedStockTransfer"]] = Relationship(
         back_populates="stock_transfer_rows"
     )
 
@@ -1038,43 +1047,46 @@ class CachedStockTransfer(DeletableEntity, table=True):
     __tablename__ = "stock_transfer"
     model_config = ConfigDict(frozen=False)
 
-    id: Annotated[int, SQLField(primary_key=True, description="Unique identifier")]
+    id: Annotated[
+        Mapped[int], SQLField(primary_key=True, description="Unique identifier")
+    ]
 
     stock_transfer_number: Annotated[
-        str,
+        Mapped[str],
         Field(description="Human-readable reference number for tracking the transfer"),
     ]
     source_location_id: Annotated[
-        int,
+        Mapped[int],
         Field(
             description="ID of the source location where stock is being transferred from"
         ),
     ]
     target_location_id: Annotated[
-        int,
+        Mapped[int],
         Field(
             description="ID of the destination location where stock is being transferred to"
         ),
     ]
     status: Annotated[
-        str | None, Field(description="Current status of the stock transfer workflow")
+        Mapped[str | None],
+        Field(description="Current status of the stock transfer workflow"),
     ] = None
     transfer_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Date and time when the transfer was executed"),
     ] = None
     order_created_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Date and time when the transfer order was created"),
     ] = None
     expected_arrival_date: Annotated[
-        datetime | None,
+        Mapped[datetime | None],
         Field(description="Expected arrival date for the transferred stock"),
     ] = None
     additional_info: Annotated[
-        str | None,
+        Mapped[str | None],
         Field(description="Optional notes or comments about the transfer purpose"),
     ] = None
-    stock_transfer_rows: list["CachedStockTransferRow"] = Relationship(
+    stock_transfer_rows: Mapped[list["CachedStockTransferRow"]] = Relationship(
         back_populates="stock_transfer"
     )

--- a/katana_public_api_client/models_pydantic/_mapped_shim.py
+++ b/katana_public_api_client/models_pydantic/_mapped_shim.py
@@ -1,0 +1,39 @@
+"""Runtime identity shim for ``sqlalchemy.orm.Mapped``.
+
+The generated ``Cached*`` classes wrap each field type in ``Mapped[T]`` so
+type checkers see ``CachedX.field`` as ``InstrumentedAttribute[T]`` (which
+exposes ``.in_/.is_/.desc/.ilike``). At runtime, however, SQLModel +
+pydantic 2.13 reject ``Mapped[T]`` as a field type — pydantic's schema
+generator can't unwrap it, so class definition raises
+``PydanticSchemaGenerationError``.
+
+This shim resolves the conflict by being a *runtime identity* version of
+``Mapped``: at type-check time, ``Mapped`` resolves to the real
+``sqlalchemy.orm.Mapped``; at runtime, ``Mapped[T]`` returns ``T`` itself
+via ``__class_getitem__``. The generated ``Annotated[Mapped[T], Field(...)]``
+shape therefore evaluates to ``Annotated[T, Field(...)]`` at runtime —
+identical to the pre-shim behavior — while the type checker sees the
+descriptor-bearing ``Mapped[T]`` shape.
+
+Why a shim instead of natively typing fields as ``Mapped[T]``: SQLModel
+0.0.38 + pydantic 2.13 don't yet support that form, and the workarounds
+(``arbitrary_types_allowed=True`` plus per-field ``sa_type=`` overrides)
+re-implement SQLModel's existing type inference at every field. The shim
+is a 10-line solution that disappears once SQLModel ships native
+``Mapped[T]`` support.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Mapped as Mapped
+else:
+
+    class Mapped:
+        """Runtime identity — ``Mapped[T]`` returns ``T``."""
+
+        def __class_getitem__(cls, item: object) -> object:
+            return item
+
+
+__all__ = ["Mapped"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -539,7 +539,13 @@ format-check = ["format-python-check", "format-markdown-check"]
 # tests/conftest.py is excluded because it is pytest-specific support code.
 # tests/test_generate_tools_json.py is excluded because it imports a script via
 # sys.path manipulation that ty cannot resolve statically.
-typecheck = "ty check --exclude 'tests/conftest.py' --exclude 'tests/test_generate_tools_json.py' --exclude 'scripts/' --exclude 'katana_mcp_server/tests/' --exclude '.claude/worktrees/'"
+# katana_public_api_client/models_pydantic/_generated/ is excluded because ty
+# rejects the ``Annotated[Mapped[T | None], Field(...)] = None`` field shape
+# emitted by ``wrap_cache_fields_in_mapped`` (the trailing ``= None`` doesn't
+# match the declared ``Mapped[T | None]`` type), while pyright accepts it.
+# Generated files are auto-emitted; consistent exclusion across both checkers
+# matches ``pyrightconfig.json``'s existing ``_generated/`` skip.
+typecheck = "ty check --exclude 'tests/conftest.py' --exclude 'tests/test_generate_tools_json.py' --exclude 'scripts/' --exclude 'katana_mcp_server/tests/' --exclude 'katana_public_api_client/models_pydantic/_generated/' --exclude '.claude/worktrees/'"
 lint-ruff = "ruff check ."
 lint-ruff-fix = "ruff check --fix ."
 lint-yaml = "yamllint ."

--- a/scripts/generate_pydantic_models.py
+++ b/scripts/generate_pydantic_models.py
@@ -634,6 +634,10 @@ def parse_generated_file(
     classes = inject_relationship_fields(classes)
     classes = inject_json_columns(classes)
     classes = inject_extra_cache_fields(classes)
+    # ``Mapped[T]`` wrap runs LAST — earlier passes match
+    # ``Annotated[T, Field(...)]`` literally, and would not find their
+    # targets if the type was already wrapped.
+    classes = wrap_cache_fields_in_mapped(classes)
 
     print(
         f"  Found {len(imports)} imports, {len(classes)} classes, "
@@ -1324,6 +1328,85 @@ def inject_extra_cache_fields(classes: list[ClassInfo]) -> list[ClassInfo]:
     return fixed
 
 
+def wrap_cache_fields_in_mapped(classes: list[ClassInfo]) -> list[ClassInfo]:
+    """Wrap each cache class's field types in ``Mapped[...]``.
+
+    Lets foundation-file query call sites use ``CachedX.field.in_(...)``
+    without ``sqlmodel.col()`` wrappers — type checkers see ``Mapped[T]``
+    (which exposes ``.in_/.is_/.desc/.ilike``), while the runtime
+    ``Mapped`` shim makes ``Mapped[T]`` reduce to ``T`` so
+    SQLModel + pydantic schema generation is unaffected.
+
+    Operates on both ``Cached*`` siblings *and* the shared entity base
+    classes (BaseEntity, UpdatableEntity, DeletableEntity, etc.) because
+    ``Cached*`` inherits ``id`` / ``created_at`` / ``updated_at`` /
+    ``deleted_at`` / ``archived_at`` from those bases. Wrapping only the
+    Cached classes would leave the inherited fields as bare ``T`` from
+    the type checker's point of view — and those are exactly the fields
+    most query call sites filter on. The API classes that share the same
+    bases are unaffected at runtime (Mapped → identity) and only see
+    ``Mapped[T]`` typing on class-level attribute access, which no API
+    consumer relies on (instance-level access stays as ``T`` per
+    pydantic's normal field handling).
+
+    Must run **after** all field-rewrite passes (``inject_primary_key``,
+    ``inject_foreign_keys``, ``inject_json_columns``,
+    ``inject_relationship_fields``, ``inject_extra_cache_fields``).
+    Those passes match ``Annotated[T, Field(...)]`` literally; running
+    this wrap before them would leave them unable to find their targets.
+    """
+    target_class_names = {_cached_name(n) for n in CACHE_TABLES} | ENTITY_BASE_CLASSES
+    # Match 1: ``Annotated[<type>,`` — wraps the column-field type. Type
+    # captures any chars that aren't ``,[]`` PLUS up to two levels of
+    # balanced brackets, covering ``list["X"]``, ``dict[str, list[int]]``,
+    # ``Optional[list["X"]]``. Multi-line tolerant; relationship fields
+    # (no ``Annotated[`` shape) are naturally skipped. Three-level nesting
+    # is not handled — see the post-substitution assertion below.
+    inner_balanced = r"(?:[^\[\]]|\[[^\[\]]*\])*"
+    annotated_pattern = re.compile(
+        rf"(Annotated\[\s*)((?:[^,\[\]]|\[{inner_balanced}\])+?)(\s*,)"
+    )
+    # Match 2: relationship-field annotations of shape
+    # ``    name: <type> = Relationship(...)`` — wraps the relationship
+    # type so ``selectinload(Cached*.<rel>)`` type-checks without a
+    # ``cast(QueryableAttribute, ...)``. SQLAlchemy 2.0 docs canonically
+    # type relationships as ``Mapped[List[X]]`` / ``Mapped[Optional[X]]``,
+    # so this brings the generated form into line.
+    relationship_pattern = re.compile(
+        rf"(^\s+\w+:\s+)((?:[^=\n\[\]]|\[{inner_balanced}\])+?)(\s*=\s*Relationship\()",
+        re.MULTILINE,
+    )
+    # Safety net: any ``Annotated[`` that survives substitution without
+    # ``Mapped[`` immediately inside is a missed wrap (e.g., a field
+    # whose type uses bracket nesting deeper than the regex handles).
+    # Crash loud rather than emit silently-untyped class fields.
+    # ``\s*+`` is the atomic (no-backtrack) variant; without it the
+    # negative lookahead would let the engine reconsider shorter
+    # whitespace runs and falsely match already-wrapped fields.
+    unwrapped_annotated = re.compile(r"\bAnnotated\[\s*+(?!Mapped\[)")
+    fixed = []
+    for cls in classes:
+        if cls.name not in target_class_names:
+            fixed.append(cls)
+            continue
+        new_source = annotated_pattern.sub(r"\1Mapped[\2]\3", cls.source)
+        new_source = relationship_pattern.sub(r"\1Mapped[\2]\3", new_source)
+        if unwrapped_annotated.search(new_source):
+            sample = unwrapped_annotated.search(new_source)
+            assert sample is not None  # for type-checkers
+            line_no = new_source.count("\n", 0, sample.start()) + 1
+            msg = (
+                f"wrap_cache_fields_in_mapped: missed an Annotated[ "
+                f"on {cls.name} (line {line_no} of class body). The "
+                f"field's type likely has nesting deeper than the "
+                f"two-level regex handles — extend ``inner_balanced`` "
+                f"or refactor the field shape."
+            )
+            raise GenerationError(msg)
+        fixed.append(cls.with_source(new_source))
+    return fixed
+
+
 def inject_json_columns(classes: list[ClassInfo]) -> list[ClassInfo]:
     """Annotate specified list fields with ``sa_column=Column(JSON)``.
 
@@ -1504,6 +1587,19 @@ def generate_module_imports(
             import_lines.append(
                 "from katana_public_api_client.models_pydantic._pydantic_json import PydanticJSON"
             )
+
+    # ``Mapped`` shim import: cache-table modules and the base module
+    # both need it. ``wrap_cache_fields_in_mapped`` wraps fields on every
+    # ``Cached*`` class *and* on the shared entity base classes
+    # (BaseEntity, DeletableEntity, etc.), so ``base.py`` ships the
+    # shim too even though it has no ``table=True`` classes itself.
+    has_mapped_targets = any(
+        cls.name in (cached_class_names | ENTITY_BASE_CLASSES) for cls in classes
+    )
+    if has_mapped_targets:
+        import_lines.append(
+            "from katana_public_api_client.models_pydantic._mapped_shim import Mapped"
+        )
 
     # #342: any module whose classes had AwareDatetime swapped for plain
     # datetime needs the stdlib datetime import. Applies to both cache-table

--- a/tests/test_generate_pydantic_postprocess.py
+++ b/tests/test_generate_pydantic_postprocess.py
@@ -1,0 +1,184 @@
+"""Regression tests for the generate_pydantic_models.py post-processors.
+
+The post-processors transform datamodel-codegen output into the final
+``Cached*`` SQLModel classes. These tests pin the rewrite behavior so a
+future codegen tooling change that subtly shifts the generated text
+pattern doesn't silently disable the transform.
+
+Loads ``scripts/generate_pydantic_models.py`` via ``importlib`` so the
+test doesn't need ``sys.path`` manipulation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent / "scripts" / "generate_pydantic_models.py"
+)
+
+
+def _load_module() -> ModuleType:
+    import sys
+
+    name = "generate_pydantic_under_test"
+    spec = importlib.util.spec_from_file_location(name, _SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load module from {_SCRIPT_PATH}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    # Register in ``sys.modules`` so ``@dataclass`` (and any other
+    # decorator that looks up ``sys.modules[cls.__module__]``) can find
+    # the loader-attached classes during class-body execution.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gen() -> ModuleType:
+    return _load_module()
+
+
+def _make_cls(gen: ModuleType, name: str, body: str) -> Any:
+    """Build a ClassInfo with the given body wrapped in a class header."""
+    source = f"class {name}(DeletableEntity, table=True):\n{body}"
+    return gen.ClassInfo(
+        name=name,
+        source=source,
+        bases=["DeletableEntity"],
+        line_start=1,
+        line_end=source.count("\n") + 1,
+    )
+
+
+# ─── wrap_cache_fields_in_mapped ────────────────────────────────────────
+
+
+def test_wrap_simple_scalar(gen: ModuleType) -> None:
+    """Bare scalar field → ``Annotated[Mapped[int], Field(...)]``."""
+    # ``CACHE_TABLES`` is a dict keyed by un-prefixed entity name; pick
+    # any real cache class so ``_cached_name`` resolves it for the pass.
+    name = next(iter(gen.CACHE_TABLES))
+    cached_name = gen._cached_name(name)
+    cls = _make_cls(
+        gen,
+        cached_name,
+        '    id: Annotated[int, SQLField(primary_key=True, description="x")]\n',
+    )
+    [out] = gen.wrap_cache_fields_in_mapped([cls])
+    assert "Annotated[Mapped[int], SQLField(" in out.source
+
+
+def test_wrap_union(gen: ModuleType) -> None:
+    """Union (``T | None``) types are wrapped intact."""
+    name = next(iter(gen.CACHE_TABLES))
+    cached_name = gen._cached_name(name)
+    cls = _make_cls(
+        gen,
+        cached_name,
+        '    deleted_at: Annotated[datetime | None, Field(description="x")] = None\n',
+    )
+    [out] = gen.wrap_cache_fields_in_mapped([cls])
+    assert "Mapped[datetime | None]" in out.source
+
+
+def test_wrap_single_bracket_generic(gen: ModuleType) -> None:
+    """Single-level generic (``list["X"]``) is wrapped correctly."""
+    name = next(iter(gen.CACHE_TABLES))
+    cached_name = gen._cached_name(name)
+    cls = _make_cls(
+        gen,
+        cached_name,
+        '    rows: Annotated[list["RowSchema"], Field(description="x")] = None\n',
+    )
+    [out] = gen.wrap_cache_fields_in_mapped([cls])
+    assert 'Mapped[list["RowSchema"]]' in out.source
+
+
+def test_wrap_two_level_generic(gen: ModuleType) -> None:
+    """Two-level generic (``Optional[list["X"]]``) — the regex's documented depth limit."""
+    name = next(iter(gen.CACHE_TABLES))
+    cached_name = gen._cached_name(name)
+    cls = _make_cls(
+        gen,
+        cached_name,
+        '    items: Annotated[Optional[list["X"]], Field(description="x")] = None\n',
+    )
+    [out] = gen.wrap_cache_fields_in_mapped([cls])
+    assert 'Mapped[Optional[list["X"]]]' in out.source
+
+
+def test_wrap_relationship(gen: ModuleType) -> None:
+    """Relationship fields get ``Mapped[]`` on the outer type."""
+    name = next(iter(gen.CACHE_TABLES))
+    cached_name = gen._cached_name(name)
+    cls = _make_cls(
+        gen,
+        cached_name,
+        '    rows: list["CachedRow"] = Relationship(back_populates="parent")\n',
+    )
+    [out] = gen.wrap_cache_fields_in_mapped([cls])
+    assert 'Mapped[list["CachedRow"]] = Relationship(' in out.source
+
+
+def test_skips_non_cache_class(gen: ModuleType) -> None:
+    """Non-cache classes are left untouched."""
+    cls = gen.ClassInfo(
+        name="NotACache",
+        source=(
+            "class NotACache(KatanaPydanticBase):\n"
+            '    id: Annotated[int, Field(description="x")]\n'
+        ),
+        bases=["KatanaPydanticBase"],
+        line_start=1,
+        line_end=2,
+    )
+    [out] = gen.wrap_cache_fields_in_mapped([cls])
+    assert "Mapped[" not in out.source
+    assert out.source == cls.source
+
+
+def test_includes_entity_base_classes(gen: ModuleType) -> None:
+    """Shared entity bases (BaseEntity, DeletableEntity, etc.) get wrapping
+    too — without this, inherited ``deleted_at`` / ``created_at`` would
+    stay un-wrapped and call sites would still need ``col()``."""
+    base_name = next(iter(gen.ENTITY_BASE_CLASSES))
+    cls = gen.ClassInfo(
+        name=base_name,
+        source=(
+            f"class {base_name}(KatanaPydanticBase):\n"
+            '    deleted_at: Annotated[datetime | None, Field(description="x")] = None\n'
+        ),
+        bases=["KatanaPydanticBase"],
+        line_start=1,
+        line_end=2,
+    )
+    [out] = gen.wrap_cache_fields_in_mapped([cls])
+    assert "Mapped[datetime | None]" in out.source
+
+
+def test_raises_on_unwrappable_deep_nesting(gen: ModuleType) -> None:
+    """Three-level nesting exceeds the regex depth → assertion fires.
+
+    Pin the failure mode: the regex handles up to two levels of bracket
+    nesting (``Optional[list[X]]`` works, ``dict[str, dict[int, list[X]]]``
+    doesn't). Rather than silently emit unwrapped fields, the pass
+    raises ``GenerationError`` so a future spec addition that introduces
+    this shape is caught immediately.
+    """
+    name = next(iter(gen.CACHE_TABLES))
+    cached_name = gen._cached_name(name)
+    cls = _make_cls(
+        gen,
+        cached_name,
+        # Three levels: dict -> list -> dict
+        '    nested: Annotated[dict[str, list[dict[int, str]]], Field(description="x")]\n',
+    )
+    with pytest.raises(gen.GenerationError, match="missed an Annotated"):
+        gen.wrap_cache_fields_in_mapped([cls])

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

The generator now emits `Mapped[T]` on every cache-table field type. Type checkers see `CachedX.field` as `InstrumentedAttribute[T]` (with `.in_/.is_/.desc/.ilike`), so the **36 `sqlmodel.col()` wrappers** and **4 `cast(QueryableAttribute, ...)` calls** that landed in #624 are no longer needed and have been removed.

Closes the `Mapped[T]` thread (originally tracked in #625, closed as won't-do; this PR resurrects it via a different mechanism the original spike missed).

## How the runtime stays unchanged

The new `katana_public_api_client/models_pydantic/_mapped_shim.py` defines `Mapped` two ways:
- Under `TYPE_CHECKING`: `from sqlalchemy.orm import Mapped as Mapped` — the real one.
- At runtime: a tiny class whose `__class_getitem__` returns its argument unchanged.

So `Annotated[Mapped[int], Field(...)]` evaluates to `Annotated[int, Field(...)]` at class-definition time — exactly what SQLModel + pydantic 2.13 want. **Zero behavior change.**

This approach was surfaced by the research follow-up after #625's initial spike landed on the verbose `if TYPE_CHECKING / else` form. Sources: SQLModel discussion [#1016](https://github.com/fastapi/sqlmodel/discussions/1016) and roman.pt's `pydantic-in-sqlalchemy-fields` post.

## What changed

**`scripts/generate_pydantic_models.py`** — new pass `wrap_cache_fields_in_mapped`:
- Runs **after** every other field-rewrite pass (those passes match `Annotated[T, Field(...)]` literally; running this wrap before would break their regexes).
- Two regex sweeps:
  - `Annotated[<type>, ...]` → `Annotated[Mapped[<type>], ...]` (column fields)
  - `field: <type> = Relationship(...)` → `field: Mapped[<type>] = Relationship(...)` (relationship fields, matching SQLAlchemy 2.0's canonical shape)
- Operates on `Cached*` siblings AND the entity base classes (BaseEntity, DeletableEntity, etc.) — without the latter, inherited fields like `deleted_at`/`created_at` would stay bare `T` for type checkers.
- Mapped shim import auto-injected into cache-table modules and `base.py`.

**`katana_mcp_server/.../foundation/*.py`** — call-site cleanup:
- Dropped 36 `col(CachedX.field)` wrappers (across 6 files).
- Dropped 4 `cast("QueryableAttribute[Any]", CachedX.<rel>)` wrappers around `selectinload` calls.
- Removed corresponding unused imports.

**`pyproject.toml`** — `ty check` now also excludes `katana_public_api_client/models_pydantic/_generated/` (matching pyrightconfig.json). Ty rejects `Annotated[Mapped[T | None], Field(...)] = None`'s trailing default; pyright accepts it. Generated files are auto-emitted, so consistent exclusion is the right call.

## Why the breaking-change marker

`feat(client)!` / `chore(client)!`: the published cache-class shape changes. Third-party consumers of the published `katana_public_api_client` package who reference `CachedX.<field>` at the class level now see `InstrumentedAttribute[T]` instead of `T`. Instance-level access is unchanged (`inst.field` is still `T` per pydantic). Most consumers won't notice; flagging per the COMMIT_STANDARDS.md "Schema and Generator Changes" rule.

## Did this fix any real bugs?

**Honest answer: no.** This is purely an ergonomics improvement on the typing layer. The runtime behavior is identical to the pre-#624 state. The win is:
- Foundation files become cleaner — `CachedX.field.in_(...)` works without col().
- New code that filters Cached* tables doesn't need to remember col() or cast(QueryableAttribute, ...).
- Convention is enforced by typing rather than by social discipline.

## Test plan

- [x] `uv run poe lint` clean (ruff + ty + yamllint)
- [x] `uv run poe check` clean (full validation)
- [x] `uv run pyright katana_mcp_server/src/` 0 errors / 1 documented warning (pre-existing)
- [x] All 3,019 tests pass
- [ ] CI (gating)

## Forward compatibility

When SQLModel ships native `Mapped[T]` support, the shim becomes redundant. Deletion is a one-line PR (`_mapped_shim.py` → `from sqlalchemy.orm import Mapped`); generator output stays the same.

Refs: #480, #488, #624, #625