### PR TITLE
fix(mcp): typed-cache schema fingerprint backstop + extend rebuild_cache to catalog

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -85,7 +85,7 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **list_additional_costs** - List or fuzzy-search the additional-cost catalog (freight, duties, handling). Use for `additional_cost_id` on `modify_purchase_order`. Supports `query`, `limit`, `format`.
 
 ### Cache Administration
-- **rebuild_cache** - Force-rebuild the local typed cache for one or more transactional entity types (PO, SO, MO, stock adjustment, stock transfer). Truncates the cache table(s), clears the sync watermark, and re-fetches from Katana. Use when the cache has phantom rows (entities present locally but missing from Katana). Destructive; preview/apply.
+- **rebuild_cache** - Force-rebuild the local typed cache for one or more cached entity types. Covers transactional entities (PO, SO, MO, stock adjustment, stock transfer) and catalog entities (variant, product, material, service, customer, supplier, location, tax_rate, operator, factory, additional_cost). Truncates the cache table(s), clears the sync watermark, and re-fetches from Katana. Use when the cache has phantom rows (entities present locally but missing from Katana). Destructive; preview/apply.
 
 ## Safety Pattern
 
@@ -1820,7 +1820,7 @@ name}]`, `total_count`, `query`.
 ## Cache Administration Tools
 
 ### rebuild_cache
-Force-rebuild the local typed cache for one or more transactional entity types.
+Force-rebuild the local typed cache for one or more cached entity types.
 The steady-state sync path upserts via `session.merge` and never deletes — soft-
 deletes from Katana are folded in correctly because the tombstone surfaces in
 the next `updated_at_min` delta, but rows that left Katana without a tombstone
@@ -1837,8 +1837,11 @@ For each requested entity type, the rebuild:
 
 **Parameters:**
 - `entity_types` (required, min length 1): list of entity types to rebuild.
-  Allowed values: `purchase_order`, `sales_order`, `manufacturing_order`,
-  `stock_adjustment`, `stock_transfer`.
+  Allowed values cover transactional entities (`purchase_order`, `sales_order`,
+  `manufacturing_order`, `stock_adjustment`, `stock_transfer`) and catalog
+  entities (`variant`, `product`, `material`, `service`, `customer`,
+  `supplier`, `location`, `tax_rate`, `operator`, `factory`,
+  `additional_cost`).
 - `preview` (optional, default true): true = report current row counts and
   last-synced timestamps without modifying anything; false = perform the
   destructive rebuild.

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/cache_admin.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/cache_admin.py
@@ -3,9 +3,9 @@
 Operational utilities for the typed cache (``katana_mcp.typed_cache``).
 
 Currently provides ``rebuild_cache``: a destructive force-resync that
-truncates the cache tables for a set of transactional entity types,
-clears their ``SyncState`` watermarks, and re-fetches the live state
-from Katana — atomically under the entity's sync lock so concurrent
+truncates the cache tables for a set of cached entity types, clears
+their ``SyncState`` watermarks, and re-fetches the live state from
+Katana — atomically under the entity's sync lock so concurrent
 ``list_*`` tools never see the empty intermediate state.
 
 Why this exists: the steady-state sync path upserts via
@@ -17,6 +17,12 @@ state predating cache initialization) persist locally as phantoms.
 ``list_*`` tools filter ``deleted_at IS NULL``, but phantom rows that
 never received a soft-delete bump still leak. Rebuild is the manual
 escape hatch.
+
+Coverage: every key in ``katana_mcp.typed_cache.ENTITY_SPECS`` is
+addressable — both the transactional entities (PO, SO, MO + recipe
+rows, stock adjustments, stock transfers) and the catalog entities
+(variants, products, materials, services, customers, suppliers,
+locations, tax rates, operators, factories, additional costs).
 """
 
 from __future__ import annotations
@@ -49,11 +55,26 @@ logger = get_logger(__name__)
 # pyright ``Literal`` mismatch until added below, catching the drift at
 # review time rather than runtime).
 CacheEntityType = Literal[
+    # Transactional entities — parent + nested/related child rows.
     "purchase_order",
     "sales_order",
     "manufacturing_order",
     "stock_adjustment",
     "stock_transfer",
+    # Catalog entities — flat tables, no inline child rows. ``variant``
+    # carries denormalized parent-archive state; the rest are simple
+    # name/id lookups against the corresponding Katana endpoints.
+    "variant",
+    "product",
+    "material",
+    "service",
+    "customer",
+    "supplier",
+    "location",
+    "tax_rate",
+    "operator",
+    "factory",
+    "additional_cost",
 ]
 
 
@@ -73,7 +94,11 @@ class RebuildCacheRequest(BaseModel):
         description=(
             "Entity types to rebuild. Each entry truncates the cache "
             "table(s) for that entity, clears its sync watermark, and "
-            "re-fetches the live state from Katana."
+            "re-fetches the live state from Katana. Covers transactional "
+            "entities (purchase_order, sales_order, manufacturing_order, "
+            "stock_adjustment, stock_transfer) and catalog entities "
+            "(variant, product, material, service, customer, supplier, "
+            "location, tax_rate, operator, factory, additional_cost)."
         ),
     )
     preview: bool = Field(
@@ -271,7 +296,7 @@ def _format_markdown(response: RebuildCacheResponse) -> str:
 async def rebuild_cache(
     request: Annotated[RebuildCacheRequest, Unpack()], context: Context
 ) -> ToolResult:
-    """Force-rebuild the local typed cache for one or more transactional entity types.
+    """Force-rebuild the local typed cache for one or more cached entity types.
 
     Use this when the local cache has drifted from Katana — the most
     common symptom is "phantom" rows (entities present in the cache
@@ -290,8 +315,16 @@ async def rebuild_cache(
        locks, so concurrent ``list_*`` tools block until the cache is
        repopulated and never see the empty intermediate state.
 
-    **Supported entity types:** ``purchase_order``, ``sales_order``,
-    ``manufacturing_order``, ``stock_adjustment``, ``stock_transfer``.
+    **Supported entity types:**
+
+    - Transactional: ``purchase_order``, ``sales_order``,
+      ``manufacturing_order``, ``stock_adjustment``, ``stock_transfer``
+      (each rebuilds the parent table plus its child/related-spec
+      tables, e.g. PO + PO rows, MO + MO recipe rows).
+    - Catalog: ``variant``, ``product``, ``material``, ``service``,
+      ``customer``, ``supplier``, ``location``, ``tax_rate``,
+      ``operator``, ``factory``, ``additional_cost`` (flat tables,
+      no inline child rows).
 
     **Two-step flow:**
     - ``preview=true`` (default) — reports current row counts and last-

--- a/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/engine.py
@@ -24,7 +24,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 # Side-effect imports: register table=True SQLModel classes with
 # ``SQLModel.metadata`` so ``create_all`` emits their DDL. Add new
 # entity modules here as they come online.
-from katana_mcp.typed_cache import sync_state as _sync_state_mod
+from katana_mcp.typed_cache import (
+    schema_fingerprint as _schema_fingerprint_mod,
+    sync_state as _sync_state_mod,
+)
 from katana_public_api_client.models_pydantic._generated import (
     common as _common_mod,
     contacts as _contacts_mod,
@@ -41,6 +44,7 @@ from katana_public_api_client.models_pydantic._generated import (
 # ``contacts`` registers Cached{Customer,Supplier};
 # ``common`` registers Cached{Location,TaxRate,Operator,Factory,AdditionalCost}.
 assert _sync_state_mod is not None
+assert _schema_fingerprint_mod is not None
 assert _sales_orders_mod is not None
 assert _stock_mod is not None
 assert _manufacturing_mod is not None
@@ -206,6 +210,10 @@ class TypedCacheEngine:
             initialize_fts_for_connection,
             populate_fts_from_existing_rows,
         )
+        from .schema_fingerprint import (
+            check_and_rebuild_on_drift,
+            write_current_fingerprint,
+        )
         from .sync import ENTITY_SPECS, _validate_dependency_graph
 
         _validate_dependency_graph(ENTITY_SPECS.values())
@@ -220,7 +228,29 @@ class TypedCacheEngine:
             # repopulates from the API. The cache is a derived store —
             # losing rows on schema drift is the right trade.
             await conn.run_sync(_migrate_pre_create_all)
+            # Schema-fingerprint backstop runs AFTER the targeted
+            # migration pass so the targeted migrations get to do their
+            # fine-grained work first (only dropping one table's data
+            # for known regressions). The fingerprint backstop only
+            # fires for changes the targeted migrations didn't catch.
+            # The two coexist by design:
+            #   - ``_migrate_pre_create_all`` is the narrow optimization
+            #     for known cases where we want to keep *other* tables'
+            #     data and only drop the one we're migrating.
+            #   - ``check_and_rebuild_on_drift`` is the wide net: any
+            #     remaining change to ``SQLModel.metadata`` (column
+            #     added/removed, type changed, constraint changed) trips
+            #     it. Drops every managed table + FTS sidecar;
+            #     ``create_all`` rebuilds. After a targeted migration
+            #     ran, only the unmigrated drift remains for this pass
+            #     to catch.
+            await conn.run_sync(check_and_rebuild_on_drift)
             await conn.run_sync(SQLModel.metadata.create_all)
+            # Write the current fingerprint AFTER ``create_all`` so the
+            # ``cache_meta`` table is guaranteed to exist when we INSERT.
+            # Stamps both fresh DBs and post-rebuild DBs so the next
+            # open's drift check has a comparison baseline.
+            await conn.run_sync(write_current_fingerprint)
             # FTS5 virtual tables sit alongside the SQLModel-managed
             # tables and need their own DDL. Two steps, in order:
             # 1. ``initialize_fts_for_connection`` — emit

--- a/katana_mcp_server/src/katana_mcp/typed_cache/schema_fingerprint.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/schema_fingerprint.py
@@ -1,0 +1,257 @@
+"""Schema-fingerprint backstop for the typed-cache SQLite file.
+
+Why this exists: ``SQLModel.metadata.create_all`` only emits
+``CREATE TABLE IF NOT EXISTS`` — it can't add a column to a table that
+already exists. When a generator-driven schema change adds, removes,
+or retypes columns (e.g., #669 promoted ``CachedLocation`` from
+``KatanaPydanticBase`` to ``DeletableEntity``, adding ``id``,
+``created_at``, ``updated_at``, ``deleted_at``), an existing
+pre-upgrade SQLite cache file keeps the old, narrower table. The next
+query that emits ``WHERE deleted_at IS NULL`` blows up with
+``sqlite3.OperationalError: no such column: location.deleted_at``.
+
+There is already a finer-grained migration helper at
+``engine._migrate_pre_create_all`` that pattern-matches on stale DDL
+substrings — useful when we want to preserve the data in the *other*
+tables and only drop one. But that approach requires the developer
+who edits the schema to remember to add a migration block; #669
+forgot, which produced this regression.
+
+This module provides a backstop that auto-detects schema drift:
+
+1. Compute a deterministic SHA-256 of the current SQLModel metadata
+   by compiling each table to its SQLite ``CREATE TABLE`` DDL
+   (sorted by name), concatenating, and hashing.
+2. Persist the fingerprint in a small ``cache_meta`` table
+   (``key TEXT PRIMARY KEY, value TEXT``).
+3. On open, compare the stored fingerprint to the current one. On
+   mismatch (or if the meta table is absent but the DB already has
+   tables — the "first run after upgrade from a pre-fingerprint
+   version" case), drop every SQLModel-managed table plus the FTS5
+   sidecars and triggers, then ``create_all`` rebuilds them under the
+   current schema. The next sync repopulates from the API.
+4. After ``create_all`` completes, write the new fingerprint.
+
+The cache is a derived store — losing rows on schema drift is the
+right trade. The alternative (silently broken queries until users
+manually delete the cache file) is much worse.
+
+Note on stability: the fingerprint depends on SQLAlchemy's SQLite DDL
+emission. Across SQLAlchemy minor versions, identical metadata can
+in principle compile to slightly different DDL strings (e.g., quoting
+or whitespace nuances), which would trigger a one-time spurious
+rebuild on upgrade. In practice this is harmless — a one-time
+re-fetch on SQLAlchemy upgrade is a small price for the broad
+coverage. If we ever observe noisy churn, we can fall back to an
+explicit integer ``SCHEMA_VERSION`` constant bumped per-PR.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from sqlalchemy import DDL, text
+from sqlalchemy.dialects import sqlite as sqlite_dialect
+from sqlalchemy.schema import CreateTable
+from sqlmodel import Field, SQLModel
+
+from katana_mcp.typed_cache.fts import _safe_identifier
+
+# ``cache_meta`` lives alongside the other SQLModel-managed tables —
+# ``create_all`` will create it like any other. Single-row table keyed
+# by string. Today the only key is ``schema_fingerprint``; future
+# infrastructure-level metadata can land here too without bumping the
+# fingerprint logic.
+_FINGERPRINT_KEY = "schema_fingerprint"
+
+
+class CacheMeta(SQLModel, table=True):
+    """Single key/value store for cache-engine-level metadata.
+
+    Holds the schema fingerprint today; future infrastructure-level
+    state can land here too. Kept separate from :class:`SyncState`
+    (per-entity watermarks) because the audiences differ — meta is
+    read-by-engine on open, sync_state is read-by-sync on every fetch.
+    """
+
+    __tablename__ = "cache_meta"
+
+    key: str = Field(primary_key=True)
+    value: str
+
+
+def compute_metadata_fingerprint() -> str:
+    """SHA-256 of the SQLite-compiled DDL for every table in ``SQLModel.metadata``.
+
+    Tables are sorted by name for determinism — ``MetaData.tables``
+    iteration order isn't guaranteed stable across runs and we want
+    byte-identical input on identical schemas. The dialect is pinned
+    to SQLite because that's the only backend the typed cache runs
+    against; a different backend would emit different DDL syntax and
+    poison the comparison even when the logical schema is identical.
+    """
+    dialect = sqlite_dialect.dialect()
+    parts: list[str] = []
+    for table in sorted(SQLModel.metadata.tables.values(), key=lambda t: t.name):
+        ddl = str(CreateTable(table).compile(dialect=dialect))
+        parts.append(ddl)
+    payload = "\n".join(parts).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _table_exists(sync_conn: Any, table_name: str) -> bool:
+    """Cheap ``sqlite_master`` lookup for one table."""
+    row = sync_conn.execute(
+        text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:n"),
+        {"n": table_name},
+    ).first()
+    return row is not None
+
+
+def _has_any_managed_tables(sync_conn: Any) -> bool:
+    """True when at least one SQLModel-managed table already exists in the DB.
+
+    Used to distinguish a fresh DB (no meta + no tables — first open ever)
+    from an upgraded DB (no meta + tables present — pre-fingerprint
+    version). Only the latter needs a rebuild on the migration boundary.
+    """
+    for table in SQLModel.metadata.tables.values():
+        if _table_exists(sync_conn, table.name):
+            return True
+    return False
+
+
+def _read_stored_fingerprint(sync_conn: Any) -> str | None:
+    """Fetch the previously-written fingerprint, or None if absent.
+
+    Returns None when ``cache_meta`` doesn't exist yet (first open on
+    this DB file) and when it exists but has no fingerprint row (the
+    one-table-but-no-row case after a partial migration).
+    """
+    if not _table_exists(sync_conn, "cache_meta"):
+        return None
+    row = sync_conn.execute(
+        text("SELECT value FROM cache_meta WHERE key=:k"),
+        {"k": _FINGERPRINT_KEY},
+    ).first()
+    return row[0] if row else None
+
+
+def _drop_all_managed_tables(sync_conn: Any) -> None:
+    """Drop every SQLModel-managed table + their FTS sidecars and triggers.
+
+    Run when the stored fingerprint disagrees with the current one. The
+    drop must be wide enough to clear stale state but precise enough to
+    avoid touching unrelated SQLite metadata.
+
+    Order matters because of foreign-key references and because the FTS
+    triggers reference the content tables:
+
+    1. Drop FTS triggers first — they reference the content table by name
+       and would error on the table-drop otherwise.
+    2. Drop FTS5 virtual tables.
+    3. Drop the SQLModel content tables in reverse-dependency order
+       (``metadata.sorted_tables`` is dependency-asc; reverse it for the
+       drop pass so children go before parents).
+
+    The ``cache_meta`` table itself is included in the drop so the post-
+    rebuild ``create_all`` re-creates it cleanly. The fingerprint write
+    that follows ``create_all`` will repopulate the row.
+
+    All DDL goes through :class:`DDL` (not :func:`text`) to keep
+    Semgrep's ``avoid-sqlalchemy-text`` rule clean. Identifiers come
+    exclusively from SQLModel metadata (never user input), and each one
+    is additionally run through :func:`fts._safe_identifier` before
+    interpolation as a belt-and-suspenders guard against a future
+    generator regression that emits something exotic — matching the
+    same defense-in-depth convention ``fts._create_fts_tables_ddl``
+    applies on the FTS-sidecar side.
+    """
+    # FTS sidecar names are derived deterministically from the parent
+    # table name via the same convention ``fts._fts_table_name`` uses.
+    # Mirror it locally rather than reaching into the FTS module's
+    # private helper — keeps the dependency one-way (engine → fts) and
+    # the drop logic doesn't need the FTS module's column metadata.
+    for table in SQLModel.metadata.tables.values():
+        table_name = _safe_identifier(table.name)
+        fts_table = f"{table_name}_fts"
+        # Triggers first (they reference the content table by name).
+        sync_conn.execute(DDL(f"DROP TRIGGER IF EXISTS {table_name}_ai"))
+        sync_conn.execute(DDL(f"DROP TRIGGER IF EXISTS {table_name}_au"))
+        sync_conn.execute(DDL(f"DROP TRIGGER IF EXISTS {table_name}_ad"))
+        sync_conn.execute(DDL(f"DROP TABLE IF EXISTS {fts_table}"))
+
+    # Drop in reverse-dependency order so child tables (foreign-key
+    # holders) drop before their parents. ``sorted_tables`` is FK-asc;
+    # reverse it for the drop pass.
+    for table in reversed(SQLModel.metadata.sorted_tables):
+        table_name = _safe_identifier(table.name)
+        sync_conn.execute(DDL(f"DROP TABLE IF EXISTS {table_name}"))
+
+
+def check_and_rebuild_on_drift(sync_conn: Any) -> bool:
+    """Inspect the DB; drop everything if the fingerprint doesn't match.
+
+    Called from ``TypedCacheEngine.open()`` *before* ``create_all`` (so
+    ``create_all`` lays down a fresh schema) and *after* the
+    finer-grained ``_migrate_pre_create_all`` pass (whose targeted
+    table-level migrations are an optimization for known cases where we
+    want to preserve other tables' data; this fingerprint check is the
+    catch-all backstop for everything else).
+
+    Returns True when a rebuild was performed (caller may want to log
+    or surface it), False when the fingerprint matched and the DB was
+    left alone.
+
+    Decision matrix:
+
+    - No managed tables exist (fresh DB) → no-op, return False. The
+      caller's ``create_all`` will lay everything down.
+    - ``cache_meta`` doesn't exist but other managed tables do → upgrade
+      from a pre-fingerprint version. Rebuild and return True.
+    - ``cache_meta`` exists with a fingerprint that matches → no-op.
+    - Fingerprint mismatch (schema changed since the last write) →
+      Rebuild and return True.
+    """
+    has_tables = _has_any_managed_tables(sync_conn)
+    stored = _read_stored_fingerprint(sync_conn)
+    current = compute_metadata_fingerprint()
+
+    # Fresh DB — nothing to drop.
+    if not has_tables:
+        return False
+
+    # Tables present but no stored fingerprint → upgrade from a
+    # pre-fingerprint version. Treat as drift and rebuild. (This is the
+    # path that fixes #669-style regressions on existing user caches.)
+    if stored is None:
+        _drop_all_managed_tables(sync_conn)
+        return True
+
+    if stored == current:
+        return False
+
+    _drop_all_managed_tables(sync_conn)
+    return True
+
+
+def write_current_fingerprint(sync_conn: Any) -> None:
+    """Upsert the current fingerprint into ``cache_meta``.
+
+    Called from ``TypedCacheEngine.open()`` *after* ``create_all`` so
+    ``cache_meta`` is guaranteed to exist when we write to it.
+
+    Uses SQLite's ``ON CONFLICT(key) DO UPDATE`` rather than two
+    separate statements so concurrent opens (rare — engines are opened
+    once per process — but cheap to harden against) can't interleave
+    a delete with an insert from another connection.
+    """
+    fingerprint = compute_metadata_fingerprint()
+    sync_conn.execute(
+        text(
+            "INSERT INTO cache_meta (key, value) VALUES (:k, :v) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value"
+        ),
+        {"k": _FINGERPRINT_KEY, "v": fingerprint},
+    )

--- a/katana_mcp_server/tests/test_typed_cache.py
+++ b/katana_mcp_server/tests/test_typed_cache.py
@@ -135,6 +135,260 @@ class TestLifecycle:
             await engine.close()
 
     @pytest.mark.asyncio
+    async def test_open_rebuilds_pre_669_location_table_missing_deleted_at(
+        self, tmp_path: Path
+    ):
+        """The headline #669 regression: pre-#669 ``CachedLocation`` extended
+        ``KatanaPydanticBase``, so the SQLite ``location`` table had only the
+        explicit columns (``id``, ``name``, ``legal_name``, ...). #669 promoted
+        it to ``DeletableEntity``, adding ``created_at``, ``updated_at``, and
+        ``deleted_at``. ``SQLModel.metadata.create_all`` is a no-op against
+        existing tables, so an upgraded user keeps the narrow table — and the
+        next ``list_locations`` call's ``WHERE deleted_at IS NULL`` blows up
+        with ``sqlite3.OperationalError: no such column: location.deleted_at``.
+
+        The schema-fingerprint backstop must catch this on open (no stored
+        fingerprint + tables present → upgrade path → drop everything and
+        rebuild). After ``open()``, the ``location`` table must have all the
+        new columns, and the next ``list_locations`` query path must succeed.
+        """
+        import aiosqlite
+        from sqlalchemy import text
+
+        db_path = tmp_path / "pre_669.db"
+        # Hand-craft a pre-#669 ``location`` table — the explicit columns
+        # only, no ``DeletableEntity`` audit fields. This is byte-identical
+        # to what an upgraded user has on disk.
+        async with aiosqlite.connect(str(db_path)) as conn:
+            await conn.execute(
+                "CREATE TABLE location ("
+                "id INTEGER PRIMARY KEY, "
+                "name VARCHAR NOT NULL, "
+                "legal_name VARCHAR"
+                ")"
+            )
+            await conn.execute(
+                "INSERT INTO location (id, name) VALUES (1, 'Old Warehouse')"
+            )
+            await conn.commit()
+
+        engine = TypedCacheEngine(db_path=db_path)
+        await engine.open()
+        try:
+            # Confirm the rebuild added the missing columns.
+            async with engine.session() as session:
+                conn = await session.connection()
+                cols = (
+                    await conn.execute(text("PRAGMA table_info(location)"))
+                ).fetchall()
+                col_names = {row[1] for row in cols}
+            assert "deleted_at" in col_names, (
+                f"deleted_at missing — fingerprint backstop failed to "
+                f"rebuild. Columns: {col_names}"
+            )
+            assert "created_at" in col_names
+            assert "updated_at" in col_names
+
+            # The ``WHERE deleted_at IS NULL`` query path must now succeed
+            # — this is the actual user-visible failure mode #669
+            # introduced.
+            from katana_public_api_client.models_pydantic._generated import (
+                CachedLocation,
+            )
+
+            async with engine.session() as session:
+                rows = (
+                    await session.exec(
+                        select(CachedLocation).where(
+                            CachedLocation.deleted_at.is_(None)
+                        )
+                    )
+                ).all()
+            # Pre-existing 'Old Warehouse' row was dropped along with the
+            # narrow table — cache is derivable from the API.
+            assert rows == []
+        finally:
+            await engine.close()
+
+    @pytest.mark.asyncio
+    async def test_open_rebuild_drops_fts_sidecars_alongside_main_tables(
+        self, tmp_path: Path
+    ):
+        """When the fingerprint backstop drops a content table, its FTS5
+        sidecar + the trigger trio must drop too — otherwise the next
+        ``CREATE TRIGGER`` would error on the leftover trigger and the
+        FTS5 virtual table would reference a now-missing content table.
+
+        Hand-build a stale variant table and a matching ``variant_fts``
+        sidecar (mirroring what a pre-fingerprint engine would have left
+        on disk), then confirm both get rebuilt.
+        """
+        import aiosqlite
+        from sqlalchemy import text
+
+        db_path = tmp_path / "stale_with_fts.db"
+        async with aiosqlite.connect(str(db_path)) as conn:
+            # Stale variant table (forces a fingerprint mismatch) +
+            # matching FTS sidecar + one trigger to confirm cleanup.
+            await conn.execute(
+                "CREATE TABLE variant ("
+                "id INTEGER PRIMARY KEY, sku VARCHAR, made_up_old_col VARCHAR"
+                ")"
+            )
+            await conn.execute(
+                "CREATE VIRTUAL TABLE variant_fts USING fts5("
+                "sku, content='variant', content_rowid='id'"
+                ")"
+            )
+            await conn.execute(
+                "CREATE TRIGGER variant_ai AFTER INSERT ON variant BEGIN "
+                "INSERT INTO variant_fts (rowid, sku) "
+                "VALUES (new.id, IFNULL(new.sku, '')); END"
+            )
+            await conn.commit()
+
+        engine = TypedCacheEngine(db_path=db_path)
+        await engine.open()
+        try:
+            async with engine.session() as session:
+                conn = await session.connection()
+                # FTS sidecar exists.
+                fts = (
+                    await conn.execute(
+                        text(
+                            "SELECT name FROM sqlite_master "
+                            "WHERE type='table' AND name='variant_fts'"
+                        )
+                    )
+                ).first()
+                # Trigger exists (recreated post-rebuild by FTS init).
+                trigger = (
+                    await conn.execute(
+                        text(
+                            "SELECT name FROM sqlite_master "
+                            "WHERE type='trigger' AND name='variant_ai'"
+                        )
+                    )
+                ).first()
+                # The stale fictional column is gone — proves the variant
+                # table was actually dropped + recreated, not just left in
+                # place with a bonus FTS sidecar.
+                cols = (
+                    await conn.execute(text("PRAGMA table_info(variant)"))
+                ).fetchall()
+                col_names = {row[1] for row in cols}
+            assert fts is not None
+            assert trigger is not None
+            assert "made_up_old_col" not in col_names
+        finally:
+            await engine.close()
+
+    @pytest.mark.asyncio
+    async def test_open_writes_fingerprint_to_cache_meta(self, tmp_path: Path):
+        """First open of a fresh DB stamps a fingerprint row in ``cache_meta``."""
+        from katana_mcp.typed_cache.schema_fingerprint import (
+            CacheMeta,
+            compute_metadata_fingerprint,
+        )
+
+        engine = TypedCacheEngine(db_path=tmp_path / "fresh.db")
+        await engine.open()
+        try:
+            async with engine.session() as session:
+                row = await session.get(CacheMeta, "schema_fingerprint")
+            assert row is not None
+            assert row.value == compute_metadata_fingerprint()
+            # SHA-256 hex is exactly 64 chars — sanity check we're not
+            # storing something pathological like the empty string.
+            assert len(row.value) == 64
+        finally:
+            await engine.close()
+
+    @pytest.mark.asyncio
+    async def test_second_open_with_unchanged_metadata_is_a_noop(self, tmp_path: Path):
+        """Reopen against an already-stamped DB must NOT rebuild — user
+        rows survive across engine restarts unless the schema actually
+        changed. This is the most important non-headline guarantee:
+        without it, every server restart would clear the cache.
+        """
+        from katana_public_api_client.models_pydantic._generated import (
+            CachedLocation,
+        )
+
+        db_path = tmp_path / "stable.db"
+
+        # First open: stamps fingerprint + lays down schema. Seed a row.
+        engine = TypedCacheEngine(db_path=db_path)
+        await engine.open()
+        try:
+            async with engine.session() as session:
+                session.add(CachedLocation(id=42, name="Survivor Warehouse"))
+                await session.commit()
+        finally:
+            await engine.close()
+
+        # Second open: fingerprint matches → no rebuild → row survives.
+        engine = TypedCacheEngine(db_path=db_path)
+        await engine.open()
+        try:
+            async with engine.session() as session:
+                row = await session.get(CachedLocation, 42)
+            assert row is not None, (
+                "Cache row was wiped on a no-op reopen — the fingerprint "
+                "backstop is rebuilding when it shouldn't be."
+            )
+            assert row.name == "Survivor Warehouse"
+        finally:
+            await engine.close()
+
+    @pytest.mark.asyncio
+    async def test_open_rebuilds_when_fingerprint_mismatch(self, tmp_path: Path):
+        """Synthetic drift: write a wrong fingerprint to ``cache_meta``,
+        seed a row, reopen — the row must be wiped (proves the mismatch
+        path runs) and the new fingerprint must overwrite the wrong one.
+        """
+        from katana_mcp.typed_cache.schema_fingerprint import (
+            CacheMeta,
+            compute_metadata_fingerprint,
+        )
+
+        from katana_public_api_client.models_pydantic._generated import (
+            CachedLocation,
+        )
+
+        db_path = tmp_path / "drifty.db"
+
+        # First open lays down the schema + writes the correct fingerprint.
+        engine = TypedCacheEngine(db_path=db_path)
+        await engine.open()
+        try:
+            async with engine.session() as session:
+                session.add(CachedLocation(id=1, name="Will Vanish"))
+                # Replace the correct fingerprint with a synthetic wrong one.
+                meta = await session.get(CacheMeta, "schema_fingerprint")
+                assert meta is not None
+                meta.value = "0" * 64
+                session.add(meta)
+                await session.commit()
+        finally:
+            await engine.close()
+
+        # Second open: stored fingerprint != current → rebuild fires.
+        engine = TypedCacheEngine(db_path=db_path)
+        await engine.open()
+        try:
+            async with engine.session() as session:
+                vanished = await session.get(CachedLocation, 1)
+                meta = await session.get(CacheMeta, "schema_fingerprint")
+            assert vanished is None, (
+                "Row survived a fingerprint-mismatch open — rebuild didn't fire."
+            )
+            assert meta is not None
+            assert meta.value == compute_metadata_fingerprint()
+        finally:
+            await engine.close()
+
+    @pytest.mark.asyncio
     async def test_file_backed_engine_uses_wal_and_busy_timeout(self, tmp_path: Path):
         """File-backed engines apply WAL + busy_timeout PRAGMAs.
 

--- a/katana_mcp_server/tests/tools/test_cache_admin.py
+++ b/katana_mcp_server/tests/tools/test_cache_admin.py
@@ -564,6 +564,89 @@ class TestForceResyncAtomicity:
 
 
 # ============================================================================
+# Catalog entity coverage — `rebuild_cache` accepts all 16 keys in
+# `ENTITY_SPECS`, not just the 5 transactional ones it shipped with.
+# Smoke-test one catalog entity end-to-end (location — the headline #669
+# regression source) plus a literal-shape test that pins the full
+# accepted set against `ENTITY_SPECS` so adding a new entity to the
+# typed cache surfaces the missing literal at review time.
+# ============================================================================
+
+
+class TestCatalogEntityRebuild:
+    @pytest.mark.asyncio
+    async def test_rebuild_location_clears_phantom_and_repulls(
+        self, typed_cache_engine
+    ):
+        """End-to-end smoke test for the catalog tier of `rebuild_cache`.
+
+        Exercises one catalog entity (location) through the full
+        `force_resync` path: seed two locations (one of which the live
+        API will omit), patch the API to return only the live one,
+        confirm the phantom is gone after rebuild and that the live row
+        survives. Same shape as the headline transactional test
+        `test_phantom_purchase_order_is_removed_after_rebuild`, just
+        against a flat catalog table.
+        """
+        from katana_public_api_client.models import Location as AttrsLocation
+        from katana_public_api_client.models_pydantic._generated import (
+            CachedLocation,
+        )
+
+        # Seed: one row Katana still has, one phantom Katana doesn't.
+        async with typed_cache_engine.session() as session:
+            session.add(CachedLocation(id=1, name="Main Warehouse"))
+            session.add(CachedLocation(id=999, name="Phantom Warehouse"))
+            await session.commit()
+
+        context = _build_context(typed_cache_engine)
+        live_location = AttrsLocation.from_dict({"id": 1, "name": "Main Warehouse"})
+        live_response = MagicMock()
+        live_response.status_code = 200
+        live_response.parsed = MagicMock(data=[live_location])
+
+        with patch(
+            "katana_mcp.typed_cache.sync.get_all_locations.asyncio_detailed",
+            new=AsyncMock(return_value=live_response),
+        ):
+            response = await _rebuild_cache_impl(
+                RebuildCacheRequest(entity_types=["location"], preview=False),
+                context,
+            )
+
+        assert response.is_preview is False
+        result = response.results[0]
+        assert result.entity_type == "location"
+        assert result.parent_rows_before == 2
+        assert result.parent_rows_after == 1
+        # Catalog entities have no related-spec children, so the only
+        # cleared key is the parent's own watermark.
+        assert result.sync_state_keys_cleared == ["location"]
+
+        async with typed_cache_engine.session() as session:
+            remaining = (await session.exec(select(CachedLocation))).all()
+        ids = {loc.id for loc in remaining}
+        assert ids == {1}, f"Phantom location 999 should be gone, got {ids}"
+
+    def test_request_accepts_all_entity_specs_keys(self):
+        """The `CacheEntityType` literal must stay in lock-step with
+        `ENTITY_SPECS`. Adding a new entity to the typed cache without
+        also extending the `Literal` would silently exclude it from the
+        rebuild_cache tool — tested explicitly so the gap can't ship.
+        """
+        for entity_key in ENTITY_SPECS:
+            # `model_validate` exercises the Literal check at runtime;
+            # success means the key is in the accepted set.
+            req = RebuildCacheRequest.model_validate(
+                {"entity_types": [entity_key], "preview": True}
+            )
+            assert req.entity_types == [entity_key], (
+                f"{entity_key!r} accepted by ENTITY_SPECS but rejected by "
+                f"CacheEntityType — extend the Literal in cache_admin.py."
+            )
+
+
+# ============================================================================
 # Request validation — invalid entity types fail at the request boundary
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Two related changes addressing typed-cache regressions discovered while verifying #659:

1. **`fix(mcp)`: schema-fingerprint backstop** — auto-rebuilds the SQLite cache when the SQLModel metadata schema changes between releases, so users no longer need to delete `typed_cache.db` after a schema-modifying upgrade.
2. **`feat(mcp)`: extend `rebuild_cache` to catalog entities** — the underlying `force_resync` already supports all 16 entity types in `ENTITY_SPECS`; the tool's `Literal` only allowed the 5 transactional ones. Now covers catalog entities too (variants, products, materials, services, customers, suppliers, locations, tax rates, operators, factories, additional costs).

## The bug (Commit 1)

PR #669 changed `CachedLocation` from `KatanaPydanticBase` to `DeletableEntity`, adding `id` / `created_at` / `updated_at` / `deleted_at`. `SQLModel.metadata.create_all` only emits `CREATE TABLE IF NOT EXISTS`, so existing pre-#669 cache files keep the old narrow `location` table. The next `list_locations` call's `WHERE deleted_at IS NULL` blows up with:

```
sqlite3.OperationalError: no such column: location.deleted_at
```

Reproduced live against the MCP server. The existing `_migrate_pre_create_all` substring-DDL helper requires manually adding a block per schema change — #669 forgot, and that's exactly the kind of mistake we want to make impossible going forward.

## How the fix works (Commit 1)

- New `cache_meta` SQLModel table (`key TEXT PRIMARY KEY, value TEXT`) — single row holds a SHA-256 fingerprint of `SQLModel.metadata` compiled to SQLite DDL (sorted by table name).
- On `engine.open()`, before `create_all`: read the stored fingerprint, compute the current one, and on mismatch (or "tables present but no fingerprint", the upgrade-from-pre-fingerprint case) drop every managed table + FTS5 sidecars + triggers. After `create_all`, write the new fingerprint.
- Coexists with `_migrate_pre_create_all`: the targeted helper stays useful when you want to preserve other tables' data and only drop one. Fingerprint is the catch-all backstop.

## Tests

- **Headline regression repro**: hand-build a pre-#669 `location` table missing `deleted_at`, open the engine, confirm rebuild added the missing columns AND the typed-cache `WHERE deleted_at IS NULL` query path succeeds.
- FTS sidecars + triggers also dropped/recreated alongside content tables.
- `cache_meta` row updated on first open and every rebuild.
- Critically: **second open against unchanged metadata is a no-op** — user rows survive engine restarts (the most important non-headline guarantee).
- Synthetic-mismatch test: write a wrong fingerprint, seed a row, reopen, confirm the row is wiped and the new fingerprint overwrites the wrong one.

## Commit 2: `rebuild_cache` extension

Coverage was 5/16 entity types. The literal pin (`test_request_accepts_all_entity_specs_keys`) loops over `ENTITY_SPECS` and asserts the request validator accepts each — adding a new entity to the typed cache without extending the literal will fail this test.

End-to-end smoke for `location`: seed phantom + live, patch `get_all_locations` to return only the live one, confirm phantom is gone post-rebuild.

## Caveats / follow-ups

- Fingerprint is SQLAlchemy-DDL-derived, so a SQLAlchemy minor-version upgrade *could* in principle trigger a one-time spurious rebuild if the emitter changes whitespace/quoting. In practice this is a one-time API re-fetch — small price for broad coverage. If we ever observe noisy churn, we can fall back to an explicit integer `SCHEMA_VERSION` bumped per-PR.
- No generated-file impact (no edits to `api/`, `models/`, `_generated/`, OpenAPI spec, or `client.py`).

## Test plan

- [x] `uv run poe check` (3074 tests + 16 browser tests) — all green
- [x] Pre-#669 location regression test PROVES the fingerprint catches it (drops the narrow table, query succeeds post-open)
- [x] No-op reopen test confirms user data isn't wiped on every restart
- [x] All 16 entity types accepted by `RebuildCacheRequest`

Refs #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)