### PR TITLE
fix(scripts): tools.json generator emits clean, non-duplicate descriptions

### DIFF
--- a/scripts/generate_tools_json.py
+++ b/scripts/generate_tools_json.py
@@ -80,13 +80,16 @@ def _extract_from_directory(directory: Path) -> list[dict[str, str]]:
             with open(py_file) as f:
                 tree = ast.parse(f.read(), filename=str(py_file))
 
-            # Find all async function definitions that are tools
-            # Tools are the public async functions (not starting with _)
-            for node in ast.walk(tree):
+            # Find all async function definitions that are tools.
+            # Tools are the public async functions (not starting with _).
+            # Iterate the module body directly — `ast.walk` recurses into
+            # nested function definitions (e.g. inner `async def apply()`
+            # closures inside `register_preview_tool` wiring), which would
+            # surface duplicates that aren't actually registered tools.
+            for node in tree.body:
                 if isinstance(node, ast.AsyncFunctionDef) and not node.name.startswith(
                     "_"
                 ):
-                    # This is a tool function
                     description = _extract_description(node)
                     tools.append({"name": node.name, "description": description})
 
@@ -103,21 +106,41 @@ def _extract_from_directory(directory: Path) -> list[dict[str, str]]:
 def _extract_description(node: ast.AsyncFunctionDef) -> str:
     """Extract description from function docstring.
 
-    Args:
-        node: AST node for async function
-
-    Returns:
-        First non-empty line of docstring or default description
+    Joins the first paragraph of the docstring (everything up to the first
+    blank line) into a single string, then trims to the first complete
+    sentence so we don't ship descriptions that end mid-clause when the
+    first line of the docstring wraps.
     """
     docstring = ast.get_docstring(node)
-    if docstring:
-        # Extract first non-empty line
-        lines = [line.strip() for line in docstring.split("\n") if line.strip()]
-        if lines:
-            return lines[0]
+    if not docstring:
+        return f"Tool: {node.name}"
 
-    # Fallback description
-    return f"Tool: {node.name}"
+    paragraph_lines: list[str] = []
+    for line in docstring.split("\n"):
+        stripped = line.strip()
+        if not stripped:
+            if paragraph_lines:
+                break
+            continue
+        paragraph_lines.append(stripped)
+
+    if not paragraph_lines:
+        return f"Tool: {node.name}"
+
+    paragraph = " ".join(paragraph_lines)
+
+    # Trim to the first sentence. Look for terminal punctuation followed by
+    # whitespace, so we don't split on e.g. "id, name," in mid-sentence.
+    for terminator in (". ", "! ", "? "):
+        idx = paragraph.find(terminator)
+        if idx != -1:
+            return paragraph[: idx + 1]
+
+    # No terminator — return the full first paragraph, with a trailing period
+    # if it doesn't already end in punctuation, so descriptions read cleanly.
+    if paragraph[-1] not in ".!?":
+        return paragraph + "."
+    return paragraph
 
 
 def validate_tools(tools: list[dict[str, str]]) -> None:

--- a/tests/test_generate_tools_json.py
+++ b/tests/test_generate_tools_json.py
@@ -137,6 +137,44 @@ async def _private_impl():
             tools = _extract_from_directory(test_dir)
             assert len(tools) == 0
 
+    def test_skips_nested_async_functions(self):
+        """Nested ``async def`` closures must not be mistaken for top-level tools.
+
+        Regression: ``register_preview_tool`` wiring uses inner
+        ``async def apply()`` closures to handle the apply step. A previous
+        implementation walked the AST recursively, which surfaced these
+        closures as duplicate ``apply`` tool entries (5 of them in
+        ``corrections.py`` alone) in the generated tools.json.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_dir = Path(tmpdir)
+            test_file = test_dir / "tool_with_nested.py"
+            test_file.write_text('''
+async def public_tool():
+    """Public tool description."""
+
+    async def apply():
+        """Inner closure that should NOT be extracted."""
+        pass
+
+    async def _private_helper():
+        """Inner private — also should NOT be extracted."""
+        pass
+
+    return apply
+
+async def another_public_tool():
+    """Another public tool."""
+    pass
+''')
+
+            tools = _extract_from_directory(test_dir)
+            tool_names = [t["name"] for t in tools]
+
+            assert tool_names == ["public_tool", "another_public_tool"]
+            assert "apply" not in tool_names
+            assert "_private_helper" not in tool_names
+
 
 class TestExtractDescription:
     """Tests for _extract_description function."""
@@ -192,6 +230,54 @@ async def test_tool():
         description = _extract_description(func_node)
 
         assert description == "Tool: test_tool"
+
+    def test_joins_wrapped_first_sentence(self):
+        """A first sentence that wraps onto a second line must not be truncated.
+
+        Regression: previously the extractor took only the first line of the
+        docstring, which produced descriptions ending in a comma when the
+        first sentence wrapped (e.g. ``get_inventory_movements`` shipped a
+        truncated description in the Docker MCP Registry submission).
+        """
+        import ast
+
+        code = '''
+async def wrapped_tool():
+    """Get inventory movement history for a SKU — every stock change with dates,
+    quantities, and what caused each movement.
+
+    More details below.
+    """
+    pass
+'''
+        tree = ast.parse(code)
+        func_node = tree.body[0]
+        description = _extract_description(func_node)
+
+        assert description == (
+            "Get inventory movement history for a SKU — every stock change "
+            "with dates, quantities, and what caused each movement."
+        )
+
+    def test_trims_to_first_sentence_after_paragraph_join(self):
+        """Once paragraph lines are joined, only the first sentence is kept."""
+        import ast
+
+        code = '''
+async def two_sentence_tool():
+    """Edit a closed sales order without losing its picked_date and
+    fulfillment metadata. Reopens the order, applies edits, then closes.
+    """
+    pass
+'''
+        tree = ast.parse(code)
+        func_node = tree.body[0]
+        description = _extract_description(func_node)
+
+        assert description == (
+            "Edit a closed sales order without losing its picked_date "
+            "and fulfillment metadata."
+        )
 
 
 class TestValidateTools:

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.65.0"
+version = "0.66.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Two bugs in `scripts/generate_tools_json.py` surfaced when refreshing `tools.json` for the Docker MCP Registry submission (#81, [docker/mcp-registry#2563](https://github.com/docker/mcp-registry/pull/2563)):

- **Nested async-def duplicates** — `ast.walk()` recursed into nested function definitions, picking up inner `async def apply()` closures inside `register_preview_tool` wiring as if they were public tools. This produced 5 duplicate `apply` entries on top of the real 54 tools. Fixed by iterating `tree.body` directly so only top-level async defs are considered.

- **Truncated descriptions** — `_extract_description` took only the first non-empty line of the docstring, which truncated mid-sentence whenever the first sentence wrapped. Most visible victim was `get_inventory_movements` (description ended in a trailing comma — flagged by Copilot review on the upstream PR). 8 other tools had the same issue. Fixed by joining the first paragraph and trimming to the first complete sentence.

After the fix, `uv run python scripts/generate_tools_json.py --pretty` produces 54 clean tool entries matching the production tool set, with no truncations or duplicates.

The companion update on the upstream Docker MCP Registry PR is already pushed (commit `0cabec9` on `dougborg/mcp-registry add-katana-erp`) — it picked up the regenerated, non-truncated tool list this fix produces.

## Test plan

- [x] `uv run pytest tests/test_generate_tools_json.py -v` — 26/26 passing, including 3 new regression tests
- [x] `uv run poe check` — all green (ruff, ty, pytest 3083 unit + 16 browser)
- [x] Manual: `uv run python scripts/generate_tools_json.py --pretty` produces 54 clean entries (matches production `katana-erp` tool list, zero `apply` dupes, no trailing-comma descriptions)
- [x] Verified the regenerated `tools.json` against `pkg/servers/types.go` schema in `docker/mcp-registry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)