### PR TITLE
feat(mcp): background cache warm-up at lifespan startup (#593)

### DIFF
--- a/katana_mcp_server/pyproject.toml
+++ b/katana_mcp_server/pyproject.toml
@@ -80,6 +80,7 @@ markers = [
     "unit: Unit tests with mocks",
     "integration: Integration tests requiring API key",
     "browser: Browser-render tests via Playwright + fastmcp dev-apps (slow, needs `playwright install chromium`)",
+    "cache_warmup_enabled: opt in to the lifespan cache-warmup task (default-off in tests via autouse fixture)",
 ]
 
 [tool.semantic_release]

--- a/katana_mcp_server/src/katana_mcp/server.py
+++ b/katana_mcp_server/src/katana_mcp/server.py
@@ -12,13 +12,17 @@ Features:
 - Response caching for improved performance (FastMCP 2.13+)
 """
 
+import asyncio
 import os
+import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Literal, cast
 
 if TYPE_CHECKING:
     from fastmcp.server.auth import AuthProvider  # pragma: no cover
+
+    from katana_mcp.typed_cache import TypedCacheEngine  # pragma: no cover
 
 from dotenv import load_dotenv
 from fastmcp import FastMCP
@@ -42,6 +46,97 @@ _apply_patches()
 # Initialize structured logging
 setup_logging()
 logger = get_logger(__name__)
+
+
+async def _warm_caches_in_background(
+    client: KatanaClient,
+    typed_cache: "TypedCacheEngine",
+) -> None:
+    """Kick off ``ensure_<entity>_synced`` for every cache-backed entity.
+
+    Runs concurrently with the server accepting MCP requests so the gap
+    between Claude/MCP startup and the first user-facing tool call gets
+    used to warm the typed cache. Tool calls that arrive mid-warmup
+    serialize on each entity's ``cache.lock_for(...)`` — they wait the
+    same amount of time they would have waited without warmup, with the
+    warmup's incremental progress available on later calls (closes #500's
+    cold-cache window, the remaining mitigation for #463 after #592 and
+    #591).
+
+    Per-entity failures are swallowed and logged so a transient error on
+    one entity never blocks the others from warming and never crashes
+    the server. ``manufacturing_order_recipe_row`` is pulled implicitly
+    via ``MANUFACTURING_ORDER_SPEC.related_specs`` when MOs are warmed,
+    so it's intentionally absent from this list.
+    """
+    from katana_mcp.typed_cache import (
+        ensure_additional_costs_synced,
+        ensure_customers_synced,
+        ensure_factory_synced,
+        ensure_locations_synced,
+        ensure_manufacturing_orders_synced,
+        ensure_materials_synced,
+        ensure_operators_synced,
+        ensure_products_synced,
+        ensure_purchase_orders_synced,
+        ensure_sales_orders_synced,
+        ensure_services_synced,
+        ensure_stock_adjustments_synced,
+        ensure_stock_transfers_synced,
+        ensure_suppliers_synced,
+        ensure_tax_rates_synced,
+        ensure_variants_synced,
+    )
+
+    helpers = (
+        ensure_sales_orders_synced,
+        ensure_purchase_orders_synced,
+        ensure_manufacturing_orders_synced,
+        ensure_stock_adjustments_synced,
+        ensure_stock_transfers_synced,
+        ensure_customers_synced,
+        ensure_suppliers_synced,
+        ensure_locations_synced,
+        ensure_tax_rates_synced,
+        ensure_operators_synced,
+        ensure_additional_costs_synced,
+        ensure_variants_synced,
+        ensure_products_synced,
+        ensure_materials_synced,
+        ensure_services_synced,
+        ensure_factory_synced,
+    )
+
+    started = time.monotonic()
+    # ``return_exceptions=True`` keeps the gather alive when any one
+    # helper raises, so a transient API hiccup on one entity doesn't
+    # block the others from warming. ``CancelledError`` propagates
+    # through ``gather`` regardless of this flag, which is what we want
+    # on shutdown.
+    results = await asyncio.gather(
+        *(fn(client, typed_cache) for fn in helpers),
+        return_exceptions=True,
+    )
+    elapsed_s = round(time.monotonic() - started, 1)
+    failures = [
+        (fn.__name__, type(r).__name__, str(r))
+        for fn, r in zip(helpers, results, strict=True)
+        if isinstance(r, BaseException)
+    ]
+    if failures:
+        logger.warning(
+            "cache_warmup_partial",
+            elapsed_s=elapsed_s,
+            success_count=len(helpers) - len(failures),
+            failure_count=len(failures),
+            failures=failures,
+        )
+    else:
+        logger.info(
+            "cache_warmup_complete",
+            elapsed_s=elapsed_s,
+            entity_count=len(helpers),
+        )
 
 
 @asynccontextmanager
@@ -109,6 +204,20 @@ async def lifespan(server: FastMCP) -> AsyncIterator[Services]:
             typed_cache = TypedCacheEngine()
             await typed_cache.open()
             logger.info("typed_cache_initialized", db_path=str(typed_cache.db_path))
+
+            # Fire-and-forget background warm-up so the gap between
+            # MCP startup and the first user-facing tool call gets used
+            # to populate the typed cache. Default ON; set
+            # ``MCP_DISABLE_CACHE_WARMUP=1`` to skip (test runs do this
+            # via the autouse fixture in ``conftest.py``).
+            warmup_task: asyncio.Task[None] | None = None
+            if os.getenv("MCP_DISABLE_CACHE_WARMUP") != "1":
+                warmup_task = asyncio.create_task(
+                    _warm_caches_in_background(cast(KatanaClient, client), typed_cache),
+                    name="katana_cache_warmup",
+                )
+                logger.info("cache_warmup_started")
+
             try:
                 # The generated ``AuthenticatedClient.__aenter__`` is
                 # annotated to return its own class, dropping the
@@ -120,6 +229,31 @@ async def lifespan(server: FastMCP) -> AsyncIterator[Services]:
                 logger.info("server_ready", version=__version__)
                 yield context
             finally:
+                # Always await the warmup task on shutdown, regardless of
+                # done-state, so any exception it raised is consumed
+                # rather than emitted as an asyncio "Task exception was
+                # never retrieved" warning. If still running, cancel
+                # first so the await returns promptly. Awaiting before
+                # ``typed_cache.close()`` also prevents the warmup from
+                # writing against a closed engine.
+                if warmup_task is not None:
+                    if not warmup_task.done():
+                        warmup_task.cancel()
+                    try:
+                        await warmup_task
+                    except asyncio.CancelledError:
+                        logger.info("cache_warmup_cancelled")
+                    except Exception as exc:
+                        # ``_warm_caches_in_background`` already swallows
+                        # per-helper errors via ``return_exceptions=True``,
+                        # so reaching this branch means something
+                        # unexpected raised at the task scope (import
+                        # error, logging failure, programmer bug).
+                        logger.warning(
+                            "cache_warmup_task_raised",
+                            error_type=type(exc).__name__,
+                            error=str(exc),
+                        )
                 await typed_cache.close()
                 logger.info("typed_cache_closed")
 

--- a/katana_mcp_server/tests/conftest.py
+++ b/katana_mcp_server/tests/conftest.py
@@ -1,10 +1,40 @@
 """Shared pytest fixtures for MCP server tests."""
 
 import os
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
+
+
+@pytest.fixture(autouse=True)
+def _disable_cache_warmup_by_default(
+    request: pytest.FixtureRequest,
+) -> Iterator[None]:
+    """Skip the background cache warm-up unless a test explicitly opts in.
+
+    ``server.lifespan()`` schedules an ``asyncio.create_task`` that fans
+    out ``ensure_*_synced`` calls (closes #500 / #593). Tests that don't
+    intentionally exercise warmup don't want it kicking off against a
+    mock client — it produces noisy logs, racy task lifecycles, and
+    unintentional coverage of unrelated code. Tests that want to verify
+    warmup behavior opt in with ``@pytest.mark.cache_warmup_enabled``.
+    """
+    if "cache_warmup_enabled" in request.keywords:
+        # Test wants the real warmup path; let MCP_DISABLE_CACHE_WARMUP
+        # flow through unchanged (or be set by the test itself).
+        yield
+        return
+    prev = os.environ.get("MCP_DISABLE_CACHE_WARMUP")
+    os.environ["MCP_DISABLE_CACHE_WARMUP"] = "1"
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("MCP_DISABLE_CACHE_WARMUP", None)
+        else:
+            os.environ["MCP_DISABLE_CACHE_WARMUP"] = prev
 
 
 @pytest_asyncio.fixture

--- a/katana_mcp_server/tests/test_server.py
+++ b/katana_mcp_server/tests/test_server.py
@@ -1,5 +1,6 @@
 """Unit tests for Katana MCP Server and authentication."""
 
+import asyncio
 import os
 from collections.abc import Iterator
 from pathlib import Path
@@ -246,6 +247,230 @@ class TestLifespan:
 
             # Verify cleanup was called (context manager exit)
             mock_client_instance.__aexit__.assert_called_once()
+
+
+@pytest.mark.usefixtures("isolated_caches")
+class TestCacheWarmup:
+    """Tests for the lifespan cache warm-up task (#593)."""
+
+    @staticmethod
+    def _find_warmup_task() -> asyncio.Task[object] | None:
+        """Look up the running warmup task by its well-known name.
+
+        Avoids spying on ``asyncio.create_task`` (which also fires for
+        SQLAlchemy-internal connection close, sqlite engine teardown,
+        etc., producing noisy false positives).
+        """
+        for task in asyncio.all_tasks():
+            if task.get_name() == "katana_cache_warmup":
+                return task
+        return None
+
+    @pytest.mark.asyncio
+    async def test_disable_env_var_skips_warmup(self):
+        """``MCP_DISABLE_CACHE_WARMUP=1`` prevents the warmup task from being created.
+
+        Pinned because the conftest autouse fixture relies on this
+        contract — if a future refactor decouples the env-var check from
+        the task creation, the entire test suite suddenly schedules real
+        warmup tasks against the mock client.
+        """
+        mock_server = MagicMock(spec=FastMCP)
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "KATANA_API_KEY": "test-api-key-123",
+                    "MCP_DISABLE_CACHE_WARMUP": "1",
+                },
+            ),
+            patch("katana_mcp.server.load_dotenv"),
+            patch("katana_mcp.server.KatanaClient") as mock_client_class,
+        ):
+            mock_client_instance = AsyncMock(spec=KatanaClient)
+            mock_client_instance.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client_instance
+
+            async with lifespan(mock_server):
+                # No warmup task should be running with the disable flag set.
+                assert self._find_warmup_task() is None
+
+    @pytest.mark.cache_warmup_enabled
+    @pytest.mark.asyncio
+    async def test_warmup_task_scheduled_when_enabled(self):
+        """Without the disable flag, lifespan schedules the warmup task and
+        the yield happens immediately — proving the task is fire-and-forget
+        rather than awaited inline (the whole point of #593).
+        """
+        import katana_mcp.server as server_mod
+
+        mock_server = MagicMock(spec=FastMCP)
+
+        async def fake_warmup(*_args: object, **_kwargs: object) -> None:
+            # Sleep longer than yield will plausibly wait — if the yield
+            # blocked on this, the test would hang. Cancelled by lifespan
+            # shutdown.
+            await asyncio.sleep(60)
+
+        with (
+            patch.dict(
+                os.environ,
+                {"KATANA_API_KEY": "test-api-key-123"},
+            ),
+            patch("katana_mcp.server.load_dotenv"),
+            patch("katana_mcp.server.KatanaClient") as mock_client_class,
+            patch.object(server_mod, "_warm_caches_in_background", fake_warmup),
+        ):
+            os.environ.pop("MCP_DISABLE_CACHE_WARMUP", None)
+
+            mock_client_instance = AsyncMock(spec=KatanaClient)
+            mock_client_instance.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client_instance
+
+            warmup_task_in_lifespan: asyncio.Task[object] | None = None
+            async with lifespan(mock_server):
+                # Yield reached without waiting on the warmup — the task
+                # is running but not done.
+                warmup_task_in_lifespan = self._find_warmup_task()
+                assert warmup_task_in_lifespan is not None
+                assert not warmup_task_in_lifespan.done()
+
+            # After lifespan exit, the task is cancelled cleanly.
+            assert warmup_task_in_lifespan is not None
+            assert warmup_task_in_lifespan.cancelled() or warmup_task_in_lifespan.done()
+
+    @pytest.mark.cache_warmup_enabled
+    @pytest.mark.asyncio
+    async def test_warmup_failure_does_not_crash_server(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """A warmup task that raises an unexpected exception must not
+        propagate out of the lifespan, and the exception must be consumed
+        on shutdown — not left to surface as an asyncio "Task exception
+        was never retrieved" warning later.
+
+        ``_warm_caches_in_background`` already swallows per-helper errors
+        internally via ``return_exceptions=True`` in the inner gather; this
+        test exercises the unexpected-error path at the task scope itself
+        (something unrelated to a helper raised, e.g. an import bug or
+        logging failure).
+        """
+        import katana_mcp.server as server_mod
+
+        mock_server = MagicMock(spec=FastMCP)
+
+        async def boom_warmup(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("simulated unexpected task-scope failure")
+
+        with (
+            patch.dict(os.environ, {"KATANA_API_KEY": "test-api-key-123"}),
+            patch("katana_mcp.server.load_dotenv"),
+            patch("katana_mcp.server.KatanaClient") as mock_client_class,
+            patch.object(server_mod, "_warm_caches_in_background", boom_warmup),
+        ):
+            os.environ.pop("MCP_DISABLE_CACHE_WARMUP", None)
+
+            mock_client_instance = AsyncMock(spec=KatanaClient)
+            mock_client_instance.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client_instance
+
+            # Should NOT raise even though warmup body raises.
+            async with lifespan(mock_server) as context:
+                assert isinstance(context, Services)
+                # Give the warmup task a turn to fire its exception.
+                await asyncio.sleep(0)
+
+        # The shutdown handler must have consumed the task's exception and
+        # logged it — proves the exception was retrieved rather than left
+        # to surface later as a noisy asyncio "Task exception was never
+        # retrieved" warning. Log records use structlog's event-key, so
+        # check both the message and the event attribute.
+        warmup_failure_records = [
+            r
+            for r in caplog.records
+            if "cache_warmup_task_raised" in r.getMessage()
+            or getattr(r, "event", None) == "cache_warmup_task_raised"
+        ]
+        assert warmup_failure_records, (
+            "lifespan shutdown must log cache_warmup_task_raised when the "
+            "warmup task ends with an unexpected exception; otherwise the "
+            "task exception goes unretrieved and surfaces as an asyncio "
+            "warning later."
+        )
+
+    @pytest.mark.asyncio
+    async def test_warm_caches_in_background_swallows_per_entity_errors(self):
+        """``_warm_caches_in_background`` calls 16 ``ensure_*_synced``
+        helpers via ``asyncio.gather(..., return_exceptions=True)``. A
+        single helper raising must not stop the others, and the function
+        itself must return without raising so the wrapping task doesn't
+        surface an exception.
+        """
+        import katana_mcp.server as server_mod
+
+        mock_client = MagicMock(spec=KatanaClient)
+        mock_cache = MagicMock()
+
+        async def ok(*_args: object, **_kwargs: object) -> None:
+            return None
+
+        async def boom(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("transient")
+
+        # Patch one helper to raise; all others succeed. The function
+        # must still return cleanly.
+        with (
+            patch.object(
+                server_mod,
+                "_warm_caches_in_background",
+                wraps=server_mod._warm_caches_in_background,
+            ),
+            patch(
+                "katana_mcp.typed_cache.ensure_sales_orders_synced",
+                side_effect=boom,
+            ),
+            patch(
+                "katana_mcp.typed_cache.ensure_purchase_orders_synced",
+                side_effect=ok,
+            ),
+            patch(
+                "katana_mcp.typed_cache.ensure_manufacturing_orders_synced",
+                side_effect=ok,
+            ),
+            patch(
+                "katana_mcp.typed_cache.ensure_stock_adjustments_synced",
+                side_effect=ok,
+            ),
+            patch(
+                "katana_mcp.typed_cache.ensure_stock_transfers_synced",
+                side_effect=ok,
+            ),
+            patch("katana_mcp.typed_cache.ensure_customers_synced", side_effect=ok),
+            patch("katana_mcp.typed_cache.ensure_suppliers_synced", side_effect=ok),
+            patch("katana_mcp.typed_cache.ensure_locations_synced", side_effect=ok),
+            patch("katana_mcp.typed_cache.ensure_tax_rates_synced", side_effect=ok),
+            patch("katana_mcp.typed_cache.ensure_operators_synced", side_effect=ok),
+            patch(
+                "katana_mcp.typed_cache.ensure_additional_costs_synced",
+                side_effect=ok,
+            ),
+            patch("katana_mcp.typed_cache.ensure_variants_synced", side_effect=ok),
+            patch("katana_mcp.typed_cache.ensure_products_synced", side_effect=ok),
+            patch("katana_mcp.typed_cache.ensure_materials_synced", side_effect=ok),
+            patch("katana_mcp.typed_cache.ensure_services_synced", side_effect=ok),
+            patch("katana_mcp.typed_cache.ensure_factory_synced", side_effect=ok),
+        ):
+            # Must not raise.
+            await server_mod._warm_caches_in_background(mock_client, mock_cache)
 
 
 class TestMCPServerInitialization:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,7 @@ markers = [
   "schema_validation: marks tests that validate OpenAPI schema quality (run with pytest-xdist disabled)",
   "looptime: marks tests that use the looptime fake-clock asyncio loop (the looptime plugin auto-registers this marker; explicit registration here keeps the suite robust under --strict-markers if plugin autoload is ever disabled)",
   "browser: marks tests that drive a headless browser via Playwright against the fastmcp dev-apps preview server (slower, needs `playwright install chromium`)",
+  "cache_warmup_enabled: opt in to the lifespan cache-warmup task (default-off in tests via the conftest autouse fixture in katana_mcp_server/tests)",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary

- Adds `_warm_caches_in_background` (fan-out of 16 `ensure_*_synced` calls via `asyncio.gather(..., return_exceptions=True)`) and schedules it as a background `asyncio.create_task` in `server.lifespan` right after `typed_cache.open()`.
- Yield happens immediately — the warmup is genuinely fire-and-forget, so MCP requests start serving the moment lifespan reaches the yield. Tool calls that arrive mid-warmup serialize on each entity's `cache.lock_for(...)` and wait the same amount of time they would have without warmup (with the warmup's incremental progress available on later calls — no extra cost in the worst case).
- Per-entity failures are swallowed and logged; one helper crashing never blocks the others from warming or crashes the server.
- On lifespan exit the task is cancelled cleanly before `typed_cache.close()` so writes can't race a closed engine.
- `MCP_DISABLE_CACHE_WARMUP=1` skips the warmup; the test suite turns this on by default via a new conftest autouse fixture, and tests that want the real warmup path opt in with `@pytest.mark.cache_warmup_enabled`.
- `manufacturing_order_recipe_row` is pulled implicitly via `MANUFACTURING_ORDER_SPEC.related_specs` when MOs are warmed, so it's intentionally absent from the explicit warmup list.

## Why

The SQLite-backed typed cache is persistent across MCP sessions, so the expensive case is the very first run or one after long idleness. Today the first tool call that needs a cold entity pays the full sync RTT, which under Katana's 60/min rate limit can exceed the MCP client's ~60s request timeout — surfacing as opaque `-32001` errors. There's typically a gap between Claude/MCP startup and the first user-facing tool call; this PR uses that gap.

Closes #500 (the customer-module + MO timeout cluster) and #593 (the impl itself). Completes the mitigation cluster for #463 alongside the already-shipped #590 (adaptive rate limit), #591 (bulk upsert), and #592 (filtered write-through).

## Tests

- `test_disable_env_var_skips_warmup` — pins that `MCP_DISABLE_CACHE_WARMUP=1` prevents the task from being created, which the conftest autouse fixture depends on. Future refactors decoupling the env-var check from task creation will trip this.
- `test_warmup_task_scheduled_when_enabled` — pins fire-and-forget semantics (yield reaches user code while the warmup is still pending) and clean cancellation on lifespan exit. Uses task-name lookup rather than spying on `asyncio.create_task` to avoid false positives from SQLAlchemy-internal connection teardown.
- `test_warmup_failure_does_not_crash_server` — a raising warmup body doesn't propagate out of `async with lifespan(...)`.
- `test_warm_caches_in_background_swallows_per_entity_errors` — direct test of the `return_exceptions=True` gather contract: 1 helper raises, 15 succeed, function returns cleanly.

## Test plan

- [x] `uv run poe agent-check` — clean
- [x] `uv run poe test` — 3086 passed, 2 skipped
- [x] `uv run pytest katana_mcp_server/tests/test_server.py::TestCacheWarmup -v` — 4/4 pass
- [ ] Live deploy: bring up a fresh MCP server against a real tenant, observe `cache_warmup_started` → `cache_warmup_complete` (or `cache_warmup_partial`) log lines in the lifespan window, then run `search_customers(query="...")` and confirm it answers without `-32001`

🤖 Generated with [Claude Code](https://claude.com/claude-code)