### PR TITLE
test(mcp): suppress webbrowser.open during browser-test fixture

### DIFF
--- a/katana_mcp_server/tests/browser/conftest.py
+++ b/katana_mcp_server/tests/browser/conftest.py
@@ -93,7 +93,18 @@ def apps_dev_server() -> Iterator[str]:
             str(_DEV_PORT),
             "--no-reload",
         ],
-        env={**os.environ, "FASTMCP_LOG_LEVEL": "WARNING"},
+        # ``fastmcp dev apps`` unconditionally calls ``webbrowser.open(dev_url)``
+        # on startup with no flag to disable it. Setting ``BROWSER=true`` makes
+        # Python's webbrowser module dispatch to the ``true`` command (resolved
+        # via PATH) — exits 0, opens nothing. Skipped on Windows: there's no
+        # ``true`` there, and webbrowser would fall through to the default
+        # browser. The suite is documented as macOS/Linux-only, matching the
+        # ``start_new_session`` guard below.
+        env={
+            **os.environ,
+            "FASTMCP_LOG_LEVEL": "WARNING",
+            **({"BROWSER": "true"} if sys.platform != "win32" else {}),
+        },
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         start_new_session=sys.platform != "win32",

--- a/uv.lock
+++ b/uv.lock
@@ -1307,7 +1307,7 @@ requires-dist = [
 
 [[package]]
 name = "katana-openapi-client"
-version = "0.61.0"
+version = "0.62.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

- `fastmcp dev apps` — which `katana_mcp_server/tests/browser/conftest.py` spawns as a subprocess — unconditionally calls `webbrowser.open(dev_url)` at startup (`.venv/.../fastmcp/cli/apps_dev.py:1773`). No CLI flag disables it. Result: a real Chromium window pops on the developer's desktop every test run, alongside Playwright's headless instance.
- Set `BROWSER=true` in the subprocess env. Python's `webbrowser` module then builds a `GenericBrowser` controller that runs `/usr/bin/true %s` — exits 0, opens nothing. Playwright continues to drive its own headless Chromium for the actual iframe render tests.
- Rationale comment in `conftest.py` so the next reader doesn't undo it.

## Test plan

- [x] `uv run pytest katana_mcp_server/tests/browser/` — 16/16 pass in ~147s on macOS, **no window appeared**
- [x] `uv run poe check` — full PR-readiness gate (3062 unit tests + 16 browser tests) all green
- [ ] CI: re-runs the same suite

## Notes

- `uv.lock` is the workspace-version bump from the recent `chore(release): client v0.62.0` on main, bundled per CLAUDE.md "uv.lock drift during pre-commit" — no dependency changes.
- `test:` scope = no semantic-release impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)