### PR TITLE
fix(mcp): coerce numerics in modification helpers to drop verification false-positives

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 from enum import Enum
 from typing import Any, ClassVar
 
@@ -261,8 +262,14 @@ def _normalize(value: Any) -> Any:
     """Normalize a value for diff comparison.
 
     UNSET sentinels collapse to ``None``; datetimes flatten to ISO strings;
-    enums to their wire value. Lists and dicts are returned as-is — the
-    caller is responsible for upstream comparability.
+    enums to their wire value. Numeric values (and decimal-looking strings —
+    those containing a decimal point) coerce to ``Decimal`` so caller-supplied
+    ints/floats compare cleanly against Katana's zero-padded decimal-string
+    representation of monetary fields (e.g. ``"1100.0000000000"`` vs ``1100``).
+    Integer-only strings stay as strings — order numbers, ZIP codes, and
+    zero-padded SKUs like ``"00123"`` carry semantically meaningful
+    formatting that Decimal coercion would silently drop. Lists and dicts
+    are returned as-is — the caller is responsible for upstream comparability.
     """
     if value is UNSET:
         return None
@@ -270,6 +277,20 @@ def _normalize(value: Any) -> Any:
         return value.isoformat()
     if isinstance(value, Enum):
         return value.value
+    # bool is a subclass of int — short-circuit so True/False don't
+    # accidentally become Decimal('1') / Decimal('0').
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float, Decimal)):
+        return Decimal(str(value))
+    if isinstance(value, str) and "." in value:
+        # Only coerce decimal-looking strings. Integer-only strings keep
+        # their formatting — Katana's monetary-string pattern always has
+        # a decimal point, so this still catches the bug we're fixing.
+        try:
+            return Decimal(value)
+        except InvalidOperation:
+            return value
     return value
 
 

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -18,6 +18,7 @@ from katana_mcp.tools._modification import (
     FieldChange,
     ModificationResponse,
     compute_field_diff,
+    make_response_verifier,
     render_modification_md,
     to_tool_result,
 )
@@ -99,6 +100,73 @@ def test_compute_field_diff_normalizes_enum_to_value():
     diff = compute_field_diff(existing, request)
     assert diff[0].old == "DRAFT"
     assert diff[0].new == "DONE"
+
+
+def test_compute_field_diff_numeric_string_matches_int_request():
+    # Katana returns monetary fields as zero-padded decimal strings
+    # (e.g. ``"1100.0000000000"``); request supplies plain ints/floats.
+    # Without numeric normalization the diff would mark these as changed.
+    existing = MagicMock()
+    existing.qty = "1100.0000000000"
+    request = _SampleRequest(id=1, qty=1100)
+    diff = compute_field_diff(existing, request)
+    assert diff[0].is_unchanged is True
+
+
+def test_compute_field_diff_zero_string_matches_zero_request():
+    # Mirrors the production case where ``total_discount: 0`` is sent and
+    # Katana stores ``"0.0000000000"``.
+    existing = MagicMock()
+    existing.qty = "0.0000000000"
+    request = _SampleRequest(id=1, qty=0)
+    diff = compute_field_diff(existing, request)
+    assert diff[0].is_unchanged is True
+
+
+def test_compute_field_diff_non_numeric_strings_compare_as_strings():
+    # Decimal coercion must fall back gracefully for arbitrary strings —
+    # SKUs, names, etc. should still compare exactly.
+    existing = MagicMock()
+    existing.name = "M14025LG4STRLB"
+    request = _SampleRequest(id=1, name="M14025LG4STRLB")
+    diff = compute_field_diff(existing, request)
+    assert diff[0].is_unchanged is True
+
+
+def test_compute_field_diff_preserves_leading_zeros_in_integer_strings():
+    # Digit-only strings (order numbers, ZIP codes, zero-padded SKUs) must
+    # NOT coerce to Decimal — that would drop leading zeros and silently
+    # mask real mismatches like ``"00123"`` vs ``"123"``. Only strings
+    # containing a decimal point (Katana's monetary format) are coerced.
+    existing = MagicMock()
+    existing.name = "00123"
+    request = _SampleRequest(id=1, name="123")
+    diff = compute_field_diff(existing, request)
+    assert diff[0].is_unchanged is False
+    assert diff[0].old == "00123"
+    assert diff[0].new == "123"
+
+
+@pytest.mark.asyncio
+async def test_response_verifier_passes_when_decimal_string_equals_int():
+    # The verifier closure compares the post-update API response (which
+    # carries decimal strings on monetary fields) against the
+    # pre-normalized ``FieldChange.new`` from the request. Without
+    # numeric normalization this read as ``"1100.0000000000" != 1100``
+    # and produced a spurious "verification mismatch" status. See the
+    # session that triggered the fix — modify_sales_order on
+    # SO 44256191 set total_discount and the verifier flagged it
+    # despite the value landing correctly server-side.
+    diff = compute_field_diff(
+        MagicMock(qty=0),
+        _SampleRequest(id=1, qty=1100),
+    )
+    verify = make_response_verifier(diff)
+    response_outcome = MagicMock()
+    response_outcome.qty = "1100.0000000000"
+    verified, actual = await verify(response_outcome)
+    assert verified is True
+    assert actual is None
 
 
 def test_compute_field_diff_field_map_renames_attr_lookup():

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.63.0"
+version = "0.64.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

`_modification.py::_normalize` previously returned Katana's zero-padded decimal-string monetary values (e.g. `"1100.0000000000"`) verbatim while the request side carried plain ints/floats. The strict-equality comparisons in `compute_field_diff` and `make_response_verifier` then fired false positives on every monetary update — `modify_sales_order` reported `APPLIED (verification mismatch)` even when Katana stored the value correctly.

Fix: `_normalize` now coerces `int`/`float`/`Decimal` and decimal-looking strings to `Decimal`. Non-numeric strings fall back to the original string on `InvalidOperation`, so SKUs, names, and addresses continue to compare exactly. `bool` short-circuits to avoid `True`/`False` becoming `Decimal('1')`/`Decimal('0')`.

## Where this surfaced

Live recovery session on SO 44256191 — every `total_discount` and `price_per_unit` update returned `APPLIED (verification mismatch)` despite the post-write `get_sales_order` confirming the row landed as requested. The mismatch flag obscured an unrelated real issue (Katana auto-rescaling discount when price changes), making both behaviors harder to read.

## Tests

- `test_compute_field_diff_numeric_string_matches_int_request` — `"1100.0000000000"` vs `1100`
- `test_compute_field_diff_zero_string_matches_zero_request` — the production zero-discount case
- `test_compute_field_diff_non_numeric_strings_compare_as_strings` — fallback for SKUs / arbitrary strings
- `test_response_verifier_passes_when_decimal_string_equals_int` — `make_response_verifier` end-to-end with the production decimal-string value

## Out of scope (filed separately)

- #632 — `list_manufacturing_orders` cache write fails on datetime-in-JSON-column (separate cache-sync bug)
- #648 — MCP preview tools emit Prefab cards even in non-rendering hosts like Claude Code (UX fallback bug)

## Test plan

- [x] `uv run python -m pytest katana_mcp_server/tests/tools/test_modification.py -q` — 31 pass
- [x] `uv run python -m pytest katana_mcp_server/tests/tools/ -q` — 579 pass, 15 skip
- [x] `uv run poe agent-check` — format + ruff + ty all clean

## Notes

`uv.lock` bundles the workspace version bump from main's recent `chore(release): mcp v0.63.0` (a17e0cd7) per CLAUDE.md's lockfile-drift guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)