### PR TITLE
docs(harness): wire Rolling Backlog board into daily workflow (#568 Phase 1)

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -193,6 +193,47 @@ uv run poe check
 
 1. **Print the PR URL** for the user.
 
+1. **Surface linked-issue board status** — after creating the PR, parse the PR body
+   for GitHub closing keywords (`Closes #N` / `Fixes #N` / `Resolves #N` — the three
+   forms GitHub recognizes as "linked issues") and confirm each linked issue is on
+   project #5 (the Rolling Backlog). `Refs #N` is a reference, not a link, and won't
+   trigger GitHub's auto-move workflow — so it's intentionally excluded from both the
+   regex and the workflow expectations. The two-step check:
+
+   ```bash
+   # Find linked issues (closing keywords only — Refs/See excluded by design).
+   gh pr view <number> --json body --jq '.body' \
+     | grep -oiE '(close[sd]?|fixe[sd]?|resolve[sd]?) #[0-9]+' \
+     | grep -oE '[0-9]+' \
+     | sort -u
+
+   # For each linked issue, fetch the project item (if any) and surface its
+   # Priority + Workstream so we can see the classification at a glance.
+   gh issue view <issue#> --json projectItems \
+     --jq '.projectItems[]
+           | select(.title=="Katana MCP — Rolling Backlog")
+           | {status, priority, workstream}'
+   ```
+
+   If a linked issue is **not** on the board, add it now (it should auto-add via the
+   project workflow, but the workflow has a delay or could be misconfigured):
+
+   ```bash
+   gh project item-add 5 --owner @me --url "$issue_url"
+   # then set Priority + Workstream — see CLAUDE.md "Project Backlog" for the
+   # field-IDs / option-IDs lookup via `gh project field-list 5 --owner @me --format json`.
+   ```
+
+   The board's "Pull request linked to issue" workflow should auto-move the linked
+   issue's Status to **In Progress** once the PR opens. Confirm by re-reading the
+   issue's project status after creating the PR. If Status didn't move (sometimes
+   the workflow lags or doesn't fire for cross-repo references), nudge it manually
+   via `gh project item-edit --field-id <Status> --single-select-option-id <In Progress>`.
+
+   Don't gate the PR on this — board status is observability, not a release gate. But
+   surface the result in the summary (Phase 8) so the user knows the board reflects
+   reality.
+
 ## Phase 5: Wait for CI
 
 1. **Poll CI status**:
@@ -260,6 +301,9 @@ Print an overall summary:
 - **CI status** (all green / any failures)
 - **Review comments addressed** (count, if any)
 - **Current PR state** (ready for re-review, approved, etc.)
+- **Board state** — for each linked issue, the project #5 Status (In Progress / Done /
+  not-on-board) so the user can see at a glance that the board reflects the work
+  (see Phase 4 step 4).
 
 ## Important Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,11 @@ hooks aren't shared across worktrees. The `pre-push-guard.sh` that blocks uninte
 pushes to `main` (see `Known Pitfalls`) only fires when the hook is installed in the
 worktree's `.git/hooks/`.
 
+**For ongoing work pickup, open the
+[Rolling Backlog](https://github.com/users/dougborg/projects/5) board first — it's the
+canonical answer to "what should I work on?"** See `Project Backlog` below for the
+Priority / Workstream conventions and the issue-status contract.
+
 ## Essential Commands
 
 | Command                   | Time   | When to Use                          |
@@ -51,6 +56,68 @@ Always run the appropriate validation tier before considering work complete. See
 Essential Commands table above - use `quick-check` during development, `agent-check`
 before committing, and `check` before opening a PR. Don't trust that code works just
 because it looks right.
+
+## Project Backlog
+
+**Board:** [Katana MCP — Rolling Backlog](https://github.com/users/dougborg/projects/5)
+(project #5) is the durable answer to "what's next?" — not `gh issue list`. The board
+classifies every open issue across four dimensions (Priority / Effort / Workstream /
+Umbrella) and surfaces them in three views (List, Board, Roadmap). Every new Issue and
+PR auto-adds in the **Todo** column with unset Priority/Workstream until a human
+triages.
+
+### Session-start anchor
+
+First thing in a session: glance at the Board view. Look at the **In Progress** column
+(anything already running) and the top of **Todo** (P0 and P1). If the user asks "what
+should I work on?", the answer is the top of Todo. **Do not re-derive the queue from
+`gh issue list` — the board is the source of truth.**
+
+### Priority bucket definitions
+
+| Priority         | Definition                                                                                  | Examples                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **P0-now**       | Breaks a workflow that's already shipped; user-visible failure; should not survive the day. | #527 (every PATCH raises), #547 (browser bail-out for serial-tracked)    |
+| **P1-this-week** | Real value, no acute breakage, but compounding cost if deferred.                            | #500 (timeouts), #503 (silent drop), umbrella-driven workstream advances |
+| **P2-soon**      | Worth doing; not blocking; has a path.                                                      | Card sub-issues, audits, secondary umbrellas                             |
+| **P3-someday**   | Backlog parking; revisit on next groom; close if stale.                                     | Dead skill ideas, infrastructure ideas without a forcing function        |
+
+### Workstream definitions
+
+- **Cards** — Prefab UI builders + per-entity card design (driven by #537).
+- **Cache** — typed cache, FTS5, sync, cold-cache recovery (driven by #472, #473).
+- **Fulfillment** — `fulfill_order` / `receive_purchase_order` / order lifecycle.
+  Orthogonal to umbrellas.
+- **Spec-drift** — Katana API spec misalignment, codegen issues.
+- **Harness** — `.claude/`, harness-kit integration, skills, agents.
+- **Process** — backlog hygiene, docs, ADRs, retros.
+- **Other** — anything that doesn't fit above; usually means the schema needs a new
+  bucket.
+
+### Status contract
+
+- Issue → **In Progress** when a linked PR opens. Use a GitHub closing keyword in the PR
+  body to create the link: **`Closes #N`** is the canonical form for this repo
+  (`Fixes #N` / `Resolves #N` also work — GitHub recognizes all three as closing
+  keywords). `Refs #N` and `See #N` are *references*, not links — they don't trigger the
+  auto-move workflow and won't auto-close the issue on merge.
+- Issue → **Done** when the linked PR merges, regardless of whether the issue itself is
+  closed — issues may stay open as parents to future sub-work.
+- Status moves are driven by GitHub's built-in project workflows; the auto-add-workflow
+  keeps new Issues + PRs on the board so nothing slips through.
+
+### Adding to the board manually
+
+If the auto-add workflow misses something (rare), or to retroactively classify a
+pre-board issue, use the gh CLI:
+
+```bash
+gh project item-add 5 --owner @me --url <issue-or-pr-url>
+# then set Priority + Workstream via gh project item-edit --single-select-option-id
+```
+
+The field IDs / option IDs are stable;
+`gh project field-list 5 --owner @me --format json` prints them.
 
 ## Continuous Improvement
 


### PR DESCRIPTION
## Summary

- Adds the **Project Backlog** section to `CLAUDE.md` with the board URL, session-start convention, Priority/Workstream definitions, and the issue-status contract — so future sessions stop re-deriving the priority queue from `gh issue list`.
- Adds a one-liner to **Quick Start** pointing at the board as the canonical "what should I work on?" answer.
- Updates the `/open-pr` skill to surface linked-issue board status: parse `Closes/Fixes/Refs #N` from the PR body, confirm each linked issue is on project #5, add if missing, report Status in the final summary.
- Verified that all 6 default GitHub project workflows are enabled (Auto-add sub-issues, Auto-close issue, Item added, Item closed, PR linked to issue, PR merged) — the auto-move-to-In-Progress and auto-move-to-Done behaviors we've been observing this session are already wired.
- Filed 4 follow-ups for the deferred phases of #568:
  - #682 — `/start` (or `/today`) board-aware session-start skill
  - #683 — `/groom` skill that mutates the board instead of re-deriving from scratch
  - #684 — `/triage` skill for interactive classification of un-classified items
  - #685 — harness-kit upstream proposal for generic project-board integration

## Why

The board (#5) went live 2026-05-05 but nothing in the harness pointed agents at it. The failure modes #568 calls out — issues filed without classification, PRs that don't surface board state, sessions re-deriving the queue — all show up because the convention isn't in CLAUDE.md and the skills don't reference the board.

This PR ships the foundational pieces (CLAUDE.md docs + `/open-pr` Phase 2). The deeper integrations (board-mutating skills, harness-kit upstream) are larger and tracked separately.

## Acceptance checklist (from #568)

- [x] Phase 1 automation configured (default workflows enabled; documented auto-add gap)
- [x] CLAUDE.md updated with: board URL, session-start convention, Priority definitions, Workstream definitions
- [x] `/open-pr` references the board (Phase 2)
- [ ] `/groom` mutates the board → deferred to #683
- [ ] First post-board session demonstrates the workflow → this session arguably is it (5 PRs merged this session driven from the board, no ad-hoc PM grooming)

3 of 5 acceptance items here; 2 deferred to follow-ups. Leaving #568 open as the umbrella.

## Test plan

- [x] `uv run poe agent-check` — clean (docs + skill markdown only; no code paths exercised)
- [x] `gh project item-list 5 --owner @me --format json` shows the 4 newly-filed follow-ups (#682–#685) with Priority + Workstream set
- [ ] Next session: open this CLAUDE.md cold and confirm the Project Backlog section makes the board the obvious first action

Refs #568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)