### PR TITLE
feat(harness): /groom skill — observed drift, not re-derivation (#683)

### DIFF
--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: groom
+description: >-
+  Groom the Rolling Backlog (project #5) by reading current state and proposing
+  diffs — not re-deriving the queue from scratch. Surfaces drift between issue
+  state and project status, missing classification, and stale priorities. Asks
+  per-category confirmation before mutating the board.
+argument-hint: "[--dry-run]"
+allowed-tools:
+  - Bash(gh project *)
+  - Bash(gh issue *)
+  - Bash(python3 *)
+---
+
+# /groom — Backlog hygiene against the Rolling Backlog
+
+## PURPOSE
+
+Mutate the [Rolling Backlog](https://github.com/users/dougborg/projects/5)
+(project #5) based on observed drift, not re-classify the world. A clean
+groom run says "X items drifted, Y need triage, Z went stale — confirm each
+category" and then applies the corresponding `gh project item-edit` /
+`gh issue close` mutations. **Default behavior is read-only**: it always
+prints what it would do and asks for per-category confirmation before any
+mutation happens.
+
+This is the long-term version of #568's §4: the board IS the priority
+queue, and grooming evolves it forward. Do **not** re-derive priorities
+from `gh issue list` — that produces a one-off transcript snapshot that
+goes stale immediately. The board is durable; mutate it in place.
+
+## CRITICAL
+
+- **Default to read-only** — print proposals first, never auto-apply.
+- **Per-category confirmation** — use `AskUserQuestion` to confirm each
+  category of changes independently (the user may want to apply the
+  triage queue but skip the stale-P3 closures).
+- **Never close an issue without confirming** — closures are destructive
+  and require an explicit per-issue acknowledgement, not blanket approval
+  for the category.
+- **Surface, don't decide** — the heuristics flag *candidates*, not
+  certainties. A 90-day-stale P3 might still be relevant; let the user
+  judge.
+- **Don't grow the heuristics arbitrarily** — keep the rule set tight.
+  Each new heuristic must have a concrete observed drift it solves; soft
+  signals belong in a richer `/triage` skill (#684), not here.
+
+## ASSUMES
+
+- You have GitHub CLI (`gh`) installed and authenticated.
+- Project #5 exists, owned by `@me`, with the field schema documented in
+  `CLAUDE.md` "Project Backlog" (Priority / Effort / Workstream /
+  Umbrella).
+- Python 3.12+ on PATH (the analyzer uses stdlib only).
+
+## STANDARD PATH
+
+### Phase 1 — Analyze the board
+
+Run the analyzer:
+
+```bash
+python3 .claude/skills/groom/analyze.py | tee /tmp/groom-proposals.json
+```
+
+It fetches `gh project item-list 5 --owner @me --format json` and the
+state of every linked issue, then groups items into five categories:
+
+| Category | What it flags |
+| --- | --- |
+| `needs_triage` | Project item has no Priority or no Workstream. |
+| `drift_done_open` | Status=Done but linked issue is still OPEN. |
+| `drift_closed_not_done` | Linked issue is CLOSED but Status≠Done. |
+| `stale_p3` | P3-someday whose project-item `updatedAt` > 90 days ago. |
+| `idle_p0_p1` | P0/P1 in Todo/In Progress, `updatedAt` > 21 days, no open PR. |
+
+Each category prints a list of `{number, title, status, priority,
+workstream, ago_days}` records. If a category is empty, skip it — no
+confirmation prompt needed.
+
+### Phase 2 — Present the diff
+
+Format a compact summary for the user. Don't print the raw JSON; render
+it as a table per category. Example:
+
+```
+Groom proposals (analyzed 128 items):
+
+needs_triage (3):
+  #719 [Todo, P(unset)/W(unset)]  feat(mcp): expose ...
+  #720 [Todo, P(unset)/W(unset)]  bug(client): ...
+  #721 [Todo, P(unset)/W(unset)]  docs: ...
+
+drift_done_open (2):
+  #659 [Done, P0/Spec-drift, 5d ago]  Bug umbrella for 0.66 — partially fixed
+  #560 [Done, P1/Process, 7d ago]    docs(mcp): help resource sync
+
+drift_closed_not_done (0): clean
+
+stale_p3 (5):
+  #53  [Todo, P3/Process, 180d ago]  MCP-22: usage examples for Claude Code
+  ...
+
+idle_p0_p1 (0): clean
+```
+
+When a category is empty, the corresponding section reads "clean". A
+**fully-green** groom run (all categories clean) prints "Board is clean
+— no proposals." and exits.
+
+### Phase 3 — Confirm per category
+
+For each non-empty category, ask the user separately via
+`AskUserQuestion`. Don't bundle: someone might want to apply the
+`needs_triage` queue but not the `stale_p3` closures.
+
+Question template:
+
+> "Apply the **{category}** proposals?"
+>
+> - **Apply all** — apply the mutation for every item in this category.
+> - **Apply selected** — let the user list specific issue numbers to
+>   apply (the rest are skipped this run).
+> - **Skip** — leave this category alone.
+
+For **destructive** categories (anything that closes an issue —
+currently just `stale_p3` if the user wants to close-not-downgrade),
+add a per-item second confirmation before each close. **Never bulk-close
+without one prompt per issue.** Non-destructive mutations (status moves,
+adding Priority/Workstream) can go through the category-level apply.
+
+### Phase 4 — Apply mutations
+
+For each accepted change:
+
+**`needs_triage`** → delegate to `/triage` (#684) for interactive
+classification. Until #684 exists, present the items and ask the user
+for Priority + Workstream per item, then:
+
+```bash
+# Look up the project-item ID for the issue.
+item_id="$(gh project item-list 5 --owner @me --format json \
+  | jq -r --arg n "$issue_number" '.items[] | select(.content.number==($n|tonumber)) | .id')"
+# Set Priority.
+gh project item-edit --id "$item_id" \
+  --field-id "$PRIORITY_FIELD_ID" \
+  --project-id "PVT_kwHOABM-ps4BW02d" \
+  --single-select-option-id "$priority_option_id"
+# Set Workstream.
+gh project item-edit --id "$item_id" \
+  --field-id "$WORKSTREAM_FIELD_ID" \
+  --project-id "PVT_kwHOABM-ps4BW02d" \
+  --single-select-option-id "$workstream_option_id"
+```
+
+Field and option IDs are stable; look them up once via
+`gh project field-list 5 --owner @me --format json` and cache for the
+run.
+
+**`drift_done_open`** → ask the user per-item: close the issue (because
+the PR landed and we forgot the closing keyword) or move the item back
+to "In Progress" / "Todo" (because the Done was applied prematurely).
+Apply accordingly via `gh issue close <n>` or
+`gh project item-edit ... --field-id <Status> --single-select-option-id
+<In Progress|Todo>`.
+
+**`drift_closed_not_done`** → straightforward: move the item to Done.
+
+```bash
+gh project item-edit --id "$item_id" \
+  --field-id "$STATUS_FIELD_ID" \
+  --project-id "PVT_kwHOABM-ps4BW02d" \
+  --single-select-option-id "$DONE_OPTION_ID"
+```
+
+**`stale_p3`** → per-item: close the issue (most common — P3 stale = no
+forcing function), downgrade to "archive" (no such status today, so this
+collapses to close), or keep (mark via a brief comment "kept on
+{date}").
+
+**`idle_p0_p1`** → per-item: downgrade Priority (most common — the work
+isn't actually P1 if it's been sitting 3 weeks with no PR), or move
+Status to "Todo" if it was wedged in "In Progress".
+
+### Phase 5 — Summary
+
+After all confirmed mutations have applied, print a summary:
+
+- Items touched per category (counts + numbers)
+- Field IDs of mutations applied
+- Any items that errored on the apply path (and why)
+
+If the user wants a record for the session retro, suggest saving the
+proposal JSON (`/tmp/groom-proposals.json`) alongside the summary.
+
+## EDGE CASES
+
+- **The board is clean (all categories empty)** — Print
+  "Board is clean — no proposals." and exit. This is the win state; a
+  daily/weekly `/groom` finding nothing means the integration is
+  working.
+
+- **Many proposals (>30 across categories)** — Don't paginate
+  interactively; render the full list, then ask the user to opt in
+  per-category. If a single category has >20 items, suggest the user
+  apply "selected" with a narrower issue-number list rather than "all".
+
+- **`gh project item-edit` rate-limited** — pause and retry; the project
+  endpoints aren't rate-limited as aggressively as the issue endpoints,
+  but bulk runs may still hit secondary limits. Fall back to sequential
+  applies with `sleep 1` between items if a 403 surfaces.
+
+- **The skill is run in a worktree** — pre-commit hooks may be missing.
+  The skill itself doesn't commit; it mutates GitHub state. Worktree
+  context doesn't affect correctness.
+
+## CONFIGURATION
+
+The analyzer's thresholds live as module-level constants in
+`.claude/skills/groom/analyze.py`:
+
+- `STALE_P3_DAYS = 90` — Trip threshold for `stale_p3`.
+- `IDLE_P0_P1_DAYS = 21` — Trip threshold for `idle_p0_p1`.
+
+Tune by editing the file. New heuristics get added as new categories in
+`classify_items()` and surfaced in the SKILL.md table above.
+
+## RELATED
+
+- `/open-pr` — surfaces linked-issue board status when opening a PR.
+- `/triage` (#684, planned) — interactive Priority/Workstream prompts
+  for un-classified items. Until that exists, `/groom` walks the
+  `needs_triage` category inline.
+- CLAUDE.md "Project Backlog" — the field schema, Priority bucket
+  definitions, and Workstream definitions that `/groom` reasons about.
+- #568 — parent umbrella for board-integration work.
+- #683 — issue tracking this skill's full delivery (you are here).

--- a/.claude/skills/groom/analyze.py
+++ b/.claude/skills/groom/analyze.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Read project-board state + issue states, emit structured groom proposals.
+
+Output is a JSON object grouped by category — the `/groom` skill reads it,
+presents to the user, and asks for category-level opt-in before applying.
+
+Phase 1 heuristics (#683):
+
+- **needs_triage** — item has no Priority or no Workstream set
+- **drift_done_open** — Status=Done but linked issue is OPEN; either close
+  the issue or move the item back to Todo/In Progress
+- **drift_closed_not_done** — linked issue is CLOSED but Status≠Done; move
+  the item to Done
+- **stale_p3** — P3-someday items whose project-item ``updatedAt`` > 90
+  days ago; candidate for review or closure
+- **idle_p0_p1** — P0-now or P1-this-week items in Todo or In Progress
+  whose ``updatedAt`` > 21 days ago; candidate for re-prioritization or
+  closure
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from datetime import UTC, datetime
+from typing import Any
+
+PROJECT_NUMBER = "5"
+OWNER = "@me"
+PROJECT_TITLE = "Katana MCP — Rolling Backlog"
+
+STALE_P3_DAYS = 90
+IDLE_P0_P1_DAYS = 21
+
+
+def run_gh(args: list[str]) -> str:
+    proc = subprocess.run(["gh", *args], check=True, capture_output=True, text=True)
+    return proc.stdout
+
+
+def fetch_project_items() -> list[dict[str, Any]]:
+    """Return the full project-item list with all fields populated."""
+    raw = run_gh(
+        [
+            "project",
+            "item-list",
+            PROJECT_NUMBER,
+            "--owner",
+            OWNER,
+            "--limit",
+            "300",
+            "--format",
+            "json",
+        ]
+    )
+    data = json.loads(raw)
+    return data.get("items", [])
+
+
+def fetch_issue_states(issue_numbers: set[int]) -> dict[int, dict[str, Any]]:
+    """Batch-fetch ``state`` (+ has-open-PR signal) for each issue number.
+
+    Returns ``{number: {state: "open"|"closed", has_open_pr: bool,
+    updated_at: ISO8601}}``. Skips fetches for numbers in
+    ``issue_numbers`` that aren't actually issues (e.g., PR numbers) —
+    ``gh issue view`` errors on those and we just omit them.
+    """
+    out: dict[int, dict[str, Any]] = {}
+    for num in sorted(issue_numbers):
+        try:
+            raw = run_gh(
+                [
+                    "issue",
+                    "view",
+                    str(num),
+                    "--json",
+                    "state,updatedAt,closedByPullRequestsReferences",
+                ]
+            )
+            data = json.loads(raw)
+            prs = data.get("closedByPullRequestsReferences") or []
+            has_open_pr = any(pr.get("state") == "OPEN" for pr in prs)
+            out[num] = {
+                "state": (data.get("state") or "").lower(),
+                "updated_at": data.get("updatedAt"),
+                "has_open_pr": has_open_pr,
+            }
+        except subprocess.CalledProcessError:
+            # Not an issue (PR or invalid number) — skip silently.
+            continue
+    return out
+
+
+def parse_issue_number(url: str | None) -> int | None:
+    if not url:
+        return None
+    match = re.search(r"/issues/(\d+)$", url)
+    return int(match.group(1)) if match else None
+
+
+def parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def days_since(value: str | None, *, now: datetime) -> int | None:
+    parsed = parse_iso(value)
+    if parsed is None:
+        return None
+    return (now - parsed).days
+
+
+def classify_items(
+    items: list[dict[str, Any]],
+    issue_states: dict[int, dict[str, Any]],
+    now: datetime,
+) -> dict[str, list[dict[str, Any]]]:
+    """Apply all heuristics to the project items; return grouped proposals."""
+    out: dict[str, list[dict[str, Any]]] = {
+        "needs_triage": [],
+        "drift_done_open": [],
+        "drift_closed_not_done": [],
+        "stale_p3": [],
+        "idle_p0_p1": [],
+    }
+
+    for item in items:
+        content = item.get("content") or {}
+        number = content.get("number")
+        title = content.get("title") or item.get("title") or ""
+        url = content.get("url")
+        item_id = item.get("id")
+        status = (item.get("status") or "").strip()
+        priority = (item.get("priority") or "").strip()
+        workstream = (item.get("workstream") or "").strip()
+        updated_at = item.get("updatedAt") or content.get("updatedAt")
+        ago_days = days_since(updated_at, now=now)
+
+        # Skip draft items (no linked issue/PR). They don't have a state to
+        # cross-reference and shouldn't normally exist on this board.
+        if number is None or url is None:
+            continue
+
+        # Only operate on issues — PRs land on the board but their lifecycle
+        # is handled by the "Pull request merged" workflow and they shouldn't
+        # surface in groom proposals.
+        issue_no = parse_issue_number(url)
+        if issue_no is None:
+            continue
+
+        base = {
+            "number": issue_no,
+            "title": title,
+            "url": url,
+            "item_id": item_id,
+            "status": status or "(unset)",
+            "priority": priority or "(unset)",
+            "workstream": workstream or "(unset)",
+            "updated_at": updated_at,
+            "ago_days": ago_days,
+        }
+
+        # Heuristic 1: needs triage
+        if not priority or not workstream:
+            out["needs_triage"].append(base)
+
+        # Cross-reference heuristics need the linked issue's state.
+        issue_info = issue_states.get(issue_no)
+        issue_state = (issue_info or {}).get("state")
+
+        # Heuristic 2: Done but issue open
+        if status.lower() == "done" and issue_state == "open":
+            out["drift_done_open"].append(base)
+
+        # Heuristic 3: issue closed but project status != Done
+        if issue_state == "closed" and status.lower() != "done":
+            out["drift_closed_not_done"].append(base)
+
+        # Heuristic 4: stale P3
+        if (
+            priority.lower().startswith("p3")
+            and ago_days is not None
+            and ago_days > STALE_P3_DAYS
+        ):
+            out["stale_p3"].append(base)
+
+        # Heuristic 5: idle P0/P1
+        is_active = priority.lower().startswith(("p0", "p1"))
+        is_open_status = status.lower() in ("todo", "in progress")
+        has_open_pr = (issue_info or {}).get("has_open_pr", False)
+        if (
+            is_active
+            and is_open_status
+            and ago_days is not None
+            and ago_days > IDLE_P0_P1_DAYS
+            and not has_open_pr
+        ):
+            out["idle_p0_p1"].append(base)
+
+    return out
+
+
+def main() -> int:
+    now = datetime.now(tz=UTC)
+    items = fetch_project_items()
+    issue_numbers: set[int] = set()
+    for item in items:
+        content = item.get("content") or {}
+        issue_no = parse_issue_number(content.get("url"))
+        if issue_no is not None:
+            issue_numbers.add(issue_no)
+
+    issue_states = fetch_issue_states(issue_numbers)
+    proposals = classify_items(items, issue_states, now)
+
+    summary = {category: len(rows) for category, rows in proposals.items()}
+    output = {
+        "project_number": PROJECT_NUMBER,
+        "project_title": PROJECT_TITLE,
+        "analyzed_at": now.isoformat(),
+        "summary": summary,
+        "total_items": len(items),
+        "proposals": proposals,
+    }
+    json.dump(output, sys.stdout, indent=2)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,15 @@ gh project item-add 5 --owner @me --url <issue-or-pr-url>
 The field IDs / option IDs are stable;
 `gh project field-list 5 --owner @me --format json` prints them.
 
+### Grooming the board
+
+Use **`/groom`** to surface drift between issues and project state — closed issues still
+in Todo, items in Done with open issues, P3 items stale for >90 days, P0/P1 sitting idle
+\>21 days, items missing Priority or Workstream. The skill reads the board, classifies
+items across five heuristic categories, and asks for per-category confirmation before
+applying any mutation. Don't re-derive the priority queue from `gh issue list` —
+`/groom` evolves the board forward.
+
 ## Continuous Improvement
 
 This file is meant to evolve. Update it when you learn something that would help future


### PR DESCRIPTION
## Summary

- Adds `/groom` — a project-local skill that reads the Rolling Backlog (project #5) + linked-issue state, applies five heuristics, and asks per-category confirmation before mutating the board.
- Adds `.claude/skills/groom/analyze.py` (stdlib-only) that does the fetch + classify and prints structured JSON proposals; the skill's SKILL.md tells the agent how to render, confirm, and apply.
- Adds a "Grooming the board" subsection to `CLAUDE.md` "Project Backlog" pointing at the skill and reiterating the no-re-derivation convention.

## Heuristics

| Category | Trips when |
| --- | --- |
| `needs_triage` | Project item has no Priority or no Workstream. |
| `drift_done_open` | Status=Done but linked issue is still OPEN. |
| `drift_closed_not_done` | Linked issue is CLOSED but Status≠Done. |
| `stale_p3` | P3-someday items, project-item `updatedAt` > 90 days ago. |
| `idle_p0_p1` | P0/P1 in Todo/In Progress, `updatedAt` > 21 days, no open PR. |

Destructive mutations (closures) require **per-issue** confirmation, not just per-category — bulk-close without per-item acknowledgement is forbidden by the skill.

## Why

#568's §4 calls out that today's grooming produces a one-off prioritized list in conversation transcripts — it drifts the moment the session ends. The board (project #5) is the durable form; `/groom` evolves it forward via observed drift, not fresh re-classification.

Closes #683 (Phase 1). Phase 2 (cross-session diff view + persisted last-groom timestamp) and Phase 3 (richer interactive `/triage` integration) stay open as follow-ups on #683 and #684.

## Verification

Running `python3 .claude/skills/groom/analyze.py` against the current project state:

```
total_items: 128
needs_triage: 0
drift_done_open: 0
drift_closed_not_done: 0
stale_p3: 0
idle_p0_p1: 0
```

Board is clean post-this-session's triage — that's the win state. A future session that lets items drift will see the heuristics fire.

## Test plan

- [x] `uv run poe agent-check` — clean
- [x] `python3 .claude/skills/groom/analyze.py` produces well-formed JSON; categories empty on the current clean board
- [ ] Next session: invoke `/groom` cold; confirm the skill discovers the (hopefully still clean) state, and that the agent renders categories correctly per the SKILL.md instructions

Refs #683 #568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)