### PR TITLE
fix(mcp): write modified entity through to typed cache on apply

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -53,9 +53,15 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    # ``TypedCacheEngine`` is the runtime type of ``CacheMerge.cache``.
+    # Top-level import would cycle through tool code; the ``TYPE_CHECKING``
+    # guard keeps IDE / pyright accurate without runtime overhead.
+    from katana_mcp.typed_cache import TypedCacheEngine
 
 from katana_mcp.logging import get_logger
 from katana_mcp.tools._derived_fields import (
@@ -87,6 +93,77 @@ ApplyCallable = Callable[[], Awaitable[Any]]
 # return ``(False, snapshot)`` rather than raising — the action itself
 # succeeded; the caller just needs the divergence visible.
 VerifyCallable = Callable[[Any], Awaitable[tuple[bool, dict[str, Any] | None]]]
+
+
+@dataclass(frozen=True)
+class EntityNaming:
+    """Entity-identifying strings used by ``run_modify_plan``.
+
+    Bundled into one record to keep ``run_modify_plan`` under its
+    8-argument PLR0913 budget after ``cache_merge`` was added. The three
+    strings move together — every per-tool impl computes them at the same
+    time. ``run_delete_plan`` was deliberately left with flat kwargs —
+    it doesn't take ``cache_merge`` so it stays under budget without the
+    bundle; a future migration for consistency is tracked separately.
+
+    - ``entity_type``: stable machine-readable tag (matches a key in
+      ``ENTITY_SPECS`` when the entity is cached). Used for the cache
+      merge spec lookup and as the response's ``entity_type`` field.
+    - ``entity_label``: human-readable noun including the id
+      (e.g. ``"purchase order 42"``). Used in messages and warnings.
+    - ``tool_name``: the calling tool's name (e.g.
+      ``"modify_purchase_order"``). Used in the manual-revert hint in
+      failure messages.
+    """
+
+    entity_type: str
+    entity_label: str
+    tool_name: str
+
+
+@dataclass(frozen=True)
+class CacheMerge:
+    """Plumbing for end-of-plan typed-cache write-through.
+
+    Before this hook existed, ``run_modify_plan`` had no cache awareness —
+    every successful modify left the typed cache stale until the next sync
+    (2026-05-12 SRAM PO-reconciliation session, where ``get_variant_details``
+    returned pre-modification ``supplier_item_codes`` 10+ minutes after a
+    confirmed apply). With ``cache_merge`` wired, ``run_modify_plan``
+    re-fetches the parent entity after the plan succeeds and merges it into
+    the cache via ``merge_filtered_fetch`` — which does not advance the
+    watermark, see ``typed_cache/sync.py:536``. The same refetch naturally
+    captures server-side cascades (e.g. PO header ``expected_arrival_date``
+    → row ``arrival_date`` cascade).
+
+    Fields:
+
+    - ``cache`` — the ``TypedCacheEngine`` from ``services.typed_cache``.
+      Imported under ``TYPE_CHECKING`` to avoid a top-level import cycle
+      through tool code; the annotation resolves at type-check time.
+    - ``refetch_for_merge(id)`` — returns the post-state parent attrs.
+      ``merge_filtered_fetch`` only writes through what the parent's
+      ``EntitySpec`` knows about: the parent row itself plus any nested
+      children declared via ``child_cls`` / ``rows_field`` (PO/SO rows are
+      embedded). Anything the spec lists in ``related_specs`` (separate
+      endpoints — MO recipe rows, PO/SO sibling row-watermarks) is NOT
+      covered by this single fetch.
+    - ``refetch_related`` — optional list of ``(entity_key, refetcher)``
+      tuples for any ``related_specs`` that need their own refetch after
+      a modify. Currently used by ``modify_manufacturing_order`` to
+      refresh recipe rows (separate ``/manufacturing_order_recipe_rows``
+      endpoint, not embedded in the MO GET response). Each refetcher
+      takes the parent entity id and returns the list of related-spec
+      attrs to merge.
+
+    Tools that lack a GET-by-id endpoint (stock_transfers) simply omit
+    ``cache_merge`` entirely — their cache stays stale on modify until
+    the next sync window.
+    """
+
+    cache: TypedCacheEngine
+    refetch_for_merge: Callable[[int], Awaitable[Any | None]]
+    refetch_related: tuple[tuple[str, Callable[[int], Awaitable[list[Any]]]], ...] = ()
 
 
 @dataclass
@@ -594,13 +671,12 @@ def summarize_delete_outcome(
 async def run_modify_plan(
     *,
     request: ConfirmableRequest,
-    entity_type: str,
-    entity_label: str,
-    tool_name: str,
+    naming: EntityNaming,
     web_url_kind: EntityKind | None,
     existing: Any | None,
     plan: list[ActionSpec],
     has_get_endpoint: bool = True,
+    cache_merge: CacheMerge | None = None,
 ) -> ModificationResponse:
     """Wrap a built plan in a preview-or-execute :class:`ModificationResponse`.
 
@@ -612,11 +688,8 @@ async def run_modify_plan(
 
     Args:
         request: The Pydantic request — must have ``id`` and ``preview`` fields.
-        entity_type: Stable machine-readable type tag (e.g. ``"purchase_order"``).
-        entity_label: Human-readable label including the id (e.g. ``"purchase
-            order 42"``). Used in messages and warnings.
-        tool_name: Tool name for the manual-revert hint in the failure path
-            (e.g. ``"modify_purchase_order"``).
+        naming: ``EntityNaming(entity_type, entity_label, tool_name)`` — see
+            its docstring for what each field carries.
         web_url_kind: Argument to :func:`katana_web_url`. Pass ``None`` for
             entities without a Katana web page (e.g. services); the response's
             ``katana_url`` will be ``None``.
@@ -628,7 +701,15 @@ async def run_modify_plan(
             warning about. ``False`` when the entity has no GET-by-id (e.g.
             stock transfer) and ``existing=None`` is the expected steady
             state — suppresses the spurious "could not fetch" warning.
+        cache_merge: When provided, the dispatcher refetches the parent
+            after the plan succeeds and merges it into the typed cache so
+            ``@cache_read`` tools see fresh data without ``rebuild_cache``.
+            Omit for tools without a GET-by-id (stock_transfers) — the
+            cache stays stale on modify until the next sync window.
     """
+    entity_type = naming.entity_type
+    entity_label = naming.entity_label
+    tool_name = naming.tool_name
     katana_url = katana_web_url(web_url_kind, request.id) if web_url_kind else None
     warnings = (
         [
@@ -702,6 +783,42 @@ async def run_modify_plan(
         actions, len(plan), entity_label=entity_label, tool_name=tool_name
     )
 
+    # Bug #2 (2026-05-12 SRAM session): the typed cache went stale after
+    # every modify because nothing wrote the post-state through. The next
+    # ``@cache_read`` (e.g. ``get_variant_details``, ``list_purchase_orders``)
+    # served pre-modification rows until a manual ``rebuild_cache`` ran.
+    #
+    # When the tool wires up ``cache`` + ``refetch_for_merge``, do a single
+    # post-apply parent fetch and merge it into the cache via the existing
+    # ``merge_filtered_fetch`` helper. The same fetch naturally captures
+    # server-side cascades (Bug #5 header-date → row-dates) — the cache
+    # reflects what Katana actually has, not what the agent thinks it has.
+    #
+    # Best-effort: failures are logged but do not change the tool's success
+    # response — the API write itself succeeded; cache staleness is
+    # recoverable on the next ensure_synced cycle.
+    if (
+        cache_merge is not None
+        and actions
+        and not any(a.succeeded is False for a in actions)
+    ):
+        try:
+            await _post_apply_cache_merge(
+                cache_merge=cache_merge,
+                entity_type=entity_type,
+                entity_id=request.id,
+            )
+        except asyncio.CancelledError:
+            # Cooperative cancellation (request timeout, shutdown) must
+            # propagate — never swallow it in the best-effort handler.
+            raise
+        except Exception as exc:
+            logger.warning(
+                f"Post-apply cache merge for {entity_label} failed: "
+                f"{type(exc).__name__}: {exc}. Cache may be stale until "
+                f"next sync — does not affect the API write."
+            )
+
     return ModificationResponse(
         entity_type=entity_type,
         entity_id=request.id,
@@ -713,6 +830,73 @@ async def run_modify_plan(
         katana_url=katana_url,
         message=message,
     )
+
+
+async def _post_apply_cache_merge(
+    *,
+    cache_merge: CacheMerge,
+    entity_type: str,
+    entity_id: int,
+) -> None:
+    """Re-fetch the modified entity from Katana and merge into the typed cache.
+
+    Looks up the ``EntitySpec`` by ``entity_type`` in ``ENTITY_SPECS`` —
+    entity types that aren't cached (no spec) skip silently. Returns
+    quietly if the parent refetch yields no entity (deleted, race, etc.).
+
+    For entities whose ``EntitySpec.related_specs`` reference data at
+    separate API endpoints (MO recipe rows, sibling row-watermarks), the
+    caller must wire ``CacheMerge.refetch_related`` to refresh those too
+    — the parent fetch alone doesn't cover them. See
+    ``CacheMerge.refetch_related`` for the contract.
+    """
+    # Late import: ``typed_cache`` imports the API client which imports
+    # tool code in a few places — top-level import would loop. The
+    # function-level import resolves the cycle cleanly.
+    from katana_mcp.typed_cache.sync import ENTITY_SPECS, merge_filtered_fetch
+
+    spec = ENTITY_SPECS.get(entity_type)
+    if spec is None:
+        return  # entity not cached — nothing to merge
+
+    parent = await cache_merge.refetch_for_merge(entity_id)
+    if parent is None:
+        return  # fetch returned nothing (e.g., the entity was deleted)
+
+    await merge_filtered_fetch(cache_merge.cache, spec, [parent])
+
+    # Fan out to related-spec refetches for entities whose children live
+    # at separate API endpoints (MO recipe rows; PO/SO sibling row-
+    # watermarks). Look up via the parent spec's ``related_specs`` —
+    # sibling row specs are NOT keyed in the top-level ``ENTITY_SPECS``
+    # registry (that one is for top-level entity types only). Each
+    # related refetcher is awaited independently — a failure on one
+    # doesn't block the others, and the parent merge above already
+    # succeeded.
+    related_by_key = {rs.entity_key: rs for rs in spec.related_specs}
+    for related_key, refetcher in cache_merge.refetch_related:
+        related_spec = related_by_key.get(related_key)
+        if related_spec is None:
+            logger.warning(
+                f"CacheMerge.refetch_related references {related_key!r} but "
+                f"it isn't in {entity_type!r}'s related_specs — skipping. "
+                f"Tool wiring is misconfigured."
+            )
+            continue
+        try:
+            related_rows = await refetcher(entity_id)
+        except asyncio.CancelledError:
+            # Propagate cancellation — see the outer handler's note.
+            raise
+        except Exception as exc:
+            logger.warning(
+                f"Refetch of related {related_key!r} for {entity_type} "
+                f"{entity_id} failed: {type(exc).__name__}: {exc}. "
+                f"Related cache table may be stale until next sync."
+            )
+            continue
+        if related_rows:
+            await merge_filtered_fetch(cache_merge.cache, related_spec, related_rows)
 
 
 async def run_delete_plan(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -26,6 +26,8 @@ from katana_mcp.tools._modification import (
 )
 from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
+    CacheMerge,
+    EntityNaming,
     has_any_subpayload,
     make_delete_apply,
     make_patch_apply,
@@ -705,6 +707,34 @@ async def _fetch_item_attrs(services: Any, item_id: int, item_type: ItemType) ->
     )
 
 
+async def _safe_fetch_item_attrs(
+    services: Any, item_id: int, item_type: ItemType
+) -> Any | None:
+    """Best-effort variant of ``_fetch_item_attrs``: returns None on any error.
+
+    Used as ``CacheMerge.refetch_for_merge`` so the dispatcher's
+    ``_post_apply_cache_merge`` can short-circuit on fetch failure via
+    its ``if parent is None: return`` guard — instead of unwinding
+    through the outer best-effort handler with a misleading
+    ``AuthenticationError`` / ``APIError`` traceback. Mirrors how
+    ``safe_fetch_for_diff`` shields the existing diff-context path.
+    """
+    try:
+        return await _fetch_item_attrs(services, item_id, item_type)
+    except asyncio.CancelledError:
+        # Cooperative cancellation must propagate, not get swallowed by
+        # the best-effort handler — see the dispatcher's outer handler
+        # for the same convention.
+        raise
+    except Exception as exc:
+        logger.info(
+            f"Post-apply refetch of {item_type.value} {item_id} for cache "
+            f"merge failed: {type(exc).__name__}: {exc} — cache row may be "
+            f"stale until next sync. Does not affect the API write."
+        )
+        return None
+
+
 async def _get_item_impl(
     request: GetItemRequest, context: Context
 ) -> ItemDetailsResponse:
@@ -1330,12 +1360,28 @@ async def _modify_item_impl(
 
     response = await run_modify_plan(
         request=request,
-        entity_type=request.type.value,
-        entity_label=f"{cfg['label']} {request.id}",
-        tool_name="modify_item",
+        naming=EntityNaming(
+            entity_type=request.type.value,
+            entity_label=f"{cfg['label']} {request.id}",
+            tool_name="modify_item",
+        ),
         web_url_kind=cfg["web_url_kind"],
         existing=existing_item,
         plan=plan,
+        # ``_fetch_item_attrs`` calls ``unwrap()`` directly and raises on
+        # any 4xx/5xx (unlike ``safe_fetch_for_diff`` used by other modify
+        # tools). Wrap in a try/except so the ``refetch_for_merge``
+        # contract — ``returns Any | None`` — holds: a refetch failure
+        # returns ``None`` and the dispatcher's ``_post_apply_cache_merge``
+        # short-circuits cleanly instead of unwinding through the outer
+        # best-effort handler with a misleading traceback. Same data shape
+        # as before — ``extend=[SUPPLIER]`` is preserved.
+        cache_merge=CacheMerge(
+            cache=services.typed_cache,
+            refetch_for_merge=lambda eid: _safe_fetch_item_attrs(
+                services, eid, request.type
+            ),
+        ),
     )
 
     if not request.preview:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -35,6 +35,8 @@ from katana_mcp.tools._modification import (
 )
 from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
+    CacheMerge,
+    EntityNaming,
     has_any_subpayload,
     make_delete_apply,
     make_patch_apply,
@@ -971,10 +973,26 @@ def _serial_number_info_from_attrs(sn: Any) -> SerialNumberInfo:
     )
 
 
-async def _fetch_mo_recipe_rows(
+async def _fetch_mo_recipe_row_attrs(
     services: Any, manufacturing_order_id: int
-) -> list[RecipeRowInfo]:
-    """Fetch every recipe row for the MO and enrich with cached SKU."""
+) -> list[Any]:
+    """Return raw attrs ``ManufacturingOrderRecipeRow`` list for an MO.
+
+    Thin wrapper used by ``modify_manufacturing_order``'s post-apply
+    cache merge: recipe rows live at the separate
+    ``/manufacturing_order_recipe_rows`` endpoint, NOT embedded in the
+    MO parent fetch, so the dispatcher's parent refetch alone can't
+    refresh them. Wired into ``CacheMerge.refetch_related`` so the merge
+    fans out and the next ``get_manufacturing_order_recipe`` /
+    ``list_blocking_ingredients`` read serves fresh data without a
+    manual ``rebuild_cache``.
+
+    Passes ``include_deleted=True`` so soft-deleted rows (tombstones)
+    come back in the response. Without it, a ``delete_recipe_row``
+    action would land at Katana but the cached row would persist as a
+    ghost until the next watermark sync — same trap the typed-cache
+    spec already documents on its row-watermark setup.
+    """
     from katana_public_api_client.api.manufacturing_order_recipe import (
         get_all_manufacturing_order_recipe_rows,
     )
@@ -984,8 +1002,16 @@ async def _fetch_mo_recipe_rows(
         client=services.client,
         manufacturing_order_id=manufacturing_order_id,
         limit=250,
+        include_deleted=True,
     )
-    raw_rows = unwrap_data(response, default=[])
+    return unwrap_data(response, default=[])
+
+
+async def _fetch_mo_recipe_rows(
+    services: Any, manufacturing_order_id: int
+) -> list[RecipeRowInfo]:
+    """Fetch every recipe row for the MO and enrich with cached SKU."""
+    raw_rows = await _fetch_mo_recipe_row_attrs(services, manufacturing_order_id)
 
     # One batched IN-clause SQLite read instead of one read per recipe row —
     # a full-bike Mayhem MO has ~30 rows, all looked up by variant_id.
@@ -3292,12 +3318,34 @@ async def _modify_manufacturing_order_impl(
 
     return await run_modify_plan(
         request=request,
-        entity_type="manufacturing_order",
-        entity_label=f"manufacturing order {request.id}",
-        tool_name="modify_manufacturing_order",
+        naming=EntityNaming(
+            entity_type="manufacturing_order",
+            entity_label=f"manufacturing order {request.id}",
+            tool_name="modify_manufacturing_order",
+        ),
         web_url_kind="manufacturing_order",
         existing=existing_mo,
         plan=plan,
+        cache_merge=CacheMerge(
+            cache=services.typed_cache,
+            refetch_for_merge=lambda eid: _fetch_manufacturing_order_attrs(
+                services, eid
+            ),
+            # Recipe rows live at the separate
+            # ``/manufacturing_order_recipe_rows`` endpoint (per
+            # ``MANUFACTURING_ORDER_SPEC.related_specs``), not embedded
+            # in the MO GET response. Without this fan-out, recipe-row
+            # modifications (add/update/delete) would land at Katana but
+            # leave ``CachedManufacturingOrderRecipeRow`` stale until
+            # the next sync — visible to ``get_manufacturing_order_recipe``
+            # and ``list_blocking_ingredients``.
+            refetch_related=(
+                (
+                    "manufacturing_order_recipe_row",
+                    lambda eid: _fetch_mo_recipe_row_attrs(services, eid),
+                ),
+            ),
+        ),
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -32,6 +32,8 @@ from katana_mcp.tools._modification import (
 )
 from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
+    CacheMerge,
+    EntityNaming,
     has_any_subpayload,
     make_delete_apply,
     make_patch_apply,
@@ -2351,6 +2353,36 @@ async def _fetch_purchase_order_row(
     )
 
 
+async def _fetch_po_row_attrs_for_merge(
+    services: Any, purchase_order_id: int
+) -> list[Any]:
+    """Return raw attrs ``PurchaseOrderRow`` list for the cache merge fan-out.
+
+    The PO parent fetch (PATCH or GET /purchase_orders/{id}) returns
+    rows embedded in ``purchase_order_rows`` — but Katana hides
+    soft-deleted rows from that nested view even with
+    ``include_deleted=true`` at the parent level (the flag only affects
+    top-level inclusion). The sibling endpoint ``/purchase_order_rows``
+    exposes ``include_deleted`` for its own scope, so the typed-cache
+    schema syncs rows independently to catch tombstones. Mirror that
+    here for post-apply merge: a ``delete_row_id`` action would
+    otherwise land at Katana but leave the cached row as a ghost until
+    the next watermark sync.
+    """
+    from katana_public_api_client.api.purchase_order_row import (
+        get_all_purchase_order_rows,
+    )
+    from katana_public_api_client.utils import unwrap_data
+
+    response = await get_all_purchase_order_rows.asyncio_detailed(
+        client=services.client,
+        purchase_order_id=purchase_order_id,
+        include_deleted=True,
+        limit=250,
+    )
+    return unwrap_data(response, default=[])
+
+
 async def _fetch_po_additional_cost_row(
     services: Any, row_id: int
 ) -> PurchaseOrderAdditionalCostRow | None:
@@ -2824,12 +2856,30 @@ async def _modify_purchase_order_impl(
 
     return await run_modify_plan(
         request=request,
-        entity_type="purchase_order",
-        entity_label=f"purchase order {request.id}",
-        tool_name="modify_purchase_order",
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label=f"purchase order {request.id}",
+            tool_name="modify_purchase_order",
+        ),
         web_url_kind="purchase_order",
         existing=existing_po,
         plan=plan,
+        cache_merge=CacheMerge(
+            cache=services.typed_cache,
+            refetch_for_merge=lambda eid: _fetch_purchase_order_attrs(services, eid),
+            # Soft-deleted rows are hidden from the parent fetch even
+            # when ``include_deleted=true`` is set on the PO endpoint
+            # (the flag only controls top-level inclusion). Fan out to
+            # the sibling ``/purchase_order_rows`` endpoint to capture
+            # tombstones — mirrors the typed-cache row-watermark
+            # rationale documented on ``_PURCHASE_ORDER_ROW_SPEC``.
+            refetch_related=(
+                (
+                    "purchase_order_row",
+                    lambda eid: _fetch_po_row_attrs_for_merge(services, eid),
+                ),
+            ),
+        ),
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -34,6 +34,8 @@ from katana_mcp.tools._modification import (
 )
 from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
+    CacheMerge,
+    EntityNaming,
     has_any_subpayload,
     make_delete_apply,
     make_patch_apply,
@@ -1605,6 +1607,34 @@ async def _fetch_so_row(services: Any, row_id: int) -> SalesOrderRow | None:
     )
 
 
+async def _fetch_so_row_attrs_for_merge(
+    services: Any, sales_order_id: int
+) -> list[Any]:
+    """Return raw attrs ``SalesOrderRow`` list for the cache merge fan-out.
+
+    Same rationale as the PO row fetcher: Katana hides soft-deleted SO
+    rows from the parent fetch even with ``include_deleted=true`` at
+    the parent level. The sibling ``/sales_order_rows`` endpoint
+    exposes ``include_deleted`` for its own scope, so the typed-cache
+    schema syncs rows independently to catch tombstones (see
+    ``_SALES_ORDER_ROW_SPEC`` in ``typed_cache/sync.py``). Wire this
+    into ``CacheMerge.refetch_related`` so ``modify_sales_order`` row
+    deletions write through to the cache immediately.
+    """
+    from katana_public_api_client.api.sales_order_row import (
+        get_all_sales_order_rows,
+    )
+    from katana_public_api_client.utils import unwrap_data
+
+    response = await get_all_sales_order_rows.asyncio_detailed(
+        client=services.client,
+        sales_order_ids=[sales_order_id],
+        include_deleted=True,
+        limit=250,
+    )
+    return unwrap_data(response, default=[])
+
+
 async def _fetch_so_fulfillment(
     services: Any, fulfillment_id: int
 ) -> SalesOrderFulfillment | None:
@@ -2297,12 +2327,29 @@ async def _modify_sales_order_impl(
 
     return await run_modify_plan(
         request=request,
-        entity_type="sales_order",
-        entity_label=f"sales order {request.id}",
-        tool_name="modify_sales_order",
+        naming=EntityNaming(
+            entity_type="sales_order",
+            entity_label=f"sales order {request.id}",
+            tool_name="modify_sales_order",
+        ),
         web_url_kind="sales_order",
         existing=existing_so,
         plan=plan,
+        cache_merge=CacheMerge(
+            cache=services.typed_cache,
+            refetch_for_merge=lambda eid: _fetch_sales_order_attrs(services, eid),
+            # Soft-deleted rows are hidden from the parent fetch even
+            # with ``include_deleted=true`` (parent-scope only). Fan
+            # out to the sibling ``/sales_order_rows`` endpoint with
+            # ``include_deleted=True`` to catch tombstones — mirrors
+            # ``_SALES_ORDER_ROW_SPEC``'s row-watermark rationale.
+            refetch_related=(
+                (
+                    "sales_order_row",
+                    lambda eid: _fetch_so_row_attrs_for_merge(services, eid),
+                ),
+            ),
+        ),
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -34,6 +34,7 @@ from katana_mcp.tools._modification import (
 )
 from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
+    EntityNaming,
     has_any_subpayload,
     make_patch_apply,
     run_delete_plan,
@@ -983,14 +984,19 @@ async def _modify_stock_transfer_impl(
 
     return await run_modify_plan(
         request=request,
-        entity_type="stock_transfer",
-        entity_label=f"stock transfer {request.id}",
-        tool_name="modify_stock_transfer",
+        naming=EntityNaming(
+            entity_type="stock_transfer",
+            entity_label=f"stock transfer {request.id}",
+            tool_name="modify_stock_transfer",
+        ),
         web_url_kind="stock_transfer",
         existing=None,
         plan=plan,
         # Katana exposes no GET /stock_transfers/{id}; ``existing=None`` is
         # the steady state, not a fetch failure — suppress the warning.
+        # The same lack of GET means we can't refetch for cache merge
+        # either — stock_transfers cache stays stale on modify until the
+        # next sync window.
         has_get_endpoint=False,
     )
 

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 from katana_mcp.tools._modification import (
     ActionResult,
+    ConfirmableRequest,
     FieldChange,
     ModificationResponse,
     compute_field_diff,
@@ -24,11 +26,14 @@ from katana_mcp.tools._modification import (
 )
 from katana_mcp.tools._modification_dispatch import (
     ActionSpec,
+    CacheMerge,
+    EntityNaming,
     execute_plan,
     plan_to_preview_results,
+    run_modify_plan,
     serialize_for_prior_state,
 )
-from pydantic import BaseModel
+from katana_mcp.typed_cache import TypedCacheEngine
 
 from katana_public_api_client.client_types import UNSET
 
@@ -38,13 +43,13 @@ class _SampleEnum(StrEnum):
     DONE = "DONE"
 
 
-class _SampleRequest(BaseModel):
-    id: int
+class _SampleRequest(ConfirmableRequest):
     name: str | None = None
     qty: int | None = None
     when: datetime | None = None
     state: _SampleEnum | None = None
-    preview: bool = True
+    # ``preview: bool`` is inherited from ConfirmableRequest with default
+    # ``True``; no need to re-declare here.
 
 
 def test_compute_field_diff_skips_id_and_preview_by_default():
@@ -556,3 +561,388 @@ def test_serialize_for_prior_state_falls_back_to_model_dump():
 def test_serialize_for_prior_state_returns_none_for_unsupported():
     assert serialize_for_prior_state(None) is None
     assert serialize_for_prior_state("a string") is None
+
+
+# ============================================================================
+# run_modify_plan — post-apply cache write-through (Bug #2)
+#
+# After execute_plan succeeds, if ``cache`` + ``refetch_for_merge`` are
+# provided, the dispatcher must re-fetch the parent and merge it via
+# ``merge_filtered_fetch`` so the typed cache stays in sync without a
+# rebuild_cache. Pre-2026-05-12 the cache went stale until next sync.
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_post_apply_merge_fires_on_success(monkeypatch):
+    """When cache + refetch_for_merge are wired and the plan succeeds,
+    the dispatcher refetches the parent and calls merge_filtered_fetch
+    with the matching EntitySpec.
+    """
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    captured: dict[str, object] = {}
+
+    async def fake_merge(cache, spec, attrs_objs):
+        captured["cache"] = cache
+        captured["spec_key"] = spec.entity_key
+        captured["attrs_objs"] = list(attrs_objs)
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    refetched_parent = object()
+
+    async def fake_apply():
+        return object()
+
+    async def fake_refetch(eid: int):
+        captured["refetched_id"] = eid
+        return refetched_parent
+
+    request = _SampleRequest(id=42, name="x", preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_header",
+            target_id=42,
+            diff=[FieldChange(field="status", old="DRAFT", new="DONE")],
+            apply=fake_apply,
+            verify=None,
+        )
+    ]
+
+    fake_cache = cast(TypedCacheEngine, object())
+    response = await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 42",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(cache=fake_cache, refetch_for_merge=fake_refetch),
+    )
+
+    assert response.is_preview is False
+    assert captured == {
+        "cache": fake_cache,
+        "spec_key": "purchase_order",
+        "attrs_objs": [refetched_parent],
+        "refetched_id": 42,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_no_merge_when_cache_or_refetch_missing(monkeypatch):
+    """The merge code path is gated on BOTH cache and refetch_for_merge
+    being non-None — either missing skips the merge silently. Lets tools
+    opt out without ceremony (e.g. stock_transfers, which lacks a GET).
+    """
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    call_count = {"merge": 0}
+
+    async def fake_merge(_cache, _spec, _objs):
+        call_count["merge"] += 1
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return None
+
+    plan = [ActionSpec(operation="add_row", target_id=1, apply=fake_apply, verify=None)]
+    request = _SampleRequest(id=1, name="x", preview=False)
+
+    # Neither wired (no cache_merge):
+    await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 1",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+    )
+
+    assert call_count["merge"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_no_merge_when_action_failed(monkeypatch):
+    """Cache merge must not fire if any action in the plan failed —
+    the partial post-state would corrupt the cache.
+    """
+    call_count = {"merge": 0}
+
+    async def fake_merge(_cache, _spec, _objs):
+        call_count["merge"] += 1
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def bad_apply():
+        raise ValueError("apply failed")
+
+    async def fake_refetch(_eid: int):
+        return object()
+
+    plan = [ActionSpec(operation="add_row", target_id=1, apply=bad_apply, verify=None)]
+    request = _SampleRequest(id=1, name="x", preview=False)
+
+    await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 1",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(
+            cache=cast(TypedCacheEngine, object()),
+            refetch_for_merge=fake_refetch,
+        ),
+    )
+
+    assert call_count["merge"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_merge_skips_silently_for_uncached_entity(
+    monkeypatch,
+):
+    """If entity_type isn't in ENTITY_SPECS (e.g. a custom non-cached
+    entity), the merge step skips without raising. Tool's API write is
+    still authoritative.
+    """
+    call_count = {"merge": 0}
+
+    async def fake_merge(_cache, _spec, _objs):
+        call_count["merge"] += 1
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return None
+
+    async def fake_refetch(_eid: int):
+        return object()
+
+    plan = [ActionSpec(operation="add_row", target_id=1, apply=fake_apply, verify=None)]
+    request = _SampleRequest(id=1, name="x", preview=False)
+
+    response = await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="not_a_real_entity",
+            entity_label="bogus 1",
+            tool_name="modify_bogus",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(
+            cache=cast(TypedCacheEngine, object()),
+            refetch_for_merge=fake_refetch,
+        ),
+    )
+
+    assert call_count["merge"] == 0
+    assert response.is_preview is False  # the modify response itself still succeeds
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_merge_failure_does_not_break_response(monkeypatch):
+    """If the post-apply merge raises (e.g. cache lock contention,
+    transient DB error), the dispatcher logs and returns the successful
+    modify response — the API write already landed, the only loss is
+    cache freshness.
+    """
+
+    async def boom_merge(_cache, _spec, _objs):
+        raise RuntimeError("cache I/O failed")
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", boom_merge)
+
+    async def fake_apply():
+        return None
+
+    async def fake_refetch(_eid: int):
+        return object()
+
+    plan = [ActionSpec(operation="add_row", target_id=1, apply=fake_apply, verify=None)]
+    request = _SampleRequest(id=1, name="x", preview=False)
+
+    response = await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 1",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(
+            cache=cast(TypedCacheEngine, object()),
+            refetch_for_merge=fake_refetch,
+        ),
+    )
+
+    # Modify response still reports success — merge is best-effort.
+    assert response.is_preview is False
+    assert response.actions[0].succeeded is True
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_preview_does_not_merge(monkeypatch):
+    """``preview=True`` must short-circuit before the cache merge — the
+    cache should never observe a planned-but-not-applied change.
+    Structural guarantee via the early return at the preview gate;
+    pinned here so a future refactor can't move the merge above it.
+    """
+    call_count = {"merge": 0, "refetch": 0}
+
+    async def fake_merge(_cache, _spec, _objs):
+        call_count["merge"] += 1
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return None
+
+    async def fake_refetch(_eid: int):
+        call_count["refetch"] += 1
+        return object()
+
+    plan = [ActionSpec(operation="add_row", target_id=1, apply=fake_apply, verify=None)]
+    request = _SampleRequest(id=1, name="x", preview=True)
+
+    response = await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 1",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(
+            cache=cast(TypedCacheEngine, object()),
+            refetch_for_merge=fake_refetch,
+        ),
+    )
+
+    assert response.is_preview is True
+    assert call_count == {"merge": 0, "refetch": 0}
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_refetch_related_fans_out_to_related_specs(monkeypatch):
+    """When a tool wires ``refetch_related``, the dispatcher refetches and
+    merges each related spec's rows after the parent merge. Closes the
+    MO recipe-row gap: ``MANUFACTURING_ORDER_SPEC.related_specs`` points
+    at ``manufacturing_order_recipe_row`` (separate endpoint, not
+    embedded in the MO parent fetch).
+    """
+    merges: list[str] = []
+
+    async def fake_merge(_cache, spec, attrs_objs):
+        merges.append(f"{spec.entity_key}:{len(list(attrs_objs))}")
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return None
+
+    async def fake_refetch_parent(_eid: int):
+        return object()  # parent attrs (content irrelevant for this test)
+
+    async def fake_refetch_recipe_rows(_eid: int):
+        return [object(), object()]  # two recipe rows
+
+    plan = [ActionSpec(operation="add_row", target_id=1, apply=fake_apply, verify=None)]
+    request = _SampleRequest(id=1, name="x", preview=False)
+
+    await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="manufacturing_order",
+            entity_label="manufacturing order 1",
+            tool_name="modify_manufacturing_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(
+            cache=cast(TypedCacheEngine, object()),
+            refetch_for_merge=fake_refetch_parent,
+            refetch_related=(
+                ("manufacturing_order_recipe_row", fake_refetch_recipe_rows),
+            ),
+        ),
+    )
+
+    # Parent merged first, then related rows. Two recipe rows on the
+    # related-spec merge call.
+    assert merges == ["manufacturing_order:1", "manufacturing_order_recipe_row:2"]
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_refetch_related_error_does_not_break(monkeypatch):
+    """A failure inside one ``refetch_related`` refetcher logs and is
+    skipped — it shouldn't roll back the parent merge or the modify
+    response.
+    """
+    merges: list[str] = []
+
+    async def fake_merge(_cache, spec, _objs):
+        merges.append(spec.entity_key)
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return None
+
+    async def fake_refetch_parent(_eid: int):
+        return object()
+
+    async def bad_refetch_related(_eid: int):
+        raise RuntimeError("recipe-row fetch failed")
+
+    plan = [ActionSpec(operation="add_row", target_id=1, apply=fake_apply, verify=None)]
+    request = _SampleRequest(id=1, name="x", preview=False)
+
+    response = await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="manufacturing_order",
+            entity_label="manufacturing order 1",
+            tool_name="modify_manufacturing_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(
+            cache=cast(TypedCacheEngine, object()),
+            refetch_for_merge=fake_refetch_parent,
+            refetch_related=(("manufacturing_order_recipe_row", bad_refetch_related),),
+        ),
+    )
+
+    # Parent merge still fired; related merge skipped but no exception
+    # bubbled up. Modify response itself still succeeds.
+    assert merges == ["manufacturing_order"]
+    assert response.is_preview is False

--- a/uv.lock
+++ b/uv.lock
@@ -1278,7 +1278,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.70.0"
+version = "0.71.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Closes Bug #2 from the 2026-05-12 SRAM PO-reconciliation session: every `modify_*` tool succeeded against Katana but left the typed cache stale because nothing wrote the post-state through. The next `@cache_read` tool (e.g. `get_variant_details`, `list_purchase_orders`) served pre-modification rows until either a manual `rebuild_cache` ran or the watermark sync window crossed the modified entity. The user got a stale `updated_at: 2025-03-06` `supplier_item_codes` back from `get_variant_details` minutes after a successful `modify_item` reported `APPLIED (verified)`.

## The fix

Add `CacheMerge(cache, refetch_for_merge)` to the dispatcher signature. When wired, `run_modify_plan` re-fetches the parent entity after the plan succeeds and merges it into the typed cache via the existing `merge_filtered_fetch` (``typed_cache/sync.py:536``). That single refetch:

- Writes the post-state through to the cache so the next `@cache_read` serves fresh data
- Naturally captures Katana's server-side cascades (e.g. PO header `expected_arrival_date` → row `arrival_date`s) — the cache mirrors what Katana actually has
- Doesn't advance the sync watermark, so unrelated rows still get a full delta on the next `ensure_*_synced` cycle

### Tools wired

- `modify_purchase_order` → `_fetch_purchase_order_attrs`
- `modify_sales_order` → `_fetch_sales_order_attrs`
- `modify_manufacturing_order` → `_fetch_manufacturing_order_attrs`
- `modify_item` → `_fetch_item_attrs` (already pulls with `extend=[SUPPLIER]` for products/materials so the variant postprocess hook receives the rich attrs it needs)

### Not wired

- `modify_stock_transfer` — Katana exposes no GET /stock_transfers/{id}, so there's nothing to refetch. Cache stays stale until the next sync window. Same constraint that already drives `has_get_endpoint=False`.

## Best-effort merge

A refetch failure or cache-engine error logs a warning but doesn't change the modify tool's response — the API write already landed; cache staleness is recoverable on the next sync.

## Other change in this PR

Bundled `entity_type` / `entity_label` / `tool_name` into a new `EntityNaming` dataclass to keep `run_modify_plan` under the 8-argument PLR0913 budget without raising the linter cap. Same three strings, just grouped where they were already moving together.

## Test plan

- [x] `uv run poe agent-check` passes
- [x] `uv run poe test` passes (3091 tests, 2 skipped)
- [x] New dispatcher tests cover: merge fires on success, no-merge when missing config, no-merge when any action failed, silent skip for uncached entity types, merge failure doesn't break response
- [ ] Live Katana session: apply `modify_item` → immediately call `get_variant_details` → confirm fresh data (no `rebuild_cache` needed)
- [ ] Live Katana session: update PO header `expected_arrival_date` → confirm cascaded row dates visible in next `get_purchase_order`

## Deferred to a follow-up (Bug #3)

The original plan paired this with **eliminating the per-row prefetch in `plan_updates`** and **parallel apply within operation groups**. Both are substantial enough that they want their own review surface — kept this PR focused on the cache write-through (the user-visible "stale data after modify" failure). Bug #3 will land next.

Stacks on top of #687 (datetime TZ normalization), which fixes the *trigger* for the same SRAM session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)