### PR TITLE
feat(mcp): Prefab UI cards for stock_adjustment family + direct-apply rail (#311, #639)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -889,13 +889,31 @@ class CreateStockAdjustmentRequest(BaseModel):
     )
 
 
+class StockAdjustmentRowSummary(BaseModel):
+    """One line item in a stock adjustment, in display-ready form.
+
+    Carries enough data for the Prefab card's DataTable + the markdown
+    fallback. ``display_name`` resolves the SKU to the variant's human-
+    readable name at preview/apply time so the card doesn't have to
+    re-fetch.
+    """
+
+    sku: str
+    display_name: str
+    quantity: float
+    cost_per_unit: float | None = None
+
+
 class StockAdjustmentResponse(BaseModel):
     """Response from stock adjustment creation."""
 
     id: int | None
     is_preview: bool
+    location_id: int
     message: str
+    rows: list[StockAdjustmentRowSummary] = Field(default_factory=list)
     rows_summary: str
+    reason: str | None = None
     katana_url: str | None = None
 
 
@@ -924,6 +942,7 @@ async def _create_stock_adjustment_impl(
     # Resolve SKUs to variant IDs
     api_rows = []
     rows_summary_parts = []
+    structured_rows: list[StockAdjustmentRowSummary] = []
     for row in request.rows:
         variant = await services.cache.get_by_sku(sku=row.sku)
         if not variant:
@@ -946,6 +965,14 @@ async def _create_stock_adjustment_impl(
             )
         )
         rows_summary_parts.append(f"- {row.sku} ({display_name}): {row.quantity:+.1f}")
+        structured_rows.append(
+            StockAdjustmentRowSummary(
+                sku=row.sku,
+                display_name=display_name,
+                quantity=row.quantity,
+                cost_per_unit=row.cost_per_unit,
+            )
+        )
 
     rows_summary = "\n".join(rows_summary_parts)
 
@@ -954,8 +981,11 @@ async def _create_stock_adjustment_impl(
         return StockAdjustmentResponse(
             id=None,
             is_preview=True,
+            location_id=request.location_id,
             message="Preview — call again with preview=false to create",
+            rows=structured_rows,
             rows_summary=rows_summary,
+            reason=request.reason,
         )
 
     # Caller-supplied stock_adjustment_number takes precedence; otherwise
@@ -1007,8 +1037,11 @@ async def _create_stock_adjustment_impl(
     return StockAdjustmentResponse(
         id=adj_id,
         is_preview=False,
+        location_id=request.location_id,
         message="Stock adjustment created successfully",
+        rows=structured_rows,
         rows_summary=rows_summary,
+        reason=request.reason,
         katana_url=katana_web_url("stock_adjustment", adj_id),
     )
 
@@ -1025,25 +1058,16 @@ async def create_stock_adjustment(
 
     Use positive quantities to add stock, negative to remove.
     """
-    from katana_mcp.tools.tool_result_utils import make_simple_result
+    from katana_mcp.tools.prefab_ui import build_stock_adjustment_create_ui
+    from katana_mcp.tools.tool_result_utils import make_tool_result
 
     response = await _create_stock_adjustment_impl(request, context)
-
-    status = "PREVIEW" if response.is_preview else "CREATED"
-    md = (
-        f"## Stock Adjustment ({status})\n\n"
-        f"{response.message}\n\n"
-        f"### Items\n{response.rows_summary}\n"
+    ui = build_stock_adjustment_create_ui(
+        response.model_dump(),
+        confirm_request=request,
+        confirm_tool="create_stock_adjustment",
     )
-    if response.id:
-        md += f"\n**Adjustment ID**: {response.id}\n"
-    if response.katana_url:
-        md += f"**Katana URL**: {response.katana_url}\n"
-
-    return make_simple_result(
-        md,
-        structured_data=response.model_dump(),
-    )
+    return make_tool_result(response, ui=ui)
 
 
 # ============================================================================
@@ -1627,14 +1651,16 @@ async def update_stock_adjustment(
     additional_info). Row-level changes are not supported — create a new
     adjustment for that.
     """
+    from katana_mcp.tools.prefab_ui import build_stock_adjustment_update_ui
+    from katana_mcp.tools.tool_result_utils import make_tool_result
+
     response = await _update_stock_adjustment_impl(request, context)
-    status = "PREVIEW" if response.is_preview else "UPDATED"
-    md = (
-        f"## Stock Adjustment {response.id} ({status})\n\n"
-        f"{response.message}\n\n"
-        f"### Changes\n{response.changes_summary}\n"
+    ui = build_stock_adjustment_update_ui(
+        response.model_dump(),
+        confirm_request=request,
+        confirm_tool="update_stock_adjustment",
     )
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_tool_result(response, ui=ui)
 
 
 # ============================================================================
@@ -1760,16 +1786,16 @@ async def delete_stock_adjustment(
     `preview=false` prompts the user for confirmation, then calls DELETE.
     Deleting a stock adjustment reverses the associated inventory movements.
     """
+    from katana_mcp.tools.prefab_ui import build_stock_adjustment_delete_ui
+    from katana_mcp.tools.tool_result_utils import make_tool_result
+
     response = await _delete_stock_adjustment_impl(request, context)
-    status = "PREVIEW" if response.is_preview else "DELETED"
-    md = (
-        f"## Stock Adjustment {response.id} ({status})\n\n"
-        f"{response.message}\n\n"
-        f"- **Number**: {response.stock_adjustment_number or '—'}\n"
-        f"- **Location**: {response.location_id or '—'}\n"
-        f"- **Rows**: {response.row_count}\n"
+    ui = build_stock_adjustment_delete_ui(
+        response.model_dump(),
+        confirm_request=request,
+        confirm_tool="delete_stock_adjustment",
     )
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_tool_result(response, ui=ui)
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -1814,16 +1840,22 @@ def register_tools(mcp: FastMCP) -> None:
         create_stock_adjustment,
         tags={"inventory", "write"},
         annotations=_create,
+        meta=UI_META,
+        direct=True,
     )
     register_preview_tool(
         mcp,
         update_stock_adjustment,
         tags={"inventory", "write"},
         annotations=_destructive_write,
+        meta=UI_META,
+        direct=True,
     )
     register_preview_tool(
         mcp,
         delete_stock_adjustment,
         tags={"inventory", "write"},
         annotations=_destructive_write,
+        meta=UI_META,
+        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -836,6 +836,324 @@ def build_low_stock_ui(
 
 
 # ============================================================================
+# Stock Adjustment UIs (Create / Update / Delete)
+# ============================================================================
+
+
+_STOCK_ADJUSTMENT_ROW_COLUMNS: list[DataTableColumn] = [
+    DataTableColumn(key="sku", header="SKU"),
+    DataTableColumn(key="display_name", header="Item"),
+    DataTableColumn(key="quantity_label", header="Qty Change", align="right"),
+    DataTableColumn(key="cost_label", header="Cost / unit", align="right"),
+]
+
+_STOCK_ADJUSTMENT_FIELD_DIFF_COLUMNS: list[DataTableColumn] = [
+    DataTableColumn(key="field", header="Field"),
+    DataTableColumn(key="new_value", header="New Value"),
+]
+
+
+def _format_qty_change(qty: float) -> str:
+    """Format a quantity change with leading sign (e.g., ``+1.0``, ``-3.5``)."""
+    return f"{qty:+.1f}"
+
+
+def _format_cost(cost: float | int | None) -> str:
+    """Format a per-unit cost; ``—`` when omitted."""
+    if cost is None:
+        return "—"
+    return f"{cost:.2f}"
+
+
+# Initial state slots written by the direct-apply rail's Confirm/Cancel
+# action chains. Builders that opt into the rail seed these to ``False`` /
+# ``None`` so the iframe's If/Elif blocks have something to bind to before
+# the first click. ``SetState`` mutations from
+# ``_build_apply_action_direct`` / ``_build_cancel_action`` flip them.
+_DIRECT_APPLY_STATE_INIT: dict[str, Any] = {
+    "pending": False,
+    "cancelled": False,
+    "applied": False,
+    "error": None,
+}
+
+
+def _stock_adjustment_rows_for_table(
+    rows: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Project StockAdjustmentRowSummary dicts onto the DataTable row shape.
+
+    Trusts the upstream pydantic model's type guarantees — the dict comes
+    from ``StockAdjustmentResponse.model_dump()`` so ``sku`` /
+    ``display_name`` / ``quantity`` are already correctly typed.
+    """
+    return [
+        {
+            "sku": r["sku"],
+            "display_name": r["display_name"],
+            "quantity_label": _format_qty_change(r["quantity"]),
+            "cost_label": _format_cost(r.get("cost_per_unit")),
+        }
+        for r in (rows or [])
+    ]
+
+
+def build_stock_adjustment_create_ui(
+    response: dict[str, Any],
+    *,
+    confirm_request: BaseModel,
+    confirm_tool: str,
+) -> PrefabApp:
+    """Build the create-stock-adjustment preview card with direct-apply rail.
+
+    Used for both the ``preview=True`` branch (Confirm + Cancel buttons,
+    direct-apply morph) and the ``preview=False`` branch (no buttons,
+    "View in Katana" link). The same builder handles both via the
+    ``is_preview`` flag — symmetric with how the modification card
+    pair is structured.
+    """
+    is_preview = bool(response.get("is_preview"))
+    rows = _stock_adjustment_rows_for_table(response.get("rows"))
+    state: dict[str, Any] = {"plan_rows": rows}
+    apply_action: list[Action] | None = None
+    cancel_action: list[Action] | None = None
+    if is_preview:
+        state.update(_DIRECT_APPLY_STATE_INIT)
+        apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+        cancel_action = _build_cancel_action("the stock adjustment")
+
+    location_id = response.get("location_id")
+    adj_id = response.get("id")
+    reason = response.get("reason")
+
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
+        with CardHeader(), Row(gap=2):
+            CardTitle(content="Stock Adjustment")
+            if adj_id is not None:
+                Badge(label=f"#{adj_id}", variant="outline")
+            if location_id is not None:
+                Badge(label=f"Location {location_id}", variant="outline")
+            Badge(
+                label="PREVIEW" if is_preview else "APPLIED",
+                variant="secondary" if is_preview else "default",
+            )
+
+        with CardContent(), Column(gap=3):
+            if response.get("message"):
+                Text(content=response["message"])
+            if reason:
+                Muted(content=f"Reason: {reason}")
+
+            if rows:
+                DataTable(
+                    columns=_STOCK_ADJUSTMENT_ROW_COLUMNS,
+                    rows="{{ plan_rows }}",
+                )
+
+            if is_preview:
+                with If("error"):
+                    Separator()
+                    with Alert(variant="destructive", icon="circle-alert"):
+                        AlertTitle(content="Apply failed")
+                        AlertDescription(content="{{ error }}")
+
+        with CardFooter(), Row(gap=2):
+            if apply_action is not None and cancel_action is not None:
+                with If("applied"):
+                    Muted(content="Stock adjustment created.")
+                with Elif("error"):
+                    Muted(content="Apply failed — see error above.")
+                with Elif("cancelled"):
+                    Muted(content="Cancelled. No changes were made.")
+                with Else():
+                    Muted(content="This is a preview. No changes have been made.")
+                _render_apply_button_row(
+                    confirm_label="Confirm & Create",
+                    apply_action=apply_action,
+                    cancel_action=cancel_action,
+                    direct_apply=True,
+                )
+            elif response.get("katana_url"):
+                Button(
+                    label="View in Katana",
+                    variant="outline",
+                    on_click=SendMessage(
+                        f"Open {response['katana_url']} in the Katana web UI"
+                    ),
+                )
+    return app
+
+
+def build_stock_adjustment_update_ui(
+    response: dict[str, Any],
+    *,
+    confirm_request: BaseModel,
+    confirm_tool: str,
+) -> PrefabApp:
+    """Build the update-stock-adjustment preview card with direct-apply rail.
+
+    Renders the requested header field changes as a small DataTable so
+    the user can sanity-check what's about to be patched.
+    """
+    is_preview = bool(response.get("is_preview"))
+    diff_rows: list[dict[str, str]] = []
+    for field, label in (
+        ("stock_adjustment_number", "Number"),
+        ("stock_adjustment_date", "Date"),
+        ("location_id", "Location ID"),
+        ("reason", "Reason"),
+        ("additional_info", "Additional Info"),
+    ):
+        value = response.get(field)
+        if value is not None:
+            diff_rows.append({"field": label, "new_value": str(value)})
+
+    state: dict[str, Any] = {"diff_rows": diff_rows}
+    apply_action: list[Action] | None = None
+    cancel_action: list[Action] | None = None
+    if is_preview:
+        state.update(_DIRECT_APPLY_STATE_INIT)
+        apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+        cancel_action = _build_cancel_action("the stock-adjustment update")
+
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
+        with CardHeader(), Row(gap=2):
+            CardTitle(content="Update Stock Adjustment")
+            if response.get("id") is not None:
+                Badge(label=f"#{response['id']}", variant="outline")
+            Badge(
+                label="PREVIEW" if is_preview else "UPDATED",
+                variant="secondary" if is_preview else "default",
+            )
+
+        with CardContent(), Column(gap=3):
+            if response.get("message"):
+                Text(content=response["message"])
+            if diff_rows:
+                DataTable(
+                    columns=_STOCK_ADJUSTMENT_FIELD_DIFF_COLUMNS,
+                    rows="{{ diff_rows }}",
+                )
+            else:
+                Muted(content="No field changes supplied.")
+
+            if is_preview:
+                with If("error"):
+                    Separator()
+                    with Alert(variant="destructive", icon="circle-alert"):
+                        AlertTitle(content="Apply failed")
+                        AlertDescription(content="{{ error }}")
+
+        with CardFooter(), Row(gap=2):
+            if apply_action is not None and cancel_action is not None:
+                with If("applied"):
+                    Muted(content="Stock adjustment updated.")
+                with Elif("error"):
+                    Muted(content="Apply failed — see error above.")
+                with Elif("cancelled"):
+                    Muted(content="Cancelled. No changes were made.")
+                with Else():
+                    Muted(content="This is a preview. No changes have been made.")
+                _render_apply_button_row(
+                    confirm_label="Confirm & Update",
+                    apply_action=apply_action,
+                    cancel_action=cancel_action,
+                    direct_apply=True,
+                )
+            elif response.get("katana_url"):
+                Button(
+                    label="View in Katana",
+                    variant="outline",
+                    on_click=SendMessage(
+                        f"Open {response['katana_url']} in the Katana web UI"
+                    ),
+                )
+    return app
+
+
+def build_stock_adjustment_delete_ui(
+    response: dict[str, Any],
+    *,
+    confirm_request: BaseModel,
+    confirm_tool: str,
+) -> PrefabApp:
+    """Build the delete-stock-adjustment preview card with direct-apply rail.
+
+    Surfaces the identifying details (number, location, row count) so the
+    user can sanity-check before confirming. Apply path reverses the
+    associated inventory movements server-side — that consequence is
+    called out in the footer copy.
+    """
+    is_preview = bool(response.get("is_preview"))
+    state: dict[str, Any] = {}
+    apply_action: list[Action] | None = None
+    cancel_action: list[Action] | None = None
+    if is_preview:
+        state = dict(_DIRECT_APPLY_STATE_INIT)
+        apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+        cancel_action = _build_cancel_action("the stock-adjustment deletion")
+
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
+        with CardHeader(), Row(gap=2):
+            CardTitle(content="Delete Stock Adjustment")
+            if response.get("id") is not None:
+                Badge(label=f"#{response['id']}", variant="outline")
+            Badge(
+                label="PREVIEW" if is_preview else "DELETED",
+                variant="secondary" if is_preview else "destructive",
+            )
+
+        with CardContent(), Column(gap=3):
+            if response.get("message"):
+                Text(content=response["message"])
+
+            with Row(gap=4):
+                Metric(
+                    label="Number",
+                    value=str(response.get("stock_adjustment_number") or "—"),
+                )
+                Metric(
+                    label="Location",
+                    value=str(response.get("location_id") or "—"),
+                )
+                Metric(
+                    label="Rows",
+                    value=str(response.get("row_count", 0)),
+                )
+
+            if is_preview:
+                Muted(
+                    content=(
+                        "Deleting reverses the associated inventory "
+                        "movements server-side. This cannot be undone."
+                    )
+                )
+                with If("error"):
+                    Separator()
+                    with Alert(variant="destructive", icon="circle-alert"):
+                        AlertTitle(content="Apply failed")
+                        AlertDescription(content="{{ error }}")
+
+        with CardFooter(), Row(gap=2):
+            if apply_action is not None and cancel_action is not None:
+                with If("applied"):
+                    Muted(content="Stock adjustment deleted.")
+                with Elif("error"):
+                    Muted(content="Apply failed — see error above.")
+                with Elif("cancelled"):
+                    Muted(content="Cancelled. No changes were made.")
+                with Else():
+                    Muted(content="This is a preview. No changes have been made.")
+                _render_apply_button_row(
+                    confirm_label="Confirm & Delete",
+                    apply_action=apply_action,
+                    cancel_action=cancel_action,
+                    direct_apply=True,
+                )
+    return app
+
+
+# ============================================================================
 # Order UIs (Preview + Created)
 # ============================================================================
 

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -28,6 +28,9 @@ from katana_mcp.tools.prefab_ui import (
     build_modification_preview_ui,
     build_modification_result_ui,
     build_search_results_ui,
+    build_stock_adjustment_create_ui,
+    build_stock_adjustment_delete_ui,
+    build_stock_adjustment_update_ui,
     build_verification_ui,
 )
 from katana_mcp.tools.tool_result_utils import make_tool_result
@@ -302,6 +305,81 @@ def _batch_recipe_update_app() -> PrefabApp:
     return build_batch_recipe_update_ui(response)
 
 
+# ---------------------------------------------------------------------------
+# Stock-adjustment scenarios — preview/result for create / update / delete.
+# Adds direct-apply rail coverage for #639's stock_adjustment family.
+# ---------------------------------------------------------------------------
+
+
+def _stock_adjustment_response(*, is_preview: bool, n_rows: int = 3) -> dict:
+    """Build a canned StockAdjustmentResponse dict with N rows."""
+    rows = [
+        {
+            "sku": f"SKU-{1000 + i}",
+            "display_name": f"Test Item {i}",
+            "quantity": float(i + 1) if i % 2 == 0 else -float(i + 1),
+            "cost_per_unit": 10.50 if i == 0 else None,
+        }
+        for i in range(n_rows)
+    ]
+    return {
+        "id": None if is_preview else 9876,
+        "is_preview": is_preview,
+        "location_id": 160411,
+        "message": (
+            "Preview — call again with preview=false to create"
+            if is_preview
+            else "Stock adjustment created successfully"
+        ),
+        "rows": rows,
+        "rows_summary": "\n".join(
+            f"- {r['sku']} ({r['display_name']}): {r['quantity']:+.1f}" for r in rows
+        ),
+        "reason": "Found one in stock",
+        "katana_url": (
+            None if is_preview else "https://factory.katanamrp.com/stockadjustment/9876"
+        ),
+    }
+
+
+def _stock_adjustment_update_response(*, is_preview: bool) -> dict:
+    """Build a canned UpdateStockAdjustmentResponse dict with field changes."""
+    return {
+        "id": 9876,
+        "is_preview": is_preview,
+        "stock_adjustment_number": "SA-FY26-Q2-001",
+        "stock_adjustment_date": "2026-05-08T12:00:00+00:00",
+        "location_id": 160411,
+        "reason": "Updated reason",
+        "additional_info": None,
+        "changes_summary": "stock_adjustment_number, reason",
+        "message": (
+            "Preview — call again with preview=false to update stock adjustment 9876"
+            if is_preview
+            else "Stock adjustment 9876 updated successfully"
+        ),
+        "katana_url": "https://factory.katanamrp.com/stockadjustment/9876",
+    }
+
+
+def _stock_adjustment_delete_response(*, is_preview: bool) -> dict:
+    """Build a canned DeleteStockAdjustmentResponse dict."""
+    return {
+        "id": 9876,
+        "is_preview": is_preview,
+        "stock_adjustment_number": "SA-FY26-Q2-001",
+        "location_id": 160411,
+        "row_count": 3,
+        "message": (
+            "Preview — call again with preview=false to delete stock adjustment "
+            "SA-FY26-Q2-001 (3 rows)"
+            if is_preview
+            else "Stock adjustment SA-FY26-Q2-001 (id=9876) deleted; "
+            "associated inventory movements reversed"
+        ),
+    }
+
+
 SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
     # The bug-repro: 12 mixed actions on the preview card. Pre-fix this
     # rendered as a blank iframe; post-fix it renders one DataTable with 12
@@ -330,6 +408,37 @@ SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
     "inventory_check": _inventory_check_app,
     "verification": _verification_app,
     "batch_recipe_update": _batch_recipe_update_app,
+    # Stock-adjustment family (preview + result for each of create/update/delete).
+    "stock_adjustment_create_preview": lambda: build_stock_adjustment_create_ui(
+        _stock_adjustment_response(is_preview=True),
+        confirm_request=_StubRequest(),
+        confirm_tool="create_stock_adjustment",
+    ),
+    "stock_adjustment_create_applied": lambda: build_stock_adjustment_create_ui(
+        _stock_adjustment_response(is_preview=False),
+        confirm_request=_StubRequest(),
+        confirm_tool="create_stock_adjustment",
+    ),
+    "stock_adjustment_update_preview": lambda: build_stock_adjustment_update_ui(
+        _stock_adjustment_update_response(is_preview=True),
+        confirm_request=_StubRequest(),
+        confirm_tool="update_stock_adjustment",
+    ),
+    "stock_adjustment_update_applied": lambda: build_stock_adjustment_update_ui(
+        _stock_adjustment_update_response(is_preview=False),
+        confirm_request=_StubRequest(),
+        confirm_tool="update_stock_adjustment",
+    ),
+    "stock_adjustment_delete_preview": lambda: build_stock_adjustment_delete_ui(
+        _stock_adjustment_delete_response(is_preview=True),
+        confirm_request=_StubRequest(),
+        confirm_tool="delete_stock_adjustment",
+    ),
+    "stock_adjustment_delete_applied": lambda: build_stock_adjustment_delete_ui(
+        _stock_adjustment_delete_response(is_preview=False),
+        confirm_request=_StubRequest(),
+        confirm_tool="delete_stock_adjustment",
+    ),
     "modify_item_single_preview": lambda: build_modification_preview_ui(
         {
             "entity_type": "product",

--- a/katana_mcp_server/tests/browser/test_stock_adjustment_render.py
+++ b/katana_mcp_server/tests/browser/test_stock_adjustment_render.py
@@ -1,0 +1,100 @@
+"""Browser render tests for the stock-adjustment cards.
+
+Verifies the create / update / delete preview cards render correctly in a
+real browser, plus the post-apply state for each. Closes #311 + most of
+#639's audit gap.
+
+Each tool gets a preview test (Confirm + Cancel buttons present, table
+populated) and a result test (Confirm hidden, "View in Katana" present
+when applicable, status badge flipped).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+class TestStockAdjustmentCreateRender:
+    def test_create_preview_renders_with_rows(self, render_scenario):
+        """Preview card: 3-row stock adjustment renders with PREVIEW badge,
+        DataTable populated, Confirm button visible.
+        """
+        frame = render_scenario("stock_adjustment_create_preview")
+        # PREVIEW badge present
+        assert frame.locator("text=PREVIEW").count() >= 1
+        # 3 rows + header
+        assert frame.locator("table").count() == 1
+        assert frame.locator("table tr").count() == 4
+        # Quantity column shows signed values
+        assert frame.locator("td").filter(has_text="+1.0").count() >= 1
+        # Confirm button present
+        assert frame.locator("button").filter(has_text="Confirm").count() >= 1
+        # Reason muted line
+        assert frame.locator("text=Found one in stock").count() >= 1
+
+    def test_create_applied_renders_view_button(self, render_scenario):
+        """Result card: APPLIED badge, no Confirm button, View-in-Katana
+        link present (response carries katana_url).
+        """
+        frame = render_scenario("stock_adjustment_create_applied")
+        assert frame.locator("text=APPLIED").count() >= 1
+        # 3 rows + header still visible
+        assert frame.locator("table tr").count() == 4
+        # No Confirm button on result card
+        assert frame.locator("button").filter(has_text="Confirm").count() == 0
+        # View in Katana button present
+        assert frame.locator("button").filter(has_text="View in Katana").count() == 1
+
+
+class TestStockAdjustmentUpdateRender:
+    def test_update_preview_renders_field_changes(self, render_scenario):
+        """Preview: PREVIEW badge, DataTable with changed field rows,
+        Confirm button present.
+        """
+        frame = render_scenario("stock_adjustment_update_preview")
+        assert frame.locator("text=PREVIEW").count() >= 1
+        # The diff DataTable lists the changed fields by label.
+        assert frame.locator("td").filter(has_text="Number").count() >= 1
+        assert frame.locator("td").filter(has_text="Reason").count() >= 1
+        assert frame.locator("button").filter(has_text="Confirm").count() >= 1
+
+    def test_update_applied_renders_no_confirm(self, render_scenario):
+        """Result card: UPDATED badge, no Confirm button, View-in-Katana
+        link visible.
+        """
+        frame = render_scenario("stock_adjustment_update_applied")
+        assert frame.locator("text=UPDATED").count() >= 1
+        assert frame.locator("button").filter(has_text="Confirm").count() == 0
+        assert frame.locator("button").filter(has_text="View in Katana").count() == 1
+
+
+class TestStockAdjustmentDeleteRender:
+    def test_delete_preview_renders_metrics(self, render_scenario):
+        """Preview: PREVIEW badge, identifying Metric tiles (Number /
+        Location / Rows), Confirm button present, irreversibility warning.
+        """
+        frame = render_scenario("stock_adjustment_delete_preview")
+        assert frame.locator("text=PREVIEW").count() >= 1
+        # Metric tiles render their labels.
+        assert frame.locator("text=Number").count() >= 1
+        assert frame.locator("text=Rows").count() >= 1
+        # The number from the fixture.
+        assert frame.locator("text=SA-FY26-Q2-001").count() >= 1
+        # Confirm button present.
+        assert frame.locator("button").filter(has_text="Confirm").count() >= 1
+        # Irreversibility warning surfaces.
+        assert (
+            frame.locator("text=cannot be undone").count() >= 1
+            or frame.locator("text=reverses the associated").count() >= 1
+        )
+
+    def test_delete_applied_renders_no_confirm(self, render_scenario):
+        """Result card: DELETED badge, no Confirm button. No
+        ``View in Katana`` button — the entity is gone server-side
+        (Katana nulls the URL on successful delete).
+        """
+        frame = render_scenario("stock_adjustment_delete_applied")
+        assert frame.locator("text=DELETED").count() >= 1
+        assert frame.locator("button").filter(has_text="Confirm").count() == 0

--- a/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
+++ b/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
@@ -71,6 +71,11 @@ DIRECT_APPLY_TOOLS = [
     "correct_manufacturing_order",
     "correct_sales_order",
     "correct_purchase_order",
+    # Stock adjustment family — moved to direct-apply when their Prefab
+    # cards landed (closes part of #639).
+    "create_stock_adjustment",
+    "update_stock_adjustment",
+    "delete_stock_adjustment",
 ]
 
 # Tools still using the SendMessage rail (default, per ADR-0015). Tracked
@@ -78,9 +83,6 @@ DIRECT_APPLY_TOOLS = [
 SEND_MESSAGE_APPLY_TOOLS = [
     "receive_purchase_order",
     "create_stock_transfer",
-    "create_stock_adjustment",
-    "update_stock_adjustment",
-    "delete_stock_adjustment",
     "fulfill_order",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.62.0"
+version = "0.63.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Builds out proper Prefab UI cards for the three stock_adjustment write tools (`create` / `update` / `delete`) and switches them onto the direct-apply rail. Resolves a latent host-crash bug where these tools were registered as preview-mode tools (their auto-appended docstrings promise "returns a Prefab card") without actually emitting a card — Claude Desktop's `read_widget_context` would fail looking for the widget.

Closes **#311**. Closes the `stock_adjustment` portion of **#639** (`create_stock_transfer` remains; tracked for a follow-up PR).

## What changed

### Three new card builders in `prefab_ui.py`

- `build_stock_adjustment_create_ui` — header (Location + adjustment-ID + PREVIEW/APPLIED badge), DataTable of rows (SKU / Item / signed Qty / Cost), reason muted, Confirm + Cancel via direct-apply on preview, "View in Katana" on result.
- `build_stock_adjustment_update_ui` — header (#id + PREVIEW/UPDATED badge), DataTable of changed fields (Field / New Value), Confirm + Cancel on preview.
- `build_stock_adjustment_delete_ui` — header (#id + PREVIEW/DELETED badge), Metric tiles (Number / Location / Rows), irreversibility warning, Confirm + Cancel on preview.

All three reuse the existing direct-apply infrastructure (`_build_apply_action_direct`, `_build_cancel_action`, `_render_apply_button_row`) and a new `_DIRECT_APPLY_STATE_INIT` constant for the standard initial state slots. No new card-skeleton plumbing.

### Response-model enrichment

`StockAdjustmentResponse` gains `rows: list[StockAdjustmentRowSummary]`, `location_id: int`, `reason: str | None` so the card can render a real DataTable instead of the markdown-blob `rows_summary`. The string field stays for the markdown-fallback path.

### Tool wiring

Each of `create_stock_adjustment`, `update_stock_adjustment`, `delete_stock_adjustment` switches from `make_simple_result(md, ...)` to `make_tool_result(response, ui=builder(response.model_dump(), ...))`. `register_tools` now passes `meta=UI_META, direct=True` for all three.

### Browser-render coverage

Six new scenarios in `render_test_server.py` (preview + applied for each tool). Six new tests in `test_stock_adjustment_render.py` covering: badge transitions (PREVIEW → APPLIED/UPDATED/DELETED), Confirm button presence, View-in-Katana button on result cards, Metric tiles + irreversibility warning on the delete card.

Test-config: the three tools move from `SEND_MESSAGE_APPLY_TOOLS` to `DIRECT_APPLY_TOOLS` in `test_tool_descriptions_and_annotations.py`.

## Test plan

- [x] All 1019 MCP unit tests pass (`uv run poe test`)
- [x] All 16 browser-render tests pass (`uv run poe test-browser`, ~146s — adds 6 new tests, ~50s)
- [x] Full `uv run poe check` green
- [x] `/simplify` pass clean (extracted `_DIRECT_APPLY_STATE_INIT`, dropped dead defensive casts, collapsed tautological None-checks in footers)
- [ ] **Live smoke (recommended before merge):** call `create_stock_adjustment` against the real Katana via Claude Desktop / Cowork to confirm the host's renderer matches `apps_dev` behavior — and that the `read_widget_context` crash from earlier this session is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)