### PR TITLE
chore(harness): require rebased-on-target-branch in /open-pr and /review-pr

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -28,6 +28,7 @@ Take a feature branch from "implementation done" to "PR open, CI green, review a
 
 ## CRITICAL
 
+- **Rebase on the target branch before opening — no exceptions** — `git fetch origin <base>` then check `git log HEAD..origin/<base>` first. If anything appears, the branch is stale; rebase before doing anything else. Opening a PR from a stale tip means: (a) CI runs against an old base — green checks here don't prove the code works on `main`'s actual current state; (b) reviewers see merge artifacts that aren't yours; (c) `uv.lock` drift from sibling-package releases shows up mid-pre-commit; (d) GitHub auto-merge gets stuck on `mergeStateStatus=BEHIND` and can't fire. Use `git rebase origin/<base>` directly, or invoke `harness-kit:rebase` if you have the harness-kit plugin installed (it handles conflicts + lockfile bundling more cleanly). Same check applies before every `--force-with-lease` push during the cycle.
 - **Validate before opening** — `uv run poe check` must pass; never use `--no-verify`, `noqa`, or `type: ignore`.
 - **Self-review the full diff** — review every change before opening, not just the latest commit.
 - **Stage specific files** — never `git add -A` or `git add .`.
@@ -41,14 +42,13 @@ Take a feature branch from "implementation done" to "PR open, CI green, review a
 
 ## STANDARD PATH
 
-1. **If the branch is behind the chosen base branch (default `main`), run `/rebase` first** — opening a PR from a stale tip means CI runs against the old base, conflict resolution happens mid-review, and `uv.lock` drift from sibling-package releases isn't caught until pre-commit fights with you. `/rebase` handles the conflict resolution + lockfile-bundling protocol cleanly. Resolve the base from `$ARGUMENTS` (default `main`), then check freshness with `git fetch origin <base> && git log --oneline HEAD..origin/<base> | head -1` — if anything appears, rebase first. The `git fetch` is required: `origin/<base>` is a remote-tracking ref that may be stale without it, which would silently let a "behind" branch through.
-2. **Pre-flight** — confirm not on `main`, run `uv run poe check`, check for existing PR (Phase 1).
-3. **Self-review** — read the full diff vs base; fix issues found (Phase 2).
-4. **Organize commits** — group into logical commits with conventional format (Phase 3).
-5. **Push and create** — `git push -u origin HEAD:refs/heads/<branch>`, `gh pr create` with HEREDOC body (Phase 4).
-6. **Wait for CI** — `gh pr checks --watch`; fix failures in-place (Phase 5).
-7. **Wait for review** — poll for ≤15 min; if comments arrive, delegate to `/review-pr` (Phases 6–7).
-8. **Summary** — print PR URL, commit count, CI status, review state (Phase 8).
+1. **Pre-flight** — confirm not on `main`, **rebase on latest target branch** (mandatory; see CRITICAL), run `uv run poe check`, check for existing PR (Phase 1).
+2. **Self-review** — read the full diff vs base; fix issues found (Phase 2).
+3. **Organize commits** — group into logical commits with conventional format (Phase 3).
+4. **Push and create** — `git push -u origin HEAD:refs/heads/<branch>`, `gh pr create` with HEREDOC body (Phase 4).
+5. **Wait for CI** — `gh pr checks --watch`; fix failures in-place (Phase 5).
+6. **Wait for review** — poll for ≤15 min; if comments arrive, delegate to `/review-pr` (Phases 6–7).
+7. **Summary** — print PR URL, commit count, CI status, review state (Phase 8).
 
 See phase detail below.
 
@@ -70,6 +70,29 @@ See phase detail below.
 
 1. **Determine base branch** — use `$ARGUMENTS` if provided and non-empty, otherwise
    default to `main`.
+
+1. **Rebase on latest target branch** — fetch the base and check freshness:
+
+   ```bash
+   git fetch origin <base>
+   git log HEAD..origin/<base> --oneline
+   ```
+
+   If any commits appear, the branch is behind — rebase before doing anything else:
+
+   ```bash
+   git rebase origin/<base>
+   # If uv.lock or other artifacts drifted post-rebase, stage them and
+   # bundle into the existing commit (or amend if it makes sense).
+   ```
+
+   The `harness-kit:rebase` skill (if installed) wraps this with conflict
+   resolution and uv.lock bundling; use it when available, otherwise the
+   plain `git rebase` above is the canonical command.
+
+   This step is **mandatory**, not optional. Skipping it produces every failure mode
+   listed in CRITICAL above. The fetch is required — `origin/<base>` is a
+   remote-tracking ref that may be stale without it.
 
 1. **Run validation**:
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -32,6 +32,7 @@ Address every unresolved PR review comment: fix code, validate, commit, push, re
 
 ## CRITICAL
 
+- **Rebase on the target branch before fixing — no exceptions** — if the PR shows `mergeStateStatus=BEHIND` or `git log HEAD..origin/<base>` shows anything, the branch is stale. Rebase before reading comments or making code changes. Reasons: (a) some comments may already be obsolete after the base advanced and you'd waste time addressing them; (b) fixes pushed onto a stale branch trigger a new CI run against the still-stale base; (c) auto-merge stays blocked on BEHIND status even when CI is green and all threads are resolved. Same check applies before every `--force-with-lease` after a fixup. See Phase 1b.
 - **Fix first, reply after push** — replies confirm the fix is live; never reply on stale code.
 - **Reply to every unresolved comment** — none left without a response.
 - **No shortcuts** — never `--no-verify`, `noqa`, `type: ignore`, or `@pytest.mark.skip` to make validation pass.
@@ -79,29 +80,67 @@ If no PR is found, tell the user and stop.
 Store the PR's base branch (from `baseRefName`) — use `origin/<baseRefName>` as the
 rebase/log target throughout the workflow. Do **not** assume `main`.
 
-## Phase 1b: Check for merge conflicts and CI failures
+## Phase 1b: Sync branch with target + check CI
 
-Before reviewing comments, check if the PR is mergeable and if CI is passing:
+**Check out the PR's head branch first** — `/review-pr` is often invoked with an
+explicit PR number while the current checkout is a different branch (or `main`).
+Without this step the rebase-status check would compare the wrong `HEAD`:
+
+```bash
+# Determine the PR's head branch.
+head_ref=$(gh pr view {number} --json headRefName --jq '.headRefName')
+
+# Switch to it (gh pr checkout creates/updates the local branch).
+gh pr checkout {number}
+
+# Sanity-check: HEAD should now be on the PR's head branch.
+test "$(git branch --show-current)" = "$head_ref"
+```
+
+Now check the PR's mergeability and rebase status against its base:
 
 ```bash
 gh pr view {number} --json mergeable,mergeStateStatus,statusCheckRollup
+git fetch origin <baseRefName>
+git log HEAD..origin/<baseRefName> --oneline
 ```
+
+### If the branch is behind the target (commits appear in `HEAD..origin/<base>` OR `mergeStateStatus=BEHIND`):
+
+Rebase before addressing any review comments. This step is **mandatory** (see CRITICAL).
+
+```bash
+# Rebase onto the latest base. (You're already on the PR's head branch
+# from the gh pr checkout above.)
+git rebase origin/<baseRefName>
+
+# Handle uv.lock / other drift bundled in.
+git status --short  # if uv.lock shows up, stage it into the rebased commit head
+git add uv.lock  # if applicable
+git commit --amend --no-edit  # or rebase --continue if mid-rebase
+
+# Force-push the rebased branch.
+git push --force-with-lease origin HEAD:refs/heads/<branch-name>
+```
+
+After the rebase, re-fetch the comment list — some comments may now reference
+deleted/moved lines and need to be re-classified or marked as resolved.
 
 ### If there are merge conflicts (`mergeable: CONFLICTING`):
 
-1. Fetch the latest base branch and attempt a merge:
-   ```bash
-   git fetch origin <baseRefName>
-   git merge origin/<baseRefName>
-   ```
+The rebase above may have surfaced conflicts. If so:
+
 1. Resolve conflicts by reading each conflicted file, understanding both sides, and
    keeping the correct resolution (usually our branch's intent integrated with the base
    branch's changes).
-1. After resolving, stage the files and continue the merge:
+1. After resolving, stage the files and continue the rebase:
    ```bash
    git add <resolved files>
-   git commit -m "merge: resolve conflicts with <baseRefName>"
+   git rebase --continue
    ```
+1. If the conflicts originated from an explicit `git merge` instead (e.g., GitHub's
+   "Update branch" button created a merge commit on the remote), pull that merge first
+   with `git pull --no-rebase` and resolve normally.
 
 ### If CI is failing (`mergeStateStatus: not SUCCESS`):
 
@@ -113,8 +152,8 @@ gh pr view {number} --json mergeable,mergeStateStatus,statusCheckRollup
 1. If it's an infrastructure issue (flaky CI, timeout), note it in the summary but don't
    block on it.
 
-**Always resolve conflicts and build failures before addressing review comments** —
-review comments may no longer apply after a conflict resolution.
+**Always sync the branch and resolve conflicts/build failures before addressing review
+comments** — review comments may no longer apply after a rebase + base advance.
 
 ## Phase 2: Fetch all review comments
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,19 @@ Common mistakes to avoid:
   PAT-based pushes); tightening that bypass is tracked in #429 (GitHub App migration).
   Until #429 lands, the local hook is the only mechanical guardrail.
 
+- **Rebase on the target branch before opening a PR or addressing review** - A branch
+  that's behind the target produces a chain of compounding problems: CI runs against a
+  stale base (green checks here don't prove the code works on `main`'s actual current
+  state); reviewers see merge artifacts that aren't yours; `uv.lock` drift from
+  sibling-package releases shows up mid-pre-commit (this happened ~5 times in one
+  session before the rule was codified); GitHub auto-merge gets stuck on
+  `mergeStateStatus=BEHIND` and can't fire even when CI is green and all threads are
+  resolved (this trapped PR #690 mid-cycle). The `/open-pr` and `/review-pr` skills'
+  CRITICAL sections enforce this — always
+  `git fetch origin <base> && git log HEAD..origin/<base>` before opening or before each
+  fixup push. If anything appears, `git rebase origin/<base>` first, bundle any
+  `uv.lock` drift, then push.
+
 - **Prefab `DataTable.rows` requires mustache `{{ key }}` for state binding, not bare
   string** - The Python pydantic field type accepts `rows: str` either way, but the JS
   renderer crashes the entire iframe with `t.some is not a function` if it sees a bare

--- a/uv.lock
+++ b/uv.lock
@@ -1278,7 +1278,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.70.0"
+version = "0.71.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- **CRITICAL upgrade in both `/open-pr` and `/review-pr`**: rebase on the target branch before opening / before fixing review comments. Was previously a STANDARD PATH bullet in `/open-pr` only; the skim-past failure mode caught PR #690 mid-cycle on `mergeStateStatus=BEHIND` with auto-merge wedged.
- New explicit Phase 1 rebase step in `/open-pr` with the fetch + check + rebase commands inline.
- Phase 1b in `/review-pr` renamed "Sync branch with target + check CI" with the rebase step now explicit, distinct from the conflict-resolution step it already covered. Re-fetching the comment list after rebase is called out because some comments may reference moved/deleted lines.
- New Known Pitfall in `CLAUDE.md` documenting the rule for agents reading CLAUDE.md without invoking the skills. References #690 as the concrete forcing function.
- Bundles `uv.lock` v0.70.0 → v0.71.0 (the exact drift pattern the rule prevents).

## Failure modes this rule prevents

All observed in the past 24 hours of work:

1. CI runs against a stale base — green checks don't prove the code works on `main`'s actual current state.
2. `uv.lock` drift from sibling-package releases shows up mid-pre-commit (happened ~5× this session pre-rule).
3. Reviewers see merge artifacts they didn't introduce.
4. Auto-merge stays blocked on BEHIND even when everything else is clean (PR #690).
5. Review comments may already be obsolete after the base advanced — agents waste time addressing them.

## Test plan

- [x] `uv run poe agent-check` — clean
- [x] Followed the new process for this PR: branched from current `origin/main`, validated, committed; will hold off on `gh pr merge --auto` until after `/review-pr` cycle completes (the other half of the same process gap)
- [ ] Next session: confirm a fresh `/open-pr` invocation against a stale branch actually trips the new rebase-first check

Refs #568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)