### PR TITLE
chore: complete MCP test typecheck cleanup + wire pyright into CI (#480 Phase B + #626)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,34 @@ questions** — they are faster, more accurate, and cross-reference the real typ
   fastmcp), the langserver is stale — flag to the user that Claude Code needs a restart
   to re-read `pyrightconfig.json`. All project-internal imports should always resolve.
 
+### Handling `<new-diagnostics>` system reminders
+
+After each edit, the harness may surface a `<new-diagnostics>` block listing
+pyright/ruff diagnostics on the file. **Treat these as real until proven otherwise** —
+both pyright and ty run in CI (`uv run poe lint`), so an LSP-flagged error will likely
+break the build.
+
+The protocol when a `<new-diagnostics>` block appears:
+
+1. **Check pyright CLI on the affected file** — `uv run pyright <path>`. Pyright CLI is
+   the source of truth; the LSP can be stale (especially after generator regen,
+   stash/pop, or rebase).
+1. **If pyright CLI agrees**, fix it. Don't push code with pending pyright errors — CI
+   will fail.
+1. **If pyright CLI disagrees**, the LSP is stale. **Note it explicitly in your reply to
+   the user** ("LSP shows X but pyright CLI is clean — likely stale after regen") so
+   they know whether their editor needs a restart. Do NOT silently move on without
+   verifying.
+1. **Stale-LSP common triggers** — running `uv run poe generate-pydantic`, rebasing onto
+   main, or stashing & popping. Pyright re-indexes lazily; the system reminder may show
+   pre-edit state until the next save.
+
+The repo's house rule (no `# type: ignore` / `# noqa`) means **a real diagnostic is
+always a fix, never a suppression**. If the diagnostic is wrong (third-party stub gap),
+document the rationale and use a config-level rule override in `pyrightconfig.json`
+(already done for `reportIncompatibleVariableOverride` and `reportAssignmentType` — see
+`sync_state.py`).
+
 ## Architecture Overview
 
 **Monorepo with 3 packages:**

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
@@ -48,17 +48,19 @@ class CreateProductRequest(BaseModel):
     uom: str = Field(
         default="pcs", description="Unit of measure (e.g., pcs, kg, hours)"
     )
-    category_name: str | None = Field(None, description="Category for grouping")
-    is_sellable: bool = Field(True, description="Whether product can be sold")
-    is_producible: bool = Field(False, description="Can be manufactured")
-    is_purchasable: bool = Field(True, description="Can be purchased")
-    sales_price: float | None = Field(None, description="Sales price per unit")
-    purchase_price: float | None = Field(None, description="Purchase cost per unit")
+    category_name: str | None = Field(default=None, description="Category for grouping")
+    is_sellable: bool = Field(default=True, description="Whether product can be sold")
+    is_producible: bool = Field(default=False, description="Can be manufactured")
+    is_purchasable: bool = Field(default=True, description="Can be purchased")
+    sales_price: float | None = Field(default=None, description="Sales price per unit")
+    purchase_price: float | None = Field(
+        default=None, description="Purchase cost per unit"
+    )
     default_supplier_id: int | None = Field(
-        None,
+        default=None,
         description=("Default supplier ID. Look up via `list_suppliers`."),
     )
-    additional_info: str | None = Field(None, description="Additional notes")
+    additional_info: str | None = Field(default=None, description="Additional notes")
 
     # Variant-level fields — forwarded to the embedded CreateVariantRequest.
     # Mirror modify_item.add_variants (VariantAdd) so create/modify symmetry holds.
@@ -236,15 +238,17 @@ class CreateMaterialRequest(BaseModel):
     uom: str = Field(
         default="pcs", description="Unit of measure (e.g., pcs, kg, meters)"
     )
-    category_name: str | None = Field(None, description="Category for grouping")
-    is_sellable: bool = Field(False, description="Whether material can be sold")
-    sales_price: float | None = Field(None, description="Sales price per unit")
-    purchase_price: float | None = Field(None, description="Purchase cost per unit")
+    category_name: str | None = Field(default=None, description="Category for grouping")
+    is_sellable: bool = Field(default=False, description="Whether material can be sold")
+    sales_price: float | None = Field(default=None, description="Sales price per unit")
+    purchase_price: float | None = Field(
+        default=None, description="Purchase cost per unit"
+    )
     default_supplier_id: int | None = Field(
-        None,
+        default=None,
         description=("Default supplier ID. Look up via `list_suppliers`."),
     )
-    additional_info: str | None = Field(None, description="Additional notes")
+    additional_info: str | None = Field(default=None, description="Additional notes")
 
     # Variant-level fields — forwarded to the embedded CreateVariantRequest.
     # Mirror modify_item.add_variants (VariantAdd) so create/modify symmetry holds.

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -261,25 +261,27 @@ class CreateItemRequest(BaseModel):
     uom: str = Field(
         default="pcs", description="Unit of measure (e.g., pcs, kg, hours)"
     )
-    category_name: str | None = Field(None, description="Category for grouping")
-    is_sellable: bool = Field(True, description="Whether item can be sold")
-    sales_price: float | None = Field(None, description="Sales price per unit")
-    purchase_price: float | None = Field(None, description="Purchase cost per unit")
+    category_name: str | None = Field(default=None, description="Category for grouping")
+    is_sellable: bool = Field(default=True, description="Whether item can be sold")
+    sales_price: float | None = Field(default=None, description="Sales price per unit")
+    purchase_price: float | None = Field(
+        default=None, description="Purchase cost per unit"
+    )
 
     # Product-specific
     is_producible: bool = Field(
-        False, description="Can be manufactured (products only)"
+        default=False, description="Can be manufactured (products only)"
     )
     is_purchasable: bool = Field(
-        True, description="Can be purchased (products/materials)"
+        default=True, description="Can be purchased (products/materials)"
     )
 
     # Optional common fields
     default_supplier_id: int | None = Field(
-        None,
+        default=None,
         description=("Default supplier ID. Look up via `list_suppliers`."),
     )
-    additional_info: str | None = Field(None, description="Additional notes")
+    additional_info: str | None = Field(default=None, description="Additional notes")
 
     # Variant-level fields — apply only when type is product or material.
     # Services carry pricing on the header; these fields are ignored for type=service.

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -122,15 +122,17 @@ class PurchaseOrderItem(BaseModel):
     quantity: float = Field(..., description="Quantity to order", gt=0)
     price_per_unit: float = Field(..., description="Unit price")
     tax_rate_id: int | None = Field(
-        None,
+        default=None,
         description=("Tax rate ID (optional). Look up via `list_tax_rates`."),
     )
-    purchase_uom: str | None = Field(None, description="Purchase unit of measure")
+    purchase_uom: str | None = Field(
+        default=None, description="Purchase unit of measure"
+    )
     purchase_uom_conversion_rate: float | None = Field(
-        None, description="Conversion rate for purchase UOM"
+        default=None, description="Conversion rate for purchase UOM"
     )
     arrival_date: datetime | None = Field(
-        None,
+        default=None,
         description=(
             "Expected arrival date — ISO 8601 date or datetime "
             "(e.g. '2026-05-08' or '2026-05-08T14:30:00Z')"
@@ -155,14 +157,16 @@ class CreatePurchaseOrderRequest(BaseModel):
     )
     order_number: str = Field(..., description="Purchase order number")
     items: list[PurchaseOrderItem] = Field(..., description="Line items", min_length=1)
-    notes: str | None = Field(None, description="Order notes (additional_info)")
-    currency: str | None = Field(None, description="Currency code (e.g., USD, EUR)")
+    notes: str | None = Field(default=None, description="Order notes (additional_info)")
+    currency: str | None = Field(
+        default=None, description="Currency code (e.g., USD, EUR)"
+    )
     status: Literal["DRAFT", "NOT_RECEIVED"] | None = Field(
-        None,
+        default=None,
         description="Initial status — 'DRAFT' or 'NOT_RECEIVED' (default: NOT_RECEIVED)",
     )
     entity_type: PurchaseOrderEntityType | None = Field(
-        None,
+        default=None,
         description=(
             "Type of purchase order. 'regular' (default) buys raw materials or "
             "finished goods from a supplier; 'outsourced' tracks subcontractor "
@@ -171,7 +175,7 @@ class CreatePurchaseOrderRequest(BaseModel):
         ),
     )
     order_created_date: datetime | None = Field(
-        None,
+        default=None,
         description=(
             "Date the order was placed. Leave None to let Katana stamp the "
             "current time server-side; supply a value for back-fills (e.g. "
@@ -180,7 +184,7 @@ class CreatePurchaseOrderRequest(BaseModel):
         ),
     )
     expected_arrival_date: datetime | None = Field(
-        None,
+        default=None,
         description=(
             "Expected full-arrival date for the order. Distinct from per-row "
             "`arrival_date` — this is the order-level estimate; row-level "
@@ -188,14 +192,14 @@ class CreatePurchaseOrderRequest(BaseModel):
         ),
     )
     tracking_location_id: int | None = Field(
-        None,
+        default=None,
         description=(
             "Location ID for tracking outsourced orders. Required when "
             "`entity_type='outsourced'`. Look up via `list_locations`."
         ),
     )
     preview: bool = Field(
-        True,
+        default=True,
         description="If true (default), returns preview. If false, creates order.",
     )
 
@@ -484,7 +488,7 @@ class ReceiveItemRequest(BaseModel):
     purchase_order_row_id: int = Field(..., description="Purchase order row ID")
     quantity: float = Field(..., description="Quantity to receive", gt=0)
     received_date: datetime | None = Field(
-        None,
+        default=None,
         description=(
             "Optional ISO 8601 timestamp for when the items were actually "
             "received. Defaults to the time of the call, which is wrong for "
@@ -493,7 +497,7 @@ class ReceiveItemRequest(BaseModel):
         ),
     )
     batch_transactions: list[ReceiveBatchTransaction] | None = Field(
-        None,
+        default=None,
         description=(
             "Optional batch allocations for this row. Required when the "
             "underlying material is batch-tracked — without it the receive "
@@ -531,7 +535,7 @@ class ReceivePurchaseOrderRequest(BaseModel):
         ..., description="Items to receive", min_length=1
     )
     preview: bool = Field(
-        True,
+        default=True,
         description="If true (default), returns preview. If false, receives items.",
     )
 
@@ -1497,7 +1501,7 @@ class DocumentItem(BaseModel):
 
     sku: str = Field(..., description="Item SKU from document")
     quantity: float = Field(..., description="Quantity from document")
-    unit_price: float | None = Field(None, description="Price from document")
+    unit_price: float | None = Field(default=None, description="Price from document")
 
 
 class MatchResult(BaseModel):
@@ -1505,7 +1509,7 @@ class MatchResult(BaseModel):
 
     sku: str = Field(..., description="Item SKU")
     quantity: float = Field(..., description="Matched quantity")
-    unit_price: float | None = Field(None, description="Matched price")
+    unit_price: float | None = Field(default=None, description="Matched price")
     status: str = Field(
         ...,
         description="Match status (perfect, quantity_diff, price_diff, both_diff)",
@@ -1525,8 +1529,10 @@ class Discrepancy(BaseModel):
 
     sku: str = Field(..., description="Item SKU")
     type: DiscrepancyType = Field(..., description="Type of discrepancy")
-    expected: float | None = Field(None, description="Expected value (from PO)")
-    actual: float | None = Field(None, description="Actual value (from document)")
+    expected: float | None = Field(default=None, description="Expected value (from PO)")
+    actual: float | None = Field(
+        default=None, description="Actual value (from document)"
+    )
     message: str = Field(..., description="Human-readable description")
 
 

--- a/katana_mcp_server/src/katana_mcp/unpack.py
+++ b/katana_mcp_server/src/katana_mcp/unpack.py
@@ -11,7 +11,7 @@ Usage:
 
     class MyRequest(BaseModel):
         name: str = Field(..., description="Item name")
-        limit: int = Field(10, description="Max results")
+        limit: int = Field(default=10, description="Max results")
 
     @unpack_pydantic_params
     async def my_tool(

--- a/katana_mcp_server/tests/conftest.py
+++ b/katana_mcp_server/tests/conftest.py
@@ -174,24 +174,35 @@ async def context_with_typed_cache(typed_cache_engine):
 
 
 @pytest.fixture
-def mock_get_purchase_order():
-    """Fixture for mocking get_purchase_order API call."""
+def mock_get_purchase_order(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Fixture for mocking get_purchase_order API call.
+
+    Uses ``monkeypatch.setattr`` so pytest restores the original function
+    after the test — without it, the mock would leak across the rest of
+    the suite (especially under xdist) and produce ordering-dependent
+    flakes for any test that hits the real endpoint or installs a
+    different mock.
+    """
     from katana_public_api_client.api.purchase_order import (
         get_purchase_order as api_get_purchase_order,
     )
 
     mock_api = AsyncMock()
-    api_get_purchase_order.asyncio_detailed = mock_api
+    monkeypatch.setattr(api_get_purchase_order, "asyncio_detailed", mock_api)
     return mock_api
 
 
 @pytest.fixture
-def mock_receive_purchase_order():
-    """Fixture for mocking receive_purchase_order API call."""
+def mock_receive_purchase_order(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Fixture for mocking receive_purchase_order API call.
+
+    Uses ``monkeypatch.setattr`` so pytest restores the original function
+    after the test — see ``mock_get_purchase_order`` for the rationale.
+    """
     from katana_public_api_client.api.purchase_order import (
         receive_purchase_order as api_receive_purchase_order,
     )
 
     mock_api = AsyncMock()
-    api_receive_purchase_order.asyncio_detailed = mock_api
+    monkeypatch.setattr(api_receive_purchase_order, "asyncio_detailed", mock_api)
     return mock_api

--- a/katana_mcp_server/tests/factories.py
+++ b/katana_mcp_server/tests/factories.py
@@ -34,6 +34,7 @@ from katana_public_api_client.models_pydantic._generated import (
     CachedStockTransfer,
     CachedStockTransferRow,
     ManufacturingOrderStatus,
+    PurchaseOrderBillingStatus,
     PurchaseOrderEntityType,
     PurchaseOrderStatus,
     SalesOrderProductionStatus,
@@ -329,7 +330,7 @@ def make_purchase_order(
     order_no: str = "PO-TEST",
     entity_type: PurchaseOrderEntityType | str = "regular",
     status: PurchaseOrderStatus | str | None = None,
-    billing_status: str | None = None,
+    billing_status: PurchaseOrderBillingStatus | str | None = None,
     supplier_id: int | None = 4001,
     location_id: int | None = 1,
     tracking_location_id: int | None = None,
@@ -361,13 +362,18 @@ def make_purchase_order(
         if isinstance(status, str)
         else (status if status is not None else PurchaseOrderStatus.not_received)
     )
+    resolved_billing_status = (
+        PurchaseOrderBillingStatus(billing_status)
+        if isinstance(billing_status, str)
+        else billing_status
+    )
 
     cached = CachedPurchaseOrder(
         id=id,
         order_no=order_no,
         entity_type=resolved_entity_type,
         status=resolved_status,
-        billing_status=billing_status,
+        billing_status=resolved_billing_status,
         supplier_id=supplier_id,
         location_id=location_id,
         tracking_location_id=tracking_location_id,

--- a/katana_mcp_server/tests/integration/test_error_scenarios.py
+++ b/katana_mcp_server/tests/integration/test_error_scenarios.py
@@ -26,8 +26,7 @@ from katana_mcp.tools.foundation.items import (
     _get_variant_details_impl,
     _search_items_impl,
 )
-
-from tests.conftest import create_mock_context
+from katana_mcp_server.tests.conftest import create_mock_context
 
 
 @pytest.fixture(autouse=True)

--- a/katana_mcp_server/tests/integration/test_manufacturing_workflow.py
+++ b/katana_mcp_server/tests/integration/test_manufacturing_workflow.py
@@ -158,9 +158,8 @@ class TestManufacturingOrderValidation:
         }
 
         # Preview mode - should not create
-        preview_request = CreateManufacturingOrderRequest(
-            **base_request_data,
-            preview=True,
+        preview_request = CreateManufacturingOrderRequest.model_validate(
+            {**base_request_data, "preview": True}
         )
         preview_result = await _create_manufacturing_order_impl(
             preview_request, integration_context

--- a/katana_mcp_server/tests/integration/test_purchase_order_workflow.py
+++ b/katana_mcp_server/tests/integration/test_purchase_order_workflow.py
@@ -221,9 +221,8 @@ class TestPurchaseOrderValidation:
         }
 
         # Preview mode
-        preview_request = CreatePurchaseOrderRequest(
-            **base_request_data,
-            preview=True,
+        preview_request = CreatePurchaseOrderRequest.model_validate(
+            {**base_request_data, "preview": True}
         )
         preview_result = await _create_purchase_order_impl(
             preview_request, integration_context

--- a/katana_mcp_server/tests/integration/test_utils.py
+++ b/katana_mcp_server/tests/integration/test_utils.py
@@ -280,7 +280,9 @@ async def cleanup_orphaned_test_data(client: KatanaClient) -> dict[str, int]:
     )
     from katana_public_api_client.api.material import get_all_materials
     from katana_public_api_client.api.product import get_all_products
-    from katana_public_api_client.api.purchase_order import get_all_purchase_orders
+    from katana_public_api_client.api.purchase_order import (
+        find_purchase_orders as get_all_purchase_orders,
+    )
     from katana_public_api_client.api.sales_order import get_all_sales_orders
 
     deleted_counts: dict[str, int] = {}

--- a/katana_mcp_server/tests/resources/test_inventory.py
+++ b/katana_mcp_server/tests/resources/test_inventory.py
@@ -18,8 +18,7 @@ from katana_mcp.resources.inventory import (
     get_inventory_items,
     register_resources,
 )
-
-from tests.conftest import create_mock_context
+from katana_mcp_server.tests.conftest import create_mock_context
 
 ENSURE_PRODUCTS = "katana_mcp.resources.inventory.ensure_products_synced"
 ENSURE_MATERIALS = "katana_mcp.resources.inventory.ensure_materials_synced"

--- a/katana_mcp_server/tests/test_json_string_coercion_middleware.py
+++ b/katana_mcp_server/tests/test_json_string_coercion_middleware.py
@@ -161,7 +161,7 @@ class TestMiddlewareBehavior:
             captured["args"] = c.message.arguments
             return MagicMock()
 
-        await JsonStringCoercionMiddleware().on_call_tool(ctx, call_next)
+        await JsonStringCoercionMiddleware().on_call_tool(ctx, cast(Any, call_next))
         return captured["args"]
 
     async def test_decodes_stringified_int_list(self):

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -42,11 +42,11 @@ class _StubRequest(BaseModel):
     preview: bool = True
 
 
-def _walk_view_tree(node: object) -> list[dict[str, Any]]:
+def _walk_view_tree(node: Any) -> list[dict[str, Any]]:
     """Yield every Component dict in a view tree (for test traversal)."""
     found: list[dict[str, Any]] = []
 
-    def visit(o: object) -> None:
+    def visit(o: Any) -> None:
         if isinstance(o, dict):
             if "type" in o:
                 found.append(o)
@@ -1084,6 +1084,7 @@ class TestConfirmButtonDirectApplyRail:
 
         buttons = _find_buttons_by_label(envelope, "Confirm & Create Purchase Order")
         on_click = buttons[0].get("onClick") or buttons[0].get("on_click")
+        assert on_click is not None
         # Click chain: [SetState(pending, True), CallTool(...)].
         assert on_click[0].get("action") == "setState"
         assert on_click[0].get("key") == "pending"
@@ -1320,7 +1321,11 @@ class TestBuildApplyActionXorInvariant:
         assert actions is not None
         send_messages = [a for a in actions if hasattr(a, "content")]
         assert len(send_messages) == 1
-        text = send_messages[0].content
+        # ``Action`` is a discriminated union; only some variants expose
+        # ``content``. ``hasattr`` filters at runtime, but the static type
+        # is the bare union — read via ``getattr`` to satisfy the checker.
+        text = getattr(send_messages[0], "content", None)
+        assert isinstance(text, str)
         assert text.startswith("Apply: call fulfill_order(")
         assert "order_id=42" in text
         assert "order_type='sales'" in text
@@ -1370,7 +1375,7 @@ class TestBuildApplyResultUIs:
         # Title appears verbatim somewhere in the rendered card
         text_nodes: list[str] = []
 
-        def collect(o: object) -> None:
+        def collect(o: Any) -> None:
             if isinstance(o, dict):
                 if isinstance(o.get("content"), str):
                     text_nodes.append(o["content"])
@@ -1398,7 +1403,7 @@ class TestBuildApplyResultUIs:
         envelope = app.to_json()
         text_nodes: list[str] = []
 
-        def collect(o: object) -> None:
+        def collect(o: Any) -> None:
             if isinstance(o, dict):
                 if isinstance(o.get("content"), str):
                     text_nodes.append(o["content"])
@@ -1418,7 +1423,7 @@ class TestBuildApplyResultUIs:
         assert "Check the SO's current production_status" in joined
 
 
-def _find_buttons_by_label(tree: object, label: str) -> list[dict]:
+def _find_buttons_by_label(tree: Any, label: str) -> list[dict]:
     """Walk a Prefab envelope and return every Button node whose label
     matches ``label`` exactly. Used by BLOCK-warning regression tests to
     assert the Confirm button is/isn't rendered.
@@ -1435,7 +1440,7 @@ def _find_buttons_by_label(tree: object, label: str) -> list[dict]:
     return found
 
 
-def _has_node_of_type(tree: object, node_type: str) -> bool:
+def _has_node_of_type(tree: Any, node_type: str) -> bool:
     """Return ``True`` if any node anywhere in the Prefab envelope has
     ``type == node_type``. Used by empty-state tests (#470) to assert
     that DataTable / Slot are or aren't rendered.
@@ -1449,7 +1454,7 @@ def _has_node_of_type(tree: object, node_type: str) -> bool:
     return False
 
 
-def _collect_node_content(tree: object, node_type: str) -> list[str]:
+def _collect_node_content(tree: Any, node_type: str) -> list[str]:
     """Walk a Prefab envelope and return every ``content`` string from
     nodes whose ``type`` equals ``node_type``. Used by empty-state tests
     to assert on the actual hint text rendered by ``Muted`` (rather than
@@ -1597,7 +1602,7 @@ class TestBlockWarningSuppressesConfirm:
             confirm_tool="create_manufacturing_order",
         )
 
-        def collect_badge_labels(tree: object, out: list[str]) -> None:
+        def collect_badge_labels(tree: Any, out: list[str]) -> None:
             if isinstance(tree, dict):
                 if tree.get("type") == "Badge":
                     label = tree.get("label")
@@ -1746,7 +1751,7 @@ class TestBuildModificationPreviewUI:
         envelope = app.to_json()
 
         # Find the CallTool action — it's nested under a Button's onClick.
-        def find_call_tool(tree: object) -> dict | None:
+        def find_call_tool(tree: Any) -> dict | None:
             if isinstance(tree, dict):
                 if tree.get("action") == "toolCall":
                     return tree
@@ -1854,7 +1859,7 @@ class TestBuildModificationPreviewUI:
         envelope = app.to_json()
         titles: list[str] = []
 
-        def collect_titles(o: object) -> None:
+        def collect_titles(o: Any) -> None:
             if isinstance(o, dict):
                 if o.get("type") == "CardTitle" and isinstance(o.get("content"), str):
                     titles.append(o["content"])
@@ -1896,7 +1901,7 @@ class TestBuildModificationPreviewUI:
         envelope = app.to_json()
         titles: list[str] = []
 
-        def collect_titles(o: object) -> None:
+        def collect_titles(o: Any) -> None:
             if isinstance(o, dict):
                 if o.get("type") == "CardTitle" and isinstance(o.get("content"), str):
                     titles.append(o["content"])
@@ -2034,7 +2039,7 @@ class TestBuildModificationPreviewUI:
         )
         envelope = app.to_json()
 
-        def find_action(o: object, action_name: str) -> dict[str, Any] | None:
+        def find_action(o: Any, action_name: str) -> dict[str, Any] | None:
             if isinstance(o, dict):
                 if o.get("action") == action_name:
                     return o
@@ -2114,7 +2119,7 @@ class TestBuildModificationResultUI:
         envelope = app.to_json()
         labels: list[str] = []
 
-        def collect_badges(o: object) -> None:
+        def collect_badges(o: Any) -> None:
             if isinstance(o, dict):
                 if o.get("type") == "Badge" and isinstance(o.get("label"), str):
                     labels.append(o["label"])
@@ -2156,7 +2161,7 @@ class TestBuildModificationResultUI:
         envelope = app.to_json()
         labels: list[str] = []
 
-        def collect_badges(o: object) -> None:
+        def collect_badges(o: Any) -> None:
             if isinstance(o, dict):
                 if o.get("type") == "Badge" and isinstance(o.get("label"), str):
                     labels.append(o["label"])
@@ -2237,7 +2242,7 @@ class TestBuildModificationResultUI:
         envelope = app.to_json()
         titles: list[str] = []
 
-        def collect_titles(o: object) -> None:
+        def collect_titles(o: Any) -> None:
             if isinstance(o, dict):
                 if o.get("type") == "CardTitle" and isinstance(o.get("content"), str):
                     titles.append(o["content"])

--- a/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
+++ b/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
@@ -13,12 +13,13 @@ module-level fixture; they're slower than the unit tests in
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 
 
 @pytest.fixture(scope="module")
-def registered_tools() -> dict[str, object]:
+def registered_tools() -> dict[str, Any]:
     """Boot the server once and return ``{tool_name: ToolInfo}``.
 
     Module-scoped so the (somewhat heavy) FastMCP setup runs only once
@@ -89,7 +90,7 @@ PREVIEW_BUTTON_TOOLS = DIRECT_APPLY_TOOLS + SEND_MESSAGE_APPLY_TOOLS
 
 @pytest.mark.parametrize("tool_name", PREVIEW_BUTTON_TOOLS)
 def test_preview_button_tool_has_no_renarrate_coaching(
-    registered_tools: dict[str, object], tool_name: str
+    registered_tools: dict[str, Any], tool_name: str
 ) -> None:
     """Every preview-button tool's description must include the
     "do not re-narrate" coaching (closes #544). Required for both rails.
@@ -105,7 +106,7 @@ def test_preview_button_tool_has_no_renarrate_coaching(
 
 @pytest.mark.parametrize("tool_name", SEND_MESSAGE_APPLY_TOOLS)
 def test_send_message_apply_tool_has_apply_call_coaching(
-    registered_tools: dict[str, object], tool_name: str
+    registered_tools: dict[str, Any], tool_name: str
 ) -> None:
     """SendMessage-rail tools must coach the agent to recognize the
     ``Apply: call <tool>(...)`` chat hint and re-issue.
@@ -121,7 +122,7 @@ def test_send_message_apply_tool_has_apply_call_coaching(
 
 @pytest.mark.parametrize("tool_name", DIRECT_APPLY_TOOLS)
 def test_direct_apply_tool_has_update_model_context_coaching(
-    registered_tools: dict[str, object], tool_name: str
+    registered_tools: dict[str, Any], tool_name: str
 ) -> None:
     """Direct-apply-rail tools must coach the agent that the apply result
     arrives via ``ui/update-model-context``, not via re-issue.
@@ -141,7 +142,7 @@ def test_direct_apply_tool_has_update_model_context_coaching(
 
 
 def test_read_only_tools_do_not_have_coaching(
-    registered_tools: dict[str, object],
+    registered_tools: dict[str, Any],
 ) -> None:
     """Tools with no ``preview`` parameter must NOT carry the coaching —
     the description shouldn't lie about a flow the tool doesn't expose.
@@ -230,7 +231,7 @@ DESTRUCTIVE_HINT_POLICY = [
 
 @pytest.mark.parametrize("tool_name, expected", DESTRUCTIVE_HINT_POLICY)
 def test_destructive_hint_matches_policy(
-    registered_tools: dict[str, object],
+    registered_tools: dict[str, Any],
     tool_name: str,
     expected: bool,
 ) -> None:

--- a/katana_mcp_server/tests/test_typed_cache_invalidation.py
+++ b/katana_mcp_server/tests/test_typed_cache_invalidation.py
@@ -121,6 +121,7 @@ class TestSoftDeleteSync:
         ):
             await ensure_purchase_orders_synced(MagicMock(), typed_cache_engine)
 
+        assert mock_api.call_args is not None
         assert mock_api.call_args.kwargs["include_deleted"] is True
 
     @pytest.mark.asyncio

--- a/katana_mcp_server/tests/test_unpack.py
+++ b/katana_mcp_server/tests/test_unpack.py
@@ -204,7 +204,7 @@ class TestUnpackDecorator:
         with pytest.raises(TypeError, match="must be a Pydantic BaseModel"):
 
             @unpack_pydantic_params
-            def process(request: Annotated[NotAModel, Unpack()]) -> dict:  # type: ignore
+            def process(request: Annotated[NotAModel, Unpack()]) -> dict:
                 return {}
 
     def test_field_with_factory_default(self):

--- a/katana_mcp_server/tests/tools/test_cache_admin.py
+++ b/katana_mcp_server/tests/tools/test_cache_admin.py
@@ -12,6 +12,7 @@ from katana_mcp.tools.foundation.cache_admin import (
     _rebuild_cache_impl,
 )
 from katana_mcp.typed_cache import ENTITY_SPECS, SyncState, force_resync
+from katana_mcp_server.tests.conftest import create_mock_context
 from sqlmodel import select
 
 from katana_public_api_client.models import (
@@ -25,7 +26,6 @@ from katana_public_api_client.models_pydantic._generated import (
     CachedStockAdjustment,
     CachedStockTransfer,
 )
-from tests.conftest import create_mock_context
 from tests.factories import (
     make_manufacturing_order,
     make_purchase_order,
@@ -570,9 +570,16 @@ class TestForceResyncAtomicity:
 
 class TestRequestValidation:
     def test_unknown_entity_type_fails_pydantic_validation(self):
-        """The Literal-typed ``entity_types`` field rejects unknown values."""
+        """The Literal-typed ``entity_types`` field rejects unknown values.
+
+        ``model_validate`` is used (not the constructor) so the static-checker
+        doesn't reject the bad literal — the test is *about* runtime
+        validation, not constructor type-checking.
+        """
         with pytest.raises(ValueError):
-            RebuildCacheRequest(entity_types=["not_a_real_entity"], preview=True)  # type: ignore[list-item]
+            RebuildCacheRequest.model_validate(
+                {"entity_types": ["not_a_real_entity"], "preview": True}
+            )
 
     def test_empty_entity_types_fails_pydantic_validation(self):
         """``min_length=1`` blocks empty lists at construction time."""

--- a/katana_mcp_server/tests/tools/test_catalog.py
+++ b/katana_mcp_server/tests/tools/test_catalog.py
@@ -468,25 +468,25 @@ async def test_create_material_error_handling():
 def test_create_product_requires_name():
     """Test create_product requires name field."""
     with pytest.raises(ValueError):
-        CreateProductRequest(sku="TEST-001")
+        CreateProductRequest.model_validate({"sku": "TEST-001"})
 
 
 def test_create_product_requires_sku():
     """Test create_product requires sku field."""
     with pytest.raises(ValueError):
-        CreateProductRequest(name="Test Product")
+        CreateProductRequest.model_validate({"name": "Test Product"})
 
 
 def test_create_material_requires_name():
     """Test create_material requires name field."""
     with pytest.raises(ValueError):
-        CreateMaterialRequest(sku="MAT-001")
+        CreateMaterialRequest.model_validate({"sku": "MAT-001"})
 
 
 def test_create_material_requires_sku():
     """Test create_material requires sku field."""
     with pytest.raises(ValueError):
-        CreateMaterialRequest(name="Test Material")
+        CreateMaterialRequest.model_validate({"name": "Test Material"})
 
 
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_corrections.py
+++ b/katana_mcp_server/tests/tools/test_corrections.py
@@ -21,6 +21,7 @@ from katana_mcp.tools.foundation.corrections import (
     _correct_purchase_order_impl,
     _correct_sales_order_impl,
 )
+from katana_mcp_server.tests.conftest import create_mock_context
 
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.models import (
@@ -38,7 +39,6 @@ from katana_public_api_client.models import (
     SalesOrderStatus,
     SerialNumber,
 )
-from tests.conftest import create_mock_context
 from tests.factories import mock_entity_for_modify
 
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_customers.py
+++ b/katana_mcp_server/tests/tools/test_customers.py
@@ -12,8 +12,7 @@ from katana_mcp.tools.foundation.customers import (
     get_customer,
     search_customers,
 )
-
-from tests.conftest import create_mock_context
+from katana_mcp_server.tests.conftest import create_mock_context
 
 
 @pytest.fixture(autouse=True)

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -35,10 +35,10 @@ from katana_mcp.tools.foundation.items import (
     get_variant_details,
     search_items,
 )
+from katana_mcp_server.tests.conftest import create_mock_context, patch_typed_cache_sync
 from pydantic import ValidationError
 
 from katana_public_api_client.client_types import UNSET
-from tests.conftest import create_mock_context, patch_typed_cache_sync
 from tests.factories import (
     make_stock_adjustment,
     make_stock_adjustment_row,
@@ -801,6 +801,7 @@ async def test_create_stock_adjustment_apply_forwards_new_fields():
         )
         await _create_stock_adjustment_impl(request, context)
 
+    assert mock_api_call.call_args is not None
     api_body = mock_api_call.call_args.kwargs["body"]
     assert api_body.stock_adjustment_number == "SA-IMPORT-001"
     assert api_body.stock_adjustment_date == physical_count_date
@@ -1654,6 +1655,7 @@ async def test_delete_stock_adjustment_preview_returns_what_would_be_deleted():
     assert result.row_count == 1
     mock_delete.assert_not_called()
     # The delete-preview lookup should short-circuit auto-pagination.
+    assert mock_get_all.call_args is not None
     assert mock_get_all.call_args.kwargs["page"] == 1
 
 
@@ -1998,6 +2000,7 @@ async def test_check_inventory_single_variant_id():
     # Verify the variant_id path (not the SKU path) was taken
     mock_fetch.assert_awaited_once()
     call_args = mock_fetch.await_args
+    assert call_args is not None
     assert call_args.args[1] == 42
 
 
@@ -2059,6 +2062,7 @@ async def test_check_inventory_mixed_sku_and_variant_id():
 
     lifespan_ctx.cache.get_by_sku.assert_awaited_once()
     mock_fetch.assert_awaited_once()
+    assert mock_fetch.await_args is not None
     assert mock_fetch.await_args.args[1] == 42
 
     # Output order matches input order.
@@ -2313,6 +2317,7 @@ async def test_update_stock_adjustment_echoes_additional_info_when_unchanged():
         result = await _update_stock_adjustment_impl(request, context)
 
     assert result.is_preview is False
+    assert update_mock.call_args is not None
     body = update_mock.call_args.kwargs["body"]
     assert body.additional_info == "UPS tracking 1Z123 — preserve me"
     assert body.reason == "Updated reason"
@@ -2498,6 +2503,7 @@ async def test_check_inventory_location_filter_threads_to_api():
         await _check_inventory_impl(request, context)
 
     # The API was called with location_id=161114 forwarded
+    assert mock_api.call_args is not None
     assert mock_api.call_args.kwargs["location_id"] == 161114
     assert mock_api.call_args.kwargs["variant_id"] == 3001
 

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -22,9 +22,8 @@ from katana_mcp.tools.foundation.items import (
     get_item,
     get_variant_details,
 )
+from katana_mcp_server.tests.conftest import create_mock_context
 from pydantic import ValidationError
-
-from tests.conftest import create_mock_context
 
 
 def _content_text(result) -> str:
@@ -1270,6 +1269,7 @@ async def test_modify_item_add_variant_injects_parent_id_for_product():
 
     assert response.actions[0].operation == "add_variant"
     mock_create.assert_awaited_once()
+    assert mock_create.await_args is not None
     body = mock_create.await_args.kwargs["body"]
     assert body.product_id == 42
     # material_id should be UNSET, not 42 — it's a PRODUCT.

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import UTC, datetime
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,6 +23,7 @@ from katana_mcp.tools.foundation.manufacturing_orders import (
     get_manufacturing_order_recipe,
     list_manufacturing_orders,
 )
+from katana_mcp_server.tests.conftest import create_mock_context, patch_typed_cache_sync
 
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.models import (
@@ -29,7 +31,6 @@ from katana_public_api_client.models import (
     ManufacturingOrderStatus,
 )
 from katana_public_api_client.utils import APIError
-from tests.conftest import create_mock_context, patch_typed_cache_sync
 from tests.factories import (
     make_manufacturing_order,
     mock_entity_for_modify,
@@ -99,7 +100,7 @@ async def test_create_manufacturing_order_confirm_success():
     import katana_public_api_client.api.manufacturing_order.create_manufacturing_order as create_mo_module
 
     original_asyncio_detailed = create_mo_module.asyncio_detailed
-    create_mo_module.asyncio_detailed = mock_api_call
+    cast(Any, create_mo_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreateManufacturingOrderRequest(
@@ -156,7 +157,7 @@ async def test_create_manufacturing_order_make_to_order_preview_populates_fields
     import katana_public_api_client.api.sales_order_row.get_sales_order_row as get_sor_module
 
     original = get_sor_module.asyncio_detailed
-    get_sor_module.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sor_module).asyncio_detailed = AsyncMock(return_value=mock_response)
     try:
         request = CreateManufacturingOrderRequest(
             sales_order_row_id=99001,
@@ -173,7 +174,7 @@ async def test_create_manufacturing_order_make_to_order_preview_populates_fields
         # No BLOCK warnings on the happy path → Confirm button stays.
         assert not any(w.startswith("BLOCK:") for w in result.warnings)
     finally:
-        get_sor_module.asyncio_detailed = original
+        cast(Any, get_sor_module).asyncio_detailed = original
 
 
 @pytest.mark.asyncio
@@ -205,9 +206,9 @@ async def test_create_manufacturing_order_make_to_order_confirm_refuses_when_alr
 
     original_get = get_sor_module.asyncio_detailed
     original_mto = getattr(mto_module, "asyncio_detailed", None)
-    get_sor_module.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sor_module).asyncio_detailed = AsyncMock(return_value=mock_response)
     mto_mock = AsyncMock()
-    mto_module.asyncio_detailed = mto_mock
+    cast(Any, mto_module).asyncio_detailed = mto_mock
     try:
         request = CreateManufacturingOrderRequest(
             sales_order_row_id=99003,
@@ -253,7 +254,7 @@ async def test_create_manufacturing_order_make_to_order_blocks_when_already_link
     import katana_public_api_client.api.sales_order_row.get_sales_order_row as get_sor_module
 
     original = get_sor_module.asyncio_detailed
-    get_sor_module.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sor_module).asyncio_detailed = AsyncMock(return_value=mock_response)
     try:
         request = CreateManufacturingOrderRequest(
             sales_order_row_id=99002,
@@ -270,7 +271,7 @@ async def test_create_manufacturing_order_make_to_order_blocks_when_already_link
         assert "88888" in block_warnings[0]
         assert "already linked" in block_warnings[0]
     finally:
-        get_sor_module.asyncio_detailed = original
+        cast(Any, get_sor_module).asyncio_detailed = original
 
 
 @pytest.mark.asyncio
@@ -328,7 +329,7 @@ async def test_create_manufacturing_order_confirm_with_minimal_fields():
     import katana_public_api_client.api.manufacturing_order.create_manufacturing_order as create_mo_module
 
     original_asyncio_detailed = create_mo_module.asyncio_detailed
-    create_mo_module.asyncio_detailed = mock_api_call
+    cast(Any, create_mo_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreateManufacturingOrderRequest(
@@ -369,7 +370,7 @@ async def test_create_manufacturing_order_api_error():
     import katana_public_api_client.api.manufacturing_order.create_manufacturing_order as create_mo_module
 
     original_asyncio_detailed = create_mo_module.asyncio_detailed
-    create_mo_module.asyncio_detailed = mock_api_call
+    cast(Any, create_mo_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreateManufacturingOrderRequest(
@@ -398,7 +399,7 @@ async def test_create_manufacturing_order_api_exception():
     import katana_public_api_client.api.manufacturing_order.create_manufacturing_order as create_mo_module
 
     original_asyncio_detailed = create_mo_module.asyncio_detailed
-    create_mo_module.asyncio_detailed = mock_api_call
+    cast(Any, create_mo_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreateManufacturingOrderRequest(
@@ -698,7 +699,7 @@ async def test_create_manufacturing_order_make_to_order_preview():
     import katana_public_api_client.api.sales_order_row.get_sales_order_row as get_sor_module
 
     original = get_sor_module.asyncio_detailed
-    get_sor_module.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sor_module).asyncio_detailed = AsyncMock(return_value=mock_response)
     try:
         request = CreateManufacturingOrderRequest(
             sales_order_row_id=105664660,
@@ -710,7 +711,7 @@ async def test_create_manufacturing_order_make_to_order_preview():
         assert "Make-to-order" in result.message or "make-to-order" in result.message
         assert "105664660" in result.message
     finally:
-        get_sor_module.asyncio_detailed = original
+        cast(Any, get_sor_module).asyncio_detailed = original
 
 
 @pytest.mark.asyncio
@@ -738,7 +739,7 @@ async def test_create_manufacturing_order_make_to_order_with_subassemblies():
     import katana_public_api_client.api.sales_order_row.get_sales_order_row as get_sor_module
 
     original = get_sor_module.asyncio_detailed
-    get_sor_module.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sor_module).asyncio_detailed = AsyncMock(return_value=mock_response)
     try:
         request = CreateManufacturingOrderRequest(
             sales_order_row_id=105664660,
@@ -750,7 +751,7 @@ async def test_create_manufacturing_order_make_to_order_with_subassemblies():
         assert result.is_preview is True
         assert "subassemblies" in result.message
     finally:
-        get_sor_module.asyncio_detailed = original
+        cast(Any, get_sor_module).asyncio_detailed = original
 
 
 # ============================================================================
@@ -819,8 +820,8 @@ async def test_list_manufacturing_orders_filters_by_status(
         _list_manufacturing_orders_impl,
     )
 
-    from katana_public_api_client.models_pydantic._generated import (
-        ManufacturingOrderStatus,
+    from katana_public_api_client.models import (
+        ManufacturingOrderStatus as APIManufacturingOrderStatus,
     )
 
     context, _, typed_cache = context_with_typed_cache
@@ -834,7 +835,7 @@ async def test_list_manufacturing_orders_filters_by_status(
     )
 
     result = await _list_manufacturing_orders_impl(
-        ListManufacturingOrdersRequest(status=ManufacturingOrderStatus.in_progress),
+        ListManufacturingOrdersRequest(status=APIManufacturingOrderStatus.IN_PROGRESS),
         context,
     )
 
@@ -1441,10 +1442,13 @@ async def test_get_manufacturing_order_fetches_related_resources():
 
     # Each helper called exactly once with the MO id:
     mock_fetch_recipe.assert_awaited_once()
+    assert mock_fetch_recipe.await_args is not None
     assert mock_fetch_recipe.await_args.args[1] == 3001
     mock_fetch_ops.assert_awaited_once()
+    assert mock_fetch_ops.await_args is not None
     assert mock_fetch_ops.await_args.args[1] == 3001
     mock_fetch_prods.assert_awaited_once()
+    assert mock_fetch_prods.await_args is not None
     assert mock_fetch_prods.await_args.args[1] == 3001
 
     # Results flow through to the response:
@@ -1525,6 +1529,9 @@ async def test_get_manufacturing_order_recipe_full_field_coverage():
         _recipe_row_info_from_attrs,
     )
 
+    from katana_public_api_client.models.ingredient_availability import (
+        IngredientAvailability,
+    )
     from katana_public_api_client.models.manufacturing_order_recipe_row import (
         ManufacturingOrderRecipeRow,
     )
@@ -1542,7 +1549,7 @@ async def test_get_manufacturing_order_recipe_full_field_coverage():
         notes="Use only grade 304 material",
         planned_quantity_per_unit=2.5,
         total_actual_quantity=125.0,
-        ingredient_availability="IN_STOCK",
+        ingredient_availability=IngredientAvailability.IN_STOCK,
         ingredient_expected_date=datetime(2024, 1, 18, 0, 0, 0, tzinfo=UTC),
         batch_transactions=[
             ManufacturingOrderRecipeRowBatchTransactionsItem(
@@ -2335,6 +2342,7 @@ async def test_list_blocking_ingredients_resolves_skus_only_for_kept_variants(
     # cache, validating slice-then-resolve over fetch-then-trim.
     cache_mock = context.request_context.lifespan_context.cache.get_many_by_ids
     assert cache_mock.await_count == 1
+    assert cache_mock.await_args is not None
     awaited_vids = cache_mock.await_args.args[1]
     assert set(awaited_vids) == {500}
 

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -221,7 +221,11 @@ def test_to_tool_result_emits_prefab_envelope_and_response_in_content():
 
     # content carries the response JSON for the LLM.
     assert result.content
-    text = result.content[0].text  # type: ignore[union-attr]
+    first_content = result.content[0]
+    from mcp.types import TextContent
+
+    assert isinstance(first_content, TextContent)
+    text = first_content.text
     payload = _json.loads(text)
     assert payload["entity_type"] == "purchase_order"
     assert payload["operation"] == "update"

--- a/katana_mcp_server/tests/tools/test_orders.py
+++ b/katana_mcp_server/tests/tools/test_orders.py
@@ -1,5 +1,6 @@
 """Tests for order fulfillment MCP tools."""
 
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,6 +10,7 @@ from katana_mcp.tools.foundation.orders import (
     FulfillRowOverride,
     _fulfill_order_impl,
 )
+from katana_mcp_server.tests.conftest import create_mock_context
 
 from katana_public_api_client.models import (
     ManufacturingOrder,
@@ -17,7 +19,6 @@ from katana_public_api_client.models import (
 )
 from katana_public_api_client.models.sales_order_status import SalesOrderStatus
 from katana_public_api_client.utils import APIError
-from tests.conftest import create_mock_context
 
 # ============================================================================
 # Manufacturing Order Tests
@@ -43,7 +44,9 @@ async def test_fulfill_manufacturing_order_preview():
         get_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_response
+    )
 
     request = FulfillOrderRequest(
         order_id=1234, order_type="manufacturing", preview=True
@@ -89,8 +92,10 @@ async def test_fulfill_manufacturing_order_confirm():
         update_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    update_manufacturing_order.asyncio_detailed = AsyncMock(
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, update_manufacturing_order).asyncio_detailed = AsyncMock(
         return_value=mock_update_response
     )
 
@@ -108,7 +113,7 @@ async def test_fulfill_manufacturing_order_confirm():
     assert "marked" in result.message.lower() or "done" in result.message.lower()
 
     # Verify update was called
-    update_manufacturing_order.asyncio_detailed.assert_called_once()
+    cast(Any, update_manufacturing_order.asyncio_detailed).assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -129,7 +134,9 @@ async def test_fulfill_manufacturing_order_already_done():
         get_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_response
+    )
 
     # Preview mode
     request = FulfillOrderRequest(
@@ -170,7 +177,9 @@ async def test_fulfill_manufacturing_order_blocked():
         get_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_response
+    )
 
     request = FulfillOrderRequest(
         order_id=1234, order_type="manufacturing", preview=True
@@ -195,7 +204,9 @@ async def test_fulfill_manufacturing_order_not_found():
         get_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_response
+    )
 
     request = FulfillOrderRequest(
         order_id=9999, order_type="manufacturing", preview=True
@@ -238,7 +249,7 @@ async def test_fulfill_sales_order_preview():
 
     from katana_public_api_client.api.sales_order import get_sales_order
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
 
     request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=True)
     result = await _fulfill_order_impl(request, context)
@@ -273,7 +284,9 @@ async def test_fulfill_sales_order_confirm_creates_fulfillment():
         create_sales_order_fulfillment,
     )
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
 
     from katana_public_api_client.models import SalesOrderFulfillment
 
@@ -281,7 +294,7 @@ async def test_fulfill_sales_order_confirm_creates_fulfillment():
     fulfillment_obj.id = 9999
     mock_create_response = MagicMock(status_code=201, parsed=fulfillment_obj)
     create_mock = AsyncMock(return_value=mock_create_response)
-    create_sales_order_fulfillment.asyncio_detailed = create_mock
+    cast(Any, create_sales_order_fulfillment).asyncio_detailed = create_mock
 
     request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=False)
     result = await _fulfill_order_impl(request, context)
@@ -312,9 +325,9 @@ async def test_fulfill_sales_order_confirm_refuses_when_no_rows():
         create_sales_order_fulfillment,
     )
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
     create_mock = AsyncMock()
-    create_sales_order_fulfillment.asyncio_detailed = create_mock
+    cast(Any, create_sales_order_fulfillment).asyncio_detailed = create_mock
 
     request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=False)
     result = await _fulfill_order_impl(request, context)
@@ -342,7 +355,7 @@ async def test_fulfill_sales_order_blocks_when_already_delivered():
 
     from katana_public_api_client.api.sales_order import get_sales_order
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
 
     # Preview path: BLOCK warning present.
     request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=True)
@@ -372,7 +385,7 @@ async def test_fulfill_sales_order_not_found():
 
     from katana_public_api_client.api.sales_order import get_sales_order
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
 
     request = FulfillOrderRequest(order_id=9999, order_type="sales", preview=True)
 
@@ -424,8 +437,10 @@ async def test_fulfill_manufacturing_order_api_error():
         update_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    update_manufacturing_order.asyncio_detailed = AsyncMock(
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, update_manufacturing_order).asyncio_detailed = AsyncMock(
         return_value=mock_update_response
     )
 
@@ -490,7 +505,7 @@ async def test_fulfill_sales_order_preview_blocks_serial_tracked_without_overrid
     mock_response = MagicMock(status_code=200, parsed=mock_so)
     from katana_public_api_client.api.sales_order import get_sales_order
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
 
     request = FulfillOrderRequest(order_id=42, order_type="sales", preview=True)
     result = await _fulfill_order_impl(request, context)
@@ -516,7 +531,7 @@ async def test_fulfill_sales_order_preview_accepts_serial_override():
     mock_response = MagicMock(status_code=200, parsed=mock_so)
     from katana_public_api_client.api.sales_order import get_sales_order
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
 
     request = FulfillOrderRequest(
         order_id=42,
@@ -549,12 +564,14 @@ async def test_fulfill_sales_order_apply_passes_serials_to_api():
     )
     from katana_public_api_client.models import SalesOrderFulfillment
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
     fulfillment_obj = MagicMock(spec=SalesOrderFulfillment)
     fulfillment_obj.id = 7777
     mock_create_response = MagicMock(status_code=201, parsed=fulfillment_obj)
     create_mock = AsyncMock(return_value=mock_create_response)
-    create_sales_order_fulfillment.asyncio_detailed = create_mock
+    cast(Any, create_sales_order_fulfillment).asyncio_detailed = create_mock
 
     request = FulfillOrderRequest(
         order_id=42,
@@ -567,6 +584,7 @@ async def test_fulfill_sales_order_apply_passes_serials_to_api():
     assert result.is_preview is False
     assert result.status == "DELIVERED"
     create_mock.assert_called_once()
+    assert create_mock.call_args is not None
     sent_body = create_mock.call_args.kwargs["body"]
     sent_rows = sent_body.sales_order_fulfillment_rows
     assert len(sent_rows) == 1
@@ -592,9 +610,9 @@ async def test_fulfill_sales_order_apply_refuses_serial_tracked_without_override
         create_sales_order_fulfillment,
     )
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
     create_mock = AsyncMock()
-    create_sales_order_fulfillment.asyncio_detailed = create_mock
+    cast(Any, create_sales_order_fulfillment).asyncio_detailed = create_mock
 
     request = FulfillOrderRequest(order_id=42, order_type="sales", preview=False)
     result = await _fulfill_order_impl(request, context)
@@ -621,7 +639,7 @@ async def test_fulfill_sales_order_blocks_quantity_serials_mismatch():
     mock_response = MagicMock(status_code=200, parsed=mock_so)
     from katana_public_api_client.api.sales_order import get_sales_order
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
 
     request = FulfillOrderRequest(
         order_id=42,
@@ -648,7 +666,7 @@ async def test_fulfill_sales_order_blocks_unknown_row_override():
     mock_response = MagicMock(status_code=200, parsed=mock_so)
     from katana_public_api_client.api.sales_order import get_sales_order
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
 
     request = FulfillOrderRequest(
         order_id=42,
@@ -698,9 +716,15 @@ async def test_fulfill_sales_order_serial_tracked_detection_falls_back_to_api():
     from katana_public_api_client.api.sales_order import get_sales_order
     from katana_public_api_client.api.variant import get_variant
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_get_so_response)
-    get_variant.asyncio_detailed = AsyncMock(return_value=mock_get_variant_response)
-    get_product.asyncio_detailed = AsyncMock(return_value=mock_get_product_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_so_response
+    )
+    cast(Any, get_variant).asyncio_detailed = AsyncMock(
+        return_value=mock_get_variant_response
+    )
+    cast(Any, get_product).asyncio_detailed = AsyncMock(
+        return_value=mock_get_product_response
+    )
 
     request = FulfillOrderRequest(order_id=42, order_type="sales", preview=True)
     result = await _fulfill_order_impl(request, context)
@@ -708,8 +732,8 @@ async def test_fulfill_sales_order_serial_tracked_detection_falls_back_to_api():
     block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
     assert any("serial-tracked" in w and "ROCKER-V2" in w for w in block_warnings)
     # Verify both API endpoints were hit.
-    get_variant.asyncio_detailed.assert_called_once()
-    get_product.asyncio_detailed.assert_called_once()
+    cast(Any, get_variant.asyncio_detailed).assert_called_once()
+    cast(Any, get_product.asyncio_detailed).assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -730,7 +754,7 @@ async def test_fulfill_sales_order_blocks_duplicate_row_override():
     mock_response = MagicMock(status_code=200, parsed=mock_so)
     from katana_public_api_client.api.sales_order import get_sales_order
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
 
     request = FulfillOrderRequest(
         order_id=42,
@@ -768,7 +792,7 @@ async def test_fulfill_sales_order_blocks_serial_tracked_non_integer_quantity():
     mock_response = MagicMock(status_code=200, parsed=mock_so)
     from katana_public_api_client.api.sales_order import get_sales_order
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
 
     request = FulfillOrderRequest(
         order_id=42,
@@ -819,12 +843,14 @@ async def test_fulfill_sales_order_non_serial_tracked_no_change():
     )
     from katana_public_api_client.models import SalesOrderFulfillment
 
-    get_sales_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
     fulfillment_obj = MagicMock(spec=SalesOrderFulfillment)
     fulfillment_obj.id = 8888
     mock_create_response = MagicMock(status_code=201, parsed=fulfillment_obj)
     create_mock = AsyncMock(return_value=mock_create_response)
-    create_sales_order_fulfillment.asyncio_detailed = create_mock
+    cast(Any, create_sales_order_fulfillment).asyncio_detailed = create_mock
 
     request = FulfillOrderRequest(order_id=42, order_type="sales", preview=False)
     result = await _fulfill_order_impl(request, context)
@@ -875,7 +901,9 @@ async def test_fulfill_manufacturing_order_preview_blocks_serial_tracked_without
         get_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_response
+    )
 
     request = FulfillOrderRequest(order_id=42, order_type="manufacturing", preview=True)
     result = await _fulfill_order_impl(request, context)
@@ -900,7 +928,9 @@ async def test_fulfill_manufacturing_order_preview_accepts_serial_numbers():
         get_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_response
+    )
 
     request = FulfillOrderRequest(
         order_id=42,
@@ -933,9 +963,11 @@ async def test_fulfill_manufacturing_order_apply_passes_serials_to_api():
         update_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
     update_mock = AsyncMock(return_value=mock_update_response)
-    update_manufacturing_order.asyncio_detailed = update_mock
+    cast(Any, update_manufacturing_order).asyncio_detailed = update_mock
 
     request = FulfillOrderRequest(
         order_id=42,
@@ -948,6 +980,7 @@ async def test_fulfill_manufacturing_order_apply_passes_serials_to_api():
     assert result.is_preview is False
     assert result.status == "DONE"
     update_mock.assert_called_once()
+    assert update_mock.call_args is not None
     sent_body = update_mock.call_args.kwargs["body"]
     assert sent_body.serial_numbers == [501, 502]
 
@@ -966,9 +999,11 @@ async def test_fulfill_manufacturing_order_apply_refuses_serial_tracked_without_
         update_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_response
+    )
     update_mock = AsyncMock()
-    update_manufacturing_order.asyncio_detailed = update_mock
+    cast(Any, update_manufacturing_order).asyncio_detailed = update_mock
 
     request = FulfillOrderRequest(
         order_id=42, order_type="manufacturing", preview=False
@@ -996,7 +1031,9 @@ async def test_fulfill_manufacturing_order_blocks_quantity_serials_mismatch():
         get_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_response
+    )
 
     request = FulfillOrderRequest(
         order_id=42,
@@ -1027,7 +1064,9 @@ async def test_fulfill_manufacturing_order_blocks_serial_tracked_non_integer_qua
         get_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_response)
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_response
+    )
 
     request = FulfillOrderRequest(
         order_id=42,
@@ -1078,11 +1117,15 @@ async def test_fulfill_manufacturing_order_serial_tracked_detection_falls_back_t
     from katana_public_api_client.api.product import get_product
     from katana_public_api_client.api.variant import get_variant
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
         return_value=mock_get_mo_response
     )
-    get_variant.asyncio_detailed = AsyncMock(return_value=mock_get_variant_response)
-    get_product.asyncio_detailed = AsyncMock(return_value=mock_get_product_response)
+    cast(Any, get_variant).asyncio_detailed = AsyncMock(
+        return_value=mock_get_variant_response
+    )
+    cast(Any, get_product).asyncio_detailed = AsyncMock(
+        return_value=mock_get_product_response
+    )
 
     request = FulfillOrderRequest(order_id=42, order_type="manufacturing", preview=True)
     result = await _fulfill_order_impl(request, context)
@@ -1090,8 +1133,8 @@ async def test_fulfill_manufacturing_order_serial_tracked_detection_falls_back_t
     block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
     assert any("serial-tracked" in w and "ROCKER-V2" in w for w in block_warnings)
     # Verify both API endpoints were hit.
-    get_variant.asyncio_detailed.assert_called_once()
-    get_product.asyncio_detailed.assert_called_once()
+    cast(Any, get_variant.asyncio_detailed).assert_called_once()
+    cast(Any, get_product.asyncio_detailed).assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -1124,9 +1167,11 @@ async def test_fulfill_manufacturing_order_non_serial_tracked_no_change():
         update_manufacturing_order,
     )
 
-    get_manufacturing_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
     update_mock = AsyncMock(return_value=mock_update_response)
-    update_manufacturing_order.asyncio_detailed = update_mock
+    cast(Any, update_manufacturing_order).asyncio_detailed = update_mock
 
     request = FulfillOrderRequest(
         order_id=42, order_type="manufacturing", preview=False

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -3,6 +3,7 @@
 import json
 import os
 from datetime import UTC, datetime
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -35,18 +36,19 @@ from katana_mcp.tools.foundation.purchase_orders import (
     list_purchase_orders,
     verify_order_document,
 )
+from katana_mcp_server.tests.conftest import create_mock_context, patch_typed_cache_sync
 
 from katana_public_api_client.api.purchase_order import (
     get_purchase_order as api_get_purchase_order,
 )
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.models import (
+    PurchaseOrderEntityType,
     PurchaseOrderReceiveRow,
     PurchaseOrderRow,
     RegularPurchaseOrder,
 )
 from katana_public_api_client.utils import APIError
-from tests.conftest import create_mock_context, patch_typed_cache_sync
 from tests.factories import (
     make_purchase_order,
     make_purchase_order_row,
@@ -210,7 +212,7 @@ async def test_create_purchase_order_apply_echoes_notes_and_resolves_names():
     import katana_public_api_client.api.purchase_order.create_purchase_order as create_po_module
 
     original_asyncio_detailed = create_po_module.asyncio_detailed
-    create_po_module.asyncio_detailed = mock_api_call
+    cast(Any, create_po_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreatePurchaseOrderRequest(
@@ -273,7 +275,7 @@ async def test_create_purchase_order_apply_falls_back_to_request_notes_when_unse
     import katana_public_api_client.api.purchase_order.create_purchase_order as create_po_module
 
     original_asyncio_detailed = create_po_module.asyncio_detailed
-    create_po_module.asyncio_detailed = mock_api_call
+    cast(Any, create_po_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreatePurchaseOrderRequest(
@@ -331,7 +333,7 @@ async def test_create_purchase_order_apply_proceeds_when_cache_is_unhealthy():
     import katana_public_api_client.api.purchase_order.create_purchase_order as create_po_module
 
     original_asyncio_detailed = create_po_module.asyncio_detailed
-    create_po_module.asyncio_detailed = mock_api_call
+    cast(Any, create_po_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreatePurchaseOrderRequest(
@@ -389,7 +391,7 @@ async def test_create_purchase_order_apply_forwards_new_header_fields():
     import katana_public_api_client.api.purchase_order.create_purchase_order as create_po_module
 
     original = create_po_module.asyncio_detailed
-    create_po_module.asyncio_detailed = mock_api_call
+    cast(Any, create_po_module).asyncio_detailed = mock_api_call
     try:
         placed_at = datetime(2026, 4, 1, 10, 0, tzinfo=UTC)
         eta = datetime(2026, 4, 15, 17, 0, tzinfo=UTC)
@@ -398,7 +400,7 @@ async def test_create_purchase_order_apply_forwards_new_header_fields():
             location_id=1,
             order_number="PO-OS-001",
             items=[PurchaseOrderItem(variant_id=1, quantity=1, price_per_unit=10.0)],
-            entity_type="outsourced",
+            entity_type=APIPurchaseOrderEntityType.OUTSOURCED,
             tracking_location_id=2,
             order_created_date=placed_at,
             expected_arrival_date=eta,
@@ -406,8 +408,9 @@ async def test_create_purchase_order_apply_forwards_new_header_fields():
         )
         await _create_purchase_order_impl(request, context)
     finally:
-        create_po_module.asyncio_detailed = original
+        cast(Any, create_po_module).asyncio_detailed = original
 
+    assert mock_api_call.call_args is not None
     api_body = mock_api_call.call_args.kwargs["body"]
     assert api_body.entity_type == APIPurchaseOrderEntityType.OUTSOURCED
     assert api_body.tracking_location_id == 2
@@ -448,7 +451,7 @@ async def test_create_purchase_order_apply_omits_unset_header_fields():
     import katana_public_api_client.api.purchase_order.create_purchase_order as create_po_module
 
     original = create_po_module.asyncio_detailed
-    create_po_module.asyncio_detailed = mock_api_call
+    cast(Any, create_po_module).asyncio_detailed = mock_api_call
     try:
         request = CreatePurchaseOrderRequest(
             supplier_id=4001,
@@ -459,7 +462,7 @@ async def test_create_purchase_order_apply_omits_unset_header_fields():
         )
         await _create_purchase_order_impl(request, context)
     finally:
-        create_po_module.asyncio_detailed = original
+        cast(Any, create_po_module).asyncio_detailed = original
 
     api_body = mock_api_call.call_args.kwargs["body"]
     # entity_type defaults to REGULAR (not UNSET — the impl chooses regular
@@ -487,7 +490,7 @@ async def test_create_purchase_order_apply_fails_fast_on_outsourced_without_trac
         location_id=1,
         order_number="PO-OS-MISSING",
         items=[PurchaseOrderItem(variant_id=1, quantity=1, price_per_unit=1.0)],
-        entity_type="outsourced",
+        entity_type=PurchaseOrderEntityType.OUTSOURCED,
         # tracking_location_id intentionally omitted
         preview=False,
     )
@@ -509,7 +512,7 @@ async def test_create_purchase_order_preview_warns_on_outsourced_without_trackin
         location_id=1,
         order_number="PO-OS-MISSING-TRACK",
         items=[PurchaseOrderItem(variant_id=1, quantity=1, price_per_unit=1.0)],
-        entity_type="outsourced",
+        entity_type=PurchaseOrderEntityType.OUTSOURCED,
         # tracking_location_id intentionally omitted
         preview=True,
     )
@@ -612,7 +615,9 @@ async def test_verify_order_document_perfect_match():
 
     # Setup mocks
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
     lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
 
     # Document items matching PO perfectly
@@ -662,7 +667,9 @@ async def test_verify_order_document_quantity_mismatch():
 
     mock_variants = [create_mock_variant(variant_id=1, sku="WIDGET-001")]
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
     lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
 
     # Document with different quantity
@@ -717,7 +724,9 @@ async def test_verify_order_document_price_mismatch():
 
     mock_variants = [create_mock_variant(variant_id=1, sku="WIDGET-001")]
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
     lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
 
     # Document with different price
@@ -770,7 +779,9 @@ async def test_verify_order_document_missing_in_po():
 
     mock_variants = [create_mock_variant(variant_id=1, sku="WIDGET-001")]
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
     lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
 
     # Document includes WIDGET-002 which is not in PO
@@ -825,7 +836,9 @@ async def test_verify_order_document_extra_in_document():
         create_mock_variant(variant_id=2, sku="WIDGET-002"),
     ]
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
     lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
 
     # Document only has WIDGET-001 (missing WIDGET-002 from PO)
@@ -871,7 +884,9 @@ async def test_verify_order_document_mixed_discrepancies():
         create_mock_variant(variant_id=2, sku="WIDGET-002"),
     ]
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
     lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
 
     # Document with: perfect match, quantity mismatch, missing item
@@ -938,7 +953,9 @@ async def test_verify_order_document_empty_po():
     mock_po_response.status_code = 200
     mock_po_response.parsed = mock_po
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
 
     request = VerifyOrderDocumentRequest(
         order_id=1234,
@@ -970,7 +987,9 @@ async def test_verify_order_document_po_not_found():
     mock_po_response.status_code = 404
     mock_po_response.parsed = None
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
 
     request = VerifyOrderDocumentRequest(
         order_id=9999,
@@ -1002,7 +1021,9 @@ async def test_verify_order_document_unset_values():
 
     mock_variants = [create_mock_variant(variant_id=1, sku="WIDGET-001")]
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
     lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
 
     request = VerifyOrderDocumentRequest(
@@ -1040,7 +1061,9 @@ async def test_verify_order_document_no_price_in_document():
 
     mock_variants = [create_mock_variant(variant_id=1, sku="WIDGET-001")]
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
     lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
 
     # Document without price
@@ -1079,7 +1102,9 @@ async def test_verify_order_document_variant_not_found():
     # Variants list doesn't include variant_id=1
     mock_variants = []
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
     lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
 
     request = VerifyOrderDocumentRequest(
@@ -1120,7 +1145,9 @@ async def test_verify_order_document_unset_order_no():
 
     mock_variants = [create_mock_variant(variant_id=1, sku="WIDGET-001")]
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
     lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
 
     request = VerifyOrderDocumentRequest(
@@ -1180,7 +1207,9 @@ async def test_verify_order_document_no_match():
 
     mock_variants = [create_mock_variant(variant_id=1, sku="WIDGET-001")]
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_po_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
     lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
 
     # Document with completely different items
@@ -1239,7 +1268,9 @@ async def test_receive_purchase_order_preview():
         get_purchase_order as api_get_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
 
     # Create request with preview=true (preview mode)
     request = ReceivePurchaseOrderRequest(
@@ -1292,8 +1323,10 @@ async def test_receive_purchase_order_confirm_success():
         receive_purchase_order as api_receive_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    api_receive_purchase_order.asyncio_detailed = AsyncMock(
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, api_receive_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_receive_response
     )
 
@@ -1319,8 +1352,8 @@ async def test_receive_purchase_order_confirm_success():
     assert "Inventory has been updated" in result.next_actions
 
     # Verify API was called with correct data
-    api_receive_purchase_order.asyncio_detailed.assert_called_once()
-    call_args = api_receive_purchase_order.asyncio_detailed.call_args
+    cast(Any, api_receive_purchase_order.asyncio_detailed).assert_called_once()
+    call_args = cast(Any, api_receive_purchase_order.asyncio_detailed).call_args
     body = call_args.kwargs["body"]
 
     # Verify the body contains correct receive rows
@@ -1359,8 +1392,10 @@ async def test_receive_purchase_order_single_item():
         receive_purchase_order as api_receive_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    api_receive_purchase_order.asyncio_detailed = AsyncMock(
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, api_receive_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_receive_response
     )
 
@@ -1394,7 +1429,9 @@ async def test_receive_purchase_order_get_po_fails():
         get_purchase_order as api_get_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
 
     request = ReceivePurchaseOrderRequest(
         order_id=9999,
@@ -1441,8 +1478,10 @@ async def test_receive_purchase_order_receive_api_fails():
         receive_purchase_order as api_receive_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    api_receive_purchase_order.asyncio_detailed = AsyncMock(
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, api_receive_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_receive_response
     )
 
@@ -1484,7 +1523,9 @@ async def test_receive_purchase_order_order_no_unset():
         get_purchase_order as api_get_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
 
     request = ReceivePurchaseOrderRequest(
         order_id=1234,
@@ -1531,8 +1572,10 @@ async def test_receive_purchase_order_received_date_falls_back_to_now():
         receive_purchase_order as api_receive_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    api_receive_purchase_order.asyncio_detailed = AsyncMock(
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, api_receive_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_receive_response
     )
 
@@ -1551,7 +1594,7 @@ async def test_receive_purchase_order_received_date_falls_back_to_now():
     after_time = datetime.now(UTC)
 
     # Verify received_date was set
-    call_args = api_receive_purchase_order.asyncio_detailed.call_args
+    call_args = cast(Any, api_receive_purchase_order.asyncio_detailed).call_args
     body = call_args.kwargs["body"]
     received_date = body[0].received_date
 
@@ -1594,8 +1637,10 @@ async def test_receive_purchase_order_received_date_passthrough():
         receive_purchase_order as api_receive_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    api_receive_purchase_order.asyncio_detailed = AsyncMock(
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, api_receive_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_receive_response
     )
 
@@ -1620,7 +1665,10 @@ async def test_receive_purchase_order_received_date_passthrough():
 
     await _receive_purchase_order_impl(request, context)
 
-    body = api_receive_purchase_order.asyncio_detailed.call_args.kwargs["body"]
+    assert cast(Any, api_receive_purchase_order.asyncio_detailed).call_args is not None
+    body = cast(Any, api_receive_purchase_order.asyncio_detailed).call_args.kwargs[
+        "body"
+    ]
     assert body[0].received_date == actual_delivery
     assert body[1].received_date == actual_delivery
 
@@ -1657,8 +1705,10 @@ async def test_receive_purchase_order_batch_transactions_passthrough():
         receive_purchase_order as api_receive_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    api_receive_purchase_order.asyncio_detailed = AsyncMock(
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, api_receive_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_receive_response
     )
 
@@ -1679,7 +1729,9 @@ async def test_receive_purchase_order_batch_transactions_passthrough():
 
     await _receive_purchase_order_impl(request, context)
 
-    body = api_receive_purchase_order.asyncio_detailed.call_args.kwargs["body"]
+    body = cast(Any, api_receive_purchase_order.asyncio_detailed).call_args.kwargs[
+        "body"
+    ]
     sent_batches = body[0].batch_transactions
     assert len(sent_batches) == 2
     assert sent_batches[0].batch_id == 9001
@@ -1725,8 +1777,10 @@ async def test_receive_purchase_order_omits_batch_transactions_when_unset():
         receive_purchase_order as api_receive_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    api_receive_purchase_order.asyncio_detailed = AsyncMock(
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, api_receive_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_receive_response
     )
 
@@ -1738,7 +1792,9 @@ async def test_receive_purchase_order_omits_batch_transactions_when_unset():
 
     await _receive_purchase_order_impl(request, context)
 
-    body = api_receive_purchase_order.asyncio_detailed.call_args.kwargs["body"]
+    body = cast(Any, api_receive_purchase_order.asyncio_detailed).call_args.kwargs[
+        "body"
+    ]
     assert "batch_transactions" not in body[0].to_dict()
 
 
@@ -1806,7 +1862,9 @@ async def test_receive_purchase_order_wrapper():
         get_purchase_order as api_get_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
 
     # Create request
     request = ReceivePurchaseOrderRequest(
@@ -1850,8 +1908,10 @@ async def test_receive_purchase_order_multiple_items_various_quantities():
         receive_purchase_order as api_receive_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    api_receive_purchase_order.asyncio_detailed = AsyncMock(
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, api_receive_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_receive_response
     )
 
@@ -1873,7 +1933,7 @@ async def test_receive_purchase_order_multiple_items_various_quantities():
     assert result.is_preview is False
 
     # Verify all items were sent to API
-    call_args = api_receive_purchase_order.asyncio_detailed.call_args
+    call_args = cast(Any, api_receive_purchase_order.asyncio_detailed).call_args
     body = call_args.kwargs["body"]
     assert len(body) == 4
     assert body[0].quantity == 100.0
@@ -1915,7 +1975,7 @@ async def test_receive_purchase_order_exception_handling():
         get_purchase_order as api_get_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         side_effect=Exception("Network error")
     )
 
@@ -1960,8 +2020,10 @@ async def test_receive_purchase_order_builds_correct_api_payload():
         receive_purchase_order as api_receive_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    api_receive_purchase_order.asyncio_detailed = AsyncMock(
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, api_receive_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_receive_response
     )
 
@@ -1978,8 +2040,8 @@ async def test_receive_purchase_order_builds_correct_api_payload():
     await _receive_purchase_order_impl(request, context)
 
     # Verify the API was called with correct parameters
-    api_receive_purchase_order.asyncio_detailed.assert_called_once()
-    call_args = api_receive_purchase_order.asyncio_detailed.call_args
+    cast(Any, api_receive_purchase_order.asyncio_detailed).assert_called_once()
+    call_args = cast(Any, api_receive_purchase_order.asyncio_detailed).call_args
 
     # Check client parameter
     assert "client" in call_args.kwargs
@@ -2032,9 +2094,11 @@ async def test_receive_purchase_order_confirm_refuses_when_already_received():
         receive_purchase_order as api_receive_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
     receive_mock = AsyncMock()
-    api_receive_purchase_order.asyncio_detailed = receive_mock
+    cast(Any, api_receive_purchase_order).asyncio_detailed = receive_mock
 
     request = ReceivePurchaseOrderRequest(
         order_id=8888,
@@ -2085,8 +2149,10 @@ async def test_receive_purchase_order_response_structure():
         receive_purchase_order as api_receive_purchase_order,
     )
 
-    api_get_purchase_order.asyncio_detailed = AsyncMock(return_value=mock_get_response)
-    api_receive_purchase_order.asyncio_detailed = AsyncMock(
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+    cast(Any, api_receive_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_receive_response
     )
 
@@ -2457,8 +2523,10 @@ async def test_get_purchase_order_fetches_additional_costs_and_accounting_metada
 
     # Side-data helpers called with the right PO-scope identifiers
     mock_fetch_costs.assert_awaited_once()
+    assert mock_fetch_costs.await_args is not None
     assert mock_fetch_costs.await_args.args[1] == 8080  # default_group_id
     mock_fetch_meta.assert_awaited_once()
+    assert mock_fetch_meta.await_args is not None
     assert mock_fetch_meta.await_args.args[1] == 12345  # PO id
 
     # Fetched values flow through to the response
@@ -2671,6 +2739,7 @@ async def test_get_purchase_order_accepts_zero_order_id_via_is_none_check():
     mock_detailed.assert_awaited_once()
     # ``find_purchase_orders`` (the list-by-order_no branch) must NOT have
     # been exercised — the get-by-id path was taken.
+    assert mock_detailed.await_args is not None
     assert mock_detailed.await_args.kwargs["id"] == 0
     assert result.id == 0
 
@@ -2700,6 +2769,7 @@ async def test_get_purchase_order_runs_side_data_fetches_concurrently():
 
     # gather called with two awaitables — the two side-data coroutines.
     spy_gather.assert_called_once()
+    assert spy_gather.call_args is not None
     assert len(spy_gather.call_args.args) == 2
 
 

--- a/katana_mcp_server/tests/tools/test_reference.py
+++ b/katana_mcp_server/tests/tools/test_reference.py
@@ -24,9 +24,8 @@ from katana_mcp.tools.foundation.reference import (
     list_tax_rates,
     register_tools,
 )
+from katana_mcp_server.tests.conftest import create_mock_context
 from mcp.types import TextContent
-
-from tests.conftest import create_mock_context
 
 
 @pytest.fixture(autouse=True)
@@ -510,12 +509,12 @@ class TestRequestModels:
 
     def test_format_must_be_known(self):
         with pytest.raises(ValueError):
-            ListSuppliersRequest(format="xml")  # type: ignore[arg-type]
+            ListSuppliersRequest.model_validate({"format": "xml"})
 
     def test_extra_fields_forbidden(self):
         """``extra="forbid"`` keeps callers honest about parameter names."""
         with pytest.raises(ValueError):
-            ListSuppliersRequest(querystr="SRAM")  # type: ignore[call-arg]
+            ListSuppliersRequest.model_validate({"querystr": "SRAM"})
 
     def test_default_query_is_none_default_format_markdown(self):
         req = ListSuppliersRequest()

--- a/katana_mcp_server/tests/tools/test_reporting.py
+++ b/katana_mcp_server/tests/tools/test_reporting.py
@@ -20,9 +20,9 @@ from katana_mcp.tools.foundation.reporting import (
     sales_summary,
     top_selling_variants,
 )
+from katana_mcp_server.tests.conftest import create_mock_context
 
 from katana_public_api_client.client_types import UNSET
-from tests.conftest import create_mock_context
 
 # ============================================================================
 # Mock helpers
@@ -589,7 +589,7 @@ async def test_inventory_velocity_batch_returns_multiple_rows():
     context, lifespan_ctx = create_mock_context()
 
     # Both resolved via get_by_sku
-    async def fake_get_by_sku(sku: str) -> dict:
+    async def fake_get_by_sku(sku: str) -> dict | None:
         return {
             "WIDGET-1": {"id": 10, "sku": "WIDGET-1"},
             "WIDGET-2": {"id": 20, "sku": "WIDGET-2"},
@@ -720,7 +720,7 @@ def test_inventory_velocity_rejects_batch_too_large():
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
-        InventoryVelocityRequest(sku_or_variant_ids=["SKU"] * 101)
+        InventoryVelocityRequest.model_validate({"sku_or_variant_ids": ["SKU"] * 101})
 
 
 # ============================================================================
@@ -844,7 +844,7 @@ async def test_inventory_velocity_format_json_returns_json():
 @pytest.fixture
 def _no_mo_or_recipe_sync():
     """Stub both ``ensure_*_synced`` helpers used by the MO-consumption path."""
-    from tests.conftest import patch_typed_cache_sync
+    from katana_mcp_server.tests.conftest import patch_typed_cache_sync
 
     with (
         patch_typed_cache_sync("manufacturing_orders"),

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import UTC, datetime
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -24,6 +25,7 @@ from katana_mcp.tools.foundation.sales_orders import (
     get_sales_order,
     list_sales_orders,
 )
+from katana_mcp_server.tests.conftest import create_mock_context, patch_typed_cache_sync
 
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.models import (
@@ -31,7 +33,6 @@ from katana_public_api_client.models import (
     SalesOrderStatus,
 )
 from katana_public_api_client.utils import APIError
-from tests.conftest import create_mock_context, patch_typed_cache_sync
 from tests.factories import (
     make_sales_order,
     make_sales_order_row,
@@ -175,7 +176,7 @@ async def test_create_sales_order_confirm_success():
     import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
 
     original_asyncio_detailed = create_so_module.asyncio_detailed
-    create_so_module.asyncio_detailed = mock_api_call
+    cast(Any, create_so_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreateSalesOrderRequest(
@@ -236,7 +237,7 @@ async def test_create_sales_order_forwards_new_header_and_row_fields():
     import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
 
     original = create_so_module.asyncio_detailed
-    create_so_module.asyncio_detailed = mock_api_call
+    cast(Any, create_so_module).asyncio_detailed = mock_api_call
     try:
         placed_at = datetime(2026, 3, 15, 10, 0, tzinfo=UTC)
         request = CreateSalesOrderRequest(
@@ -268,8 +269,9 @@ async def test_create_sales_order_forwards_new_header_and_row_fields():
         )
         await _create_sales_order_impl(request, context)
     finally:
-        create_so_module.asyncio_detailed = original
+        cast(Any, create_so_module).asyncio_detailed = original
 
+    assert mock_api_call.call_args is not None
     api_body = mock_api_call.call_args.kwargs["body"]
 
     # Header fields
@@ -318,7 +320,7 @@ async def test_create_sales_order_apply_omits_unset_fields():
     import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
 
     original = create_so_module.asyncio_detailed
-    create_so_module.asyncio_detailed = mock_api_call
+    cast(Any, create_so_module).asyncio_detailed = mock_api_call
     try:
         request = CreateSalesOrderRequest(
             customer_id=1501,
@@ -328,7 +330,7 @@ async def test_create_sales_order_apply_omits_unset_fields():
         )
         await _create_sales_order_impl(request, context)
     finally:
-        create_so_module.asyncio_detailed = original
+        cast(Any, create_so_module).asyncio_detailed = original
 
     api_body = mock_api_call.call_args.kwargs["body"]
     assert api_body.order_created_date is UNSET
@@ -365,7 +367,7 @@ async def test_create_sales_order_with_addresses():
     import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
 
     original_asyncio_detailed = create_so_module.asyncio_detailed
-    create_so_module.asyncio_detailed = mock_api_call
+    cast(Any, create_so_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreateSalesOrderRequest(
@@ -407,6 +409,7 @@ async def test_create_sales_order_with_addresses():
         mock_api_call.assert_called_once()
 
         # Verify addresses were passed to API
+        assert mock_api_call.call_args is not None
         call_kwargs = mock_api_call.call_args.kwargs
         api_request = call_kwargs["body"]
         assert not isinstance(api_request.addresses, type(UNSET))
@@ -455,7 +458,7 @@ async def test_create_sales_order_api_error():
     import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
 
     original_asyncio_detailed = create_so_module.asyncio_detailed
-    create_so_module.asyncio_detailed = mock_api_call
+    cast(Any, create_so_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreateSalesOrderRequest(
@@ -484,7 +487,7 @@ async def test_create_sales_order_api_exception():
     import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
 
     original_asyncio_detailed = create_so_module.asyncio_detailed
-    create_so_module.asyncio_detailed = mock_api_call
+    cast(Any, create_so_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreateSalesOrderRequest(
@@ -527,7 +530,7 @@ async def test_create_sales_order_confirm_with_minimal_fields():
     import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
 
     original_asyncio_detailed = create_so_module.asyncio_detailed
-    create_so_module.asyncio_detailed = mock_api_call
+    cast(Any, create_so_module).asyncio_detailed = mock_api_call
 
     try:
         request = CreateSalesOrderRequest(

--- a/katana_mcp_server/tests/tools/test_stock_transfers.py
+++ b/katana_mcp_server/tests/tools/test_stock_transfers.py
@@ -29,10 +29,10 @@ from katana_mcp.tools.foundation.stock_transfers import (
     _modify_stock_transfer_impl,
     list_stock_transfers,
 )
+from katana_mcp_server.tests.conftest import create_mock_context, patch_typed_cache_sync
 
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.utils import APIError
-from tests.conftest import create_mock_context, patch_typed_cache_sync
 from tests.factories import (
     make_stock_transfer,
     make_stock_transfer_row,
@@ -161,6 +161,7 @@ async def test_create_stock_transfer_confirm_success():
 
     # Verify API was called
     mock_api.assert_awaited_once()
+    assert mock_api.await_args is not None
     call_body = mock_api.await_args.kwargs["body"]
     assert call_body.source_location_id == 1
     assert call_body.target_location_id == 2
@@ -207,6 +208,7 @@ async def test_create_stock_transfer_auto_generates_number_when_order_no_omitted
         )
         await _create_stock_transfer_impl(request, context)
 
+    assert mock_api.await_args is not None
     call_body = mock_api.await_args.kwargs["body"]
     # Auto-generated number is a real string in ``ST-<unix_timestamp>`` form
     # (not UNSET, not empty, not None).
@@ -250,6 +252,7 @@ async def test_create_stock_transfer_apply_forwards_dates():
         )
         await _create_stock_transfer_impl(request, context)
 
+    assert mock_api.await_args is not None
     body = mock_api.await_args.kwargs["body"]
     assert body.order_created_date == placed_at
     assert body.transfer_date == shipped_at
@@ -285,6 +288,7 @@ async def test_create_stock_transfer_apply_omits_unset_dates():
         )
         await _create_stock_transfer_impl(request, context)
 
+    assert mock_api.await_args is not None
     body = mock_api.await_args.kwargs["body"]
     assert body.order_created_date is UNSET
     assert body.transfer_date is UNSET
@@ -324,6 +328,7 @@ async def test_create_stock_transfer_passes_through_provided_order_no():
         )
         await _create_stock_transfer_impl(request, context)
 
+    assert mock_api.await_args is not None
     call_body = mock_api.await_args.kwargs["body"]
     assert call_body.stock_transfer_number == "MY-CUSTOM-99"
 
@@ -634,6 +639,7 @@ async def test_modify_st_header_confirm_dispatches_to_update_endpoint():
     assert response.actions[0].operation == "update_header"
     assert response.actions[0].succeeded is True
     mock_update.assert_awaited_once()
+    assert mock_update.await_args is not None
     kwargs = mock_update.await_args.kwargs
     assert kwargs["id"] == 42
     assert kwargs["body"].stock_transfer_number == "ST-42-revised"
@@ -661,6 +667,7 @@ async def test_modify_st_status_confirm_dispatches_to_status_endpoint():
     assert response.actions[0].operation == "update_status"
     assert response.actions[0].succeeded is True
     mock_status.assert_awaited_once()
+    assert mock_status.await_args is not None
     kwargs = mock_status.await_args.kwargs
     assert kwargs["id"] == 42
     # The API status enum should be the camelCase wire value ``inTransit``.
@@ -768,6 +775,7 @@ async def test_delete_stock_transfer_confirm_success():
     assert response.is_preview is False
     assert response.actions[0].succeeded is True
     mock_delete.assert_awaited_once()
+    assert mock_delete.await_args is not None
     kwargs = mock_delete.await_args.kwargs
     assert kwargs["id"] == 42
 

--- a/katana_mcp_server/tests/tools/test_tool_result_utils.py
+++ b/katana_mcp_server/tests/tools/test_tool_result_utils.py
@@ -63,7 +63,11 @@ def test_make_tool_result_emits_response_json_as_content():
     # content comes back as a list of TextContent blocks; assert the first
     # block parses as the response JSON.
     assert result.content
-    text = result.content[0].text  # type: ignore[union-attr]
+    first_content = result.content[0]
+    from mcp.types import TextContent
+
+    assert isinstance(first_content, TextContent)
+    text = first_content.text
     assert json.loads(text) == {"id": 42, "label": "hello"}
 
 

--- a/katana_public_api_client/domain/base.py
+++ b/katana_public_api_client/domain/base.py
@@ -61,13 +61,14 @@ class KatanaBaseModel(BaseModel):
     # Common timestamp fields (most Katana entities have these)
     # Using AwareDatetime to match generated Pydantic models and ensure timezone awareness
     created_at: AwareDatetime | None = Field(
-        None, description="Timestamp when entity was created"
+        default=None, description="Timestamp when entity was created"
     )
     updated_at: AwareDatetime | None = Field(
-        None, description="Timestamp when entity was last updated"
+        default=None, description="Timestamp when entity was last updated"
     )
     deleted_at: AwareDatetime | None = Field(
-        None, description="Timestamp when entity was soft-deleted (if applicable)"
+        default=None,
+        description="Timestamp when entity was soft-deleted (if applicable)",
     )
 
     def model_dump_for_etl(self) -> dict[str, Any]:

--- a/katana_public_api_client/domain/material.py
+++ b/katana_public_api_client/domain/material.py
@@ -60,37 +60,46 @@ class KatanaMaterial(KatanaBaseModel):
     id: int = Field(..., description="Unique material ID")
     name: str = Field(..., description="Material name", min_length=1)
     type_: Literal["material"] = Field(
-        "material", alias="type", description="Entity type"
+        default="material", alias="type", description="Entity type"
     )
 
     # ============ Classification & Units ============
 
-    uom: str | None = Field(None, description="Unit of measure (e.g., 'kg', 'm²')")
-    category_name: str | None = Field(None, description="Material category name")
+    uom: str | None = Field(
+        default=None, description="Unit of measure (e.g., 'kg', 'm²')"
+    )
+    category_name: str | None = Field(
+        default=None, description="Material category name"
+    )
 
     # ============ Capabilities ============
 
     is_sellable: bool | None = Field(
-        None, description="Can be sold to customers (usually False for materials)"
+        default=None,
+        description="Can be sold to customers (usually False for materials)",
     )
 
     # ============ Tracking Features ============
 
-    batch_tracked: bool | None = Field(None, description="Track by batch/lot numbers")
+    batch_tracked: bool | None = Field(
+        default=None, description="Track by batch/lot numbers"
+    )
 
     # ============ Supplier & Ordering ============
 
-    default_supplier_id: int | None = Field(None, description="Default supplier ID")
+    default_supplier_id: int | None = Field(
+        default=None, description="Default supplier ID"
+    )
 
     # ============ Purchase Unit Conversion ============
 
     purchase_uom: str | None = Field(
-        None,
+        default=None,
         max_length=7,
         description="Purchase unit of measure (if different from base UOM)",
     )
     purchase_uom_conversion_rate: float | None = Field(
-        None,
+        default=None,
         ge=0,
         le=1_000_000_000_000,
         description="Conversion rate from purchase UOM to base UOM",
@@ -98,20 +107,24 @@ class KatanaMaterial(KatanaBaseModel):
 
     # ============ Additional Info ============
 
-    additional_info: str | None = Field(None, description="Additional notes/info")
+    additional_info: str | None = Field(
+        default=None, description="Additional notes/info"
+    )
     custom_field_collection_id: int | None = Field(
-        None, description="Custom field collection ID"
+        default=None, description="Custom field collection ID"
     )
     archived_at: AwareDatetime | None = Field(
-        None, description="Timestamp when material was archived"
+        default=None, description="Timestamp when material was archived"
     )
 
     # ============ Nested Data ============
 
     variant_count: int = Field(
-        0, ge=0, description="Number of variants for this material"
+        default=0, ge=0, description="Number of variants for this material"
     )
-    config_count: int = Field(0, ge=0, description="Number of configuration attributes")
+    config_count: int = Field(
+        default=0, ge=0, description="Number of configuration attributes"
+    )
 
     # ============ Factory Methods ============
 

--- a/katana_public_api_client/domain/product.py
+++ b/katana_public_api_client/domain/product.py
@@ -61,52 +61,64 @@ class KatanaProduct(KatanaBaseModel):
     id: int = Field(..., description="Unique product ID")
     name: str = Field(..., description="Product name", min_length=1)
     type_: Literal["product"] = Field(
-        "product", alias="type", description="Entity type"
+        default="product", alias="type", description="Entity type"
     )
 
     # ============ Classification & Units ============
 
-    uom: str | None = Field(None, description="Unit of measure (e.g., 'pcs', 'kg')")
-    category_name: str | None = Field(None, description="Product category name")
+    uom: str | None = Field(
+        default=None, description="Unit of measure (e.g., 'pcs', 'kg')"
+    )
+    category_name: str | None = Field(default=None, description="Product category name")
 
     # ============ Capabilities ============
 
-    is_sellable: bool | None = Field(None, description="Can be sold to customers")
-    is_producible: bool | None = Field(None, description="Can be manufactured in-house")
+    is_sellable: bool | None = Field(
+        default=None, description="Can be sold to customers"
+    )
+    is_producible: bool | None = Field(
+        default=None, description="Can be manufactured in-house"
+    )
     is_purchasable: bool | None = Field(
-        None, description="Can be purchased from suppliers"
+        default=None, description="Can be purchased from suppliers"
     )
     is_auto_assembly: bool | None = Field(
-        None, description="Automatically assemble when components available"
+        default=None, description="Automatically assemble when components available"
     )
 
     # ============ Tracking Features ============
 
-    batch_tracked: bool | None = Field(None, description="Track by batch/lot numbers")
-    serial_tracked: bool | None = Field(None, description="Track by serial numbers")
+    batch_tracked: bool | None = Field(
+        default=None, description="Track by batch/lot numbers"
+    )
+    serial_tracked: bool | None = Field(
+        default=None, description="Track by serial numbers"
+    )
     operations_in_sequence: bool | None = Field(
-        None, description="Manufacturing operations must be done in sequence"
+        default=None, description="Manufacturing operations must be done in sequence"
     )
 
     # ============ Supplier & Ordering ============
 
-    default_supplier_id: int | None = Field(None, description="Default supplier ID")
+    default_supplier_id: int | None = Field(
+        default=None, description="Default supplier ID"
+    )
     lead_time: int | None = Field(
-        None, ge=0, le=999, description="Lead time in days to fulfill order"
+        default=None, ge=0, le=999, description="Lead time in days to fulfill order"
     )
     minimum_order_quantity: float | None = Field(
-        None, ge=0, le=999_999_999, description="Minimum order quantity"
+        default=None, ge=0, le=999_999_999, description="Minimum order quantity"
     )
 
     # ============ Purchase Unit Conversion ============
 
     purchase_uom: str | None = Field(
-        None,
+        default=None,
         max_length=7,
         description="Purchase unit of measure (if different from base UOM)",
     )
     purchase_uom_conversion_rate: float | None = Field(
-        None,
+        default=None,
         ge=0,
         le=1_000_000_000_000,
         description="Conversion rate from purchase UOM to base UOM",
@@ -114,20 +126,24 @@ class KatanaProduct(KatanaBaseModel):
 
     # ============ Additional Info ============
 
-    additional_info: str | None = Field(None, description="Additional notes/info")
+    additional_info: str | None = Field(
+        default=None, description="Additional notes/info"
+    )
     custom_field_collection_id: int | None = Field(
-        None, description="Custom field collection ID"
+        default=None, description="Custom field collection ID"
     )
     archived_at: AwareDatetime | None = Field(
-        None, description="Timestamp when product was archived"
+        default=None, description="Timestamp when product was archived"
     )
 
     # ============ Nested Data ============
 
     variant_count: int = Field(
-        0, ge=0, description="Number of variants for this product"
+        default=0, ge=0, description="Number of variants for this product"
     )
-    config_count: int = Field(0, ge=0, description="Number of configuration attributes")
+    config_count: int = Field(
+        default=0, ge=0, description="Number of configuration attributes"
+    )
 
     # ============ Factory Methods ============
 

--- a/katana_public_api_client/domain/service.py
+++ b/katana_public_api_client/domain/service.py
@@ -56,34 +56,40 @@ class KatanaService(KatanaBaseModel):
     # ============ Core Fields (always present) ============
 
     id: int = Field(..., description="Unique service ID")
-    name: str | None = Field(None, description="Service name")
+    name: str | None = Field(default=None, description="Service name")
     type_: Literal["service"] = Field(
-        "service", alias="type", description="Entity type (always 'service')"
+        default="service", alias="type", description="Entity type (always 'service')"
     )
 
     # ============ Classification & Units ============
 
-    uom: str | None = Field(None, description="Unit of measure (e.g., 'pcs', 'hours')")
-    category_name: str | None = Field(None, description="Service category name")
+    uom: str | None = Field(
+        default=None, description="Unit of measure (e.g., 'pcs', 'hours')"
+    )
+    category_name: str | None = Field(default=None, description="Service category name")
 
     # ============ Capabilities ============
 
-    is_sellable: bool | None = Field(None, description="Can be sold to customers")
+    is_sellable: bool | None = Field(
+        default=None, description="Can be sold to customers"
+    )
 
     # ============ Additional Info ============
 
-    additional_info: str | None = Field(None, description="Additional notes/info")
+    additional_info: str | None = Field(
+        default=None, description="Additional notes/info"
+    )
     custom_field_collection_id: int | None = Field(
-        None, description="Custom field collection ID"
+        default=None, description="Custom field collection ID"
     )
     archived_at: AwareDatetime | None = Field(
-        None, description="Timestamp when service was archived"
+        default=None, description="Timestamp when service was archived"
     )
 
     # ============ Nested Data ============
 
     variant_count: int = Field(
-        0, ge=0, description="Number of variants for this service"
+        default=0, ge=0, description="Number of variants for this service"
     )
 
     # ============ Factory Methods ============

--- a/katana_public_api_client/domain/variant.py
+++ b/katana_public_api_client/domain/variant.py
@@ -59,34 +59,38 @@ class KatanaVariant(KatanaBaseModel):
     # ============ Pricing Fields ============
 
     sales_price: float | None = Field(
-        None, ge=0, le=100_000_000_000, description="Sales price"
+        default=None, ge=0, le=100_000_000_000, description="Sales price"
     )
     purchase_price: float | None = Field(
-        None, ge=0, le=100_000_000_000, description="Purchase cost"
+        default=None, ge=0, le=100_000_000_000, description="Purchase cost"
     )
 
     # ============ Relationship Fields ============
 
     product_id: int | None = Field(
-        None, description="ID of parent product (if product variant)"
+        default=None, description="ID of parent product (if product variant)"
     )
     material_id: int | None = Field(
-        None, description="ID of parent material (if material variant)"
+        default=None, description="ID of parent material (if material variant)"
     )
     product_or_material_name: str | None = Field(
-        None, description="Name of parent product or material"
+        default=None, description="Name of parent product or material"
     )
 
     # ============ Classification ============
 
     type_: Literal["product", "material", "service"] | None = Field(
-        None, alias="type", description="Variant type (product, material, or service)"
+        default=None,
+        alias="type",
+        description="Variant type (product, material, or service)",
     )
 
     # ============ Inventory & Barcode Fields ============
 
-    internal_barcode: str | None = Field(None, description="Internal barcode")
-    registered_barcode: str | None = Field(None, description="Registered/UPC barcode")
+    internal_barcode: str | None = Field(default=None, description="Internal barcode")
+    registered_barcode: str | None = Field(
+        default=None, description="Registered/UPC barcode"
+    )
     supplier_item_codes: list[str] = Field(
         default_factory=list, description="Supplier item codes"
     )
@@ -94,10 +98,10 @@ class KatanaVariant(KatanaBaseModel):
     # ============ Ordering Fields ============
 
     lead_time: int | None = Field(
-        None, ge=0, le=999, description="Lead time in days to fulfill order"
+        default=None, ge=0, le=999, description="Lead time in days to fulfill order"
     )
     minimum_order_quantity: float | None = Field(
-        None, ge=0, le=999_999_999, description="Minimum order quantity"
+        default=None, ge=0, le=999_999_999, description="Minimum order quantity"
     )
 
     # ============ Configuration & Custom Data ============
@@ -170,8 +174,17 @@ class KatanaVariant(KatanaBaseModel):
                 if hasattr(generated.type, "value")
                 else generated.type
             )
-            if raw_type in ("product", "material", "service"):
-                type_value = raw_type
+            # Per-branch narrowing satisfies both pyright and ty:
+            # ``raw_type`` is ``VariantType | str``; pyright doesn't
+            # narrow membership-against-literals, and ty calls a wrapping
+            # cast redundant. Direct equality on each literal narrows
+            # cleanly under both checkers.
+            if raw_type == "product":
+                type_value = "product"
+            elif raw_type == "material":
+                type_value = "material"
+            elif raw_type == "service":
+                type_value = "service"
 
         return cls(
             id=generated.id,
@@ -234,7 +247,10 @@ class KatanaVariant(KatanaBaseModel):
         ):
             from ..client_types import UNSET
 
-            pom = attrs_variant.product_or_material
+            # Attribute exists per ``hasattr`` but isn't on the static
+            # ``Variant`` shape (it comes in via ``?extend=`` API
+            # responses) — read via ``getattr`` to satisfy the checker.
+            pom = getattr(attrs_variant, "product_or_material", None)
             if pom is not UNSET and pom is not None and hasattr(pom, "name"):
                 name = pom.name
                 if name is not UNSET and isinstance(name, str):

--- a/katana_public_api_client/katana_client.py
+++ b/katana_public_api_client/katana_client.py
@@ -101,12 +101,19 @@ def _sanitize_url(url: str) -> str:
                 sanitized[k] = [_REDACTED]
             else:
                 sanitized[k] = values
-        # Use urlencode with custom quote function that preserves * characters
+        # Use urlencode with custom quote function that preserves * characters.
+        # ``urlencode``'s ``quote_via`` has overloaded protocols for
+        # ``str`` and ``bytes`` that don't unify under a single
+        # callable shape; cast the lambda to ``Any`` to satisfy the
+        # checker without picking one overload.
         clean_query = urlencode(
             sanitized,
             doseq=True,
-            quote_via=lambda s, safe="", encoding=None, errors=None: quote(
-                s, safe=safe + "*", encoding=encoding, errors=errors
+            quote_via=cast(
+                "Any",
+                lambda s, safe="", encoding=None, errors=None: quote(
+                    s, safe=safe + "*", encoding=encoding, errors=errors
+                ),
             ),
         )
         return urlunparse(parsed._replace(query=clean_query))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ dev = [
     "aiohttp>=3.13.3",
     "brotli>=1.2.0",
     "poethepoet>=0.37.0",
+    "pyright>=1.1.400",
     "ty>=0.0.1a25",
     "types-jsonschema>=4.25.1.20251009",
 ]
@@ -552,12 +553,18 @@ format-check = ["format-python-check", "format-markdown-check"]
 # match the declared ``Mapped[T | None]`` type), while pyright accepts it.
 # Generated files are auto-emitted; consistent exclusion across both checkers
 # matches ``pyrightconfig.json``'s existing ``_generated/`` skip.
-typecheck = "ty check --exclude 'tests/conftest.py' --exclude 'tests/test_generate_tools_json.py' --exclude 'scripts/' --exclude 'katana_mcp_server/tests/' --exclude 'katana_public_api_client/models_pydantic/_generated/' --exclude '.claude/worktrees/'"
+typecheck = "ty check --exclude 'tests/conftest.py' --exclude 'tests/test_generate_tools_json.py' --exclude 'scripts/' --exclude 'katana_public_api_client/models_pydantic/_generated/' --exclude '.claude/worktrees/'"
+# Pyright runs alongside ty: ty is the primary CI gate (faster, drives
+# CI), pyright catches things ty doesn't yet (e.g., generic-invariance
+# on ``Response[T]`` unions, pydantic positional-default detection).
+# Configuration lives in ``pyrightconfig.json`` — exclusions there match
+# the typecheck exclusions plus a few pyright-specific ones.
+typecheck-pyright = "pyright"
 lint-ruff = "ruff check ."
 lint-ruff-fix = "ruff check --fix ."
 lint-yaml = "yamllint ."
 
-lint = ["lint-ruff", "typecheck", "lint-yaml"]
+lint = ["lint-ruff", "typecheck", "typecheck-pyright", "lint-yaml"]
 
 # -----------------------------------------------------------------------------
 # Testing Tasks

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -16,7 +16,8 @@
     "katana_public_api_client/api",
     "katana_public_api_client/models",
     "katana_public_api_client/client.py",
-    "katana_public_api_client/models_pydantic/_generated"
+    "katana_public_api_client/models_pydantic/_generated",
+    "scripts/test_mcp_resources.py"
   ],
   "executionEnvironments": [
     {

--- a/scripts/generate_pydantic_models.py
+++ b/scripts/generate_pydantic_models.py
@@ -519,7 +519,7 @@ def _rewrite_identifiers_outside_strings(
                 rewritten.append(tok)
             else:
                 rewritten.append(tok._replace(string=new_string))
-    except (tokenize.TokenizeError, IndentationError):
+    except (tokenize.TokenError, IndentationError):
         result = source
         for key in sorted(replacements, key=len, reverse=True):
             result = re.sub(rf"\b{re.escape(key)}\b", replacements[key], result)

--- a/scripts/regenerate_client.py
+++ b/scripts/regenerate_client.py
@@ -23,6 +23,8 @@ The script should be run with 'uv run python' to ensure all dependencies
 Node.js and npx are required for Redocly validation.
 """
 
+from __future__ import annotations
+
 import re
 import shutil
 import subprocess
@@ -78,6 +80,7 @@ def run_command_streaming(
     if timeout:
         print(f"   ⏱️  Timeout: {timeout}s")
 
+    process: subprocess.Popen[str] | None = None
     try:
         process = subprocess.Popen(
             cmd,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -79,8 +79,12 @@ def katana_client_with_mock_transport(mock_api_credentials, mock_transport):
         transport=mock_transport, base_url=mock_api_credentials["base_url"]
     )
 
-    # Replace the authenticated client's async client
-    client._client._async_client = mock_httpx_client
+    # Replace the authenticated client's async client. ``_client`` is
+    # the stale alias on ``KatanaClient`` (private), and ``_async_client``
+    # is httpx's lazily-set internal handle; both are runtime attributes
+    # the static type doesn't expose.
+    inner_client = cast(Any, client)._client
+    cast(Any, inner_client)._async_client = mock_httpx_client
 
     return client
 

--- a/tests/test_generate_pydantic_postprocess.py
+++ b/tests/test_generate_pydantic_postprocess.py
@@ -443,7 +443,11 @@ def test_generated_cached_location_uses_name_override() -> None:
     ``__tablename__`` ``location`` (not ``location_1``)."""
     from katana_public_api_client.models_pydantic._generated import CachedLocation
 
-    assert CachedLocation.__tablename__ == "location"
+    # SQLModel's metaclass exposes ``__tablename__`` as ``declared_attr[str]``
+    # at class-level access; pyright sees ``==`` on that as
+    # ``ColumnElement[bool]``. Read via ``str()`` to compare the actual
+    # tablename string.
+    assert str(CachedLocation.__tablename__) == "location"
 
 
 def test_generated_cached_material_flattens_inventory_item() -> None:

--- a/tests/test_real_api.py
+++ b/tests/test_real_api.py
@@ -147,13 +147,16 @@ class TestRealAPIIntegration:
                     f"Expected 200, got {response.status_code}"
                 )
 
-                # Extract products from response
+                # Extract products from response. ``response.parsed`` is a
+                # union of error/success types; only the success branches
+                # have ``.data``. ``hasattr`` filters at runtime; read via
+                # ``getattr`` to satisfy the static checker.
                 if (
                     hasattr(response, "parsed")
                     and response.parsed
                     and hasattr(response.parsed, "data")
                 ):
-                    products = response.parsed.data
+                    products = getattr(response.parsed, "data", None)
                     if isinstance(products, list) and len(products) > 0:
                         assert len(products) > 0, "Should get at least some products"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.62.0"
+version = "0.63.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1367,6 +1367,7 @@ dev = [
     { name = "aiohttp" },
     { name = "brotli" },
     { name = "poethepoet" },
+    { name = "pyright" },
     { name = "ty" },
     { name = "types-jsonschema" },
 ]
@@ -1426,6 +1427,7 @@ dev = [
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "brotli", specifier = ">=1.2.0" },
     { name = "poethepoet", specifier = ">=0.37.0" },
+    { name = "pyright", specifier = ">=1.1.400" },
     { name = "ty", specifier = ">=0.0.1a25" },
     { name = "types-jsonschema", specifier = ">=4.25.1.20251009" },
 ]
@@ -2502,6 +2504,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/33/0c/6e78218e6ef726be35a4c0a5e2e281e36ddd940566800219e96d13de99ad/pyrate_limiter-4.1.0.tar.gz", hash = "sha256:be1ac413a263aa410b98757d1b01a880650948a1fc3a959512f15865eb58dbf3", size = 306136, upload-time = "2026-03-22T14:43:03.739Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/fd/57181fafae08385d00ea2702be246ab8035352a0a8e1f63391c2bcad74d4/pyrate_limiter-4.1.0-py3-none-any.whl", hash = "sha256:2696b4e4a6cffb3d40fc76662baccb766697893f0979e12bebbfc7d3b6b19603", size = 38197, upload-time = "2026-03-22T14:43:01.975Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

**Closes #480 Phase B and #626 in one shot.**

1. **Phase B** — Cut test-side ty diagnostics from 236 → 0. Drop the `katana_mcp_server/tests/` exclude from `[tool.poe.tasks].typecheck`.
2. **#626** — Wire `pyright` into `[tool.poe.tasks].lint` alongside `ty`. Cut full-repo pyright errors from 119 → 0 (with 2 documented warnings on SQLModel stub mismatches).

All 3,060 tests pass throughout. Both type checkers run clean in `uv run poe lint` / `uv run poe check`.

## Phase B sweeps (test-side)

1. **Conftest import resolution** (-20). `from tests.conftest import X` resolved to the wrong file (repo-root collision); switched to fully-qualified `from katana_mcp_server.tests.conftest import X`.
2. **AsyncMock typed-attribute assignment** (-114, two passes). `module.field = AsyncMock(...)` → `cast(Any, module).field = AsyncMock(...)`. Restore lines (`module.field = original_X`) didn't need wrapping.
3. **call_args / await_args asserts with full dotted-chain prefix** (-25). `assert <expr>.call_args is not None` before each access; the regex captures `module.attr.call_args`, not just `attr.call_args`.
4. **test_prefab_ui.py walk-helper typing** (-36). Switched 12 walk-helper params from `tree: object` → `tree: Any`.
5. **Mock-method access via cast** (-15). `cast(Any, module.asyncio_detailed).<X>` for `assert_called_once`, `call_args`, etc.
6. **Per-site cleanups** (-26). Enum literals, `model_validate`, fixture construction, factory parameters, namespace mismatches.
7. **Drop the test-side exclude.**

## Pyright wiring (#626)

Pre-existing pyright errors discovered while wiring:

- **39 sites of `Field(None, ...)` positional default** — pyright's pydantic plugin only recognizes `default=None` keyword form. The positional form is valid at runtime but treated as missing-default, producing `Arguments missing for parameters` errors at every caller. Mechanical sweep across `katana_mcp_server/src/`, `katana_public_api_client/domain/`, etc. converted all to `Field(default=None, ...)`.
- **Test fixture issues** — `entity_type="outsourced"` literal → `PurchaseOrderEntityType.OUTSOURCED`, `"IN_STOCK"` → `IngredientAvailability.IN_STOCK`, etc.
- **`urlencode quote_via` typing** in `katana_client.py` — overloaded `_QuoteVia` protocol with conflicting `safe: str | bytes` shapes; cast lambda to `Any` at the boundary (the simplest sound fix).
- **`hasattr` narrowing** in `domain/variant.py`, `tests/test_real_api.py`, `tests/test_prefab_ui.py` — pyright doesn't narrow on `hasattr(...)`. Switched to `getattr(obj, "name", None)` + `assert isinstance(...)` for the static-checker.
- **Possibly-unbound variable** in `scripts/regenerate_client.py:102` — `process` only set in the `try` block, used in the `except`. Initialized to `None` before.
- **`scripts/test_mcp_resources.py`** — outdated dev script (references removed `katana_mcp.resources.reference` module). Excluded from pyright.
- **`tests/conftest.py:_async_client` private-attribute write** — `cast(Any, ...)` at the seam.

## What's now in CI

```toml
[tool.poe.tasks]
typecheck = "ty check ..."           # primary checker
typecheck-pyright = "pyright"        # second-opinion checker
lint = ["lint-ruff", "typecheck", "typecheck-pyright", "lint-yaml"]
```

`pyright` added to dev deps so it runs without `uv run --with pyright`. Rule overrides in `pyrightconfig.json` documented:
- `reportIncompatibleVariableOverride: "none"` (SQLModel `__tablename__` stub mismatch)
- `reportAssignmentType: "warning"` (SQLModel literal-vs-`declared_attr` mismatch)

## Validation

- [x] `uv run poe lint` clean (ruff + ty + pyright + yamllint)
- [x] `uv run poe check` clean (full validation)
- [x] All 3,060 tests pass
- [x] `ty check` reports 0 diagnostics
- [x] `pyright` reports **0 errors, 2 documented warnings**
- [ ] CI

## Did this fix any real bugs?

**One real correctness improvement:** The `Field(None, ...)` → `Field(default=None, ...)` sweep makes the MCP request models correctly typed for tools that introspect them. Pyright's pydantic plugin (and many third-party tools) only recognize the keyword form; consumers calling these as factories may have been getting the wrong type information. Runtime behavior is identical.

Everything else was type-system narrowing on code that was already correct at runtime.

## Closes
- **#480 Phase B** — `katana_mcp_server/tests/` is now type-checked
- **#626** — pyright runs alongside ty in CI

## Follow-ups
- **#480 Phase C** — third-party stub gaps (sqlalchemy, fastmcp). Smaller; can follow.

Refs: closes-phase-B-of #480, closes #626