### PR TITLE
feat(mcp): wire catalog typed-cache sync + FTS sidecar + CatalogQueries adapter (#472 Phase B)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/typed_cache/__init__.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/__init__.py
@@ -71,7 +71,6 @@ from .sync import (
     ensure_variants_synced,
     force_resync,
     merge_filtered_fetch,
-    topo_sort_specs,
 )
 from .sync_state import SyncState
 
@@ -102,5 +101,4 @@ __all__ = [
     "ensure_variants_synced",
     "force_resync",
     "merge_filtered_fetch",
-    "topo_sort_specs",
 ]

--- a/katana_mcp_server/src/katana_mcp/typed_cache/__init__.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/__init__.py
@@ -1,36 +1,44 @@
-"""SQLModel-backed cache for transactional list tools (#342, ADR-0018).
+"""SQLModel-backed typed cache for Katana entities (#342, ADR-0018, #472).
 
-Complements ``katana_mcp.cache.CatalogCache`` — the two caches serve
-different concerns and both are permanent:
+``TypedCacheEngine`` holds all cached entity types (catalog +
+transactional) in per-entity SQLModel tables with proper FK relationships
+and JSON columns. The legacy ``katana_mcp.cache.CatalogCache`` is in
+the process of being retired — see #472. While the migration is in
+flight Phase B (the catalog ``Cached*`` siblings + FTS5 sidecar +
+``CatalogQueries`` adapter) ships in parallel with the legacy cache;
+Phase D flips the call sites and removes the legacy module.
 
-- **CatalogCache** holds the 10 reference entity types (variants, products,
-  materials, services, suppliers, customers, locations, tax rates,
-  operators, factories) in a generic SQLite + FTS5 store. Powers
-  ``search_items`` / ``get_variant_details`` and other lookup tools.
-- **TypedCacheEngine** (this package) holds transactional types
-  (sales_orders, manufacturing_orders, purchase_orders, stock_adjustments,
-  stock_transfers, manufacturing_order_recipe_rows) in per-entity SQLModel
-  tables with proper FK relationships and JSON columns. Powers the
-  cache-backed ``list_*`` tools.
+End-state coverage:
 
-The transactional types' richer filter needs (status, customer/supplier
-IDs, date ranges, variant-id-via-rows) and 30+-field schemas don't fit
-``CatalogCache``'s three-text-column ``entity_index`` projection — see
-ADR-0018 for the full rationale. The two caches will continue to coexist.
+- Catalog: variants, products, materials, services, customers,
+  suppliers, locations, tax rates, operators, factories, additional
+  costs (11 types). Search uses per-entity FTS5 virtual tables; the
+  ``CatalogQueries`` adapter wraps ``smart_search`` / ``get_by_id`` /
+  ``get_by_sku`` / ``get_many_by_ids`` / ``get_all`` /
+  ``search_fuzzy`` with default ``include_archived=False`` /
+  ``include_deleted=False`` filters.
+- Transactional: sales orders, manufacturing orders (+ recipe rows),
+  purchase orders (+ rows), stock adjustments, stock transfers (10
+  ``Cached*`` siblings counting child rows). Search via SQL WHERE
+  clauses; no FTS sidecar — these tables don't carry free-text fields.
 
 Public API::
 
     from katana_mcp.typed_cache import (
         TypedCacheEngine,
         ensure_sales_orders_synced,
+        ensure_variants_synced,
     )
 
     engine = TypedCacheEngine()
     await engine.open()
     try:
-        await ensure_sales_orders_synced(client, engine)
-        async with engine.session() as session:
-            orders = (await session.exec(select(SalesOrder))).all()
+        await ensure_variants_synced(client, engine)
+        # Typed lookups via the CatalogQueries adapter on engine.catalog.
+        variant = await engine.catalog.get_by_sku("FOX-FORK-160")
+        results = await engine.catalog.smart_search(
+            CachedVariant, "kitchen knife"
+        )
     finally:
         await engine.close()
 """
@@ -38,19 +46,32 @@ Public API::
 from __future__ import annotations
 
 from .engine import TypedCacheEngine
+from .queries import CatalogQueries
 from .sync import (
     ENTITY_SPECS,
     MANUFACTURING_ORDER_RECIPE_ROW_SPEC,
     MANUFACTURING_ORDER_SPEC,
     EntitySpec,
+    ensure_additional_costs_synced,
+    ensure_customers_synced,
+    ensure_factory_synced,
+    ensure_locations_synced,
     ensure_manufacturing_order_recipe_rows_synced,
     ensure_manufacturing_orders_synced,
+    ensure_materials_synced,
+    ensure_operators_synced,
+    ensure_products_synced,
     ensure_purchase_orders_synced,
     ensure_sales_orders_synced,
+    ensure_services_synced,
     ensure_stock_adjustments_synced,
     ensure_stock_transfers_synced,
+    ensure_suppliers_synced,
+    ensure_tax_rates_synced,
+    ensure_variants_synced,
     force_resync,
     merge_filtered_fetch,
+    topo_sort_specs,
 )
 from .sync_state import SyncState
 
@@ -58,15 +79,28 @@ __all__ = [
     "ENTITY_SPECS",
     "MANUFACTURING_ORDER_RECIPE_ROW_SPEC",
     "MANUFACTURING_ORDER_SPEC",
+    "CatalogQueries",
     "EntitySpec",
     "SyncState",
     "TypedCacheEngine",
+    "ensure_additional_costs_synced",
+    "ensure_customers_synced",
+    "ensure_factory_synced",
+    "ensure_locations_synced",
     "ensure_manufacturing_order_recipe_rows_synced",
     "ensure_manufacturing_orders_synced",
+    "ensure_materials_synced",
+    "ensure_operators_synced",
+    "ensure_products_synced",
     "ensure_purchase_orders_synced",
     "ensure_sales_orders_synced",
+    "ensure_services_synced",
     "ensure_stock_adjustments_synced",
     "ensure_stock_transfers_synced",
+    "ensure_suppliers_synced",
+    "ensure_tax_rates_synced",
+    "ensure_variants_synced",
     "force_resync",
     "merge_filtered_fetch",
+    "topo_sort_specs",
 ]

--- a/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
@@ -25,6 +25,9 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 # entity modules here as they come online.
 from katana_mcp.typed_cache import sync_state as _sync_state_mod
 from katana_public_api_client.models_pydantic._generated import (
+    common as _common_mod,
+    contacts as _contacts_mod,
+    inventory as _inventory_mod,
     manufacturing as _manufacturing_mod,
     purchase_orders as _purchase_orders_mod,
     sales_orders as _sales_orders_mod,
@@ -33,11 +36,17 @@ from katana_public_api_client.models_pydantic._generated import (
 
 # ``stock`` already covers StockTransfer (sibling to StockAdjustment in the
 # same generated module), so no extra side-effect import is needed.
+# ``inventory`` registers Cached{Variant,Product,Material,Service};
+# ``contacts`` registers Cached{Customer,Supplier};
+# ``common`` registers Cached{Location,TaxRate,Operator,Factory,AdditionalCost}.
 assert _sync_state_mod is not None
 assert _sales_orders_mod is not None
 assert _stock_mod is not None
 assert _manufacturing_mod is not None
 assert _purchase_orders_mod is not None
+assert _inventory_mod is not None
+assert _contacts_mod is not None
+assert _common_mod is not None
 
 _DEFAULT_DB_PATH = Path(user_cache_dir("katana-mcp")) / "typed_cache.db"
 
@@ -69,6 +78,11 @@ class TypedCacheEngine:
     shutdown to flush and dispose the engine. Tools obtain sessions via
     the ``session()`` context manager and take ``lock_for(entity_type)``
     before kicking off a sync so concurrent callers don't fan out.
+
+    The ``catalog`` attribute exposes a :class:`CatalogQueries` adapter
+    that wraps typed reads (``get_by_id``, ``smart_search``, ...) over
+    the catalog tier of the cache. Phase D will migrate ~33 legacy
+    ``services.cache.*`` call sites onto it.
     """
 
     def __init__(
@@ -102,6 +116,11 @@ class TypedCacheEngine:
         )
         self._engine: AsyncEngine | None = None
         self._locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+        # Lazy import — ``queries`` imports from this module's siblings,
+        # so doing it at function definition time would create a cycle.
+        from .queries import CatalogQueries
+
+        self.catalog: CatalogQueries = CatalogQueries(self)
 
     @property
     def db_path(self) -> Path | None:
@@ -141,8 +160,27 @@ class TypedCacheEngine:
             )
             event.listen(self._engine.sync_engine, "connect", _apply_sqlite_pragmas)
 
+        # Validate the EntitySpec dependency graph before any sync runs.
+        # Lazy import — ``sync`` imports from ``engine`` for typing
+        # (``TYPE_CHECKING``), but the runtime call needs to land here.
+        from .fts import (
+            initialize_fts_for_connection,
+            install_fts_listeners,
+            populate_fts_from_existing_rows,
+        )
+        from .sync import ENTITY_SPECS, _validate_dependency_graph
+
+        _validate_dependency_graph(ENTITY_SPECS.values())
+
         async with self._engine.begin() as conn:
             await conn.run_sync(SQLModel.metadata.create_all)
+            # FTS5 virtual tables sit alongside the SQLModel-managed
+            # tables and need their own DDL. Install the after_*
+            # listeners first so any rows already on disk re-emit FTS
+            # entries during the rebuild.
+            await conn.run_sync(lambda sync_conn: install_fts_listeners())
+            await conn.run_sync(initialize_fts_for_connection)
+            await conn.run_sync(populate_fts_from_existing_rows)
 
     async def close(self) -> None:
         """Dispose the underlying SQLAlchemy engine.

--- a/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
@@ -165,7 +165,6 @@ class TypedCacheEngine:
         # (``TYPE_CHECKING``), but the runtime call needs to land here.
         from .fts import (
             initialize_fts_for_connection,
-            install_fts_listeners,
             populate_fts_from_existing_rows,
         )
         from .sync import ENTITY_SPECS, _validate_dependency_graph
@@ -175,10 +174,21 @@ class TypedCacheEngine:
         async with self._engine.begin() as conn:
             await conn.run_sync(SQLModel.metadata.create_all)
             # FTS5 virtual tables sit alongside the SQLModel-managed
-            # tables and need their own DDL. Install the after_*
-            # listeners first so any rows already on disk re-emit FTS
-            # entries during the rebuild.
-            await conn.run_sync(lambda sync_conn: install_fts_listeners())
+            # tables and need their own DDL. Two steps, in order:
+            # 1. ``initialize_fts_for_connection`` — emit
+            #    ``CREATE VIRTUAL TABLE IF NOT EXISTS <entity>_fts``
+            #    plus the trigger trio (``<entity>_ai`` / ``_au`` /
+            #    ``_ad``) that keeps the inverted index in sync with
+            #    the content table for every write mode (ORM, Core,
+            #    raw SQL). Triggers replace the pre-#646 mapper-event
+            #    listeners, which fired only for ORM writes and so
+            #    silently missed the typed-cache bulk-upsert path.
+            # 2. ``populate_fts_from_existing_rows`` — direct-SQL
+            #    rebuild from the main tables. Backfills pre-existing
+            #    rows on reopen and is the canonical recovery path if
+            #    the FTS index ever drifts out of sync with the main
+            #    table (cheap server-side ``DELETE`` + ``INSERT
+            #    ... SELECT`` per entity, idempotent).
             await conn.run_sync(initialize_fts_for_connection)
             await conn.run_sync(populate_fts_from_existing_rows)
 

--- a/katana_mcp_server/src/katana_mcp/typed_cache/fts.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/fts.py
@@ -29,24 +29,35 @@ on the table — a generator regression that drops a column from the
 schema but leaves it in the FTS spec would otherwise corrupt every
 search until the next user-visible failure.
 
-**SQL-injection safety**: every ``text()`` call in this module
-interpolates only ``__table__.name`` / ``__fts_columns__`` values.
-Both come from the Python-class metadata set by the SQLModel
-generator at import time, *not* from user input. User-supplied
-values (FTS row content, row IDs) reach the database exclusively
-through bound parameters (``:rid``, ``:c0``, ...). FTS5 virtual
-tables can't be expressed through the SQLAlchemy ORM — there's no
-``Table`` declarative object for them — so raw text is the only
-path. The ``# nosemgrep`` annotations below acknowledge the rule
-while documenting why the input is trusted.
+**SQL safety**: FTS5 virtual tables can't be expressed through the
+SQLAlchemy ORM (no ``Table`` declarative object exists for them), so
+the SQL must be assembled as strings. Two SQLAlchemy primitives keep
+the security audit clean:
+
+- ``DDL(...)`` for schema operations (``CREATE VIRTUAL TABLE`` and
+  the truncate-style ``DELETE FROM <fts>``). DDL is the SQLAlchemy
+  construct designated for raw schema SQL — no user input is ever
+  meant to flow through it, and Semgrep's ``avoid-sqlalchemy-text``
+  rule correctly leaves it alone.
+- ``conn.exec_driver_sql(...)`` for FTS row INSERT/DELETE. Driver-SQL
+  takes positional ``?`` placeholders bound by the DBAPI, so user
+  input (FTS row content, row IDs) never reaches the SQL string.
+
+Identifiers (table names, column names) come exclusively from the
+Python-class metadata set by the SQLModel generator at import time —
+never from user input. We additionally validate them against
+``_IDENTIFIER_RE`` before interpolation as a belt-and-suspenders
+guard against a future regression where the generator emits
+something exotic.
 """
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import event, text
+from sqlalchemy import DDL, event
 from sqlmodel import SQLModel
 
 if TYPE_CHECKING:
@@ -54,9 +65,25 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Mapper
 
 
+# SQL identifiers (table + column names) must match this pattern before
+# we interpolate them into a DDL/DML statement. The cache-class
+# metadata set by the SQLModel generator already produces snake_case
+# identifiers, so the regex is just a defense-in-depth check against a
+# future generator regression — never a real attack vector.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _safe_identifier(name: str) -> str:
+    """Validate ``name`` matches ``_IDENTIFIER_RE``; raise otherwise."""
+    if not _IDENTIFIER_RE.fullmatch(name):
+        msg = f"Invalid SQL identifier from cache metadata: {name!r}"
+        raise ValueError(msg)
+    return name
+
+
 def _fts_table_name(table_name: str) -> str:
     """``variant`` -> ``variant_fts``. Keep the convention symmetric."""
-    return f"{table_name}_fts"
+    return f"{_safe_identifier(table_name)}_fts"
 
 
 def _all_subclasses(cls: type[SQLModel]) -> Iterator[type[SQLModel]]:
@@ -159,20 +186,22 @@ def _create_fts_tables_ddl(conn: Any) -> None:
     for cls in _classes_with_fts_columns():
         _validate_fts_columns(cls)
         table = _table_for(cls)
-        fts_table = _fts_table_name(table.name)
+        table_name = _safe_identifier(table.name)
+        fts_table = _fts_table_name(table_name)
         cols = _fts_columns(cls)
-        col_list = ", ".join(cols)
+        col_list = ", ".join(_safe_identifier(c) for c in cols)
         # ``content`` + ``content_rowid`` make the FTS table reference
         # rows in the main table by ``id`` (the integer PK on every
         # Cached* class). FTS5 uses the rowid for ranking + lookups; the
         # FTS row mirrors the content columns at insert/update time.
         sql = (
             f"CREATE VIRTUAL TABLE IF NOT EXISTS {fts_table} "
-            f"USING fts5({col_list}, content='{table.name}', content_rowid='id')"
+            f"USING fts5({col_list}, content='{table_name}', content_rowid='id')"
         )
-        # Trusted input: ``fts_table`` / ``col_list`` / ``table.name`` come
-        # from SQLModel-generated cache-class metadata (no user input).
-        conn.execute(text(sql))  # nosemgrep: avoid-sqlalchemy-text
+        # ``DDL`` is the SQLAlchemy primitive for raw schema statements
+        # (FTS5 virtual tables have no ORM construct). Identifiers are
+        # validated by ``_safe_identifier``.
+        conn.execute(DDL(sql))
 
 
 def _row_value(target: Any, col: str) -> Any:
@@ -193,14 +222,10 @@ def _delete_fts_row(conn: Connection, table_name: str, row_id: int) -> None:
     the inverted index never carries stale tokens.
     """
     fts = _fts_table_name(table_name)
-    # Trusted input: ``fts`` derives from cache-class ``__table__.name``;
-    # ``row_id`` is bound separately via the ``:rid`` parameter.
-    conn.execute(
-        text(  # nosemgrep: avoid-sqlalchemy-text
-            f"DELETE FROM {fts} WHERE rowid = :rid"
-        ),
-        {"rid": row_id},
-    )
+    # ``exec_driver_sql`` binds ``row_id`` via the DBAPI's positional
+    # ``?`` placeholder — user input never reaches the SQL string.
+    # ``fts`` is a validated identifier from cache-class metadata.
+    conn.exec_driver_sql(f"DELETE FROM {fts} WHERE rowid = ?", (row_id,))
 
 
 def _insert_fts_row(
@@ -218,19 +243,16 @@ def _insert_fts_row(
     nothing) but never match real tokens, so ranking stays correct.
     """
     fts = _fts_table_name(table_name)
-    placeholders = ", ".join(f":c{i}" for i in range(len(fts_cols)))
-    col_list = ", ".join(fts_cols)
-    bind: dict[str, Any] = {"rid": row_id}
-    for idx, value in enumerate(values):
-        bind[f"c{idx}"] = "" if value is None else str(value)
-    # Trusted input: ``fts`` / ``col_list`` / ``placeholders`` derive
-    # from cache-class metadata; user-supplied ``values`` flow through
-    # bound parameters (``:c0``, ``:c1``, ...).
-    conn.execute(
-        text(  # nosemgrep: avoid-sqlalchemy-text
-            f"INSERT INTO {fts} (rowid, {col_list}) VALUES (:rid, {placeholders})"
-        ),
-        bind,
+    col_list = ", ".join(_safe_identifier(c) for c in fts_cols)
+    placeholders = ", ".join("?" for _ in fts_cols)
+    coerced = tuple("" if v is None else str(v) for v in values)
+    # ``exec_driver_sql`` passes ``coerced`` as positional ``?`` binds
+    # at the DBAPI layer — user input never reaches the SQL string.
+    # ``fts`` / ``col_list`` are validated identifiers from cache-class
+    # metadata.
+    conn.exec_driver_sql(
+        f"INSERT INTO {fts} (rowid, {col_list}) VALUES (?, {placeholders})",
+        (row_id, *coerced),
     )
 
 
@@ -338,25 +360,25 @@ def populate_fts_from_existing_rows(connection: Any) -> None:
     """
     for cls in _classes_with_fts_columns():
         table = _table_for(cls)
-        fts = _fts_table_name(table.name)
+        table_name = _safe_identifier(table.name)
+        fts = _fts_table_name(table_name)
         cols = _fts_columns(cls)
+        safe_cols = [_safe_identifier(c) for c in cols]
+        col_list = ", ".join(safe_cols)
         # Truncate the FTS sidecar first so the rebuild is canonical.
-        # Trusted input: ``fts`` is the cache class's table name +
-        # ``_fts`` suffix (no user input).
-        connection.execute(
-            text(f"DELETE FROM {fts}")  # nosemgrep: avoid-sqlalchemy-text
-        )
-        col_list = ", ".join(cols)
+        # ``DDL`` is the SQLAlchemy primitive for raw schema-level SQL;
+        # ``fts`` is a validated identifier (no user input).
+        connection.execute(DDL(f"DELETE FROM {fts}"))
         # Pull every row from the main table and re-emit FTS rows. Use
         # ``IFNULL(col, '')`` so the SQL coercion mirrors the Python
         # path's None -> '' behavior.
-        coerced_cols = ", ".join(f"IFNULL({col}, '')" for col in cols)
-        # Trusted input: every interpolation comes from cache-class
-        # metadata. Row content rebuilds from the main table's existing
-        # rows; user data already passed through bound-parameter inserts.
+        coerced_cols = ", ".join(f"IFNULL({c}, '')" for c in safe_cols)
+        # ``DDL`` again — this is a server-side rebuild (data flows
+        # main-table -> FTS sidecar without leaving the database), so
+        # there is no user input to bind.
         connection.execute(
-            text(  # nosemgrep: avoid-sqlalchemy-text
+            DDL(
                 f"INSERT INTO {fts} (rowid, {col_list}) "
-                f"SELECT id, {coerced_cols} FROM {table.name}"
+                f"SELECT id, {coerced_cols} FROM {table_name}"
             )
         )

--- a/katana_mcp_server/src/katana_mcp/typed_cache/fts.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/fts.py
@@ -16,32 +16,33 @@ entity's FTS columns can mirror its actual schema. ``content='<table>'``
 table — row content lives in the main table, FTS5 only stores the
 inverted index.
 
-Mutations (insert/update/delete) flow through SQLAlchemy event
-listeners on ``engine.sync_engine``. The events run synchronously on
-the connection pool's sync side; the work is just a few INSERT/DELETE
-statements per row, so adding async overhead would gain nothing.
-``after_insert`` / ``after_update`` keep the FTS index in lock-step
-with the main table; ``after_delete`` removes the corresponding FTS
-row so soft-deleted entities (and force-resyncs) clean up correctly.
+Mutations flow through **SQLite triggers** on the content tables:
+``<entity>_ai`` (after-insert) emits an FTS row, ``<entity>_au``
+(after-update) issues an FTS5 ``delete`` for the old content followed
+by an INSERT of the new content, and ``<entity>_ad`` (after-delete)
+issues the FTS5 ``delete`` command. Triggers fire for *every* write
+mode — SQLAlchemy ORM (``session.add`` / ``session.merge``), Core
+statements (``sqlalchemy.dialects.sqlite.insert(...).on_conflict_do_update``,
+``sqlmodel.delete``), and raw SQL — so the typed-cache bulk-upsert
+path in ``sync._sync_one_locked`` keeps the FTS index in lock-step
+without an extra reindex pass. The trigger-based design is the
+SQLite-recommended pattern for external-content FTS5 tables (see
+https://sqlite.org/fts5.html#external_content_tables).
 
 Startup also asserts every column in ``Cached*.__fts_columns__`` exists
 on the table — a generator regression that drops a column from the
 schema but leaves it in the FTS spec would otherwise corrupt every
 search until the next user-visible failure.
 
-**SQL safety**: FTS5 virtual tables can't be expressed through the
-SQLAlchemy ORM (no ``Table`` declarative object exists for them), so
-the SQL must be assembled as strings. Two SQLAlchemy primitives keep
-the security audit clean:
-
-- ``DDL(...)`` for schema operations (``CREATE VIRTUAL TABLE`` and
-  the truncate-style ``DELETE FROM <fts>``). DDL is the SQLAlchemy
-  construct designated for raw schema SQL — no user input is ever
-  meant to flow through it, and Semgrep's ``avoid-sqlalchemy-text``
-  rule correctly leaves it alone.
-- ``conn.exec_driver_sql(...)`` for FTS row INSERT/DELETE. Driver-SQL
-  takes positional ``?`` placeholders bound by the DBAPI, so user
-  input (FTS row content, row IDs) never reaches the SQL string.
+**SQL safety**: FTS5 virtual tables and triggers can't be expressed
+through the SQLAlchemy ORM (no ``Table`` declarative object exists
+for them), so the schema SQL must be assembled as strings. All FTS
+schema work goes through ``DDL(...)`` (``CREATE VIRTUAL TABLE``,
+``CREATE TRIGGER``, ``DROP TRIGGER IF EXISTS``, the data-rebuild
+``DELETE FROM <fts>`` + ``INSERT ... SELECT FROM <main>``) —
+the SQLAlchemy construct designated for raw schema SQL. No user
+input ever flows through it, and Semgrep's ``avoid-sqlalchemy-text``
+rule correctly leaves it alone.
 
 Identifiers (table names, column names) come exclusively from the
 Python-class metadata set by the SQLModel generator at import time —
@@ -55,15 +56,10 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from sqlalchemy import DDL, event
+from sqlalchemy import DDL
 from sqlmodel import SQLModel
-
-if TYPE_CHECKING:
-    from sqlalchemy.engine import Connection
-    from sqlalchemy.orm import Mapper
-
 
 # SQL identifiers (table + column names) must match this pattern before
 # we interpolate them into a DDL/DML statement. The cache-class
@@ -174,14 +170,38 @@ def _validate_fts_columns(cls: type[SQLModel]) -> None:
 
 
 def _create_fts_tables_ddl(conn: Any) -> None:
-    """Emit ``CREATE VIRTUAL TABLE IF NOT EXISTS <entity>_fts USING fts5(...)``.
+    """Emit FTS5 virtual tables + the trigger trio that keeps them in sync.
 
-    External-content table: ``content='<table>'`` + ``content_rowid='id'``.
-    The FTS index stays in lock-step with the main table only via the
-    after-insert/update/delete listeners — we deliberately do *not*
-    install SQL triggers, because pre-existing rows on cold-start come
-    in through SQLAlchemy event hooks and triggers would double-write
-    every FTS row.
+    For each FTS-enabled cache class:
+
+    1. ``CREATE VIRTUAL TABLE IF NOT EXISTS <entity>_fts USING fts5(...)``
+       — external-content table: ``content='<table>'`` +
+       ``content_rowid='id'``. The FTS row content lives in the main
+       table; FTS5 stores only the inverted index.
+    2. Three triggers on the main table — ``<entity>_ai`` (after
+       INSERT), ``<entity>_au`` (after UPDATE), ``<entity>_ad`` (after
+       DELETE) — that keep the inverted index in lock-step. Triggers
+       fire for *every* write mode (ORM, Core, raw SQL), unlike
+       SQLAlchemy mapper events (ORM-only). This matters because the
+       typed-cache bulk-upsert path in ``sync._sync_one_locked``
+       writes via ``sqlalchemy.dialects.sqlite.insert(...).on_conflict_do_update``,
+       a Core statement that bypasses ORM events but fires triggers
+       just like any other SQLite write.
+
+    The trigger trio uses FTS5's external-content maintenance pattern:
+    after-insert writes the new row's content into the inverted index;
+    after-delete issues the FTS5 ``'delete'`` command with the OLD
+    content so FTS5 can derive the tokens to remove; after-update is
+    delete-of-old + insert-of-new in one trigger body. ``IFNULL(col, '')``
+    coerces NULLs to empty strings on the way into the index so the
+    column shape stays consistent (FTS5 distinguishes empty-string rows
+    from absent-column rows in some edge cases; consistency is safer).
+
+    All trigger bodies and the virtual-table DDL go through ``DDL(...)``
+    rather than ``text(...)`` so Semgrep's ``avoid-sqlalchemy-text`` rule
+    leaves them alone — no user input ever flows through them; the only
+    interpolated values are validated identifiers from cache-class
+    metadata.
     """
     for cls in _classes_with_fts_columns():
         _validate_fts_columns(cls)
@@ -189,152 +209,63 @@ def _create_fts_tables_ddl(conn: Any) -> None:
         table_name = _safe_identifier(table.name)
         fts_table = _fts_table_name(table_name)
         cols = _fts_columns(cls)
-        col_list = ", ".join(_safe_identifier(c) for c in cols)
+        safe_cols = [_safe_identifier(c) for c in cols]
+        col_list = ", ".join(safe_cols)
         # ``content`` + ``content_rowid`` make the FTS table reference
         # rows in the main table by ``id`` (the integer PK on every
         # Cached* class). FTS5 uses the rowid for ranking + lookups; the
         # FTS row mirrors the content columns at insert/update time.
-        sql = (
-            f"CREATE VIRTUAL TABLE IF NOT EXISTS {fts_table} "
-            f"USING fts5({col_list}, content='{table_name}', content_rowid='id')"
+        conn.execute(
+            DDL(
+                f"CREATE VIRTUAL TABLE IF NOT EXISTS {fts_table} "
+                f"USING fts5({col_list}, content='{table_name}', content_rowid='id')"
+            )
         )
-        # ``DDL`` is the SQLAlchemy primitive for raw schema statements
-        # (FTS5 virtual tables have no ORM construct). Identifiers are
-        # validated by ``_safe_identifier``.
-        conn.execute(DDL(sql))
 
-
-def _row_value(target: Any, col: str) -> Any:
-    """Pull ``col`` off the ORM instance, returning ``None`` on missing.
-
-    SQLAlchemy event hooks pass the mapped instance; pydantic-side
-    ``model_dump`` would re-emit cache-only fields and is heavier, so
-    direct ``getattr`` is the right tool.
-    """
-    return getattr(target, col, None)
-
-
-def _delete_fts_row(conn: Connection, table_name: str, row_id: int) -> None:
-    """Remove the row's FTS entry (if any). No-op when row never indexed.
-
-    External-content FTS5 tables don't auto-purge on main-table DELETE,
-    so we delete by rowid here. Update flow uses delete-then-insert so
-    the inverted index never carries stale tokens.
-    """
-    fts = _fts_table_name(table_name)
-    # ``exec_driver_sql`` binds ``row_id`` via the DBAPI's positional
-    # ``?`` placeholder — user input never reaches the SQL string.
-    # ``fts`` is a validated identifier from cache-class metadata.
-    conn.exec_driver_sql(f"DELETE FROM {fts} WHERE rowid = ?", (row_id,))
-
-
-def _insert_fts_row(
-    conn: Connection,
-    table_name: str,
-    fts_cols: tuple[str, ...],
-    row_id: int,
-    values: list[Any],
-) -> None:
-    """Insert one row into the FTS sidecar. Empty / NULL values become ``''``.
-
-    FTS5 stores NULL as the absence of a token, which is fine — except
-    we want the row to exist so ``MATCH`` can rank it; coerce to empty
-    string. The empty-string rows still match ``""`` queries (i.e.
-    nothing) but never match real tokens, so ranking stays correct.
-    """
-    fts = _fts_table_name(table_name)
-    col_list = ", ".join(_safe_identifier(c) for c in fts_cols)
-    placeholders = ", ".join("?" for _ in fts_cols)
-    coerced = tuple("" if v is None else str(v) for v in values)
-    # ``exec_driver_sql`` passes ``coerced`` as positional ``?`` binds
-    # at the DBAPI layer — user input never reaches the SQL string.
-    # ``fts`` / ``col_list`` are validated identifiers from cache-class
-    # metadata.
-    conn.exec_driver_sql(
-        f"INSERT INTO {fts} (rowid, {col_list}) VALUES (?, {placeholders})",
-        (row_id, *coerced),
-    )
-
-
-def _make_after_insert(cls: type[SQLModel]) -> Any:
-    """Bind one event handler per FTS-enabled class.
-
-    SQLAlchemy events take ``(mapper, connection, target)``; the closure
-    captures ``cls`` so the handler can read the right ``__fts_columns__``
-    without re-walking the registry on every row.
-    """
-    fts_cols = _fts_columns(cls)
-    table_name: str = _table_for(cls).name
-
-    def after_insert(mapper: Mapper[Any], connection: Connection, target: Any) -> None:
-        del mapper
-        row_id = _row_value(target, "id")
-        if row_id is None:
-            # Generator-side primary keys never hit this branch — IDs
-            # arrive from Katana — but defensively skip rather than
-            # raise, since FTS state shouldn't break a real INSERT.
-            return
-        values = [_row_value(target, col) for col in fts_cols]
-        _insert_fts_row(connection, table_name, fts_cols, int(row_id), values)
-
-    return after_insert
-
-
-def _make_after_update(cls: type[SQLModel]) -> Any:
-    """Delete-then-insert keeps the FTS row token-fresh on update."""
-    fts_cols = _fts_columns(cls)
-    table_name: str = _table_for(cls).name
-
-    def after_update(mapper: Mapper[Any], connection: Connection, target: Any) -> None:
-        del mapper
-        row_id = _row_value(target, "id")
-        if row_id is None:
-            return
-        _delete_fts_row(connection, table_name, int(row_id))
-        values = [_row_value(target, col) for col in fts_cols]
-        _insert_fts_row(connection, table_name, fts_cols, int(row_id), values)
-
-    return after_update
-
-
-def _make_after_delete(cls: type[SQLModel]) -> Any:
-    """Remove the orphaned FTS row when the main row is deleted."""
-    table_name: str = _table_for(cls).name
-
-    def after_delete(mapper: Mapper[Any], connection: Connection, target: Any) -> None:
-        del mapper
-        row_id = _row_value(target, "id")
-        if row_id is None:
-            return
-        _delete_fts_row(connection, table_name, int(row_id))
-
-    return after_delete
-
-
-def install_fts_listeners() -> None:
-    """Idempotently register after_insert / after_update / after_delete listeners.
-
-    The mapper-level ``event.listens_for`` API doesn't currently expose
-    a clean "is this listener already attached" probe, so we track
-    installed classes in a module-level set and short-circuit on the
-    second call. Tests that spin up a fresh ``TypedCacheEngine`` per
-    test still re-use the global SQLModel registry, so we only want to
-    install once per process.
-    """
-    for cls in _classes_with_fts_columns():
-        if cls in _LISTENERS_INSTALLED:
-            continue
-        event.listen(cls, "after_insert", _make_after_insert(cls))
-        event.listen(cls, "after_update", _make_after_update(cls))
-        event.listen(cls, "after_delete", _make_after_delete(cls))
-        _LISTENERS_INSTALLED.add(cls)
-
-
-_LISTENERS_INSTALLED: set[type[SQLModel]] = set()
+        # Trigger trio. Drop-then-create is idempotent across reopens
+        # — ``CREATE TRIGGER IF NOT EXISTS`` would skip re-creation if
+        # the trigger body changed (e.g., an FTS column was added),
+        # silently leaving the old definition in place. Drop + create
+        # forces a refresh on every engine.open(). Cheap (the triggers
+        # don't fire during DDL) and self-healing.
+        new_value_list = ", ".join(f"IFNULL(new.{c}, '')" for c in safe_cols)
+        old_value_list = ", ".join(f"IFNULL(old.{c}, '')" for c in safe_cols)
+        ai_trigger = f"{table_name}_ai"
+        au_trigger = f"{table_name}_au"
+        ad_trigger = f"{table_name}_ad"
+        conn.execute(DDL(f"DROP TRIGGER IF EXISTS {ai_trigger}"))
+        conn.execute(DDL(f"DROP TRIGGER IF EXISTS {au_trigger}"))
+        conn.execute(DDL(f"DROP TRIGGER IF EXISTS {ad_trigger}"))
+        conn.execute(
+            DDL(
+                f"CREATE TRIGGER {ai_trigger} AFTER INSERT ON {table_name} BEGIN "
+                f"INSERT INTO {fts_table} (rowid, {col_list}) "
+                f"VALUES (new.id, {new_value_list}); "
+                f"END"
+            )
+        )
+        conn.execute(
+            DDL(
+                f"CREATE TRIGGER {ad_trigger} AFTER DELETE ON {table_name} BEGIN "
+                f"INSERT INTO {fts_table}({fts_table}, rowid, {col_list}) "
+                f"VALUES('delete', old.id, {old_value_list}); "
+                f"END"
+            )
+        )
+        conn.execute(
+            DDL(
+                f"CREATE TRIGGER {au_trigger} AFTER UPDATE ON {table_name} BEGIN "
+                f"INSERT INTO {fts_table}({fts_table}, rowid, {col_list}) "
+                f"VALUES('delete', old.id, {old_value_list}); "
+                f"INSERT INTO {fts_table} (rowid, {col_list}) "
+                f"VALUES (new.id, {new_value_list}); "
+                f"END"
+            )
+        )
 
 
 def initialize_fts_for_connection(connection: Any) -> None:
-    """Create the per-entity FTS5 virtual tables on the given connection.
+    """Create per-entity FTS5 virtual tables + their sync triggers.
 
     Called from ``TypedCacheEngine.open()`` inside the ``run_sync`` block
     that already runs ``SQLModel.metadata.create_all``. Wraps the DDL

--- a/katana_mcp_server/src/katana_mcp/typed_cache/fts.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/fts.py
@@ -1,0 +1,362 @@
+"""FTS5 sidecar for the SQLModel-backed catalog cache (#472 Phase B).
+
+The transactional half of the typed cache stores entities as plain
+SQLModel rows and queries them with WHERE clauses; the catalog half
+needs full-text search across SKU / name / barcode / supplier-code
+columns. We attach FTS5 virtual tables to entities that declare a
+``__fts_columns__: ClassVar[tuple[str, ...]]`` ClassVar (set on
+``CachedVariant``, ``CachedProduct``, ``CachedMaterial``,
+``CachedService``, ``CachedCustomer``, ``CachedSupplier``).
+
+The legacy ``CatalogCache`` used a single shared ``entity_fts`` table
+with a 3-text-column projection. This module instead emits one virtual
+table per entity (``variant_fts``, ``product_fts``, ...) so each
+entity's FTS columns can mirror its actual schema. ``content='<table>'``
++ ``content_rowid='id'`` means the FTS index is an external-content
+table — row content lives in the main table, FTS5 only stores the
+inverted index.
+
+Mutations (insert/update/delete) flow through SQLAlchemy event
+listeners on ``engine.sync_engine``. The events run synchronously on
+the connection pool's sync side; the work is just a few INSERT/DELETE
+statements per row, so adding async overhead would gain nothing.
+``after_insert`` / ``after_update`` keep the FTS index in lock-step
+with the main table; ``after_delete`` removes the corresponding FTS
+row so soft-deleted entities (and force-resyncs) clean up correctly.
+
+Startup also asserts every column in ``Cached*.__fts_columns__`` exists
+on the table — a generator regression that drops a column from the
+schema but leaves it in the FTS spec would otherwise corrupt every
+search until the next user-visible failure.
+
+**SQL-injection safety**: every ``text()`` call in this module
+interpolates only ``__table__.name`` / ``__fts_columns__`` values.
+Both come from the Python-class metadata set by the SQLModel
+generator at import time, *not* from user input. User-supplied
+values (FTS row content, row IDs) reach the database exclusively
+through bound parameters (``:rid``, ``:c0``, ...). FTS5 virtual
+tables can't be expressed through the SQLAlchemy ORM — there's no
+``Table`` declarative object for them — so raw text is the only
+path. The ``# nosemgrep`` annotations below acknowledge the rule
+while documenting why the input is trusted.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import event, text
+from sqlmodel import SQLModel
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
+    from sqlalchemy.orm import Mapper
+
+
+def _fts_table_name(table_name: str) -> str:
+    """``variant`` -> ``variant_fts``. Keep the convention symmetric."""
+    return f"{table_name}_fts"
+
+
+def _all_subclasses(cls: type[SQLModel]) -> Iterator[type[SQLModel]]:
+    """Recursive ``__subclasses__()`` traversal — generator over every descendant.
+
+    SQLModel doesn't expose a SQLAlchemy-style registry on the class
+    (``SQLModel.registry`` raises ``AttributeError`` because pydantic's
+    metaclass intercepts the attribute lookup), so we walk the Python
+    inheritance graph directly. The generated ``Cached*`` classes are
+    the only ``table=True`` SQLModel descendants in the project, so the
+    traversal stays bounded.
+    """
+    for sub in cls.__subclasses__():
+        yield sub
+        yield from _all_subclasses(sub)
+
+
+def _classes_with_fts_columns() -> list[type[SQLModel]]:
+    """Walk subclasses for table=True classes that declare ``__fts_columns__``.
+
+    The generator emits ``__fts_columns__`` as a ClassVar on the cache
+    class for each entity in ``CACHE_FTS_SPECS`` (see
+    ``scripts/generate_pydantic_models.py``). We rely on the side-effect
+    module imports in ``engine.py`` to load the cache classes; calling
+    this after ``engine.open()`` always returns the full set.
+
+    A class can show up multiple times via diamond inheritance
+    (``CachedVariant`` extends both ``UpdatableEntity`` and
+    ``DeletableEntity``, both of which are SQLModel descendants), so
+    dedupe on table name to keep DDL emission idempotent.
+    """
+    classes: list[type[SQLModel]] = []
+    seen: set[str] = set()
+    for cls in _all_subclasses(SQLModel):
+        if not _fts_columns(cls):
+            continue
+        # ``__table__`` is set on table=True classes by the SQLModel
+        # metaclass. Non-table siblings (intermediate base classes
+        # ``UpdatableEntity`` etc.) won't have it; skip them so the
+        # FTS walker stays restricted to actual cache rows.
+        table = _table_for(cls)
+        if table is None:
+            continue
+        if table.name in seen:
+            continue
+        seen.add(table.name)
+        classes.append(cls)
+    return classes
+
+
+def _fts_columns(cls: type[SQLModel]) -> tuple[str, ...]:
+    """Read the ``__fts_columns__`` ClassVar without static-checker noise."""
+    fts = getattr(cls, "__fts_columns__", ())
+    if isinstance(fts, tuple):
+        return fts
+    return ()
+
+
+def _table_for(cls: type[SQLModel]) -> Any:
+    """Return ``cls.__table__`` — the SQLAlchemy ``Table`` object.
+
+    The SQLModel metaclass populates ``__table__`` on ``table=True``
+    classes; the static type ``type[SQLModel]`` doesn't expose it, so
+    pull it via ``getattr`` and let ``Any`` propagate.
+    """
+    return getattr(cls, "__table__", None)
+
+
+def _validate_fts_columns(cls: type[SQLModel]) -> None:
+    """Assert every column in ``__fts_columns__`` exists on ``__table__.columns``.
+
+    Catches the generator regression where a cache column is dropped
+    from the schema but left in ``CACHE_FTS_SPECS`` — without this
+    check, the FTS DDL would still emit successfully (FTS5 doesn't
+    validate column names against the content table) and every search
+    would silently return no results.
+    """
+    fts_cols = _fts_columns(cls)
+    table = _table_for(cls)
+    table_cols = {col.name for col in table.columns}
+    missing = [col for col in fts_cols if col not in table_cols]
+    if missing:
+        msg = (
+            f"{cls.__name__}.__fts_columns__ references columns not present "
+            f"on {table.name}: {missing}"
+        )
+        raise RuntimeError(msg)
+
+
+def _create_fts_tables_ddl(conn: Any) -> None:
+    """Emit ``CREATE VIRTUAL TABLE IF NOT EXISTS <entity>_fts USING fts5(...)``.
+
+    External-content table: ``content='<table>'`` + ``content_rowid='id'``.
+    The FTS index stays in lock-step with the main table only via the
+    after-insert/update/delete listeners — we deliberately do *not*
+    install SQL triggers, because pre-existing rows on cold-start come
+    in through SQLAlchemy event hooks and triggers would double-write
+    every FTS row.
+    """
+    for cls in _classes_with_fts_columns():
+        _validate_fts_columns(cls)
+        table = _table_for(cls)
+        fts_table = _fts_table_name(table.name)
+        cols = _fts_columns(cls)
+        col_list = ", ".join(cols)
+        # ``content`` + ``content_rowid`` make the FTS table reference
+        # rows in the main table by ``id`` (the integer PK on every
+        # Cached* class). FTS5 uses the rowid for ranking + lookups; the
+        # FTS row mirrors the content columns at insert/update time.
+        sql = (
+            f"CREATE VIRTUAL TABLE IF NOT EXISTS {fts_table} "
+            f"USING fts5({col_list}, content='{table.name}', content_rowid='id')"
+        )
+        # Trusted input: ``fts_table`` / ``col_list`` / ``table.name`` come
+        # from SQLModel-generated cache-class metadata (no user input).
+        conn.execute(text(sql))  # nosemgrep: avoid-sqlalchemy-text
+
+
+def _row_value(target: Any, col: str) -> Any:
+    """Pull ``col`` off the ORM instance, returning ``None`` on missing.
+
+    SQLAlchemy event hooks pass the mapped instance; pydantic-side
+    ``model_dump`` would re-emit cache-only fields and is heavier, so
+    direct ``getattr`` is the right tool.
+    """
+    return getattr(target, col, None)
+
+
+def _delete_fts_row(conn: Connection, table_name: str, row_id: int) -> None:
+    """Remove the row's FTS entry (if any). No-op when row never indexed.
+
+    External-content FTS5 tables don't auto-purge on main-table DELETE,
+    so we delete by rowid here. Update flow uses delete-then-insert so
+    the inverted index never carries stale tokens.
+    """
+    fts = _fts_table_name(table_name)
+    # Trusted input: ``fts`` derives from cache-class ``__table__.name``;
+    # ``row_id`` is bound separately via the ``:rid`` parameter.
+    conn.execute(
+        text(  # nosemgrep: avoid-sqlalchemy-text
+            f"DELETE FROM {fts} WHERE rowid = :rid"
+        ),
+        {"rid": row_id},
+    )
+
+
+def _insert_fts_row(
+    conn: Connection,
+    table_name: str,
+    fts_cols: tuple[str, ...],
+    row_id: int,
+    values: list[Any],
+) -> None:
+    """Insert one row into the FTS sidecar. Empty / NULL values become ``''``.
+
+    FTS5 stores NULL as the absence of a token, which is fine — except
+    we want the row to exist so ``MATCH`` can rank it; coerce to empty
+    string. The empty-string rows still match ``""`` queries (i.e.
+    nothing) but never match real tokens, so ranking stays correct.
+    """
+    fts = _fts_table_name(table_name)
+    placeholders = ", ".join(f":c{i}" for i in range(len(fts_cols)))
+    col_list = ", ".join(fts_cols)
+    bind: dict[str, Any] = {"rid": row_id}
+    for idx, value in enumerate(values):
+        bind[f"c{idx}"] = "" if value is None else str(value)
+    # Trusted input: ``fts`` / ``col_list`` / ``placeholders`` derive
+    # from cache-class metadata; user-supplied ``values`` flow through
+    # bound parameters (``:c0``, ``:c1``, ...).
+    conn.execute(
+        text(  # nosemgrep: avoid-sqlalchemy-text
+            f"INSERT INTO {fts} (rowid, {col_list}) VALUES (:rid, {placeholders})"
+        ),
+        bind,
+    )
+
+
+def _make_after_insert(cls: type[SQLModel]) -> Any:
+    """Bind one event handler per FTS-enabled class.
+
+    SQLAlchemy events take ``(mapper, connection, target)``; the closure
+    captures ``cls`` so the handler can read the right ``__fts_columns__``
+    without re-walking the registry on every row.
+    """
+    fts_cols = _fts_columns(cls)
+    table_name: str = _table_for(cls).name
+
+    def after_insert(mapper: Mapper[Any], connection: Connection, target: Any) -> None:
+        del mapper
+        row_id = _row_value(target, "id")
+        if row_id is None:
+            # Generator-side primary keys never hit this branch — IDs
+            # arrive from Katana — but defensively skip rather than
+            # raise, since FTS state shouldn't break a real INSERT.
+            return
+        values = [_row_value(target, col) for col in fts_cols]
+        _insert_fts_row(connection, table_name, fts_cols, int(row_id), values)
+
+    return after_insert
+
+
+def _make_after_update(cls: type[SQLModel]) -> Any:
+    """Delete-then-insert keeps the FTS row token-fresh on update."""
+    fts_cols = _fts_columns(cls)
+    table_name: str = _table_for(cls).name
+
+    def after_update(mapper: Mapper[Any], connection: Connection, target: Any) -> None:
+        del mapper
+        row_id = _row_value(target, "id")
+        if row_id is None:
+            return
+        _delete_fts_row(connection, table_name, int(row_id))
+        values = [_row_value(target, col) for col in fts_cols]
+        _insert_fts_row(connection, table_name, fts_cols, int(row_id), values)
+
+    return after_update
+
+
+def _make_after_delete(cls: type[SQLModel]) -> Any:
+    """Remove the orphaned FTS row when the main row is deleted."""
+    table_name: str = _table_for(cls).name
+
+    def after_delete(mapper: Mapper[Any], connection: Connection, target: Any) -> None:
+        del mapper
+        row_id = _row_value(target, "id")
+        if row_id is None:
+            return
+        _delete_fts_row(connection, table_name, int(row_id))
+
+    return after_delete
+
+
+def install_fts_listeners() -> None:
+    """Idempotently register after_insert / after_update / after_delete listeners.
+
+    The mapper-level ``event.listens_for`` API doesn't currently expose
+    a clean "is this listener already attached" probe, so we track
+    installed classes in a module-level set and short-circuit on the
+    second call. Tests that spin up a fresh ``TypedCacheEngine`` per
+    test still re-use the global SQLModel registry, so we only want to
+    install once per process.
+    """
+    for cls in _classes_with_fts_columns():
+        if cls in _LISTENERS_INSTALLED:
+            continue
+        event.listen(cls, "after_insert", _make_after_insert(cls))
+        event.listen(cls, "after_update", _make_after_update(cls))
+        event.listen(cls, "after_delete", _make_after_delete(cls))
+        _LISTENERS_INSTALLED.add(cls)
+
+
+_LISTENERS_INSTALLED: set[type[SQLModel]] = set()
+
+
+def initialize_fts_for_connection(connection: Any) -> None:
+    """Create the per-entity FTS5 virtual tables on the given connection.
+
+    Called from ``TypedCacheEngine.open()`` inside the ``run_sync`` block
+    that already runs ``SQLModel.metadata.create_all``. Wraps the DDL
+    emission so the engine doesn't reach into the FTS module's private
+    helper directly.
+    """
+    _create_fts_tables_ddl(connection)
+
+
+def populate_fts_from_existing_rows(connection: Any) -> None:
+    """Backfill FTS index from already-cached rows on engine reopen.
+
+    SQLite persists the main tables across processes (file-backed
+    engine), and the FTS virtual table persists too, but reopens of an
+    engine that previously seeded FTS rows are idempotent: for each
+    FTS-enabled class, ``DELETE FROM <fts>`` + re-INSERT from the
+    content table by id. Cheap (rebuilds the inverted index from the
+    text already on disk) and unconditionally consistent; cost scales
+    linearly with row count, dominated by the catalog cold-start scope
+    (~5K variants on a typical Katana shop).
+
+    Skipped when the main table is empty (cold-start before sync runs).
+    """
+    for cls in _classes_with_fts_columns():
+        table = _table_for(cls)
+        fts = _fts_table_name(table.name)
+        cols = _fts_columns(cls)
+        # Truncate the FTS sidecar first so the rebuild is canonical.
+        # Trusted input: ``fts`` is the cache class's table name +
+        # ``_fts`` suffix (no user input).
+        connection.execute(
+            text(f"DELETE FROM {fts}")  # nosemgrep: avoid-sqlalchemy-text
+        )
+        col_list = ", ".join(cols)
+        # Pull every row from the main table and re-emit FTS rows. Use
+        # ``IFNULL(col, '')`` so the SQL coercion mirrors the Python
+        # path's None -> '' behavior.
+        coerced_cols = ", ".join(f"IFNULL({col}, '')" for col in cols)
+        # Trusted input: every interpolation comes from cache-class
+        # metadata. Row content rebuilds from the main table's existing
+        # rows; user data already passed through bound-parameter inserts.
+        connection.execute(
+            text(  # nosemgrep: avoid-sqlalchemy-text
+                f"INSERT INTO {fts} (rowid, {col_list}) "
+                f"SELECT id, {coerced_cols} FROM {table.name}"
+            )
+        )

--- a/katana_mcp_server/src/katana_mcp/typed_cache/fts.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/fts.py
@@ -287,7 +287,9 @@ def populate_fts_from_existing_rows(connection: Any) -> None:
     linearly with row count, dominated by the catalog cold-start scope
     (~5K variants on a typical Katana shop).
 
-    Skipped when the main table is empty (cold-start before sync runs).
+    The DELETE/INSERT pair runs unconditionally for every FTS-enabled
+    class. Cold-start (empty main table) is a cheap no-op rather than
+    an explicit skip — both statements operate on zero rows.
     """
     for cls in _classes_with_fts_columns():
         table = _table_for(cls)

--- a/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
@@ -87,11 +87,16 @@ def _is_fts_syntax_error(exc: OperationalError) -> bool:
 
     SQLite's FTS5 module surfaces query-grammar problems as
     ``OperationalError`` with a message prefixed by ``fts5:``. The
-    underlying ``orig`` is a ``sqlite3.OperationalError``; checking
-    ``str(exc)`` covers both that and the SQLAlchemy-wrapped form.
+    underlying ``orig`` is a ``sqlite3.OperationalError`` whose
+    ``str()`` is the raw SQLite message ("fts5: syntax error near
+    ..."); the SQLAlchemy wrapper's ``str(exc)`` decorates that with
+    ``(builtins.Exception) `` and a SQL statement footer, so we
+    inspect ``exc.orig`` directly with ``startswith`` to keep the
+    match narrow (no false positives on errors that happen to mention
+    ``fts5`` later in the message).
     """
-    text = str(exc)
-    return any(prefix in text for prefix in _FTS_SYNTAX_ERROR_PREFIXES)
+    orig_text = str(exc.orig) if exc.orig is not None else str(exc)
+    return any(orig_text.startswith(prefix) for prefix in _FTS_SYNTAX_ERROR_PREFIXES)
 
 
 def _tokenize_query(query: str) -> list[str]:

--- a/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
@@ -91,29 +91,29 @@ def _build_fts_match(tokens: list[str]) -> str:
     return " AND ".join(f'"{tok}"*' for tok in escaped)
 
 
-def _is_archived_filtered(cls: type[SQLModel]) -> Any:
-    """SQL predicate for "this row's archive timestamp is NULL".
+def _pk_col(cls: type[SQLModel]) -> Any:
+    """Return the SQLAlchemy InstrumentedAttribute for ``cls.id``.
 
-    Callers use this when ``include_archived=False`` and the cache
-    class actually has an archive column. Variant's archive state
-    lives on ``parent_archived_at`` (denormalized from parent);
-    everything else uses ``archived_at`` directly.
+    Every ``Cached*`` class has an ``id`` integer PK, but the static
+    checker can't narrow ``getattr`` through the ``T`` TypeVar. Centralize
+    the reach so the ``# noqa: B009`` lives in one place.
+    """
+    return getattr(cls, "id")  # noqa: B009
 
-    ``getattr`` keeps the static checker happy across catalog classes
-    that don't share an inheritance ancestor for these columns
-    (CachedProduct extends ArchivableEntity; CachedCustomer extends
-    DeletableEntity; etc.).
+
+def _archive_col_name(cls: type[SQLModel]) -> str | None:
+    """Return the cache column tracking archive state, or ``None`` if absent.
+
+    Variants don't carry their own archive lifecycle on the wire — Katana
+    archives at the parent (Product / Material) level — so the cache
+    class denormalizes ``parent_archived_at`` from the extended payload.
+    Every other class uses its own ``archived_at`` if present.
     """
     if cls is CachedVariant:
-        return getattr(cls, "parent_archived_at").is_(None)  # noqa: B009
-    return getattr(cls, "archived_at").is_(None)  # noqa: B009
-
-
-def _has_archive_column(cls: type[SQLModel]) -> bool:
-    """True iff filtering by archive state makes sense for this class."""
-    if cls is CachedVariant:
-        return True  # parent_archived_at lives on the cache row
-    return hasattr(cls, "archived_at")
+        return "parent_archived_at"
+    if hasattr(cls, "archived_at"):
+        return "archived_at"
+    return None
 
 
 def _has_deleted_column(cls: type[SQLModel]) -> bool:
@@ -133,9 +133,14 @@ def _apply_soft_state_filters(
     The two flags compose: a row that's both archived and deleted is
     dropped unless both ``include_*`` are True. Centralized here so the
     rules can't drift between ``get_*`` / ``smart_search`` / ``search_fuzzy``.
+
+    ``getattr`` keeps the static checker happy across catalog classes
+    that don't share an inheritance ancestor for archive/delete columns.
     """
-    if not include_archived and _has_archive_column(cls):
-        stmt = stmt.where(_is_archived_filtered(cls))
+    if not include_archived:
+        archive_col = _archive_col_name(cls)
+        if archive_col is not None:
+            stmt = stmt.where(getattr(cls, archive_col).is_(None))
     if not include_deleted and _has_deleted_column(cls):
         stmt = stmt.where(getattr(cls, "deleted_at").is_(None))  # noqa: B009
     return stmt
@@ -221,11 +226,7 @@ class CatalogQueries:
         include_deleted: bool = False,
     ) -> T | None:
         """Fetch one row by primary key, honoring soft-state filters."""
-        # ``cls.id`` is the SQLAlchemy InstrumentedAttribute on every
-        # ``Cached*`` PK column; the static checker can't narrow that
-        # through the ``T`` TypeVar, so reach for it via ``getattr``.
-        id_col = getattr(cls, "id")  # noqa: B009
-        stmt = select(cls).where(id_col == entity_id)
+        stmt = select(cls).where(_pk_col(cls) == entity_id)
         stmt = _apply_soft_state_filters(
             stmt,
             cls,
@@ -280,8 +281,7 @@ class CatalogQueries:
         ids = list({int(i) for i in entity_ids})
         if not ids:
             return {}
-        id_col = getattr(cls, "id")  # noqa: B009
-        stmt = select(cls).where(id_col.in_(ids))
+        stmt = select(cls).where(_pk_col(cls).in_(ids))
         stmt = _apply_soft_state_filters(
             stmt,
             cls,
@@ -384,11 +384,10 @@ class CatalogQueries:
         # SQLModel-mapped class). The bound ``?`` placeholders keep
         # user input safely separated from query text.
         archive_clause = ""
-        if not include_archived and _has_archive_column(cls):
-            archive_col = _safe_identifier(
-                "parent_archived_at" if cls is CachedVariant else "archived_at"
-            )
-            archive_clause = f" AND main.{archive_col} IS NULL"
+        if not include_archived:
+            col = _archive_col_name(cls)
+            if col is not None:
+                archive_clause = f" AND main.{_safe_identifier(col)} IS NULL"
         deleted_clause = ""
         if not include_deleted and _has_deleted_column(cls):
             deleted_clause = " AND main.deleted_at IS NULL"

--- a/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
@@ -73,6 +73,26 @@ _FUZZY_WEIGHT_SECONDARY = 20
 # tokens line up with index tokens.
 _TOKEN_RE = re.compile(r"\W+")
 
+# FTS5 syntax errors raise ``OperationalError`` with a message that
+# starts ``fts5: syntax error`` (or, for malformed prefix matches,
+# ``fts5: unknown special query``). We only want to silently fall
+# through to fuzzy on those — other ``OperationalError``s (locked DB,
+# missing FTS table, disk I/O) should propagate so callers see real
+# operational failures instead of degraded-but-silent search.
+_FTS_SYNTAX_ERROR_PREFIXES = ("fts5: syntax error", "fts5: unknown")
+
+
+def _is_fts_syntax_error(exc: OperationalError) -> bool:
+    """True iff ``exc`` is a recoverable FTS5 syntax error.
+
+    SQLite's FTS5 module surfaces query-grammar problems as
+    ``OperationalError`` with a message prefixed by ``fts5:``. The
+    underlying ``orig`` is a ``sqlite3.OperationalError``; checking
+    ``str(exc)`` covers both that and the SQLAlchemy-wrapped form.
+    """
+    text = str(exc)
+    return any(prefix in text for prefix in _FTS_SYNTAX_ERROR_PREFIXES)
+
 
 def _tokenize_query(query: str) -> list[str]:
     """Split a search query into FTS5 prefix-AND tokens."""
@@ -338,12 +358,14 @@ class CatalogQueries:
 
         1. Empty / blank query short-circuits to an empty list (no
            sense pretending an FTS5 ``MATCH ''`` query was meaningful).
-        2. FTS5 ``OperationalError`` (e.g., unbalanced parens, reserved-
-           word collision) falls through to ``search_fuzzy`` rather
-           than raising. The legacy implementation caught it and
-           returned an empty list silently — same shape, but never
-           actually offered the user fuzzy results for a malformed
-           query. Now we always offer them.
+        2. FTS5 *syntax errors* (e.g., unbalanced parens, reserved-word
+           collision) fall through to ``search_fuzzy`` rather than
+           raising. The legacy implementation caught it and returned
+           an empty list silently — same shape, but never actually
+           offered the user fuzzy results for a malformed query. Now
+           we always offer them. *Operational* ``OperationalError``s
+           (locked DB, missing FTS table, disk I/O) propagate; silently
+           returning fuzzy results would mask the underlying failure.
         """
         stripped = query.strip()
         if not stripped:
@@ -413,9 +435,16 @@ class CatalogQueries:
                 conn = await session.connection()
                 cursor = await conn.exec_driver_sql(sql, (fts_match, limit))
                 ids = [int(row[0]) for row in cursor.all()]
-        except OperationalError:
-            # FTS5 syntax error — surface fuzzy results so the user
-            # gets *something* back rather than a silent empty list.
+        except OperationalError as exc:
+            # FTS5 syntax errors surface as ``OperationalError`` with a
+            # message starting "fts5: syntax error". Fall through to
+            # fuzzy so the user gets results for a malformed query.
+            # ``OperationalError`` also covers operational issues
+            # (locked DB, missing table, disk I/O) where silent fuzzy
+            # fallback would mask real bugs — re-raise those so they
+            # surface in logs / alerts instead of being swallowed.
+            if not _is_fts_syntax_error(exc):
+                raise
             return await _fuzzy()
 
         if not ids:

--- a/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
@@ -39,14 +39,16 @@ import re
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
 from sqlmodel import SQLModel, select
 
 from katana_public_api_client.helpers.search import score_match
 from katana_public_api_client.models_pydantic._generated import CachedVariant
 
-from .fts import _fts_columns as _fts_columns_for
+from .fts import (
+    _fts_columns as _fts_columns_for,
+    _safe_identifier,
+)
 
 if TYPE_CHECKING:
     from .engine import TypedCacheEngine
@@ -371,16 +373,19 @@ class CatalogQueries:
         # classes; ``Any`` cast keeps the static checker quiet on the
         # otherwise-untyped attribute (see also ``fts.py``).
         table_obj: Any = getattr(cls, "__table__")  # noqa: B009
-        table_name: str = table_obj.name
+        # ``_safe_identifier`` validates the cache-class metadata
+        # against ``[A-Za-z_][A-Za-z0-9_]*`` before interpolation —
+        # belt-and-suspenders against a future generator regression.
+        table_name = _safe_identifier(table_obj.name)
         fts_table = f"{table_name}_fts"
 
         # Build the WHERE-clause filters as raw SQL since the FTS5
         # JOIN sits at the SQL level (FTS virtual tables don't have a
-        # SQLModel-mapped class). The bound parameters keep user input
-        # safely separated from query text.
+        # SQLModel-mapped class). The bound ``?`` placeholders keep
+        # user input safely separated from query text.
         archive_clause = ""
         if not include_archived and _has_archive_column(cls):
-            archive_col = (
+            archive_col = _safe_identifier(
                 "parent_archived_at" if cls is CachedVariant else "archived_at"
             )
             archive_clause = f" AND main.{archive_col} IS NULL"
@@ -391,30 +396,23 @@ class CatalogQueries:
         sql = (
             f"SELECT main.id FROM {fts_table} fts "
             f"JOIN {table_name} main ON main.id = fts.rowid "
-            f"WHERE {fts_table} MATCH :match"
+            f"WHERE {fts_table} MATCH ?"
             f"{archive_clause}{deleted_clause} "
             f"ORDER BY bm25({fts_table}) "
-            f"LIMIT :limit"
+            f"LIMIT ?"
         )
 
         try:
             async with self._engine.session() as session:
-                # ``session.exec`` is typed for SQLModel SELECT statements;
-                # raw ``text(...)`` queries hit the underlying
-                # ``AsyncSession.execute``. Drop to the SQLAlchemy
-                # primitive for the FTS join.
-                #
-                # Trusted SQL: ``fts_table`` / ``table_name`` /
-                # archive+deleted clauses interpolate only cache-class
-                # metadata (no user input). User-supplied ``query`` lands
-                # in the ``:match`` bound parameter; the ``limit`` is
-                # bound too. FTS5 virtual tables can't be expressed via
-                # the SQLAlchemy ORM, so raw text is the only path.
+                # FTS5 virtual tables can't be expressed via the
+                # SQLAlchemy ORM, and ``session.exec`` is typed for
+                # SQLModel SELECT statements only — drop to
+                # ``exec_driver_sql`` so user input flows through the
+                # DBAPI's positional ``?`` binds. Identifiers
+                # (``fts_table`` / ``table_name`` / archive+deleted
+                # clauses) come from validated cache-class metadata.
                 conn = await session.connection()
-                stmt = text(sql).bindparams(  # nosemgrep: avoid-sqlalchemy-text
-                    match=fts_match, limit=limit
-                )
-                cursor = await conn.execute(stmt)
+                cursor = await conn.exec_driver_sql(sql, (fts_match, limit))
                 ids = [int(row[0]) for row in cursor.all()]
         except OperationalError:
             # FTS5 syntax error — surface fuzzy results so the user

--- a/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
@@ -1,0 +1,478 @@
+"""``CatalogQueries`` adapter — typed read API over ``TypedCacheEngine`` (#472 Phase B).
+
+Phase D will migrate ~33 ``services.cache.<method>`` call sites onto this
+adapter. Until then it ships unused except by Phase B's own tests, but
+it's the single place where the new typed-cache search semantics — the
+SKU-shaped tokenizer fix, the FTS-syntax-error fall-through to fuzzy,
+and the default ``include_archived=False`` / ``include_deleted=False``
+filters — converge.
+
+The legacy ``CatalogCache`` returned ``dict[str, Any]`` rows. This
+adapter returns the typed ``Cached*`` SQLModel instances directly, so
+callers go from ``variant["sku"]`` to ``variant.sku``. Larger Phase D
+diff per-site, but the end state is fully typed.
+
+Soft-state filtering rules (per the inheritance map in the plan):
+
+- ``CachedVariant`` — ``deleted_at`` (own) + ``parent_archived_at``
+  (cache-only, lifted from parent). Filters: ``deleted_at IS NULL``
+  unless ``include_deleted=True``; ``parent_archived_at IS NULL``
+  unless ``include_archived=True``.
+- ``CachedProduct`` / ``CachedMaterial`` — ``archived_at``. Filter
+  unless ``include_archived=True``.
+- ``CachedService`` — both ``archived_at`` and ``deleted_at``. Filter
+  both.
+- ``CachedCustomer`` / ``CachedSupplier`` / ``CachedOperator`` /
+  ``CachedAdditionalCost`` — ``deleted_at``. Filter unless
+  ``include_deleted=True``.
+- ``CachedTaxRate`` / ``CachedLocation`` / ``CachedFactory`` — neither;
+  the kwargs are no-ops.
+
+Filtering is implemented generically via ``hasattr(cls, "<col>")``
+checks at query-build time so the rules stay in one place and adding
+a new ``Cached*`` sibling is hands-off.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+from sqlmodel import SQLModel, select
+
+from katana_public_api_client.helpers.search import score_match
+from katana_public_api_client.models_pydantic._generated import CachedVariant
+
+from .fts import _fts_columns as _fts_columns_for
+
+if TYPE_CHECKING:
+    from .engine import TypedCacheEngine
+
+
+T = TypeVar("T", bound=SQLModel)
+
+# Field weights match the legacy ``CatalogCache.search_fuzzy``: SKU
+# carries the most signal, primary name next, secondary descriptor (cat
+# name / parent name) last. Only Variant has a SKU column; everything
+# else uses the fuzzy fallback's "primary name + secondary text"
+# weighting and the SKU bucket stays empty.
+_FUZZY_WEIGHT_SKU = 100
+_FUZZY_WEIGHT_PRIMARY = 30
+_FUZZY_WEIGHT_SECONDARY = 20
+
+# Tokenizer for FTS5 MATCH-clause synthesis. The legacy cache used
+# ``query.split()`` which broke on SKU-shaped queries (``00.4021.018.003``
+# tokenizes to a single token, then FTS's tokenizer drops the dots and
+# the token never matches). Splitting on ``\W+`` here mirrors how FTS5's
+# default unicode61 tokenizer would have split the *content*, so query
+# tokens line up with index tokens.
+_TOKEN_RE = re.compile(r"\W+")
+
+
+def _tokenize_query(query: str) -> list[str]:
+    """Split a search query into FTS5 prefix-AND tokens."""
+    return [tok for tok in _TOKEN_RE.split(query.strip()) if tok]
+
+
+def _build_fts_match(tokens: list[str]) -> str:
+    """Build an FTS5 MATCH expression: ``"tok1"* AND "tok2"* AND ...``.
+
+    Quoting each token isolates user-supplied punctuation from FTS5
+    operator syntax (``OR``, ``NOT``, etc. become literal tokens, not
+    operators). The ``*`` suffix turns each token into a prefix match
+    so partial typing (``kitch`` matches ``kitchen``) still works.
+    """
+    escaped = [tok.replace('"', '""') for tok in tokens]
+    return " AND ".join(f'"{tok}"*' for tok in escaped)
+
+
+def _is_archived_filtered(cls: type[SQLModel]) -> Any:
+    """SQL predicate for "this row's archive timestamp is NULL".
+
+    Callers use this when ``include_archived=False`` and the cache
+    class actually has an archive column. Variant's archive state
+    lives on ``parent_archived_at`` (denormalized from parent);
+    everything else uses ``archived_at`` directly.
+
+    ``getattr`` keeps the static checker happy across catalog classes
+    that don't share an inheritance ancestor for these columns
+    (CachedProduct extends ArchivableEntity; CachedCustomer extends
+    DeletableEntity; etc.).
+    """
+    if cls is CachedVariant:
+        return getattr(cls, "parent_archived_at").is_(None)  # noqa: B009
+    return getattr(cls, "archived_at").is_(None)  # noqa: B009
+
+
+def _has_archive_column(cls: type[SQLModel]) -> bool:
+    """True iff filtering by archive state makes sense for this class."""
+    if cls is CachedVariant:
+        return True  # parent_archived_at lives on the cache row
+    return hasattr(cls, "archived_at")
+
+
+def _has_deleted_column(cls: type[SQLModel]) -> bool:
+    """True iff the class has a ``deleted_at`` column we should filter by."""
+    return hasattr(cls, "deleted_at")
+
+
+def _apply_soft_state_filters(
+    stmt: Any,
+    cls: type[SQLModel],
+    *,
+    include_archived: bool,
+    include_deleted: bool,
+) -> Any:
+    """Layer ``WHERE archived_at IS NULL`` / ``deleted_at IS NULL`` on a SELECT.
+
+    The two flags compose: a row that's both archived and deleted is
+    dropped unless both ``include_*`` are True. Centralized here so the
+    rules can't drift between ``get_*`` / ``smart_search`` / ``search_fuzzy``.
+    """
+    if not include_archived and _has_archive_column(cls):
+        stmt = stmt.where(_is_archived_filtered(cls))
+    if not include_deleted and _has_deleted_column(cls):
+        stmt = stmt.where(getattr(cls, "deleted_at").is_(None))  # noqa: B009
+    return stmt
+
+
+def _row_score_fields(row: SQLModel) -> dict[str, tuple[str, int]]:
+    """Build the ``score_match`` field dict for fuzzy-fallback ranking.
+
+    Field weights mirror the legacy cache (sku=100, name=30, name2=20)
+    so callers don't see scoring drift during the Phase D migration.
+
+    Variant: SKU + display_name + parent_name. Everything else: lift
+    the first FTS column as the primary name, the second (if any) as
+    the secondary descriptor (category / email / etc.), no SKU bucket.
+    """
+    if isinstance(row, CachedVariant):
+        return {
+            "sku": (row.sku or "", _FUZZY_WEIGHT_SKU),
+            "display_name": (row.display_name or "", _FUZZY_WEIGHT_PRIMARY),
+            "parent_name": (row.parent_name or "", _FUZZY_WEIGHT_SECONDARY),
+        }
+    fts_cols = _fts_columns_for(type(row))
+    # For FTS-enabled classes (Product, Material, Service, Customer,
+    # Supplier), score against the declared FTS columns. For lookup-
+    # only classes without FTS (TaxRate, Operator, Location, Factory,
+    # AdditionalCost), fall back to scoring against ``name`` /
+    # ``operator_name`` so smart_search degrades to a useful fuzzy
+    # match instead of always returning zero.
+    fields: dict[str, tuple[str, int]] = {}
+    if fts_cols:
+        primary_col = fts_cols[0]
+        primary_value = getattr(row, primary_col, None) or ""
+        fields[primary_col] = (str(primary_value), _FUZZY_WEIGHT_PRIMARY)
+        if len(fts_cols) > 1:
+            secondary_col = fts_cols[1]
+            secondary_value = getattr(row, secondary_col, None) or ""
+            fields[secondary_col] = (str(secondary_value), _FUZZY_WEIGHT_SECONDARY)
+        return fields
+
+    # No FTS columns declared — pick the most-likely "name" field. The
+    # SQLModel-attribute lookup is defensive: every catalog Cached*
+    # class has either ``name`` or (Operator) ``operator_name``.
+    for col in ("name", "operator_name", "display_name"):
+        value = getattr(row, col, None)
+        if value:
+            fields[col] = (str(value), _FUZZY_WEIGHT_PRIMARY)
+            break
+    return fields
+
+
+class CatalogQueries:
+    """Typed read API for the catalog tier of ``TypedCacheEngine``.
+
+    Phase B introduces the adapter; Phase D migrates ~33 call sites
+    onto it. Each method ships with the legacy semantics preserved
+    *except* for the two papercut fixes called out in the plan:
+
+    1. ``smart_search`` tokenizes via ``re.split(\\W+, ...)`` instead of
+       ``query.split()`` so SKU-shaped queries with ``.`` separators
+       (``00.4021.018.003``) tokenize correctly.
+    2. ``smart_search`` falls back to ``search_fuzzy`` on **both**
+       empty results AND ``OperationalError`` (FTS5 syntax error). The
+       legacy cache only fell through on empty results, so a syntactically
+       invalid query (e.g., unbalanced parens) returned nothing.
+
+    The third user-visible change is **default ``include_archived=False``
+    / ``include_deleted=False`` on every read method**. The legacy
+    ``get_by_id`` / ``get_by_sku`` / ``get_many_by_ids`` returned soft-
+    deleted and archived rows unconditionally; callers that need them
+    pass the flag explicitly. This is the right default — the old
+    behavior leaked archived rows into search-result expansions.
+    """
+
+    def __init__(self, engine: TypedCacheEngine) -> None:
+        self._engine = engine
+
+    async def get_by_id(
+        self,
+        cls: type[T],
+        entity_id: int,
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+    ) -> T | None:
+        """Fetch one row by primary key, honoring soft-state filters."""
+        # ``cls.id`` is the SQLAlchemy InstrumentedAttribute on every
+        # ``Cached*`` PK column; the static checker can't narrow that
+        # through the ``T`` TypeVar, so reach for it via ``getattr``.
+        id_col = getattr(cls, "id")  # noqa: B009
+        stmt = select(cls).where(id_col == entity_id)
+        stmt = _apply_soft_state_filters(
+            stmt,
+            cls,
+            include_archived=include_archived,
+            include_deleted=include_deleted,
+        )
+        async with self._engine.session() as session:
+            result = await session.exec(stmt)
+            return result.first()
+
+    async def get_by_sku(
+        self,
+        sku: str,
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+    ) -> CachedVariant | None:
+        """Variant-only SKU lookup, case-insensitive (NOCASE collation).
+
+        The legacy cache's ``entity_index.sku`` had a non-unique index
+        with NOCASE collation; we apply NOCASE at query time so the
+        cache's main-table column doesn't need to commit to a
+        collation choice. ``func.lower``-style coercion would also work
+        but ``COLLATE NOCASE`` is the SQLite-native answer.
+        """
+        sku_col: Any = CachedVariant.sku
+        stmt = select(CachedVariant).where(sku_col.collate("NOCASE") == sku)
+        stmt = _apply_soft_state_filters(
+            stmt,
+            CachedVariant,
+            include_archived=include_archived,
+            include_deleted=include_deleted,
+        )
+        async with self._engine.session() as session:
+            result = await session.exec(stmt)
+            return result.first()
+
+    async def get_many_by_ids(
+        self,
+        cls: type[T],
+        entity_ids: Iterable[int],
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+    ) -> dict[int, T]:
+        """Batch-fetch by ID; returns ``{id: row}`` for hits, drops misses.
+
+        Empty input is a no-op (no DB round-trip). IDs are deduplicated
+        before the IN-clause to keep the parameter list tight on shops
+        with batched-row enrichment that may double up on parent IDs.
+        """
+        ids = list({int(i) for i in entity_ids})
+        if not ids:
+            return {}
+        id_col = getattr(cls, "id")  # noqa: B009
+        stmt = select(cls).where(id_col.in_(ids))
+        stmt = _apply_soft_state_filters(
+            stmt,
+            cls,
+            include_archived=include_archived,
+            include_deleted=include_deleted,
+        )
+        async with self._engine.session() as session:
+            result = await session.exec(stmt)
+            rows = result.all()
+        return {int(getattr(row, "id")): row for row in rows}  # noqa: B009
+
+    async def get_all(
+        self,
+        cls: type[T],
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+    ) -> list[T]:
+        """Fetch every row of ``cls`` honoring soft-state filters.
+
+        Used for small reference tables (locations, tax rates) where
+        the entire set fits in memory and callers want the bulk pull
+        in one round trip.
+        """
+        stmt = select(cls)
+        stmt = _apply_soft_state_filters(
+            stmt,
+            cls,
+            include_archived=include_archived,
+            include_deleted=include_deleted,
+        )
+        async with self._engine.session() as session:
+            result = await session.exec(stmt)
+            return list(result.all())
+
+    async def smart_search(
+        self,
+        cls: type[T],
+        query: str,
+        limit: int = 50,
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+    ) -> list[T]:
+        """FTS5-first search with fuzzy fallback on empty / FTS syntax error.
+
+        Tokenizes via ``re.split(\\W+, ...)`` so SKU-shaped queries
+        (``00.4021.018.003``) tokenize the same way FTS5's default
+        tokenizer indexed them — single-token text projections like
+        ``supplier_item_codes_text`` ("00 4021 018 003") see each
+        chunk as a separate term and the prefix-AND match clicks.
+
+        Two papercut fixes vs. the legacy ``CatalogCache.smart_search``:
+
+        1. Empty / blank query short-circuits to an empty list (no
+           sense pretending an FTS5 ``MATCH ''`` query was meaningful).
+        2. FTS5 ``OperationalError`` (e.g., unbalanced parens, reserved-
+           word collision) falls through to ``search_fuzzy`` rather
+           than raising. The legacy implementation caught it and
+           returned an empty list silently — same shape, but never
+           actually offered the user fuzzy results for a malformed
+           query. Now we always offer them.
+        """
+        stripped = query.strip()
+        if not stripped:
+            return []
+
+        async def _fuzzy() -> list[T]:
+            return await self.search_fuzzy(
+                cls,
+                query,
+                limit=limit,
+                include_archived=include_archived,
+                include_deleted=include_deleted,
+            )
+
+        fts_cols = _fts_columns_for(cls)
+        if not fts_cols:
+            # No FTS sidecar for this entity type — the only sensible
+            # fallback is fuzzy.
+            return await _fuzzy()
+
+        tokens = _tokenize_query(stripped)
+        if not tokens:
+            return []
+
+        fts_match = _build_fts_match(tokens)
+        # ``__table__`` is set by the SQLModel metaclass on table=True
+        # classes; ``Any`` cast keeps the static checker quiet on the
+        # otherwise-untyped attribute (see also ``fts.py``).
+        table_obj: Any = getattr(cls, "__table__")  # noqa: B009
+        table_name: str = table_obj.name
+        fts_table = f"{table_name}_fts"
+
+        # Build the WHERE-clause filters as raw SQL since the FTS5
+        # JOIN sits at the SQL level (FTS virtual tables don't have a
+        # SQLModel-mapped class). The bound parameters keep user input
+        # safely separated from query text.
+        archive_clause = ""
+        if not include_archived and _has_archive_column(cls):
+            archive_col = (
+                "parent_archived_at" if cls is CachedVariant else "archived_at"
+            )
+            archive_clause = f" AND main.{archive_col} IS NULL"
+        deleted_clause = ""
+        if not include_deleted and _has_deleted_column(cls):
+            deleted_clause = " AND main.deleted_at IS NULL"
+
+        sql = (
+            f"SELECT main.id FROM {fts_table} fts "
+            f"JOIN {table_name} main ON main.id = fts.rowid "
+            f"WHERE {fts_table} MATCH :match"
+            f"{archive_clause}{deleted_clause} "
+            f"ORDER BY bm25({fts_table}) "
+            f"LIMIT :limit"
+        )
+
+        try:
+            async with self._engine.session() as session:
+                # ``session.exec`` is typed for SQLModel SELECT statements;
+                # raw ``text(...)`` queries hit the underlying
+                # ``AsyncSession.execute``. Drop to the SQLAlchemy
+                # primitive for the FTS join.
+                #
+                # Trusted SQL: ``fts_table`` / ``table_name`` /
+                # archive+deleted clauses interpolate only cache-class
+                # metadata (no user input). User-supplied ``query`` lands
+                # in the ``:match`` bound parameter; the ``limit`` is
+                # bound too. FTS5 virtual tables can't be expressed via
+                # the SQLAlchemy ORM, so raw text is the only path.
+                conn = await session.connection()
+                stmt = text(sql).bindparams(  # nosemgrep: avoid-sqlalchemy-text
+                    match=fts_match, limit=limit
+                )
+                cursor = await conn.execute(stmt)
+                ids = [int(row[0]) for row in cursor.all()]
+        except OperationalError:
+            # FTS5 syntax error — surface fuzzy results so the user
+            # gets *something* back rather than a silent empty list.
+            return await _fuzzy()
+
+        if not ids:
+            # Empty FTS result set: try fuzzy in case the user typed a
+            # near-match (``stainles`` → ``stainless``). The legacy
+            # cache had this same fall-through.
+            return await _fuzzy()
+
+        # Re-fetch the typed objects in a single round trip, preserving
+        # the bm25 order from the FTS query. Build an ID->row map then
+        # iterate the original ID order.
+        rows_by_id = await self.get_many_by_ids(
+            cls,
+            ids,
+            include_archived=include_archived,
+            include_deleted=include_deleted,
+        )
+        return [rows_by_id[rid] for rid in ids if rid in rows_by_id]
+
+    async def search_fuzzy(
+        self,
+        cls: type[T],
+        query: str,
+        limit: int = 50,
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+    ) -> list[T]:
+        """Difflib-backed fuzzy search using ``score_match``.
+
+        Pulls every (filtered) row in one query, scores in Python
+        against the entity's FTS columns, returns the top ``limit``.
+        Cost scales with row count, so callers should prefer
+        ``smart_search`` (which only falls through to fuzzy on empty
+        FTS results / syntax errors).
+
+        Field weights mirror the legacy cache (SKU=100, primary name=30,
+        secondary=20) — see ``_row_score_fields``.
+        """
+        stripped = query.strip()
+        if not stripped:
+            return []
+
+        rows = await self.get_all(
+            cls,
+            include_archived=include_archived,
+            include_deleted=include_deleted,
+        )
+
+        scored: list[tuple[T, float]] = []
+        for row in rows:
+            score = score_match(query=stripped, fields=_row_score_fields(row))
+            if score > 0:
+                scored.append((row, score))
+
+        scored.sort(key=lambda item: item[1], reverse=True)
+        return [row for row, _score in scored[:limit]]

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -35,42 +35,79 @@ from sqlmodel import SQLModel, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from katana_mcp.logging import get_logger
+from katana_public_api_client.api.additional_costs import get_additional_costs
+from katana_public_api_client.api.customer import get_all_customers
+from katana_public_api_client.api.factory import get_factory
+from katana_public_api_client.api.location import get_all_locations
 from katana_public_api_client.api.manufacturing_order import (
     get_all_manufacturing_orders,
 )
 from katana_public_api_client.api.manufacturing_order_recipe import (
     get_all_manufacturing_order_recipe_rows,
 )
+from katana_public_api_client.api.material import get_all_materials
+from katana_public_api_client.api.operator import get_all_operators
+from katana_public_api_client.api.product import get_all_products
 from katana_public_api_client.api.purchase_order import find_purchase_orders
 from katana_public_api_client.api.purchase_order_row import (
     get_all_purchase_order_rows,
 )
 from katana_public_api_client.api.sales_order import get_all_sales_orders
 from katana_public_api_client.api.sales_order_row import get_all_sales_order_rows
+from katana_public_api_client.api.services import get_all_services
 from katana_public_api_client.api.stock_adjustment import get_all_stock_adjustments
 from katana_public_api_client.api.stock_transfer import get_all_stock_transfers
+from katana_public_api_client.api.supplier import get_all_suppliers
+from katana_public_api_client.api.tax_rate import get_all_tax_rates
+from katana_public_api_client.api.variant import get_all_variants
+from katana_public_api_client.domain.converters import unwrap_unset
+from katana_public_api_client.models.get_all_variants_extend_item import (
+    GetAllVariantsExtendItem,
+)
 from katana_public_api_client.models_pydantic._generated import (
+    AdditionalCost as PydanticAdditionalCost,
+    CachedAdditionalCost,
+    CachedCustomer,
+    CachedFactory,
+    CachedLocation,
     CachedManufacturingOrder,
     CachedManufacturingOrderRecipeRow,
+    CachedMaterial,
+    CachedOperator,
+    CachedProduct,
     CachedPurchaseOrder,
     CachedPurchaseOrderRow,
     CachedSalesOrder,
     CachedSalesOrderRow,
+    CachedService,
     CachedStockAdjustment,
     CachedStockAdjustmentRow,
     CachedStockTransfer,
     CachedStockTransferRow,
+    CachedSupplier,
+    CachedTaxRate,
+    CachedVariant,
+    Customer as PydanticCustomer,
+    Factory as PydanticFactory,
+    Location1 as PydanticLocation,
     ManufacturingOrder as PydanticManufacturingOrder,
     ManufacturingOrderRecipeRow as PydanticManufacturingOrderRecipeRow,
+    Material as PydanticMaterial,
+    Operator as PydanticOperator,
+    Product as PydanticProduct,
     PurchaseOrderBase as PydanticPurchaseOrderBase,
     PurchaseOrderRow as PydanticPurchaseOrderRow,
     SalesOrder as PydanticSalesOrder,
     SalesOrderRow as PydanticSalesOrderRow,
+    Service as PydanticService,
     StockAdjustment as PydanticStockAdjustment,
     StockTransfer as PydanticStockTransfer,
+    Supplier as PydanticSupplier,
+    TaxRate as PydanticTaxRate,
+    VariantResponse as PydanticVariantResponse,
 )
 from katana_public_api_client.models_pydantic._registry import get_pydantic_class
-from katana_public_api_client.utils import unwrap_data
+from katana_public_api_client.utils import unwrap, unwrap_data
 
 from .sync_state import SyncState
 
@@ -126,6 +163,35 @@ class EntitySpec:
     that join parent ↔ child in cache can call a single
     ``ensure_<parent>_synced`` and trust that both sides are fresh —
     no caller-side ``asyncio.gather`` to forget.
+
+    Phase B (#472) additions:
+
+    - ``depends_on`` — entity_keys this spec must sync after. Catalog
+      example: ``CachedVariant`` has FK to ``CachedProduct`` /
+      ``CachedMaterial`` and lifts ``parent_archived_at`` from the
+      extended payload, so it must run after both. The validator checks
+      for unknown references and cycles at engine.open() time; topo sort
+      drives the cold-start order.
+    - ``attrs_postprocess`` — ``(attrs_obj, cache_row) -> None`` mutating
+      hook called after ``_convert`` builds the cache row. Variant uses
+      it to populate ``parent_archived_at`` / ``display_name`` /
+      ``parent_name`` / ``supplier_item_codes_text`` from the extended
+      ``product_or_material`` payload — keeps Variant-specific
+      denormalization out of the generic ``_convert``.
+    - ``extra_fetch_kwargs`` — kwargs always passed to ``api_fn``
+      regardless of incremental state. Variant uses it to enable
+      ``extend=[PRODUCT_OR_MATERIAL]`` so the postprocess hook can read
+      the parent's archive timestamp.
+    - ``supports_incremental`` — when False (operator, factory: no
+      ``updated_at_min`` support), the cold-start fetch always runs;
+      relies on the per-entity sync lock to debounce concurrent callers.
+    - ``supports_include_deleted`` — when False (operator, tax_rate,
+      factory: no ``include_deleted`` query parameter), drops the kwarg.
+      Tombstones won't propagate for these — acceptable since they're
+      reference data without practical soft-deletes.
+    - ``single_record`` — when True, the endpoint returns one record
+      directly (Factory) rather than a list-wrapped response. Bypasses
+      ``unwrap_data`` and constructs a one-element list internally.
     """
 
     entity_key: str
@@ -137,6 +203,12 @@ class EntitySpec:
     fk_field: str | None = None
     pydantic_resolver: Callable[[Any], type[_FromAttrs]] | None = None
     related_specs: tuple[EntitySpec, ...] = field(default_factory=tuple)
+    depends_on: tuple[str, ...] = ()
+    attrs_postprocess: Callable[[Any, Any], None] | None = None
+    extra_fetch_kwargs: dict[str, Any] = field(default_factory=dict)
+    supports_incremental: bool = True
+    supports_include_deleted: bool = True
+    single_record: bool = False
 
     def __post_init__(self) -> None:
         # Children are configured by a ``(child_cls, rows_field, fk_field)``
@@ -151,6 +223,87 @@ class EntitySpec:
                 "set together or all left as None"
             )
             raise ValueError(msg)
+
+
+def _topo_sort_specs(
+    specs: Iterable[EntitySpec], *, validate_unknown_deps: bool
+) -> list[EntitySpec]:
+    """Topologically sort ``specs``; raises on cycles, optionally on unknown deps.
+
+    Single source of truth for dependency-graph traversal. Returns the
+    specs in dependency order (parents before dependents). Stable across
+    independent specs — the iteration order of ``specs`` controls
+    tie-breaking so log output stays predictable.
+
+    ``validate_unknown_deps=True`` raises if any ``depends_on`` references
+    an entity_key not in ``specs``; the engine.open() validator wants
+    this strict check. ``False`` skips unknown deps quietly so the
+    public ``topo_sort_specs`` helper accepts an arbitrary subset.
+
+    Cycle detection uses a tri-state coloring (white/gray/black). Gray
+    means "on the current DFS stack" — a back-edge to a gray node is
+    a cycle.
+    """
+    spec_list = list(specs)
+    by_key = {s.entity_key: s for s in spec_list}
+
+    if validate_unknown_deps:
+        for spec in spec_list:
+            for dep in spec.depends_on:
+                if dep not in by_key:
+                    msg = (
+                        f"EntitySpec {spec.entity_key!r} declares "
+                        f"depends_on={dep!r} but no spec with that "
+                        f"entity_key is registered"
+                    )
+                    raise ValueError(msg)
+
+    visited: set[str] = set()
+    on_stack: list[str] = []
+    on_stack_set: set[str] = set()
+    result: list[EntitySpec] = []
+
+    def dfs(key: str) -> None:
+        if key in visited:
+            return
+        if key in on_stack_set:
+            cycle_path = [*on_stack[on_stack.index(key) :], key]
+            msg = f"EntitySpec dependency cycle detected: {' -> '.join(cycle_path)}"
+            raise ValueError(msg)
+        on_stack.append(key)
+        on_stack_set.add(key)
+        for dep in by_key[key].depends_on:
+            if dep in by_key:
+                dfs(dep)
+        on_stack.pop()
+        on_stack_set.discard(key)
+        visited.add(key)
+        result.append(by_key[key])
+
+    for spec in spec_list:
+        dfs(spec.entity_key)
+    return result
+
+
+def _validate_dependency_graph(specs: Iterable[EntitySpec]) -> None:
+    """Validate ``EntitySpec.depends_on`` references and detect cycles.
+
+    Raises ``ValueError`` if any spec references an unknown ``entity_key``
+    or if the dependency graph has a cycle. Run at ``engine.open()`` so
+    misconfiguration surfaces eagerly — never at the first sync.
+    """
+    _topo_sort_specs(specs, validate_unknown_deps=True)
+
+
+def topo_sort_specs(specs: Iterable[EntitySpec]) -> list[EntitySpec]:
+    """Return ``specs`` in dependency order — parents before dependents.
+
+    Stable: preserves the registration order among independent specs so
+    log output stays predictable. Assumes ``_validate_dependency_graph``
+    has already run; callers that don't pre-validate get raised cycles
+    via the same DFS.
+    """
+    return _topo_sort_specs(specs, validate_unknown_deps=False)
 
 
 def _resolve_purchase_order_class(attrs_po: Any) -> type:
@@ -203,7 +356,14 @@ def _convert(spec: EntitySpec, attrs_obj: Any) -> tuple[Any, list[Any]]:
     api_obj = api_cls.from_attrs(attrs_obj)
 
     exclude = {spec.rows_field} if spec.rows_field else set()
-    parent = spec.cache_cls.model_validate(api_obj.model_dump(exclude=exclude))
+    parent_data = api_obj.model_dump(exclude=exclude)
+    # Singleton endpoints (Factory) don't ship an ``id`` on the wire,
+    # but the cache class needs one as PK. Pin id=1 here so
+    # ``model_validate`` succeeds; postprocess hooks can still mutate
+    # the row downstream. Other entities are no-ops.
+    if spec.single_record and "id" not in parent_data:
+        parent_data["id"] = 1
+    parent = spec.cache_cls.model_validate(parent_data)
 
     children: list[Any] = []
     if (
@@ -216,6 +376,15 @@ def _convert(spec: EntitySpec, attrs_obj: Any) -> tuple[Any, list[Any]]:
             row_data = api_row.model_dump()
             row_data[spec.fk_field] = api_obj.id
             children.append(spec.child_cls.model_validate(row_data))
+
+    # The postprocess hook runs after the cache row is built so it can
+    # populate cache-only fields from the original attrs object — fields
+    # like ``parent_archived_at`` that aren't on the API pydantic class
+    # and therefore never make it through the ``from_attrs`` /
+    # ``model_dump`` path. The hook mutates ``parent`` in place; returning
+    # ``None`` keeps the convention with the pre-#472 sync helpers.
+    if spec.attrs_postprocess is not None:
+        spec.attrs_postprocess(attrs_obj, parent)
 
     return parent, children
 
@@ -341,12 +510,23 @@ async def _sync_one_locked(
     # ``include_deleted=True`` is always sent so soft-deletes after
     # the watermark surface in the response (Katana bumps
     # ``updated_at`` when ``deleted_at`` is set), letting the upsert
-    # propagate the tombstone into the cache row.
-    kwargs: dict[str, Any] = {"include_deleted": True}
-    if last_synced is not None:
+    # propagate the tombstone into the cache row. A few catalog endpoints
+    # (operator, factory, tax_rate) don't expose ``include_deleted`` —
+    # spec.supports_include_deleted=False drops the kwarg there.
+    kwargs: dict[str, Any] = dict(spec.extra_fetch_kwargs)
+    if spec.supports_include_deleted:
+        kwargs.setdefault("include_deleted", True)
+    if last_synced is not None and spec.supports_incremental:
         kwargs["updated_at_min"] = last_synced.replace(tzinfo=UTC)
     response = await spec.api_fn.asyncio_detailed(client=client, **kwargs)
-    attrs_objs = unwrap_data(response, default=[])
+    if spec.single_record:
+        # Endpoints like ``GET /factory`` return a bare object rather than
+        # a list-wrapped ``{"data": [...]}``. Normalize to a one-element
+        # list so the rest of the pipeline stays generic.
+        single = unwrap(response)
+        attrs_objs = [single] if single is not None else []
+    else:
+        attrs_objs = unwrap_data(response, default=[])
 
     cached_parents: list[Any] = []
     cached_children: list[Any] = []
@@ -553,6 +733,198 @@ _STOCK_TRANSFER_SPEC = EntitySpec(
 
 
 # ---------------------------------------------------------------------------
+# Catalog specs (#472 Phase B) — variant + product/material parents,
+# service, customer, supplier, plus reference data.
+# ---------------------------------------------------------------------------
+
+
+def _variant_postprocess(attrs_obj: Any, cache_row: CachedVariant) -> None:
+    """Populate cache-only Variant fields from the extended attrs payload.
+
+    Variants don't carry their own archive lifecycle on the wire — Katana
+    archives at the parent (Product / Material) level and cascades. We
+    fetch each variant with ``extend=[PRODUCT_OR_MATERIAL]``, then lift
+    ``parent.archived_at`` here so search can filter archived rows
+    without re-joining at query time.
+
+    Three more cache-only fields land here for FTS5 performance:
+
+    - ``parent_name`` — direct lift, surfaces in result rendering.
+    - ``display_name`` — synthesized from ``parent_name`` + each
+      ``config_attribute.config_value`` joined by `` / ``. Falls back to
+      the SKU when the parent name is empty (a defensive case the legacy
+      cache also handled).
+    - ``supplier_item_codes_text`` — space-joined ``supplier_item_codes``
+      so the FTS5 tokenizer can index multi-token supplier codes without
+      re-parsing JSON at query time.
+
+    Mirrors the legacy ``_variant_to_cache_dict`` semantics in
+    ``katana_mcp/cache_sync.py`` byte-for-byte; the only structural
+    change is that the postprocess hook runs *after* the cache row is
+    built rather than mutating a raw dict before it.
+    """
+    parent = unwrap_unset(getattr(attrs_obj, "product_or_material", None), None)
+
+    # ``parent_archived_at`` + ``parent_name`` lift directly from the
+    # extended payload. ``parent`` is an attrs object (Product/Material)
+    # when the API returns it; UNSET means the caller didn't request the
+    # extension or the row points at a non-existent parent.
+    parent_name: str | None = None
+    if parent is not None:
+        cache_row.parent_archived_at = unwrap_unset(
+            getattr(parent, "archived_at", None), None
+        )
+        parent_name = unwrap_unset(getattr(parent, "name", None), None)
+        cache_row.parent_name = parent_name
+
+    # ``display_name`` mirrors the legacy synthesis: parent name (or SKU
+    # fallback) joined with each config attribute's value. The empty-
+    # parent-name fallback to SKU is defensive — Katana always returns
+    # a non-empty parent name in practice, but the legacy cache handled
+    # the empty case so we preserve it.
+    sku = unwrap_unset(getattr(attrs_obj, "sku", None), "") or ""
+    display_parts: list[str] = [parent_name] if parent_name else [sku] if sku else []
+    config_attrs = unwrap_unset(getattr(attrs_obj, "config_attributes", None), [])
+    if config_attrs:
+        for attr in config_attrs:
+            value = unwrap_unset(getattr(attr, "config_value", None), None)
+            if value:
+                display_parts.append(value)
+    cache_row.display_name = " / ".join(display_parts) if display_parts else None
+
+    # ``supplier_item_codes_text``: FTS5's default tokenizer splits on
+    # whitespace, so the cache-side text projection is a space-joined
+    # version of the JSON-array column. ``None`` when there are no codes
+    # so the FTS sidecar's NULL-safe handling stays simple.
+    codes = unwrap_unset(getattr(attrs_obj, "supplier_item_codes", None), [])
+    cache_row.supplier_item_codes_text = " ".join(codes) if codes else None
+
+
+_PRODUCT_SPEC = EntitySpec(
+    entity_key="product",
+    api_fn=get_all_products,
+    cache_cls=CachedProduct,
+    pydantic_cls=PydanticProduct,
+    extra_fetch_kwargs={"include_archived": True},
+)
+
+
+_MATERIAL_SPEC = EntitySpec(
+    entity_key="material",
+    api_fn=get_all_materials,
+    cache_cls=CachedMaterial,
+    pydantic_cls=PydanticMaterial,
+    extra_fetch_kwargs={"include_archived": True},
+)
+
+
+# Variants depend on Product + Material because:
+# 1. ``parent_archived_at`` is lifted from the extended product_or_material
+#    payload — the postprocess hook needs the parent's archive timestamp.
+# 2. The cache class carries no FK constraint, but conceptually the
+#    parent rows must exist before variants reference them; cold-start
+#    sync respects that ordering via ``depends_on``.
+_VARIANT_SPEC = EntitySpec(
+    entity_key="variant",
+    api_fn=get_all_variants,
+    cache_cls=CachedVariant,
+    pydantic_cls=PydanticVariantResponse,
+    extra_fetch_kwargs={
+        "extend": [GetAllVariantsExtendItem.PRODUCT_OR_MATERIAL],
+        "include_archived": True,
+    },
+    depends_on=("product", "material"),
+    attrs_postprocess=_variant_postprocess,
+)
+
+
+_SERVICE_SPEC = EntitySpec(
+    entity_key="service",
+    api_fn=get_all_services,
+    cache_cls=CachedService,
+    pydantic_cls=PydanticService,
+    extra_fetch_kwargs={"include_archived": True},
+)
+
+
+_CUSTOMER_SPEC = EntitySpec(
+    entity_key="customer",
+    api_fn=get_all_customers,
+    cache_cls=CachedCustomer,
+    pydantic_cls=PydanticCustomer,
+)
+
+
+_SUPPLIER_SPEC = EntitySpec(
+    entity_key="supplier",
+    api_fn=get_all_suppliers,
+    cache_cls=CachedSupplier,
+    pydantic_cls=PydanticSupplier,
+)
+
+
+_LOCATION_SPEC = EntitySpec(
+    entity_key="location",
+    api_fn=get_all_locations,
+    cache_cls=CachedLocation,
+    pydantic_cls=PydanticLocation,
+)
+
+
+# Tax rates: ``GET /tax_rates`` supports ``updated_at_min`` but not
+# ``include_deleted``, so we sync incrementally without the deletion
+# flag. Tax rates have no soft-delete concept (no ``deleted_at``
+# column on the cache class either), so dropping the flag is safe.
+_TAX_RATE_SPEC = EntitySpec(
+    entity_key="tax_rate",
+    api_fn=get_all_tax_rates,
+    cache_cls=CachedTaxRate,
+    pydantic_cls=PydanticTaxRate,
+    supports_include_deleted=False,
+)
+
+
+# Operators: ``GET /operators`` supports neither ``updated_at_min`` nor
+# ``include_deleted`` (the API exposes the operator list as a stable
+# snapshot tied to working_area). Each sync re-fetches the full list;
+# the per-entity lock debounces concurrent callers.
+_OPERATOR_SPEC = EntitySpec(
+    entity_key="operator",
+    api_fn=get_all_operators,
+    cache_cls=CachedOperator,
+    pydantic_cls=PydanticOperator,
+    supports_incremental=False,
+    supports_include_deleted=False,
+)
+
+
+_ADDITIONAL_COST_SPEC = EntitySpec(
+    entity_key="additional_cost",
+    api_fn=get_additional_costs,
+    cache_cls=CachedAdditionalCost,
+    pydantic_cls=PydanticAdditionalCost,
+)
+
+
+# Factory: ``GET /factory`` returns a single record (not a list-wrapped
+# response). The endpoint also supports neither ``updated_at_min`` nor
+# ``include_deleted``; ``single_record=True`` swaps ``unwrap_data`` for
+# ``unwrap`` and wraps the result in a one-element list so the rest of
+# the pipeline stays generic. The wire shape has no ``id`` field, so
+# ``_convert`` synthesizes ``id=1`` for singleton specs (matches the
+# legacy ``CatalogCache._fetch_factory`` convention).
+_FACTORY_SPEC = EntitySpec(
+    entity_key="factory",
+    api_fn=get_factory,
+    cache_cls=CachedFactory,
+    pydantic_cls=PydanticFactory,
+    supports_incremental=False,
+    supports_include_deleted=False,
+    single_record=True,
+)
+
+
+# ---------------------------------------------------------------------------
 # Public per-entity wrappers
 # ---------------------------------------------------------------------------
 
@@ -608,6 +980,93 @@ async def ensure_manufacturing_order_recipe_rows_synced(
     await _ensure_synced(client, cache, MANUFACTURING_ORDER_RECIPE_ROW_SPEC)
 
 
+# Catalog wrappers (#472 Phase B). Variant explicitly syncs its parents
+# first because the cold-start postprocess hook needs the parent rows
+# already cached for ``parent_archived_at`` to be populated correctly.
+# After Phase D lands, these wrappers replace ``cache_sync.py``'s legacy
+# ``ensure_*_synced`` helpers.
+
+
+async def ensure_products_synced(client: KatanaClient, cache: TypedCacheEngine) -> None:
+    """Pull updated products from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _PRODUCT_SPEC)
+
+
+async def ensure_materials_synced(
+    client: KatanaClient, cache: TypedCacheEngine
+) -> None:
+    """Pull updated materials from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _MATERIAL_SPEC)
+
+
+async def ensure_variants_synced(client: KatanaClient, cache: TypedCacheEngine) -> None:
+    """Pull updated variants from Katana and upsert into the cache.
+
+    Syncs Product + Material parents first so the variant postprocess
+    hook can lift ``parent_archived_at`` / ``parent_name`` from rows
+    that already exist in cache. Parents have no inter-dependency, so
+    they sync in parallel; the variant sync then fans out under its own
+    lock once both parent watermarks have advanced.
+    """
+    await asyncio.gather(
+        _ensure_synced(client, cache, _PRODUCT_SPEC),
+        _ensure_synced(client, cache, _MATERIAL_SPEC),
+    )
+    await _ensure_synced(client, cache, _VARIANT_SPEC)
+
+
+async def ensure_services_synced(client: KatanaClient, cache: TypedCacheEngine) -> None:
+    """Pull updated services from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _SERVICE_SPEC)
+
+
+async def ensure_customers_synced(
+    client: KatanaClient, cache: TypedCacheEngine
+) -> None:
+    """Pull updated customers from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _CUSTOMER_SPEC)
+
+
+async def ensure_suppliers_synced(
+    client: KatanaClient, cache: TypedCacheEngine
+) -> None:
+    """Pull updated suppliers from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _SUPPLIER_SPEC)
+
+
+async def ensure_locations_synced(
+    client: KatanaClient, cache: TypedCacheEngine
+) -> None:
+    """Pull locations from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _LOCATION_SPEC)
+
+
+async def ensure_tax_rates_synced(
+    client: KatanaClient, cache: TypedCacheEngine
+) -> None:
+    """Pull updated tax rates from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _TAX_RATE_SPEC)
+
+
+async def ensure_operators_synced(
+    client: KatanaClient, cache: TypedCacheEngine
+) -> None:
+    """Pull operators from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _OPERATOR_SPEC)
+
+
+async def ensure_factory_synced(client: KatanaClient, cache: TypedCacheEngine) -> None:
+    """Pull the (singleton) factory record from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _FACTORY_SPEC)
+
+
+async def ensure_additional_costs_synced(
+    client: KatanaClient, cache: TypedCacheEngine
+) -> None:
+    """Pull updated additional costs from Katana and upsert into the cache."""
+    await _ensure_synced(client, cache, _ADDITIONAL_COST_SPEC)
+
+
 # ---------------------------------------------------------------------------
 # Force-resync (truncate + cold-start re-pull, atomically)
 # ---------------------------------------------------------------------------
@@ -619,6 +1078,17 @@ ENTITY_SPECS: dict[str, EntitySpec] = {
     "manufacturing_order": MANUFACTURING_ORDER_SPEC,
     "purchase_order": _PURCHASE_ORDER_SPEC,
     "stock_transfer": _STOCK_TRANSFER_SPEC,
+    "product": _PRODUCT_SPEC,
+    "material": _MATERIAL_SPEC,
+    "variant": _VARIANT_SPEC,
+    "service": _SERVICE_SPEC,
+    "customer": _CUSTOMER_SPEC,
+    "supplier": _SUPPLIER_SPEC,
+    "location": _LOCATION_SPEC,
+    "tax_rate": _TAX_RATE_SPEC,
+    "operator": _OPERATOR_SPEC,
+    "factory": _FACTORY_SPEC,
+    "additional_cost": _ADDITIONAL_COST_SPEC,
 }
 """Public registry of top-level entity specs by user-facing key.
 

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -169,9 +169,13 @@ class EntitySpec:
     - ``depends_on`` — entity_keys this spec must sync after. Catalog
       example: ``CachedVariant`` has FK to ``CachedProduct`` /
       ``CachedMaterial`` and lifts ``parent_archived_at`` from the
-      extended payload, so it must run after both. The validator checks
-      for unknown references and cycles at engine.open() time; topo sort
-      drives the cold-start order.
+      extended payload, so it must run after both. Today the only
+      runtime use is the validator at ``engine.open()`` (cycles +
+      unknown refs); the actual ordering is hand-coded inside
+      ``ensure_variants_synced`` via ``asyncio.gather``. The field is
+      retained so the dependency declaration lives next to the spec and
+      a future scheduler can replace the hand-coded gather with a topo
+      walk without churn.
     - ``attrs_postprocess`` — ``(attrs_obj, cache_row) -> None`` mutating
       hook called after ``_convert`` builds the cache row. Variant uses
       it to populate ``parent_archived_at`` / ``display_name`` /
@@ -225,43 +229,33 @@ class EntitySpec:
             raise ValueError(msg)
 
 
-def _topo_sort_specs(
-    specs: Iterable[EntitySpec], *, validate_unknown_deps: bool
-) -> list[EntitySpec]:
-    """Topologically sort ``specs``; raises on cycles, optionally on unknown deps.
+def _validate_dependency_graph(specs: Iterable[EntitySpec]) -> None:
+    """Validate ``EntitySpec.depends_on`` references and detect cycles.
 
-    Single source of truth for dependency-graph traversal. Returns the
-    specs in dependency order (parents before dependents). Stable across
-    independent specs — the iteration order of ``specs`` controls
-    tie-breaking so log output stays predictable.
+    Raises ``ValueError`` if any spec references an unknown ``entity_key``
+    or if the dependency graph has a cycle. Run at ``engine.open()`` so
+    misconfiguration surfaces eagerly — never at the first sync.
 
-    ``validate_unknown_deps=True`` raises if any ``depends_on`` references
-    an entity_key not in ``specs``; the engine.open() validator wants
-    this strict check. ``False`` skips unknown deps quietly so the
-    public ``topo_sort_specs`` helper accepts an arbitrary subset.
-
-    Cycle detection uses a tri-state coloring (white/gray/black). Gray
-    means "on the current DFS stack" — a back-edge to a gray node is
-    a cycle.
+    Cycle detection uses a tri-state coloring (white/gray/black) DFS.
+    Gray means "on the current DFS stack" — a back-edge to a gray node
+    is a cycle.
     """
     spec_list = list(specs)
     by_key = {s.entity_key: s for s in spec_list}
 
-    if validate_unknown_deps:
-        for spec in spec_list:
-            for dep in spec.depends_on:
-                if dep not in by_key:
-                    msg = (
-                        f"EntitySpec {spec.entity_key!r} declares "
-                        f"depends_on={dep!r} but no spec with that "
-                        f"entity_key is registered"
-                    )
-                    raise ValueError(msg)
+    for spec in spec_list:
+        for dep in spec.depends_on:
+            if dep not in by_key:
+                msg = (
+                    f"EntitySpec {spec.entity_key!r} declares "
+                    f"depends_on={dep!r} but no spec with that "
+                    f"entity_key is registered"
+                )
+                raise ValueError(msg)
 
     visited: set[str] = set()
     on_stack: list[str] = []
     on_stack_set: set[str] = set()
-    result: list[EntitySpec] = []
 
     def dfs(key: str) -> None:
         if key in visited:
@@ -273,37 +267,13 @@ def _topo_sort_specs(
         on_stack.append(key)
         on_stack_set.add(key)
         for dep in by_key[key].depends_on:
-            if dep in by_key:
-                dfs(dep)
+            dfs(dep)
         on_stack.pop()
         on_stack_set.discard(key)
         visited.add(key)
-        result.append(by_key[key])
 
     for spec in spec_list:
         dfs(spec.entity_key)
-    return result
-
-
-def _validate_dependency_graph(specs: Iterable[EntitySpec]) -> None:
-    """Validate ``EntitySpec.depends_on`` references and detect cycles.
-
-    Raises ``ValueError`` if any spec references an unknown ``entity_key``
-    or if the dependency graph has a cycle. Run at ``engine.open()`` so
-    misconfiguration surfaces eagerly — never at the first sync.
-    """
-    _topo_sort_specs(specs, validate_unknown_deps=True)
-
-
-def topo_sort_specs(specs: Iterable[EntitySpec]) -> list[EntitySpec]:
-    """Return ``specs`` in dependency order — parents before dependents.
-
-    Stable: preserves the registration order among independent specs so
-    log output stays predictable. Assumes ``_validate_dependency_graph``
-    has already run; callers that don't pre-validate get raised cycles
-    via the same DFS.
-    """
-    return _topo_sort_specs(specs, validate_unknown_deps=False)
 
 
 def _resolve_purchase_order_class(attrs_po: Any) -> type:

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -507,6 +507,13 @@ async def _sync_one_locked(
 
     async with cache.session() as session:
         # Parents first so child FK constraints resolve on insert.
+        # ``_bulk_upsert`` issues Core ``INSERT ... ON CONFLICT``
+        # statements via ``sqlalchemy.dialects.sqlite.insert``. SQLite
+        # triggers (registered by ``_create_fts_tables_ddl`` on
+        # engine.open()) keep the FTS5 inverted index in sync —
+        # SQLAlchemy mapper events would silently miss this Core path,
+        # but SQLite triggers fire for every write mode (ORM, Core,
+        # raw SQL).
         await _bulk_upsert(session, spec.cache_cls, cached_parents)
         if spec.child_cls is not None:
             await _bulk_upsert(session, spec.child_cls, cached_children)
@@ -788,12 +795,19 @@ _MATERIAL_SPEC = EntitySpec(
 )
 
 
-# Variants depend on Product + Material because:
-# 1. ``parent_archived_at`` is lifted from the extended product_or_material
-#    payload — the postprocess hook needs the parent's archive timestamp.
-# 2. The cache class carries no FK constraint, but conceptually the
-#    parent rows must exist before variants reference them; cold-start
-#    sync respects that ordering via ``depends_on``.
+# Variants depend on Product + Material for cache-completeness reasons:
+# variants carry FK references to product/material IDs, and join-style
+# queries against the cache (``v.product_id -> CachedProduct``) need
+# both sides cached for results to land. The ``parent_archived_at`` /
+# ``parent_name`` denormalization lives entirely on the variant
+# postprocess hook — it reads from the *extended* attrs payload
+# (``product_or_material`` set via ``extend=[PRODUCT_OR_MATERIAL]``),
+# not from the cached parent row, so the dependency is a soft cache-
+# completeness guarantee rather than a postprocess prerequisite. Today
+# ``ensure_variants_synced`` enforces ordering via ``asyncio.gather``;
+# the ``depends_on`` field is declarative metadata for a future
+# topo-walking scheduler (validated at ``engine.open()``, not yet
+# consulted at sync time).
 _VARIANT_SPEC = EntitySpec(
     entity_key="variant",
     api_fn=get_all_variants,
@@ -951,10 +965,13 @@ async def ensure_manufacturing_order_recipe_rows_synced(
 
 
 # Catalog wrappers (#472 Phase B). Variant explicitly syncs its parents
-# first because the cold-start postprocess hook needs the parent rows
-# already cached for ``parent_archived_at`` to be populated correctly.
-# After Phase D lands, these wrappers replace ``cache_sync.py``'s legacy
-# ``ensure_*_synced`` helpers.
+# first so any caller that joins variants to their cached parents sees
+# both sides on a single ``ensure_variants_synced`` round trip — the
+# postprocess hook itself reads ``parent_archived_at`` / ``parent_name``
+# from the extended ``product_or_material`` attrs payload, not from the
+# cached parent row, so it doesn't actually depend on the parent rows
+# having landed first. After Phase D lands, these wrappers replace
+# ``cache_sync.py``'s legacy ``ensure_*_synced`` helpers.
 
 
 async def ensure_products_synced(client: KatanaClient, cache: TypedCacheEngine) -> None:
@@ -972,11 +989,16 @@ async def ensure_materials_synced(
 async def ensure_variants_synced(client: KatanaClient, cache: TypedCacheEngine) -> None:
     """Pull updated variants from Katana and upsert into the cache.
 
-    Syncs Product + Material parents first so the variant postprocess
-    hook can lift ``parent_archived_at`` / ``parent_name`` from rows
-    that already exist in cache. Parents have no inter-dependency, so
-    they sync in parallel; the variant sync then fans out under its own
-    lock once both parent watermarks have advanced.
+    Syncs Product + Material parents in parallel first, then variants.
+    The ordering exists for cache-completeness (downstream queries that
+    join variants to their cached parents need both sides materialized);
+    the variant postprocess hook itself reads ``parent_archived_at`` /
+    ``parent_name`` from the *extended* ``product_or_material`` attrs
+    payload set by ``extend=[PRODUCT_OR_MATERIAL]``, not from the cached
+    parent row, so it works even if the parent sync hasn't run yet.
+    Parents have no inter-dependency, so they sync in parallel; the
+    variant sync then fans out under its own lock once both parent
+    watermarks have advanced.
     """
     await asyncio.gather(
         _ensure_synced(client, cache, _PRODUCT_SPEC),
@@ -1106,6 +1128,10 @@ async def force_resync(
         for related in spec.related_specs:
             children_to_delete.add(related.cache_cls)
         async with cache.session() as session:
+            # Core ``DELETE`` fires the per-row ``<entity>_ad`` trigger
+            # for each row, which issues the FTS5 ``'delete'`` command
+            # against the inverted index — so the FTS sidecar self-cleans
+            # in the same transaction without an explicit truncate pass.
             for child_cls in children_to_delete:
                 await session.exec(delete(child_cls))
             await session.exec(delete(spec.cache_cls))

--- a/katana_mcp_server/tests/test_typed_cache_catalog.py
+++ b/katana_mcp_server/tests/test_typed_cache_catalog.py
@@ -639,6 +639,93 @@ class TestCrossEntitySpecOrdering:
         assert v_product.parent_name == "Knife"
         assert v_material.parent_name == "Steel"
 
+    @pytest.mark.asyncio
+    async def test_ensure_variants_synced_populates_fts_index(self, typed_cache_engine):
+        """The bulk-upsert path keeps the FTS5 sidecar in sync.
+
+        ``_sync_one_locked`` writes via ``sqlalchemy.dialects.sqlite.insert``
+        (Core ``INSERT ... ON CONFLICT``), which bypasses SQLAlchemy
+        ORM mapper events. The FTS5 sidecar relies on **SQLite triggers**
+        (registered by ``_create_fts_tables_ddl`` on engine.open()) that
+        fire for every write mode — ORM, Core, raw SQL — so the sync
+        path keeps the inverted index in lock-step without an explicit
+        reindex pass. Pre-#646 this surface was wired through ORM-only
+        mapper-event listeners and ``smart_search`` would silently
+        return empty until the next engine reopen rebuilt the index;
+        this test pins the contract end-to-end: sync via the public
+        ``ensure_variants_synced`` entrypoint, then assert
+        ``smart_search`` against an FTS-only token (``KNF-V1-FTSTEST``)
+        finds the synced rows.
+        """
+        product_attrs = AttrsProduct.from_dict(
+            {"id": 201, "name": "Chef Knife", "type": "product"}
+        )
+        material_attrs = AttrsMaterial.from_dict(
+            {"id": 6001, "name": "Stainless Steel", "type": "material"}
+        )
+        variant_for_product = AttrsVariantResponse.from_dict(
+            {
+                "id": 4001,
+                "sku": "KNF-V1-FTSTEST",
+                "product_id": 201,
+                "type": "product",
+                "product_or_material": {
+                    "id": 201,
+                    "name": "Chef Knife",
+                    "type": "product",
+                },
+            }
+        )
+        variant_for_material = AttrsVariantResponse.from_dict(
+            {
+                "id": 4002,
+                "sku": "STL-V1-FTSTEST",
+                "material_id": 6001,
+                "type": "material",
+                "product_or_material": {
+                    "id": 6001,
+                    "name": "Stainless Steel",
+                    "type": "material",
+                },
+            }
+        )
+
+        with (
+            _stub_endpoint("get_all_products", _list_response([product_attrs])),
+            _stub_endpoint("get_all_materials", _list_response([material_attrs])),
+            _stub_endpoint(
+                "get_all_variants",
+                _list_response([variant_for_product, variant_for_material]),
+            ),
+        ):
+            await ensure_variants_synced(MagicMock(), typed_cache_engine)
+
+        # FTS-backed search should find the variant by SKU prefix even
+        # though the row was written via Core upsert (where ORM mapper
+        # events would not fire). The SQLite trigger trio fires for
+        # Core writes, so this assertion catches a regression where
+        # the trigger DDL stops being emitted on engine.open().
+        variant_results = await typed_cache_engine.catalog.smart_search(
+            CachedVariant, "KNF-V1-FTSTEST"
+        )
+        assert any(r.id == 4001 for r in variant_results), (
+            "FTS5 sidecar not populated for variant inserted via "
+            "_bulk_upsert — trigger trio likely dropped from "
+            "_create_fts_tables_ddl"
+        )
+
+        # Parents (product, material) also ride the bulk-upsert path —
+        # exercise their FTS sidecars too so a regression on either
+        # surface is caught.
+        product_results = await typed_cache_engine.catalog.smart_search(
+            CachedProduct, "Chef Knife"
+        )
+        assert any(r.id == 201 for r in product_results)
+        material_results = await typed_cache_engine.catalog.smart_search(
+            CachedMaterial, "Stainless"
+        )
+        assert any(r.id == 6001 for r in material_results)
+
 
 class TestFTSSchemaValidation:
     """FTS column declarations stay in sync with the cache table schema."""
@@ -681,20 +768,20 @@ class TestNoDoubleOpenInteraction:
 
     @pytest.mark.asyncio
     async def test_fts_index_consistent_after_insert(self, typed_cache_engine):
-        """Inserting a row populates the FTS sidecar via after_insert listener."""
+        """ORM ``session.add`` populates the FTS sidecar via the ``ai`` trigger."""
         async with typed_cache_engine.session() as session:
             session.add(
                 CachedVariant(
                     id=10,
-                    sku="LISTENER-TEST",
-                    display_name="Listener Test Item",
+                    sku="TRIGGER-TEST",
+                    display_name="Trigger Test Item",
                 )
             )
             await session.commit()
 
         # Round-trip: can we find it via the FTS-backed smart_search?
         results = await typed_cache_engine.catalog.smart_search(
-            CachedVariant, "listener"
+            CachedVariant, "trigger"
         )
         assert any(r.id == 10 for r in results)
 

--- a/katana_mcp_server/tests/test_typed_cache_catalog.py
+++ b/katana_mcp_server/tests/test_typed_cache_catalog.py
@@ -1,0 +1,726 @@
+"""Tests for the catalog tier of the typed cache (#472 Phase B).
+
+Coverage targets the acceptance criteria from the Phase B plan:
+
+- Each ``Cached*`` catalog entity round-trips through sync.
+- Variant cache-only fields (``parent_archived_at``, ``display_name``,
+  ``parent_name``, ``supplier_item_codes_text``) populate correctly
+  from the extended ``product_or_material`` payload.
+- ``CatalogQueries`` adapter:
+  - ``get_by_id`` defaults filter archived/deleted; explicit flags
+    surface them.
+  - ``get_by_sku`` uses NOCASE collation.
+  - ``smart_search`` handles SKU-shaped queries (``00.4021.018.003``),
+    UPC queries on ``registered_barcode``, multi-token queries
+    (``"kitchen knife"``), and falls through to fuzzy on FTS5 syntax
+    errors.
+- ``_validate_dependency_graph`` raises on cycles and unknown
+  references.
+- Cross-EntitySpec FK ordering: parents sync before children on cold
+  start.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import UTC, datetime
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from katana_mcp.typed_cache import (
+    EntitySpec,
+    ensure_customers_synced,
+    ensure_factory_synced,
+    ensure_locations_synced,
+    ensure_materials_synced,
+    ensure_products_synced,
+    ensure_services_synced,
+    ensure_suppliers_synced,
+    ensure_tax_rates_synced,
+    ensure_variants_synced,
+)
+from katana_mcp.typed_cache.sync import _validate_dependency_graph, topo_sort_specs
+
+from katana_public_api_client.models import (
+    Customer as AttrsCustomer,
+    Factory as AttrsFactory,
+    LocationType0 as AttrsLocation,
+    Material as AttrsMaterial,
+    Product as AttrsProduct,
+    Service as AttrsService,
+    Supplier as AttrsSupplier,
+    TaxRate as AttrsTaxRate,
+    VariantResponse as AttrsVariantResponse,
+)
+from katana_public_api_client.models_pydantic._generated import (
+    CachedCustomer,
+    CachedFactory,
+    CachedLocation,
+    CachedMaterial,
+    CachedProduct,
+    CachedService,
+    CachedSupplier,
+    CachedTaxRate,
+    CachedVariant,
+    InventoryItemType,
+)
+
+
+def _list_response(data: list) -> MagicMock:
+    """Stub a 200 list response with a ``data=[...]`` parsed body."""
+    parsed = MagicMock()
+    parsed.data = data
+    response = MagicMock()
+    response.status_code = 200
+    response.parsed = parsed
+    return response
+
+
+def _single_response(item: object) -> MagicMock:
+    """Stub a 200 single-record response (e.g., ``GET /factory``).
+
+    Single-record endpoints return the entity directly via
+    ``response.parsed``, not nested under ``data``. Mirrors what
+    ``unwrap()`` consumes.
+    """
+    response = MagicMock()
+    response.status_code = 200
+    response.parsed = item
+    return response
+
+
+@contextlib.contextmanager
+def _stub_endpoint(target: str, return_value: MagicMock):
+    """Patch one ``katana_mcp.typed_cache.sync.<target>.asyncio_detailed`` call."""
+    with patch(
+        f"katana_mcp.typed_cache.sync.{target}.asyncio_detailed",
+        new=AsyncMock(return_value=return_value),
+    ):
+        yield
+
+
+class TestEntitySpecValidation:
+    """Dependency-graph validation runs at engine.open()."""
+
+    def test_unknown_dependency_raises(self):
+        """A spec referencing an unknown ``entity_key`` is a config bug."""
+        # ``MagicMock`` doesn't statically conform to ``_FromAttrs`` — these
+        # specs never actually invoke ``from_attrs`` because the validator
+        # raises before sync runs, so the mock is fine at runtime.
+        spec = EntitySpec(
+            entity_key="orphan",
+            api_fn=MagicMock(),
+            cache_cls=CachedProduct,
+            pydantic_cls=cast(Any, MagicMock()),
+            depends_on=("nonexistent",),
+        )
+        with pytest.raises(ValueError, match="depends_on='nonexistent'"):
+            _validate_dependency_graph([spec])
+
+    def test_dependency_cycle_raises(self):
+        """Cyclic dependencies are caught at validation time."""
+        a = EntitySpec(
+            entity_key="a",
+            api_fn=MagicMock(),
+            cache_cls=CachedProduct,
+            pydantic_cls=cast(Any, MagicMock()),
+            depends_on=("b",),
+        )
+        b = EntitySpec(
+            entity_key="b",
+            api_fn=MagicMock(),
+            cache_cls=CachedMaterial,
+            pydantic_cls=cast(Any, MagicMock()),
+            depends_on=("a",),
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            _validate_dependency_graph([a, b])
+
+    def test_topo_sort_orders_parents_first(self):
+        """Variant should appear after Product + Material in topo order."""
+        # Use the real registered specs — the source of truth for the
+        # dependency graph.
+        from katana_mcp.typed_cache.sync import ENTITY_SPECS
+
+        ordered = topo_sort_specs(ENTITY_SPECS.values())
+        order = [spec.entity_key for spec in ordered]
+        assert order.index("product") < order.index("variant")
+        assert order.index("material") < order.index("variant")
+
+
+class TestCatalogSync:
+    """Cold-start sync round-trip for each catalog entity."""
+
+    @pytest.mark.asyncio
+    async def test_product_round_trips(self, typed_cache_engine):
+        attrs = AttrsProduct.from_dict(
+            {
+                "id": 101,
+                "name": "Kitchen Knife",
+                "type": "product",
+                "category_name": "Cutlery",
+            }
+        )
+        with _stub_endpoint("get_all_products", _list_response([attrs])):
+            await ensure_products_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedProduct, 101)
+        assert cached is not None
+        assert cached.name == "Kitchen Knife"
+        assert cached.category_name == "Cutlery"
+
+    @pytest.mark.asyncio
+    async def test_material_round_trips(self, typed_cache_engine):
+        attrs = AttrsMaterial.from_dict(
+            {"id": 5001, "name": "Stainless Steel", "type": "material"}
+        )
+        with _stub_endpoint("get_all_materials", _list_response([attrs])):
+            await ensure_materials_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedMaterial, 5001)
+        assert cached is not None
+        assert cached.name == "Stainless Steel"
+
+    @pytest.mark.asyncio
+    async def test_service_round_trips(self, typed_cache_engine):
+        attrs = AttrsService.from_dict({"id": 7001, "name": "Sharpening"})
+        with _stub_endpoint("get_all_services", _list_response([attrs])):
+            await ensure_services_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedService, 7001)
+        assert cached is not None
+        assert cached.name == "Sharpening"
+
+    @pytest.mark.asyncio
+    async def test_customer_round_trips(self, typed_cache_engine):
+        attrs = AttrsCustomer.from_dict(
+            {"id": 9001, "name": "Jane Doe", "email": "jane.doe@example.com"}
+        )
+        with _stub_endpoint("get_all_customers", _list_response([attrs])):
+            await ensure_customers_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedCustomer, 9001)
+        assert cached is not None
+        assert cached.name == "Jane Doe"
+        assert cached.email == "jane.doe@example.com"
+
+    @pytest.mark.asyncio
+    async def test_supplier_round_trips(self, typed_cache_engine):
+        attrs = AttrsSupplier.from_dict({"id": 8001, "name": "Acme Steel Co"})
+        with _stub_endpoint("get_all_suppliers", _list_response([attrs])):
+            await ensure_suppliers_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedSupplier, 8001)
+        assert cached is not None
+        assert cached.name == "Acme Steel Co"
+
+    @pytest.mark.asyncio
+    async def test_location_round_trips(self, typed_cache_engine):
+        attrs = AttrsLocation.from_dict({"id": 1, "name": "Main Warehouse"})
+        with _stub_endpoint("get_all_locations", _list_response([attrs])):
+            await ensure_locations_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedLocation, 1)
+        assert cached is not None
+        assert cached.name == "Main Warehouse"
+
+    @pytest.mark.asyncio
+    async def test_tax_rate_round_trips(self, typed_cache_engine):
+        attrs = AttrsTaxRate.from_dict(
+            {"id": 1, "name": "VAT 20%", "rate": 20.0, "is_default_sales": True}
+        )
+        with _stub_endpoint("get_all_tax_rates", _list_response([attrs])):
+            await ensure_tax_rates_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedTaxRate, 1)
+        assert cached is not None
+        assert cached.rate == 20.0
+
+    @pytest.mark.asyncio
+    async def test_factory_round_trips(self, typed_cache_engine):
+        """Factory uses ``single_record=True`` — pins the bare-object fetch path."""
+        attrs = AttrsFactory.from_dict(
+            {
+                "id": 1,
+                "name": "Acme Mfg",
+                "display_name": "Acme Mfg Co",
+                "base_currency_code": "USD",
+            }
+        )
+        with _stub_endpoint("get_factory", _single_response(attrs)):
+            await ensure_factory_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedFactory, 1)
+        assert cached is not None
+        assert cached.name == "Acme Mfg"
+        assert cached.base_currency_code == "USD"
+
+
+class TestVariantPostprocess:
+    """Variant cache-only fields populate from the extended payload."""
+
+    @pytest.mark.asyncio
+    async def test_parent_archived_at_lifted(self, typed_cache_engine):
+        """When the parent product is archived, the variant cache row reflects it."""
+        # Sync the parent product first so the registry has a slot for
+        # the variant's ``product_or_material`` reference. The test
+        # actually exercises the postprocess hook, not the FK.
+        archived_dt = datetime(2025, 1, 15, tzinfo=UTC)
+        product_attrs = AttrsProduct.from_dict(
+            {
+                "id": 101,
+                "name": "Kitchen Knife",
+                "type": "product",
+                "archived_at": archived_dt.isoformat(),
+            }
+        )
+        with _stub_endpoint("get_all_products", _list_response([product_attrs])):
+            await ensure_products_synced(MagicMock(), typed_cache_engine)
+
+        # Now sync a variant whose extended payload exposes the archived parent.
+        variant_attrs = AttrsVariantResponse.from_dict(
+            {
+                "id": 3001,
+                "sku": "KNF-PRO-8PC",
+                "product_id": 101,
+                "type": "product",
+                "config_attributes": [
+                    {"config_name": "Piece Count", "config_value": "8-piece"}
+                ],
+                "supplier_item_codes": ["SUPP-KNF-001"],
+                "product_or_material": {
+                    "id": 101,
+                    "name": "Kitchen Knife",
+                    "type": "product",
+                    "archived_at": archived_dt.isoformat(),
+                },
+            }
+        )
+        # Stub product/material as empty for the variant sync's
+        # ensure_*_synced fan-out (the helper re-syncs parents).
+        empty = _list_response([])
+        with (
+            _stub_endpoint("get_all_products", empty),
+            _stub_endpoint("get_all_materials", empty),
+            _stub_endpoint("get_all_variants", _list_response([variant_attrs])),
+        ):
+            await ensure_variants_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedVariant, 3001)
+        assert cached is not None
+        assert cached.parent_archived_at is not None
+        assert cached.parent_name == "Kitchen Knife"
+        assert cached.display_name == "Kitchen Knife / 8-piece"
+        assert cached.supplier_item_codes_text == "SUPP-KNF-001"
+
+    @pytest.mark.asyncio
+    async def test_display_name_falls_back_to_sku(self, typed_cache_engine):
+        """Defensive fallback when parent name is empty — mirrors legacy semantics."""
+        variant_attrs = AttrsVariantResponse.from_dict(
+            {
+                "id": 3002,
+                "sku": "FALLBACK-SKU",
+                "type": "product",
+            }
+        )
+        empty = _list_response([])
+        with (
+            _stub_endpoint("get_all_products", empty),
+            _stub_endpoint("get_all_materials", empty),
+            _stub_endpoint("get_all_variants", _list_response([variant_attrs])),
+        ):
+            await ensure_variants_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedVariant, 3002)
+        assert cached is not None
+        # No parent name → SKU fallback (mirrors legacy
+        # ``_variant_to_cache_dict``).
+        assert cached.display_name == "FALLBACK-SKU"
+        assert cached.parent_archived_at is None
+
+
+class TestCatalogQueriesGetters:
+    """Direct lookup methods on the CatalogQueries adapter."""
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_filters_archived_by_default(self, typed_cache_engine):
+        """A row with ``archived_at`` set is hidden unless ``include_archived=True``."""
+        archived_dt = datetime(2025, 1, 15, tzinfo=UTC)
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedProduct(
+                    id=42,
+                    name="Archived Product",
+                    type=InventoryItemType.product,
+                    archived_at=archived_dt,
+                )
+            )
+            await session.commit()
+
+        # Default: archived rows hidden.
+        result = await typed_cache_engine.catalog.get_by_id(CachedProduct, 42)
+        assert result is None
+
+        # Opt-in: archived rows surfaced.
+        result = await typed_cache_engine.catalog.get_by_id(
+            CachedProduct, 42, include_archived=True
+        )
+        assert result is not None
+        assert result.id == 42
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_filters_deleted_by_default(self, typed_cache_engine):
+        """A row with ``deleted_at`` set is hidden unless ``include_deleted=True``."""
+        deleted_dt = datetime(2025, 2, 1, tzinfo=UTC)
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedCustomer(id=99, name="Deleted Customer", deleted_at=deleted_dt)
+            )
+            await session.commit()
+
+        result = await typed_cache_engine.catalog.get_by_id(CachedCustomer, 99)
+        assert result is None
+
+        result = await typed_cache_engine.catalog.get_by_id(
+            CachedCustomer, 99, include_deleted=True
+        )
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_get_by_sku_is_case_insensitive(self, typed_cache_engine):
+        """NOCASE collation lets callers pass any-case SKUs."""
+        async with typed_cache_engine.session() as session:
+            session.add(CachedVariant(id=1, sku="KNF-PRO-8PC"))
+            await session.commit()
+
+        result_upper = await typed_cache_engine.catalog.get_by_sku("KNF-PRO-8PC")
+        result_lower = await typed_cache_engine.catalog.get_by_sku("knf-pro-8pc")
+        result_mixed = await typed_cache_engine.catalog.get_by_sku("Knf-Pro-8Pc")
+        assert result_upper is not None
+        assert result_lower is not None
+        assert result_mixed is not None
+        assert result_upper.id == result_lower.id == result_mixed.id == 1
+
+    @pytest.mark.asyncio
+    async def test_get_many_by_ids_dedupes_and_returns_dict(self, typed_cache_engine):
+        """Duplicates collapse; the result is keyed by id for hits only."""
+        async with typed_cache_engine.session() as session:
+            session.add(CachedProduct(id=1, name="P1", type=InventoryItemType.product))
+            session.add(CachedProduct(id=2, name="P2", type=InventoryItemType.product))
+            await session.commit()
+
+        result = await typed_cache_engine.catalog.get_many_by_ids(
+            CachedProduct, [1, 2, 1, 999]
+        )
+        assert set(result.keys()) == {1, 2}
+        assert result[1].name == "P1"
+
+    @pytest.mark.asyncio
+    async def test_get_all_filters_archived(self, typed_cache_engine):
+        """``get_all`` honors the same archive filter as the lookup methods."""
+        archived_dt = datetime(2025, 1, 15, tzinfo=UTC)
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedProduct(
+                    id=1, name="Active Product", type=InventoryItemType.product
+                )
+            )
+            session.add(
+                CachedProduct(
+                    id=2,
+                    name="Archived Product",
+                    type=InventoryItemType.product,
+                    archived_at=archived_dt,
+                )
+            )
+            await session.commit()
+
+        active = await typed_cache_engine.catalog.get_all(CachedProduct)
+        all_rows = await typed_cache_engine.catalog.get_all(
+            CachedProduct, include_archived=True
+        )
+        assert {p.id for p in active} == {1}
+        assert {p.id for p in all_rows} == {1, 2}
+
+
+class TestCatalogQueriesSearch:
+    """Smart_search + fuzzy fallback semantics."""
+
+    @pytest.mark.asyncio
+    async def test_smart_search_sku_shaped_query(self, typed_cache_engine):
+        """SKU-shaped query (``00.4021.018.003``) tokenizes via ``\\W+``.
+
+        The legacy ``CatalogCache.smart_search`` used ``query.split()``
+        which kept the ``.`` separators, producing one super-token that
+        FTS5 stripped to nothing — a real user repro from #471.
+        """
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedVariant(
+                    id=1,
+                    sku="ZSF-V2",
+                    supplier_item_codes_text="00 4021 018 003",
+                    display_name="ZSF V2 / Black",
+                )
+            )
+            await session.commit()
+
+        results = await typed_cache_engine.catalog.smart_search(
+            CachedVariant, "00.4021.018.003"
+        )
+        assert len(results) == 1
+        assert results[0].id == 1
+
+    @pytest.mark.asyncio
+    async def test_smart_search_multi_token(self, typed_cache_engine):
+        """Multi-token queries still match across columns."""
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedVariant(
+                    id=2,
+                    sku="KNF-PRO-8PC",
+                    display_name="Kitchen Knife / 8-piece",
+                    parent_name="Kitchen Knife",
+                )
+            )
+            await session.commit()
+
+        results = await typed_cache_engine.catalog.smart_search(
+            CachedVariant, "kitchen knife"
+        )
+        assert len(results) == 1
+        assert results[0].id == 2
+
+    @pytest.mark.asyncio
+    async def test_smart_search_upc_query(self, typed_cache_engine):
+        """UPC search hits ``registered_barcode`` — covers #471/#473 acceptance."""
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedVariant(
+                    id=3,
+                    sku="BARCODE-VARIANT",
+                    registered_barcode="710845916762",
+                )
+            )
+            await session.commit()
+
+        results = await typed_cache_engine.catalog.smart_search(
+            CachedVariant, "710845916762"
+        )
+        assert len(results) == 1
+        assert results[0].id == 3
+
+    @pytest.mark.asyncio
+    async def test_smart_search_falls_through_on_syntax_error(self, typed_cache_engine):
+        """Unbalanced parens trigger ``OperationalError``; fall through to fuzzy.
+
+        Legacy cache silently returned an empty list — a real bug since
+        the user got *zero* results for a typo'd query that fuzzy could
+        have rescued.
+        """
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedVariant(
+                    id=4,
+                    sku="STAINLES-V1",
+                    display_name="Stainless Steel V1",
+                    parent_name="Stainless Steel",
+                )
+            )
+            await session.commit()
+
+        # ``stainles`` is misspelled; the malformed-paren prefix forces
+        # the FTS path to raise OperationalError.
+        results = await typed_cache_engine.catalog.smart_search(
+            CachedVariant, "stainles("
+        )
+        # Fuzzy fallback should rescue the row by approximate match.
+        assert any(r.id == 4 for r in results)
+
+    @pytest.mark.asyncio
+    async def test_smart_search_empty_query_returns_empty(self, typed_cache_engine):
+        results = await typed_cache_engine.catalog.smart_search(CachedVariant, "")
+        assert results == []
+        results = await typed_cache_engine.catalog.smart_search(CachedVariant, "   ")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_smart_search_archived_filter(self, typed_cache_engine):
+        """Archived-parent variants hide by default; surface with explicit flag."""
+        archived_dt = datetime(2025, 1, 15, tzinfo=UTC)
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedVariant(
+                    id=5,
+                    sku="ARCHIVED-V1",
+                    display_name="Archived Knife",
+                    parent_name="Archived Knife",
+                    parent_archived_at=archived_dt,
+                )
+            )
+            await session.commit()
+
+        # Default: archived parent hidden.
+        default_results = await typed_cache_engine.catalog.smart_search(
+            CachedVariant, "archived"
+        )
+        assert default_results == []
+
+        # Opt-in: surface archived rows.
+        opted_in = await typed_cache_engine.catalog.smart_search(
+            CachedVariant, "archived", include_archived=True
+        )
+        assert any(r.id == 5 for r in opted_in)
+
+
+class TestCrossEntitySpecOrdering:
+    """Cross-EntitySpec FK ordering — Phase B's ``depends_on`` mechanism."""
+
+    @pytest.mark.asyncio
+    async def test_ensure_variants_synced_pulls_parents_first(self, typed_cache_engine):
+        """Cold-start sync materializes Product/Material rows before Variant inserts.
+
+        ``ensure_variants_synced`` syncs Product → Material → Variant in
+        order. The variant's ``attrs_postprocess`` then reads the parent's
+        ``archived_at`` from the extended payload and stores it on the
+        cache row. End-state: parent rows in cache, variant in cache,
+        ``parent_archived_at`` populated for any archived parent.
+        """
+        product_attrs = AttrsProduct.from_dict(
+            {"id": 101, "name": "Knife", "type": "product"}
+        )
+        material_attrs = AttrsMaterial.from_dict(
+            {"id": 5001, "name": "Steel", "type": "material"}
+        )
+        variant_for_product = AttrsVariantResponse.from_dict(
+            {
+                "id": 3001,
+                "sku": "KNF-V1",
+                "product_id": 101,
+                "type": "product",
+                "product_or_material": {
+                    "id": 101,
+                    "name": "Knife",
+                    "type": "product",
+                },
+            }
+        )
+        variant_for_material = AttrsVariantResponse.from_dict(
+            {
+                "id": 3002,
+                "sku": "STL-V1",
+                "material_id": 5001,
+                "type": "material",
+                "product_or_material": {
+                    "id": 5001,
+                    "name": "Steel",
+                    "type": "material",
+                },
+            }
+        )
+
+        with (
+            _stub_endpoint("get_all_products", _list_response([product_attrs])),
+            _stub_endpoint("get_all_materials", _list_response([material_attrs])),
+            _stub_endpoint(
+                "get_all_variants",
+                _list_response([variant_for_product, variant_for_material]),
+            ),
+        ):
+            await ensure_variants_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            assert await session.get(CachedProduct, 101) is not None
+            assert await session.get(CachedMaterial, 5001) is not None
+            v_product = await session.get(CachedVariant, 3001)
+            v_material = await session.get(CachedVariant, 3002)
+        assert v_product is not None
+        assert v_material is not None
+        assert v_product.parent_name == "Knife"
+        assert v_material.parent_name == "Steel"
+
+
+class TestFTSSchemaValidation:
+    """FTS column declarations stay in sync with the cache table schema."""
+
+    @pytest.mark.asyncio
+    async def test_engine_open_creates_per_entity_fts_tables(self, typed_cache_engine):
+        """Phase B's per-entity FTS5 sidecar emits ``<entity>_fts`` tables.
+
+        Lookup-only entities (Location, TaxRate, Operator, Factory,
+        AdditionalCost) skip FTS — they're below the minimum-content
+        threshold for FTS5 to add value.
+        """
+        from sqlalchemy import text
+
+        async with typed_cache_engine.session() as session:
+            conn = await session.connection()
+            result = await conn.execute(
+                text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name LIKE '%_fts'"
+                )
+            )
+            tables = {row[0] for row in result.fetchall()}
+
+        # The 6 entities with ``__fts_columns__`` — variants, products,
+        # materials, services, customers, suppliers — all get tables.
+        expected = {
+            "variant_fts",
+            "product_fts",
+            "material_fts",
+            "service_fts",
+            "customer_fts",
+            "supplier_fts",
+        }
+        assert expected.issubset(tables)
+
+
+class TestNoDoubleOpenInteraction:
+    """Reopening an engine should be safe and FTS rows stay consistent."""
+
+    @pytest.mark.asyncio
+    async def test_fts_index_consistent_after_insert(self, typed_cache_engine):
+        """Inserting a row populates the FTS sidecar via after_insert listener."""
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedVariant(
+                    id=10,
+                    sku="LISTENER-TEST",
+                    display_name="Listener Test Item",
+                )
+            )
+            await session.commit()
+
+        # Round-trip: can we find it via the FTS-backed smart_search?
+        results = await typed_cache_engine.catalog.smart_search(
+            CachedVariant, "listener"
+        )
+        assert any(r.id == 10 for r in results)
+
+
+class TestNonFTSEntities:
+    """smart_search degrades to fuzzy for entities without ``__fts_columns__``."""
+
+    @pytest.mark.asyncio
+    async def test_smart_search_on_taxrate_falls_back_to_fuzzy(
+        self, typed_cache_engine
+    ):
+        """TaxRate has no FTS sidecar; smart_search returns fuzzy results."""
+        async with typed_cache_engine.session() as session:
+            session.add(CachedTaxRate(id=1, name="VAT 20%", rate=20.0))
+            await session.commit()
+
+        results = await typed_cache_engine.catalog.smart_search(CachedTaxRate, "VAT")
+        assert any(r.id == 1 for r in results)

--- a/katana_mcp_server/tests/test_typed_cache_catalog.py
+++ b/katana_mcp_server/tests/test_typed_cache_catalog.py
@@ -512,12 +512,24 @@ class TestCatalogQueriesSearch:
 
     @pytest.mark.asyncio
     async def test_smart_search_falls_through_on_syntax_error(self, typed_cache_engine):
-        """Unbalanced parens trigger ``OperationalError``; fall through to fuzzy.
+        """FTS5 ``OperationalError`` falls through to fuzzy.
 
-        Legacy cache silently returned an empty list — a real bug since
-        the user got *zero* results for a typo'd query that fuzzy could
-        have rescued.
+        The tokenizer strips punctuation (``re.split(\\W+, ...)``), so
+        user-supplied punctuation like ``stainles(`` can't actually
+        trigger an FTS5 syntax error in production — the malformed
+        token never reaches the FTS5 grammar. To exercise the
+        fall-through branch directly, patch the FTS-execution path to
+        raise the same ``OperationalError`` SQLite would have raised
+        for a syntactically invalid match expression. Fuzzy fallback
+        should still rescue the row by approximate match on
+        ``display_name`` / ``parent_name``.
+
+        Legacy cache silently returned an empty list — a real bug
+        since the user got *zero* results for a query that fuzzy
+        could have rescued.
         """
+        from sqlalchemy.exc import OperationalError
+
         async with typed_cache_engine.session() as session:
             session.add(
                 CachedVariant(
@@ -529,13 +541,70 @@ class TestCatalogQueriesSearch:
             )
             await session.commit()
 
-        # ``stainles`` is misspelled; the malformed-paren prefix forces
-        # the FTS path to raise OperationalError.
-        results = await typed_cache_engine.catalog.smart_search(
-            CachedVariant, "stainles("
-        )
+        # Stub ``exec_driver_sql`` to raise the FTS5 syntax error
+        # SQLite would emit for an invalid match expression. Wrap the
+        # original so non-FTS calls (the fuzzy path's own SELECTs) keep
+        # working — only the first call (the FTS5 query in
+        # ``smart_search``) raises.
+        from sqlalchemy.ext.asyncio import AsyncConnection
+
+        original = AsyncConnection.exec_driver_sql
+        call_count = {"n": 0}
+
+        async def _raise_first(self, statement, parameters=None, *a, **kw):
+            call_count["n"] += 1
+            if call_count["n"] == 1 and "MATCH" in statement:
+                msg = 'fts5: syntax error near "("'
+                raise OperationalError(statement, parameters, Exception(msg))
+            return await original(self, statement, parameters, *a, **kw)
+
+        with patch.object(AsyncConnection, "exec_driver_sql", _raise_first):
+            results = await typed_cache_engine.catalog.smart_search(
+                CachedVariant, "stainles"
+            )
         # Fuzzy fallback should rescue the row by approximate match.
         assert any(r.id == 4 for r in results)
+        # Belt-and-suspenders: confirm the patched path actually fired.
+        assert call_count["n"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_smart_search_propagates_non_syntax_operational_error(
+        self, typed_cache_engine
+    ):
+        """Operational errors (locked DB, missing table) propagate — no silent fuzzy.
+
+        The fall-through is narrowed to FTS5 syntax errors only. A
+        generic ``OperationalError`` (e.g. ``database is locked``,
+        ``no such table: variant_fts``) signals a real problem; masking
+        it behind a fuzzy fallback would leave the operator without
+        any signal that the FTS sidecar broke.
+        """
+        from sqlalchemy.exc import OperationalError
+        from sqlalchemy.ext.asyncio import AsyncConnection
+
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedVariant(
+                    id=99,
+                    sku="OPERATIONAL-ERR",
+                    display_name="Should Not Surface",
+                )
+            )
+            await session.commit()
+
+        original = AsyncConnection.exec_driver_sql
+
+        async def _raise_locked(self, statement, parameters=None, *a, **kw):
+            if "MATCH" in statement:
+                msg = "database is locked"
+                raise OperationalError(statement, parameters, Exception(msg))
+            return await original(self, statement, parameters, *a, **kw)
+
+        with (
+            patch.object(AsyncConnection, "exec_driver_sql", _raise_locked),
+            pytest.raises(OperationalError),
+        ):
+            await typed_cache_engine.catalog.smart_search(CachedVariant, "operational")
 
     @pytest.mark.asyncio
     async def test_smart_search_empty_query_returns_empty(self, typed_cache_engine):

--- a/katana_mcp_server/tests/test_typed_cache_catalog.py
+++ b/katana_mcp_server/tests/test_typed_cache_catalog.py
@@ -40,7 +40,7 @@ from katana_mcp.typed_cache import (
     ensure_tax_rates_synced,
     ensure_variants_synced,
 )
-from katana_mcp.typed_cache.sync import _validate_dependency_graph, topo_sort_specs
+from katana_mcp.typed_cache.sync import _validate_dependency_graph
 
 from katana_public_api_client.models import (
     Customer as AttrsCustomer,
@@ -136,17 +136,6 @@ class TestEntitySpecValidation:
         )
         with pytest.raises(ValueError, match="cycle"):
             _validate_dependency_graph([a, b])
-
-    def test_topo_sort_orders_parents_first(self):
-        """Variant should appear after Product + Material in topo order."""
-        # Use the real registered specs — the source of truth for the
-        # dependency graph.
-        from katana_mcp.typed_cache.sync import ENTITY_SPECS
-
-        ordered = topo_sort_specs(ENTITY_SPECS.values())
-        order = [spec.entity_key for spec in ordered]
-        assert order.index("product") < order.index("variant")
-        assert order.index("material") < order.index("variant")
 
 
 class TestCatalogSync:


### PR DESCRIPTION
## Summary

Phase B of [#472](https://github.com/dougborg/katana-openapi-client/issues/472) (cache unification): wires the 11 catalog `Cached*` siblings (shipped as Phase A in #643) into `TypedCacheEngine`. Phase D will migrate ~33 `services.cache.*` call sites onto the new adapter; Phase B ships in parallel with the legacy cache.

- **`EntitySpec` extensions** — `depends_on` (topo-ordered cold-start), `attrs_postprocess` (cache-only field hooks), `extra_fetch_kwargs`, `supports_incremental`, `supports_include_deleted`, `single_record` (Factory). Validator runs at `engine.open()`.
- **11 catalog specs** — variant (with `_variant_postprocess` lifting `parent_archived_at` / `display_name` / `parent_name` / `supplier_item_codes_text` from the extended `product_or_material` payload), product, material, service, customer, supplier, location, tax_rate, operator, factory, additional_cost.
- **`typed_cache/fts.py`** — per-entity FTS5 virtual tables + SQLAlchemy `after_insert` / `after_update` / `after_delete` listeners. Startup asserts every `__fts_columns__` entry exists on the table.
- **`typed_cache/queries.py`** — `CatalogQueries` adapter (`engine.catalog`) with `get_by_id`, `get_by_sku` (NOCASE), `get_many_by_ids`, `get_all`, `smart_search`, `search_fuzzy`. Defaults flip to `include_archived=False` / `include_deleted=False` (papercut fix vs. legacy cache).
- **#471 / #473 search-surface fixes** ship as a free byproduct: `smart_search` tokenizes via `re.split(r"\W+", ...)` so SKU-shaped queries like `00.4021.018.003` work; FTS5 syntax errors fall through to fuzzy instead of silently returning empty.

Closes part of [#472](https://github.com/dougborg/katana-openapi-client/issues/472) (Phase B). Phase C (decorator rewire) and Phase D (call-site migration + decommission) remain.

## Test plan

- [x] `uv run poe check` clean (ruff, ty, pyright, format, 3106 tests)
- [x] 28 new tests in `test_typed_cache_catalog.py` covering: each catalog entity round-trips through sync; Variant cache-only fields populate from extended payload; `CatalogQueries` getters honor archive/delete defaults; SKU-shaped query (`00.4021.018.003`) hits via tokenizer fix; UPC query (`710845916762`) hits via `registered_barcode`; multi-token query works; FTS5 syntax-error query falls through to fuzzy; `_validate_dependency_graph` raises on cycles + unknown deps; cross-`EntitySpec` FK ordering verified on cold start.
- [x] Existing `test_typed_cache.py` + `test_typed_cache_invalidation.py` (30 tests) continue to pass — no regression on transactional sync.
- [ ] CI green
- [ ] Phase C/D follow-on PRs land before Phase B's adapter has any production callers (currently used only by tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)