### PR TITLE
feat(mcp): rewire @cache_read decorator to Cached* class keys (#472 Phase C)

### DIFF
--- a/katana_mcp_server/docs/architecture.md
+++ b/katana_mcp_server/docs/architecture.md
@@ -82,12 +82,15 @@ sync when tool surface changes.
 
 ### Cache-aware decorators
 
-`tools/decorators.py` provides `@cache_read("entity")` and
-`@cache_write("entity_a", "entity_b")` decorators. `cache_read` triggers an incremental
-sync of the named entity before invoking the tool; `cache_write` invalidates the listed
-entities after a mutating call so the next list/get returns fresh data. Tool
-implementations stay focused on business logic; sync orchestration lives in the
-decorator.
+`tools/decorators.py` provides `@cache_read(CachedVariant, ...)` and
+`@cache_write("entity_a", "entity_b")` decorators. `cache_read` keys off the typed-cache
+`Cached*` row class (e.g. `CachedVariant`, `CachedProduct`) and triggers an incremental
+sync of the named entity before invoking the tool. During the #472 unification rollout
+(Phase C) the decorator fans each sync out to BOTH the legacy `CatalogCache` helper and
+the typed-cache helper so tool bodies see fresh data on either path; Phase D drops the
+legacy half. `cache_write` invalidates the listed entities after a mutating call so the
+next list/get returns fresh data. Tool implementations stay focused on business logic;
+sync orchestration lives in the decorator.
 
 ## Resources
 
@@ -210,9 +213,9 @@ bugs at the client/generator layer").
    integration; use elicitation for any state-changing operation.
 1. **Follow ADR-0019** for naming (`<entity>_<field>s` for batch list filters, singular
    for `get_*`) and the docstring opening sentence.
-1. **If the tool reads from cache,** add `@cache_read("entity")`. If it writes, add
-   `@cache_write("entity_a", "entity_b")` listing every entity whose cache should be
-   invalidated.
+1. **If the tool reads from cache,** add `@cache_read(CachedEntity)` keyed by the typed
+   `Cached*` row class. If it writes, add `@cache_write("entity_a", "entity_b")` listing
+   every entity whose cache should be invalidated.
 1. **For new transactional list tools backed by typed cache:** add an `EntitySpec`
    literal in `typed_cache/sync.py` and a thin `ensure_<entity>_synced` wrapper. The
    `Cached<Entity>` row class is auto-generated from the spec by the next regen.

--- a/katana_mcp_server/src/katana_mcp/tools/decorators.py
+++ b/katana_mcp_server/src/katana_mcp/tools/decorators.py
@@ -5,7 +5,7 @@ keeping tool implementations focused on business logic.
 
 Usage::
 
-    @cache_read("variant")
+    @cache_read(CachedVariant)
     async def _search_items_impl(request, context):
         services = get_services(context)
         return await services.cache.smart_search("variant", request.query)
@@ -15,65 +15,124 @@ Usage::
     async def _create_item_impl(request, context):
         services = get_services(context)
         return await services.client.products.create(...)
+
+The ``cache_read`` decorator now keys off the typed-cache ``Cached*``
+classes (``CachedVariant``, ``CachedProduct``, …) instead of the legacy
+``EntityType`` enum. During the #472 unification rollout the decorator
+runs **both** the legacy ``cache_sync.ensure_*_synced`` helper and the
+typed ``typed_cache.ensure_*_synced`` helper for each registered class
+so tool bodies see fresh data on either path. Phase D drops the legacy
+half along with the call sites that read from ``services.cache``.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import asyncio
+from collections.abc import Awaitable, Callable
 from functools import wraps
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
-from katana_mcp.cache import EntityType
 from katana_mcp.services import get_services
 
-# Lazy-initialized cache of sync functions (avoids circular imports)
-_sync_fns: dict[str, Any] | None = None
+if TYPE_CHECKING:
+    from sqlmodel import SQLModel
+
+    from katana_mcp.services.dependencies import Services
 
 
-def _get_sync_fns() -> dict[str, Any]:
-    """Get the entity-type → sync function mapping (initialized once)."""
+# Lazy-initialized cache of sync functions (avoids circular imports).
+# Keys are typed-cache ``Cached*`` classes; values are async wrappers
+# that fan out to the legacy ``cache_sync.ensure_*_synced(services)``
+# AND the typed ``typed_cache.ensure_*_synced(client, typed_cache)``
+# helpers (#472 Phase C). Phase D drops the legacy half.
+_sync_fns: dict[type[SQLModel], Callable[[Services], Awaitable[None]]] | None = None
+
+# (Cached* class, ensure-helper stem) — both ``cache_sync`` and ``typed_cache``
+# expose ``ensure_<stem>_synced``, differing only in argument shape (legacy
+# takes ``services``; typed takes ``client, cache``). The dual wrapper in
+# ``_get_sync_fns`` resolves the stem against both modules.
+_DUAL_SYNC_REGISTRY: tuple[tuple[str, str], ...] = (
+    ("CachedVariant", "variants"),
+    ("CachedProduct", "products"),
+    ("CachedMaterial", "materials"),
+    ("CachedService", "services"),
+    ("CachedSupplier", "suppliers"),
+    ("CachedCustomer", "customers"),
+    ("CachedLocation", "locations"),
+    ("CachedTaxRate", "tax_rates"),
+    ("CachedOperator", "operators"),
+    ("CachedFactory", "factory"),
+    ("CachedAdditionalCost", "additional_costs"),
+)
+
+
+def _get_sync_fns() -> dict[type[SQLModel], Callable[[Services], Awaitable[None]]]:
+    """Get the ``Cached*`` class → dual-sync wrapper mapping (initialized once).
+
+    Each wrapper runs the legacy ``cache_sync.ensure_<stem>_synced(services)``
+    and the typed ``typed_cache.ensure_<stem>_synced(client, typed_cache)``
+    concurrently via ``asyncio.gather`` so both caches stay populated during
+    the Phase C → Phase D transition without serializing two API fetches.
+    The registry is tiny on purpose — Phase D removes the legacy half.
+    """
     global _sync_fns  # noqa: PLW0603
     if _sync_fns is None:
-        from katana_mcp.cache_sync import (
-            ensure_additional_costs_synced,
-            ensure_customers_synced,
-            ensure_factory_synced,
-            ensure_locations_synced,
-            ensure_materials_synced,
-            ensure_operators_synced,
-            ensure_products_synced,
-            ensure_services_synced,
-            ensure_suppliers_synced,
-            ensure_tax_rates_synced,
-            ensure_variants_synced,
-        )
+        from katana_mcp import cache_sync, typed_cache
+        from katana_public_api_client.models_pydantic import _generated as cached_models
+
+        def _dual(
+            legacy: Callable[[Services], Awaitable[None]],
+            typed: Callable[..., Awaitable[None]],
+        ) -> Callable[[Services], Awaitable[None]]:
+            async def _wrapped(services: Services) -> None:
+                await asyncio.gather(
+                    legacy(services),
+                    typed(services.client, services.typed_cache),
+                )
+
+            return _wrapped
 
         _sync_fns = {
-            EntityType.VARIANT: ensure_variants_synced,
-            EntityType.PRODUCT: ensure_products_synced,
-            EntityType.MATERIAL: ensure_materials_synced,
-            EntityType.SERVICE: ensure_services_synced,
-            EntityType.SUPPLIER: ensure_suppliers_synced,
-            EntityType.CUSTOMER: ensure_customers_synced,
-            EntityType.LOCATION: ensure_locations_synced,
-            EntityType.TAX_RATE: ensure_tax_rates_synced,
-            EntityType.OPERATOR: ensure_operators_synced,
-            EntityType.FACTORY: ensure_factory_synced,
-            EntityType.ADDITIONAL_COST: ensure_additional_costs_synced,
+            getattr(cached_models, cls_name): _dual(
+                getattr(cache_sync, f"ensure_{stem}_synced"),
+                getattr(typed_cache, f"ensure_{stem}_synced"),
+            )
+            for cls_name, stem in _DUAL_SYNC_REGISTRY
         }
     return _sync_fns
 
 
-def cache_read(*entity_types: str) -> Callable:
-    """Sync cache for entity types before executing the tool.
+def cache_read(*entity_classes: type[SQLModel]) -> Callable:
+    """Sync cache for the given typed ``Cached*`` classes before running the tool.
 
-    Calls ``ensure_{type}_synced(services)`` for each entity type before
-    running the decorated function. The function receives a context with
-    a guaranteed-fresh cache.
+    For each class the decorator looks up the registered sync wrapper in
+    ``_get_sync_fns()`` and awaits it. Each wrapper currently fans out to
+    BOTH the legacy ``CatalogCache`` sync helper AND the typed-cache
+    ``ensure_*_synced`` helper so tool bodies see fresh data on either
+    path during the #472 unification rollout. Phase D drops the legacy
+    half along with the ``services.cache`` call sites.
+
+    Unknown classes raise ``ValueError`` at decoration time so a typo
+    fails at import, not silently as a stale-cache read at first call.
 
     Args:
-        *entity_types: Entity type names to sync (e.g., "variant", "product").
+        *entity_classes: Typed ``Cached*`` classes to sync (e.g.,
+            ``CachedVariant``, ``CachedProduct``).
     """
+    # Fail fast at decoration time so a typo blows up at import, not as
+    # a silent stale-cache read on the first request. Tests that swap
+    # ``decorators._sync_fns`` in autouse fixtures still get the live
+    # mocks at call time — the wrapper re-resolves through
+    # ``_get_sync_fns()``.
+    registered = _get_sync_fns()
+    unknown = [cls for cls in entity_classes if cls not in registered]
+    if unknown:
+        names = ", ".join(cls.__name__ for cls in unknown)
+        known = ", ".join(sorted(c.__name__ for c in registered))
+        raise ValueError(
+            f"@cache_read: unregistered Cached* class(es): {names}. "
+            f"Registered classes: {known}."
+        )
 
     def decorator[F: Callable[..., Any]](fn: F) -> F:
         @wraps(fn)
@@ -82,11 +141,9 @@ def cache_read(*entity_types: str) -> Callable:
             services = get_services(context)
 
             sync_fns = _get_sync_fns()
-            for et in entity_types:
-                # EntityType is a StrEnum — normalize to ensure dict lookup works
-                key = EntityType(et) if not isinstance(et, EntityType) else et
-                sync_fn = sync_fns.get(key)
-                if sync_fn:
+            for cls in entity_classes:
+                sync_fn = sync_fns.get(cls)
+                if sync_fn is not None:
                     await sync_fn(services)
 
             return await fn(*args, **kwargs)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
@@ -20,6 +20,7 @@ from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.tool_result_utils import make_simple_result
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
+from katana_public_api_client.models_pydantic._generated import CachedCustomer
 
 # ============================================================================
 # Tool 1: search_customers
@@ -74,7 +75,7 @@ def _customer_from_dict(d: dict) -> CustomerInfo:
     )
 
 
-@cache_read(EntityType.CUSTOMER)
+@cache_read(CachedCustomer)
 async def _search_customers_impl(
     request: SearchCustomersRequest, context: Context
 ) -> SearchCustomersResponse:
@@ -274,7 +275,7 @@ async def _fetch_customer_addresses(
     return result
 
 
-@cache_read(EntityType.CUSTOMER)
+@cache_read(CachedCustomer)
 async def _get_customer_impl(
     request: GetCustomerRequest, context: Context
 ) -> GetCustomerResponse:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -37,6 +37,7 @@ from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.api.stock_adjustment import get_all_stock_adjustments
 from katana_public_api_client.client_types import UNSET, Unset
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
+from katana_public_api_client.models_pydantic._generated import CachedVariant
 from katana_public_api_client.utils import unwrap_data
 
 logger = get_logger(__name__)
@@ -415,7 +416,7 @@ class LowStockResponse(BaseModel):
     total_count: int
 
 
-@cache_read(EntityType.VARIANT)
+@cache_read(CachedVariant)
 async def _list_low_stock_items_impl(
     request: LowStockRequest, context: Context
 ) -> LowStockResponse:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -91,6 +91,12 @@ from katana_public_api_client.models import (
     UpdateVariantRequestConfigAttributesItem as APIUpdateVariantConfigItem,
     Variant,
 )
+from katana_public_api_client.models_pydantic._generated import (
+    CachedMaterial,
+    CachedProduct,
+    CachedSupplier,
+    CachedVariant,
+)
 
 logger = get_logger(__name__)
 
@@ -177,7 +183,7 @@ def _search_response_to_tool_result(
     return make_tool_result(filtered_response, ui=ui)
 
 
-@cache_read(EntityType.VARIANT)
+@cache_read(CachedVariant)
 async def _search_items_impl(
     request: SearchItemsRequest, context: Context
 ) -> SearchItemsResponse:
@@ -1755,10 +1761,10 @@ def _partition_variant_lookups(
 
 
 @cache_read(
-    EntityType.VARIANT,
-    EntityType.PRODUCT,
-    EntityType.MATERIAL,
-    EntityType.SUPPLIER,
+    CachedVariant,
+    CachedProduct,
+    CachedMaterial,
+    CachedSupplier,
 )
 async def _get_variant_details_impl(
     request: GetVariantDetailsRequest, context: Context

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
@@ -20,6 +20,13 @@ from katana_mcp.services import get_services
 from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.tool_result_utils import make_simple_result
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_public_api_client.models_pydantic._generated import (
+    CachedAdditionalCost,
+    CachedLocation,
+    CachedOperator,
+    CachedSupplier,
+    CachedTaxRate,
+)
 
 # ============================================================================
 # Shared helpers
@@ -140,7 +147,7 @@ def _supplier_summary_from_dict(d: dict[str, Any]) -> SupplierInfo:
     )
 
 
-@cache_read(EntityType.SUPPLIER)
+@cache_read(CachedSupplier)
 async def _list_suppliers_impl(
     request: ListSuppliersRequest, context: Context
 ) -> ListSuppliersResponse:
@@ -230,7 +237,7 @@ def _iso_or_none(value: Any) -> str | None:
     return str(value)
 
 
-@cache_read(EntityType.SUPPLIER)
+@cache_read(CachedSupplier)
 async def _get_supplier_impl(
     request: GetSupplierRequest, context: Context
 ) -> GetSupplierResponse:
@@ -383,7 +390,7 @@ def _location_from_dict(d: dict[str, Any]) -> LocationInfo:
     )
 
 
-@cache_read(EntityType.LOCATION)
+@cache_read(CachedLocation)
 async def _list_locations_impl(
     request: ListLocationsRequest, context: Context
 ) -> ListLocationsResponse:
@@ -482,7 +489,7 @@ def _tax_rate_from_dict(d: dict[str, Any]) -> TaxRateInfo:
     )
 
 
-@cache_read(EntityType.TAX_RATE)
+@cache_read(CachedTaxRate)
 async def _list_tax_rates_impl(
     request: ListTaxRatesRequest, context: Context
 ) -> ListTaxRatesResponse:
@@ -566,7 +573,7 @@ def _operator_from_dict(d: dict[str, Any]) -> OperatorInfo:
     return OperatorInfo(id=d.get("id") or 0, name=d.get("name") or "")
 
 
-@cache_read(EntityType.OPERATOR)
+@cache_read(CachedOperator)
 async def _list_operators_impl(
     request: ListOperatorsRequest, context: Context
 ) -> ListOperatorsResponse:
@@ -641,7 +648,7 @@ def _additional_cost_from_dict(d: dict[str, Any]) -> AdditionalCostInfo:
     return AdditionalCostInfo(id=d.get("id") or 0, name=d.get("name") or "")
 
 
-@cache_read(EntityType.ADDITIONAL_COST)
+@cache_read(CachedAdditionalCost)
 async def _list_additional_costs_impl(
     request: ListAdditionalCostsRequest, context: Context
 ) -> ListAdditionalCostsResponse:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -60,6 +60,12 @@ from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.api.inventory import get_all_inventory_point
 from katana_public_api_client.api.sales_order import get_all_sales_orders
 from katana_public_api_client.domain.converters import unwrap_unset
+from katana_public_api_client.models_pydantic._generated import (
+    CachedMaterial,
+    CachedProduct,
+    CachedService,
+    CachedVariant,
+)
 from katana_public_api_client.utils import unwrap_data
 
 logger = get_logger(__name__)
@@ -277,9 +283,7 @@ class TopSellingVariantsResponse(BaseModel):
     window_end: str
 
 
-@cache_read(
-    EntityType.VARIANT, EntityType.PRODUCT, EntityType.MATERIAL, EntityType.SERVICE
-)
+@cache_read(CachedVariant, CachedProduct, CachedMaterial, CachedService)
 async def _top_selling_variants_impl(
     request: TopSellingVariantsRequest, context: Context
 ) -> TopSellingVariantsResponse:
@@ -476,9 +480,7 @@ def _group_key_time(so_created: datetime, group_by: SalesGroupBy) -> str:
     return f"{so_created.year:04d}-{so_created.month:02d}"
 
 
-@cache_read(
-    EntityType.VARIANT, EntityType.PRODUCT, EntityType.MATERIAL, EntityType.SERVICE
-)
+@cache_read(CachedVariant, CachedProduct, CachedMaterial, CachedService)
 async def _sales_summary_impl(
     request: SalesSummaryRequest, context: Context
 ) -> SalesSummaryResponse:

--- a/katana_mcp_server/tests/integration/test_error_scenarios.py
+++ b/katana_mcp_server/tests/integration/test_error_scenarios.py
@@ -33,19 +33,27 @@ from katana_mcp_server.tests.conftest import create_mock_context
 def _patch_cache_sync():
     """Patch cache sync for all error scenario tests.
 
-    ``get_variant_details`` syncs VARIANT plus PRODUCT, MATERIAL, and SUPPLIER
+    ``get_variant_details`` syncs Variant plus Product, Material, and Supplier
     (parent-derived ``default_supplier_*`` fields are lifted from the parent
     product/material), so all four are mocked here.
+
+    Decorator keys are now typed-cache ``Cached*`` classes (#472 Phase C).
     """
-    from katana_mcp.cache import EntityType
     from katana_mcp.tools import decorators
+
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedMaterial,
+        CachedProduct,
+        CachedSupplier,
+        CachedVariant,
+    )
 
     original = decorators._sync_fns
     decorators._sync_fns = {
-        EntityType.VARIANT: AsyncMock(),
-        EntityType.PRODUCT: AsyncMock(),
-        EntityType.MATERIAL: AsyncMock(),
-        EntityType.SUPPLIER: AsyncMock(),
+        CachedVariant: AsyncMock(),
+        CachedProduct: AsyncMock(),
+        CachedMaterial: AsyncMock(),
+        CachedSupplier: AsyncMock(),
     }
     try:
         with patch(

--- a/katana_mcp_server/tests/tools/test_customers.py
+++ b/katana_mcp_server/tests/tools/test_customers.py
@@ -22,13 +22,16 @@ def _patch_cache_sync():
     The @cache_read decorator caches sync functions in a module-level dict on
     first call, so patching the cache_sync module alone is not enough — we
     also need to clear and re-mock the cached mapping in the decorators module.
+
+    Decorator keys are now typed-cache ``Cached*`` classes (#472 Phase C).
     """
-    from katana_mcp.cache import EntityType
     from katana_mcp.tools import decorators
+
+    from katana_public_api_client.models_pydantic._generated import CachedCustomer
 
     mock_sync = AsyncMock()
     original = decorators._sync_fns
-    decorators._sync_fns = {EntityType.CUSTOMER: mock_sync}
+    decorators._sync_fns = {CachedCustomer: mock_sync}
     try:
         with patch(
             "katana_mcp.cache_sync.ensure_customers_synced", new_callable=AsyncMock

--- a/katana_mcp_server/tests/tools/test_decorators.py
+++ b/katana_mcp_server/tests/tools/test_decorators.py
@@ -1,0 +1,46 @@
+"""Tests for the @cache_read / @cache_write decorators.
+
+The decorator's call-time fan-out is exercised indirectly via every tool
+test that mocks ``decorators._sync_fns``. This file pins behaviors that
+no other test covers — most importantly the decoration-time fail-fast
+on unregistered ``Cached*`` classes (#472 Phase C), which prevents a
+typo from becoming a silent stale-cache read.
+"""
+
+from __future__ import annotations
+
+import pytest
+from katana_mcp.tools.decorators import cache_read
+
+from katana_public_api_client.models_pydantic._generated import (
+    CachedSalesOrder,
+    CachedVariant,
+)
+
+
+def test_cache_read_raises_on_unregistered_class():
+    """Decorating with a Cached* class that isn't in the catalog registry
+    raises ValueError at decoration time. Catches a typo at import, not
+    as a silent stale-cache read on the first request.
+
+    ``CachedSalesOrder`` is a transactional cache class — it's a real
+    ``Cached*`` row class that the catalog @cache_read registry does not
+    own (the typed cache syncs sales orders via a different code path).
+    Using it here exercises the validation without needing a fake class.
+    """
+    with pytest.raises(ValueError, match="unregistered Cached"):
+
+        @cache_read(CachedSalesOrder)
+        async def _impl(request, context):  # pragma: no cover — never called
+            return None
+
+
+def test_cache_read_accepts_registered_class():
+    """Sanity: a registered catalog class decorates without raising."""
+
+    @cache_read(CachedVariant)
+    async def _impl(request, context):  # pragma: no cover — never called
+        return None
+
+    # No exception means the validation pass cleared.
+    assert callable(_impl)

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -61,19 +61,27 @@ def _patch_cache_sync():
     """Patch entity syncs for all unit tests.
 
     The cache sync is tested separately; tool tests verify tool logic
-    with pre-populated cache mocks. ``get_variant_details`` syncs VARIANT
-    plus PRODUCT, MATERIAL, and SUPPLIER (parent-derived ``default_supplier_*``
+    with pre-populated cache mocks. ``get_variant_details`` syncs Variant
+    plus Product, Material, and Supplier (parent-derived ``default_supplier_*``
     are lifted from the parent product/material), so all four are mocked.
+
+    Decorator keys are now typed-cache ``Cached*`` classes (#472 Phase C).
     """
-    from katana_mcp.cache import EntityType
     from katana_mcp.tools import decorators
+
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedMaterial,
+        CachedProduct,
+        CachedSupplier,
+        CachedVariant,
+    )
 
     original = decorators._sync_fns
     decorators._sync_fns = {
-        EntityType.VARIANT: AsyncMock(),
-        EntityType.PRODUCT: AsyncMock(),
-        EntityType.MATERIAL: AsyncMock(),
-        EntityType.SUPPLIER: AsyncMock(),
+        CachedVariant: AsyncMock(),
+        CachedProduct: AsyncMock(),
+        CachedMaterial: AsyncMock(),
+        CachedSupplier: AsyncMock(),
     }
     try:
         with patch(

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -9,6 +9,7 @@ headers that LLM consumers misread (the SW7083 supplier_item_codes bug).
 from __future__ import annotations
 
 import json
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -44,20 +45,28 @@ def _patch_cache_sync():
     first call, so patching the cache_sync module alone is not enough — we
     also need to clear and re-mock the cached mapping in the decorators module.
 
-    ``get_variant_details`` syncs VARIANT plus PRODUCT, MATERIAL, and SUPPLIER
+    ``get_variant_details`` syncs Variant plus Product, Material, and Supplier
     (so the parent-derived ``default_supplier_id`` / ``default_supplier_name``
     can be lifted onto the variant response — see #613-followup), so all four
     are mocked.
+
+    Decorator keys are now typed-cache ``Cached*`` classes (#472 Phase C).
     """
-    from katana_mcp.cache import EntityType
     from katana_mcp.tools import decorators
+
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedMaterial,
+        CachedProduct,
+        CachedSupplier,
+        CachedVariant,
+    )
 
     original = decorators._sync_fns
     decorators._sync_fns = {
-        EntityType.VARIANT: AsyncMock(),
-        EntityType.PRODUCT: AsyncMock(),
-        EntityType.MATERIAL: AsyncMock(),
-        EntityType.SUPPLIER: AsyncMock(),
+        CachedVariant: AsyncMock(),
+        CachedProduct: AsyncMock(),
+        CachedMaterial: AsyncMock(),
+        CachedSupplier: AsyncMock(),
     }
     try:
         with patch(
@@ -164,13 +173,19 @@ async def test_get_variant_details_format_json_includes_deleted_at():
 @pytest.mark.asyncio
 async def test_get_variant_details_syncs_parent_entity_caches():
     """get_variant_details lifts ``default_supplier_id`` / ``_name`` from the
-    parent product/material — so PRODUCT, MATERIAL, and SUPPLIER caches must
-    be synced alongside VARIANT before the lookup runs. Otherwise a fresh
+    parent product/material — so Product, Material, and Supplier caches must
+    be synced alongside Variant before the lookup runs. Otherwise a fresh
     install / cold cache yields ``default_supplier_id: null`` for variants
     whose parent simply hasn't been cached yet.
     """
-    from katana_mcp.cache import EntityType
     from katana_mcp.tools import decorators
+
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedMaterial,
+        CachedProduct,
+        CachedSupplier,
+        CachedVariant,
+    )
 
     context, lifespan_ctx = create_mock_context()
     lifespan_ctx.cache.get_by_sku = AsyncMock(return_value=dict(_FULL_VARIANT_DICT))
@@ -180,13 +195,15 @@ async def test_get_variant_details_syncs_parent_entity_caches():
 
     sync_fns = decorators._sync_fns
     assert sync_fns is not None  # set by the autouse fixture
-    for entity_type in (
-        EntityType.VARIANT,
-        EntityType.PRODUCT,
-        EntityType.MATERIAL,
-        EntityType.SUPPLIER,
+    for cls in (
+        CachedVariant,
+        CachedProduct,
+        CachedMaterial,
+        CachedSupplier,
     ):
-        sync_fns[entity_type].assert_awaited()
+        # Fixture stores AsyncMock instances; the dict's declared element
+        # type is the production callable signature, so cast for ty.
+        cast("AsyncMock", sync_fns[cls]).assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/katana_mcp_server/tests/tools/test_reference.py
+++ b/katana_mcp_server/tests/tools/test_reference.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastmcp.tools import ToolResult
-from katana_mcp.cache import EntityType
 from katana_mcp.tools import decorators
 from katana_mcp.tools.foundation.reference import (
     GetSupplierRequest,
@@ -27,22 +26,33 @@ from katana_mcp.tools.foundation.reference import (
 from katana_mcp_server.tests.conftest import create_mock_context
 from mcp.types import TextContent
 
+from katana_public_api_client.models_pydantic._generated import (
+    CachedAdditionalCost,
+    CachedLocation,
+    CachedOperator,
+    CachedSupplier,
+    CachedTaxRate,
+)
+
 
 @pytest.fixture(autouse=True)
 def _patch_cache_sync():
-    """Stub @cache_read sync fns so cache reads don't trigger API fetches."""
+    """Stub @cache_read sync fns so cache reads don't trigger API fetches.
+
+    Decorator keys are typed-cache ``Cached*`` classes (#472 Phase C).
+    """
     # Direct dict replacement (not patch.dict): the decorator caches its
-    # entity_type → sync_fn map by reference on first call, so patching
+    # class → sync_fn map by reference on first call, so patching
     # `katana_mcp.cache_sync` after the dict is populated has no effect.
     original = decorators._sync_fns
     decorators._sync_fns = {
-        et: AsyncMock()
-        for et in (
-            EntityType.SUPPLIER,
-            EntityType.LOCATION,
-            EntityType.TAX_RATE,
-            EntityType.OPERATOR,
-            EntityType.ADDITIONAL_COST,
+        cls: AsyncMock()
+        for cls in (
+            CachedSupplier,
+            CachedLocation,
+            CachedTaxRate,
+            CachedOperator,
+            CachedAdditionalCost,
         )
     }
     try:

--- a/katana_mcp_server/tests/tools/test_reporting.py
+++ b/katana_mcp_server/tests/tools/test_reporting.py
@@ -40,11 +40,11 @@ _FETCH_MO_RECIPE = (
 def _patch_cache_sync():
     """Neutralize @cache_read so aggregation tests don't drive real sync helpers.
 
-    Reporting tools are decorated with @cache_read(VARIANT, PRODUCT, MATERIAL,
-    SERVICE). The decorator caches a dict of sync fns the first time it runs,
-    so patching by source module is order-dependent. Patching the dict
-    accessor to return {} neutralizes the decorator uniformly regardless of
-    test ordering.
+    Reporting tools are decorated with @cache_read(CachedVariant, CachedProduct,
+    CachedMaterial, CachedService). The decorator caches a dict of sync fns the
+    first time it runs, so patching by source module is order-dependent.
+    Patching the dict accessor to return {} neutralizes the decorator uniformly
+    regardless of test ordering.
     """
     with patch(
         "katana_mcp.tools.decorators._get_sync_fns",

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.64.1"
+version = "0.65.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Phase C of the [#472](https://github.com/dougborg/katana-openapi-client/issues/472) cache unification: rewire the `@cache_read` decorator from `EntityType` enum keys to typed `Cached*` class keys. Phase A (#643) and Phase B (#646) are merged; this PR builds on top of them.

- **`tools/decorators.py`**: `_get_sync_fns()` now returns `dict[type[SQLModel], async_wrapper]` keyed by `Cached*` classes. Each wrapper fans out to BOTH the legacy `cache_sync.ensure_*_synced(services)` AND the typed `typed_cache.ensure_*_synced(client, typed_cache)` helpers via `asyncio.gather` — Option A in the plan, so tool bodies see fresh data on either path during the Phase C → D transition. Phase D drops the legacy half. Registry compacted via a tuple-list driven by `getattr` lookup against the `cache_sync` and `typed_cache` modules; the entity-stem naming (`variants`, `products`, …) is identical between modules so a single source-of-truth tuple suffices.
- **11 `@cache_read(EntityType.X)` call sites** in `tools/foundation/{customers,inventory,items,reference,reporting}.py` → `@cache_read(CachedX)`. Tool bodies that still read via `services.cache.<method>(EntityType.X, ...)` are untouched — Phase D migrates them onto `services.typed_cache.catalog.*` and removes the legacy cache.
- **5 test files** updated: `test_inventory`, `test_items`, `test_customers`, `test_reference`, and `integration/test_error_scenarios` flip their `decorators._sync_fns` mock dicts from `EntityType` keys to `Cached*` class keys. `test_reporting`'s `{}`-returning patch is unaffected.
- **Architecture doc** updated to reflect the new decorator surface.

### Why Option A (dual-sync) over Option B (typed-only)

Tool bodies still read from `services.cache.<method>(EntityType.X, ...)` until Phase D migrates them. If the decorator only synced the typed cache, those reads would hit a stale legacy cache for the duration of the Phase C → D window. Option A double-fetches from the API (running both syncs concurrently via `asyncio.gather`) so neither cache goes stale. The wasted concurrent fetches retire entirely with the legacy half in Phase D.

## Open questions for Phase D

- The legacy `services.cache.*` calls return `dict[str, Any]`; the typed `services.typed_cache.catalog.*` returns `Cached*` objects. Phase D's call-site migration shifts `variant["sku"]` → `variant.sku`, etc., across ~33 sites in 8 files (per the plan).
- `EntityType` enum stays alive in `cache.py` until Phase D deletes the file. No new code in this PR uses it; existing tool bodies still do (those references die with Phase D).

## Test plan

- [x] `uv run poe check` clean — ruff format, ruff check, ty, pyright, yamllint, 3112 tests passing (2 intentional skips), 16 browser tests passing.
- [x] Decorator-mock fixtures (`decorators._sync_fns = {Cached*: AsyncMock(), ...}`) round-trip through `_get_variant_details_impl` and friends; the test that asserts each registered class's mock was awaited (`test_get_variant_details_syncs_parent_entity_caches`) passes against the new key shape.
- [x] `test_reporting.py`'s `{}` patch path verified: still neutralizes the decorator regardless of class-key shape.
- [ ] Manual smoke: cold-start the MCP server with empty caches, exercise `search_items`, `list_suppliers`, `list_locations` — verify both legacy and typed caches populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)