### PR TITLE
feat(mcp): direct-apply rail for create_sales_order + create_manufacturing_order (#633 easy tier)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -492,6 +492,7 @@ async def create_manufacturing_order(
             "Manufacturing Order",
             confirm_request=request,
             confirm_tool="create_manufacturing_order",
+            direct_apply=True,
         )
     else:
         ui = build_order_created_ui(order_dict, "Manufacturing Order")
@@ -3389,6 +3390,7 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "manufacturing", "write"},
         annotations=_create,
         meta=UI_META,
+        direct=True,
     )
     mcp.tool(
         tags={"orders", "manufacturing", "read"},

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -426,6 +426,7 @@ async def create_sales_order(
             "Sales Order",
             confirm_request=request,
             confirm_tool="create_sales_order",
+            direct_apply=True,
         )
     else:
         ui = build_order_created_ui(order_dict, "Sales Order")
@@ -2288,6 +2289,7 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "sales", "write"},
         annotations=_create,
         meta=UI_META,
+        direct=True,
     )
     mcp.tool(tags={"orders", "sales", "read"}, annotations=_read)(list_sales_orders)
     mcp.tool(tags={"orders", "sales", "read"}, annotations=_read)(get_sales_order)

--- a/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
+++ b/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
@@ -52,7 +52,10 @@ def registered_tools() -> dict[str, object]:
 
 # Tools currently using the direct-apply rail (per ADR-0016 spike).
 DIRECT_APPLY_TOOLS = [
+    # Order creates that route through build_order_preview_ui.
     "create_purchase_order",
+    "create_sales_order",
+    "create_manufacturing_order",
     # Modification tools — every tool that returns a ModificationResponse
     # via _modification.to_tool_result is on the direct-apply rail.
     "modify_purchase_order",
@@ -70,11 +73,10 @@ DIRECT_APPLY_TOOLS = [
     "correct_purchase_order",
 ]
 
-# Tools using the SendMessage rail (default, per ADR-0015).
+# Tools still using the SendMessage rail (default, per ADR-0015). Tracked
+# for migration in #633.
 SEND_MESSAGE_APPLY_TOOLS = [
     "receive_purchase_order",
-    "create_sales_order",
-    "create_manufacturing_order",
     "create_stock_transfer",
     "create_stock_adjustment",
     "update_stock_adjustment",


### PR DESCRIPTION
## Summary

Easy tier of #633's Phase 2 remainder — `create_sales_order` and `create_manufacturing_order` move from the SendMessage rail to the direct-apply rail.

`build_order_preview_ui` already gained `direct_apply: bool` support in #612 (Phase 1 spike for `create_purchase_order`), so SO and MO `create_*` tools just need their call sites to opt in and their registrations to switch to `direct=True` coaching. ~9 lines of actual change.

## What's left after this

`SEND_MESSAGE_APPLY_TOOLS` shrinks from 8 → 6 tools. Remaining migration tracked in #633:

- **Medium tier** — extend `build_receipt_ui` + `build_fulfill_preview_ui` with `direct_apply` morph states (mirror what `build_order_preview_ui` got in #612). Tools: `receive_purchase_order`, `fulfill_order`.
- **Larger tier** — give the stock_* write tools a Prefab UI first (today they emit only markdown via `make_simple_result`), then put them on the direct rail. Tools: `create_stock_transfer`, `create_stock_adjustment`, `update_stock_adjustment`, `delete_stock_adjustment`.
- **Phase 3** — ADR-0016 + drop SendMessage-rail dead code once `SEND_MESSAGE_APPLY_TOOLS` is empty.

## Test plan

- [x] `uv run poe check` is green (3019 tests pass, +0 from main since the existing parametrized coaching tests automatically pick up the new direct-rail entries via the `DIRECT_APPLY_TOOLS` allowlist)
- [x] `TestConfirmButtonDirectApplyRail` already exercises both branches of the `direct_apply` switch on `build_order_preview_ui` via the PO tests; SO and MO get the same UI builder.
- [ ] Manual smoke test on Cowork: open a `create_sales_order(preview=True)` and a `create_manufacturing_order(preview=True)`, click Confirm, verify (a) the iframe morphs in place and (b) the agent's next response references the new order's `id` / `katana_url` without re-issuing the tool.

## References

- #612 — Phase 1 spike (created `direct_apply` support on `build_order_preview_ui`)
- #615 — Phase 2 partial (direct rail for every tool returning ModificationResponse)
- #633 — umbrella tracking remaining migration + Phase 3 cleanup
- ADR-0015 (current rail, will be superseded in Phase 3): `docs/adr/0015-confirmation-pattern-for-write-tools.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)