### PR TITLE
docs(claude): add stub-shape + docstring-promise pitfalls to Known Pitfalls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,40 @@ Common mistakes to avoid:
   `uv run poe test-browser` to exercise the JS renderer locally; needs one-time
   `uv run playwright install chromium`.
 
+- **MCP tool stubs in browser tests must mirror production wire shape via
+  `make_tool_result`** - When stubbing an MCP tool in
+  `katana_mcp_server/tests/browser/render_test_server.py`, return
+  `make_tool_result(response_pydantic, ui=ui_card)` exactly like real tool code in
+  `katana_mcp_server/src/katana_mcp/tools/foundation/`. A hand-built
+  `ToolResult(content="ok", structured_content=raw_dict)` silently passes browser tests
+  but misses production-shape bugs: in particular, `$result` in the on_success Rx
+  context resolves to the apply tool's `structured_content` (a PrefabApp wire envelope
+  keyed by `$prefab` / `view` / `state` — **not** the raw `ModificationResponse` shape,
+  so it has no `actions` field), not to the pydantic response model the stub might
+  construct directly. A stub with the wrong-but-convenient shape gives false green: it
+  looks like the apply rail's `Rx("$result.actions")` resolves correctly when in
+  production it does not. Discovered via Copilot review on #634; the broken live-tick
+  that "passed" against the bad stub is tracked for proper fix in #645. Rule: **a stub
+  that doesn't match production wire shape is worse than no stub.**
+
+- **A tool's docstring promises must match the UI it actually emits** -
+  `register_preview_tool` auto-appends "Preview→apply: ... returns a Prefab card with
+  Confirm/Cancel buttons" to the tool's docstring. Hosts (Claude Desktop, Cowork) read
+  that promise and look for a widget. If the tool was registered with
+  `register_preview_tool` but **without** `meta=UI_META` (or it returns via
+  `make_simple_result` with no Prefab envelope), the host's widget-fetch fails — Claude
+  Desktop crashes its internal `read_widget_context` with `tool_name=undefined` because
+  no widget exists for the tool the host believed was emitting one. The actual tool
+  result still returns successfully, but the iframe renders nothing. Rule: every
+  `register_preview_tool` call must pair `meta=UI_META` with a real Prefab card (built
+  via `make_tool_result(response, ui=...)`) — never the docstring without the card.
+  Conversely, tools that emit no UI must use plain `mcp.tool(...)`, not
+  `register_preview_tool`. Caught via a live Claude Desktop session against
+  `create_stock_adjustment` (fixed in #649); the same misregistration still applies to
+  `create_stock_transfer` — tracked in #639. (`fulfill_order` is correctly wired with
+  `meta=UI_META`; its remaining work is the direct-apply rail migration in #638, not
+  this misregistration.)
+
 ## Using the LSP tool
 
 Both Python (pyright) and TypeScript (typescript-language-server) LSPs are configured

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.64.0"
+version = "0.64.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Two CLAUDE.md Known Pitfalls captured during the #634/#649 sessions but missing from main.

### 1. Test stubs must mirror production wire shape via \`make_tool_result\`

A hand-built \`ToolResult(content=\"ok\", structured_content=raw_dict)\` silently passes browser tests but misses production-shape bugs — \`\$result\` in the apply on_success Rx context resolves to the apply tool's \`structured_content\` (a PrefabApp wire envelope, no \`actions\` field), not the raw \`ModificationResponse\` the stub might construct directly.

This rule **was originally added on #634's branch** as commit 8ec32dec but didn't make it into main when the PR merged — most likely because of one of the rebases done during the Copilot review cycle. Re-added here.

### 2. A tool's docstring promises must match the UI it actually emits

\`register_preview_tool\` auto-appends \"returns a Prefab card with Confirm/Cancel buttons\" to the tool's docstring. Hosts read that promise and crash the widget-fetch (\`read_widget_context\` with \`tool_name=undefined\`) when the tool was registered without \`meta=UI_META\` — i.e., the docstring promised a card but the tool returns plain markdown via \`make_simple_result\`. The actual tool result still returns successfully, but the iframe renders nothing.

**New rule.** Observed on \`create_stock_adjustment\` before #649 fixed it; the same misregistration still applies to \`create_stock_transfer\` (#639) and \`fulfill_order\` (#638).

## Why CLAUDE.md and not memory

Both rules are project-wide MCP / Prefab conventions, so they belong in CLAUDE.md per the \`feedback_harness_over_memory\` principle. Memory is for ephemeral session state and out-of-band facts; these are durable engineering rules.

## Test plan

- [x] \`uv run poe check\` green
- [x] \`uv run poe test-browser\` green (no behavioral change — docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)