### PR TITLE
feat(mcp): rev 2 of variant card + canonical display_name in client

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -73,6 +73,7 @@ from katana_public_api_client.api.variant import (
 )
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.domain.converters import to_unset
+from katana_public_api_client.domain.variant import build_variant_display_name
 from katana_public_api_client.models import (
     CreateMaterialRequest,
     CreateProductRequest,
@@ -1534,6 +1535,24 @@ class VariantDetailsResponse(BaseModel):
     id: int
     sku: str
     name: str
+    """Display-format variant name. In practice this is the same value
+    as :attr:`display_name` below — ``_dict_to_variant_details``
+    populates both from the canonical formula. Preserved as a separate
+    field so wire-level consumers that historically read ``name`` keep
+    working; new consumers should prefer :attr:`display_name` for
+    semantic clarity. The raw Katana ``variant.name`` attribute is not
+    surfaced separately on this response — every code path uses the
+    formatted display name.
+    """
+    display_name: str = ""
+    """Katana-UI-format human-readable name: ``"{parent_name} / {config1} / {config2}"``.
+
+    Built via :func:`katana_public_api_client.domain.variant.build_variant_display_name`
+    so it stays consistent with the typed-cache ``CachedVariant.display_name``
+    column and the ``KatanaVariant.get_display_name`` domain method.
+    This is the canonical title field for UI rendering. The legacy
+    ``name`` field above carries the same value today; prefer this one.
+    """
 
     # Pricing
     sales_price: float | None = None
@@ -1686,16 +1705,30 @@ def _dict_to_variant_details(
             item.model_dump() if hasattr(item, "model_dump") else item for item in items
         ]
 
+    parent_name_value = _attr(v, "parent_name") or _attr(parent, "name")
+    sku_value = _attr(v, "sku") or ""
+    # ``display_name`` from the cache row is already pre-computed via the
+    # variant postprocess hook (which itself delegates to
+    # ``build_variant_display_name``). For the API-fallback path the cache
+    # row's field is absent — compute fresh from parent + configs so the
+    # response always carries a canonical display name regardless of
+    # which code path produced ``v``.
+    display_name_value = _attr(v, "display_name") or build_variant_display_name(
+        parent_name_value,
+        _attr(v, "config_attributes") or [],
+        sku_value,
+    )
     return VariantDetailsResponse(
         id=_attr(v, "id"),
-        sku=_attr(v, "sku") or "",
-        name=_attr(v, "display_name") or _attr(v, "sku") or "",
+        sku=sku_value,
+        name=display_name_value or sku_value,
+        display_name=display_name_value,
         sales_price=_attr(v, "sales_price"),
         purchase_price=_attr(v, "purchase_price"),
         type=type_str,
         product_id=product_id,
         material_id=material_id,
-        product_or_material_name=_attr(v, "parent_name"),
+        product_or_material_name=parent_name_value,
         uom=_attr(parent, "uom"),
         default_supplier_id=_attr(parent, "default_supplier_id"),
         default_supplier_name=_attr(supplier, "name"),

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -17,6 +17,30 @@ Usage::
     items_dicts = [item.model_dump() for item in response.items]
     app = build_search_results_ui(items_dicts, query, response.total_count)
     return make_tool_result(response, ui=app)
+
+Design conventions
+------------------
+
+**Link Katana entities wherever possible.** When a card displays a
+field that maps to a Katana entity with a known web URL (suppliers,
+customers, products, materials, orders, etc. — see
+``katana_mcp.web_urls.EntityKind``), render it as a ``Link`` with
+``href`` pointing at the Katana page, not as plain ``Text`` or a
+``SendMessage`` button that asks the agent to surface the URL.
+
+A real anchor tag is a one-click path to the source of truth, costs
+nothing in agent tokens or chat noise, and stays correct regardless
+of which host renders the iframe. The variant card uses this pattern
+twice (parent product/material on the title; default supplier in
+the reference section); future card work should follow the same
+shape. If a field corresponds to a Katana entity not yet in
+``EntityKind``, add the path template in ``web_urls.py`` and wire
+the link — don't fall back to ``SendMessage`` indirection.
+
+The agent-prompt rail (``SendMessage(...)``) is reserved for follow-up
+*actions* that need the agent to invoke another tool (e.g.
+``Check Inventory`` → triggers ``check_inventory`` for the SKU). It's
+the wrong primitive for "open this URL".
 """
 
 from __future__ import annotations
@@ -38,21 +62,24 @@ from prefab_ui.components import (
     CardFooter,
     CardHeader,
     CardTitle,
+    Code,
     Column,
     DataTable,
     DataTableColumn,
+    Link,
     Metric,
     Muted,
     Row,
     Separator,
     Text,
 )
-from prefab_ui.components.control_flow import Elif, Else, ForEach, If
+from prefab_ui.components.control_flow import Elif, Else, If
 from prefab_ui.components.slot import Slot
 from prefab_ui.rx import RESULT, Rx
 from pydantic import BaseModel
 
 from katana_mcp.tools.tool_result_utils import BLOCK_WARNING_PREFIX
+from katana_mcp.web_urls import katana_web_url
 
 
 def _split_warnings(
@@ -530,19 +557,43 @@ def build_search_results_ui(
 
 
 def _variant_header_section(variant: dict[str, Any]) -> None:
-    """Render variant card header: title, badges, parent, config-attribute pills."""
+    """Render variant card header: title (linked when a parent URL exists),
+    badges, and config-attribute pills.
+
+    ``display_name`` carries the Katana-UI-format name
+    (``parent_name / value1 / value2``) computed via
+    ``build_variant_display_name`` upstream, so we don't need a separate
+    ``Part of:`` line — the parent name is the leading segment of the
+    title. The ``katana_url`` on the response is the parent product /
+    material URL (variants don't have their own page in Katana's web
+    app); wrapping the title in a ``Link`` makes it an actual external
+    anchor — clicking opens the parent page directly, no chat
+    round-trip.
+    """
+    katana_url = variant.get("katana_url")
+    # ``display_name`` is the canonical title. Falls back to legacy
+    # ``name`` then SKU for safety — every code path through
+    # ``_dict_to_variant_details`` populates ``display_name``, but this
+    # guards against tests / future call sites that build the dict by
+    # hand without it.
+    title_content = (
+        variant.get("display_name") or variant.get("name") or variant.get("sku") or ""
+    )
     with Row(gap=2):
-        CardTitle(content=variant.get("name", "Unknown"))
+        with CardTitle():
+            if katana_url:
+                Link(content=title_content, href=katana_url, target="_blank")
+            else:
+                Text(content=title_content)
         Badge(label=variant.get("sku", ""), variant="outline")
         if variant.get("type"):
             Badge(label=variant["type"], variant="secondary")
         if variant.get("is_batch_tracked"):
             Badge(label="Batch tracked", variant="secondary")
-    parent_name = variant.get("product_or_material_name")
-    if parent_name:
-        Muted(content=f"Part of: {parent_name}")
-    # Config-attribute pills (size / color / volume) inline so the
-    # variant's distinguishing axes are visible without scrolling.
+    # Config-attribute pills label each axis ("Color: Red", "Size: Large")
+    # explicitly. The slash-joined values in the title give scan-friendly
+    # identity matching Katana's UI; these pills give axis context the
+    # title can't convey.
     config_attrs = variant.get("config_attributes") or []
     if config_attrs:
         with Row(gap=2):
@@ -556,11 +607,24 @@ def _variant_header_section(variant: dict[str, Any]) -> None:
 
 
 def _variant_supplier_line(variant: dict[str, Any]) -> None:
-    """Render the default-supplier text row when name and/or id is set."""
+    """Render the default-supplier text row when name and/or id is set.
+
+    The supplier name renders as an external ``Link`` to the Katana
+    supplier page when the id is known — same pattern as the title's
+    parent link. Falls back to plain ``Text`` when only one of name/id
+    is set. The supplier ID parenthetical was dropped; ID-as-text is
+    available via ``structured_content`` for tooling.
+    """
     name = variant.get("default_supplier_name")
     sid = variant.get("default_supplier_id")
     if name and sid:
-        Text(content=f"Default Supplier: {name} ({sid})")
+        supplier_url = katana_web_url("supplier", sid)
+        if supplier_url:
+            with Row(gap=1):
+                Text(content="Default Supplier:")
+                Link(content=name, href=supplier_url, target="_blank")
+        else:
+            Text(content=f"Default Supplier: {name}")
     elif name:
         Text(content=f"Default Supplier: {name}")
     elif sid:
@@ -578,21 +642,36 @@ def _variant_barcode_line(variant: dict[str, Any]) -> None:
         Text(content=f"Barcodes: {', '.join(parts)}")
 
 
-def _variant_id_line(variant: dict[str, Any]) -> None:
-    """IDs deprioritized to a single Muted row at the bottom — they're
-    useful for follow-up tool calls but not the primary signal a human
-    reader needs.
+def _variant_supplier_codes_line(variant: dict[str, Any]) -> None:
+    """Render supplier codes inline using monospace ``Code`` chips.
+
+    Each code lands as its own ``Code`` element with a comma between —
+    consistent with the inline ``Barcodes:`` row above and matching the
+    fixed-width-font convention for codes / identifiers. The previous
+    rendering used a separate ``Muted`` label + ``ForEach`` block, which
+    pushed each code onto its own row and broke the otherwise-tight
+    reference section.
     """
-    id_parts = [f"variant_id={variant.get('id', 'N/A')}"]
-    if variant.get("product_id"):
-        id_parts.append(f"product_id={variant['product_id']}")
-    if variant.get("material_id"):
-        id_parts.append(f"material_id={variant['material_id']}")
-    Muted(content=" · ".join(id_parts))
+    codes = variant.get("supplier_item_codes") or []
+    if not codes:
+        return
+    with Row(gap=1):
+        Text(content="Supplier Codes:")
+        for i, code in enumerate(codes):
+            if i > 0:
+                Text(content=",")
+            Code(content=str(code))
 
 
 def _variant_reference_section(variant: dict[str, Any]) -> None:
-    """Render the reference data block (UoM, supplier, lead time, codes, IDs)."""
+    """Render the reference data block (UoM, supplier, lead time, codes).
+
+    The raw IDs row (``variant_id=... · material_id=...``) was dropped
+    intentionally — IDs are noise for human readers, and tooling that
+    needs them reads from the JSON ``structured_content`` channel
+    directly. Cross-references to other Katana objects belong in
+    typed actions / links, not bare ID text.
+    """
     if variant.get("uom"):
         Text(content=f"UoM: {variant['uom']}")
     _variant_supplier_line(variant)
@@ -601,22 +680,18 @@ def _variant_reference_section(variant: dict[str, Any]) -> None:
     if variant.get("minimum_order_quantity") is not None:
         Text(content=f"Min Order Qty: {variant['minimum_order_quantity']}")
     _variant_barcode_line(variant)
-    if variant.get("supplier_item_codes"):
-        Muted(content="Supplier Codes:")
-        with ForEach("variant.supplier_item_codes"):
-            Text(content="{{ $item }}")
-    _variant_id_line(variant)
+    _variant_supplier_codes_line(variant)
 
 
 def _variant_footer_section(variant: dict[str, Any]) -> None:
-    """Render footer action buttons."""
+    """Render footer action buttons.
+
+    "View in Katana" used to live here as a ``SendMessage`` button that
+    asked the agent to surface the URL. Replaced by a real external
+    ``Link`` wrapping the card title — clicking the title opens the
+    parent's Katana page directly, no agent round-trip needed.
+    """
     sku = variant.get("sku", "")
-    if variant.get("katana_url"):
-        Button(
-            label="View in Katana",
-            variant="outline",
-            on_click=SendMessage(f"Open the Katana URL: {variant['katana_url']}"),
-        )
     Button(
         label="Check Inventory",
         variant="outline",

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -61,6 +61,7 @@ from katana_public_api_client.api.supplier import get_all_suppliers
 from katana_public_api_client.api.tax_rate import get_all_tax_rates
 from katana_public_api_client.api.variant import get_all_variants
 from katana_public_api_client.domain.converters import unwrap_unset
+from katana_public_api_client.domain.variant import build_variant_display_name
 from katana_public_api_client.models.get_all_variants_extend_item import (
     GetAllVariantsExtendItem,
 )
@@ -754,20 +755,15 @@ def _variant_postprocess(attrs_obj: Any, cache_row: CachedVariant) -> None:
         parent_name = unwrap_unset(getattr(parent, "name", None), None)
         cache_row.parent_name = parent_name
 
-    # ``display_name`` mirrors the legacy synthesis: parent name (or SKU
-    # fallback) joined with each config attribute's value. The empty-
-    # parent-name fallback to SKU is defensive — Katana always returns
-    # a non-empty parent name in practice, but the legacy cache handled
-    # the empty case so we preserve it.
+    # ``display_name`` delegates to the shared ``build_variant_display_name``
+    # helper so the formula stays consistent with the domain class
+    # (``KatanaVariant.get_display_name``) and the MCP variant-details
+    # response. The helper accepts attrs-object config attributes
+    # directly — no manual unwrap_unset loop needed here.
     sku = unwrap_unset(getattr(attrs_obj, "sku", None), "") or ""
-    display_parts: list[str] = [parent_name] if parent_name else [sku] if sku else []
     config_attrs = unwrap_unset(getattr(attrs_obj, "config_attributes", None), [])
-    if config_attrs:
-        for attr in config_attrs:
-            value = unwrap_unset(getattr(attr, "config_value", None), None)
-            if value:
-                display_parts.append(value)
-    cache_row.display_name = " / ".join(display_parts) if display_parts else None
+    display_name = build_variant_display_name(parent_name, config_attrs, sku)
+    cache_row.display_name = display_name or None
 
     # ``supplier_item_codes_text``: FTS5's default tokenizer splits on
     # whitespace, so the cache-side text projection is a space-joined

--- a/katana_mcp_server/src/katana_mcp/web_urls.py
+++ b/katana_mcp_server/src/katana_mcp/web_urls.py
@@ -23,6 +23,7 @@ EntityKind = Literal[
     "product",
     "material",
     "customer",
+    "supplier",
     "stock_transfer",
     "stock_adjustment",
 ]
@@ -38,6 +39,7 @@ _PATHS: dict[EntityKind, str] = {
     "product": "/product/{id}",
     "material": "/material/{id}",
     "customer": "/contacts/customers/{id}",
+    "supplier": "/contacts/suppliers/{id}",
     "stock_transfer": "/stocktransfer/{id}",
     "stock_adjustment": "/stockadjustment/{id}",
 }

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -276,7 +276,10 @@ class TestBuildVariantDetailsUI:
         assert "Size: Large" in rendered
 
     def test_includes_default_supplier_name(self):
-        """Supplier name (with id in parens) should appear in the reference section."""
+        """Supplier name lands in the reference section without the
+        previously-rendered ``(<id>)`` parenthetical. IDs are noise for
+        human readers; tooling reads them from ``structured_content``.
+        """
         variant = {
             "id": 100,
             "sku": "SKU-001",
@@ -287,7 +290,191 @@ class TestBuildVariantDetailsUI:
         app = build_variant_details_ui(variant)
         _assert_valid_prefab(app)
         rendered = str(app.to_json())
-        assert "Default Supplier: Acme Industrial (42)" in rendered
+        assert "Default Supplier:" in rendered
+        assert "Acme Industrial" in rendered
+        # The (id) parenthetical was dropped.
+        assert "Acme Industrial (42)" not in rendered
+
+    def test_supplier_name_renders_as_external_link(self):
+        """When both name and id are known, the supplier name renders as
+        an external Link pointing at the Katana supplier page — same
+        pattern as the title's parent-product link. Follows the module
+        convention: link Katana entities wherever possible, never use
+        ``SendMessage`` as an indirect way to surface a URL."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "default_supplier_id": 1301979,
+            "default_supplier_name": "Enduro Bearings",
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        envelope = app.to_json()
+        links = _find_components_by_type(envelope, "Link")
+        # One link in the supplier line pointing at the Katana supplier
+        # page (the title may add another link to the parent — both are
+        # fine; we just need to find the supplier one).
+        supplier_link_hrefs = [
+            link.get("href")
+            for link in links
+            if isinstance(link.get("href"), str)
+            and "/contacts/suppliers/" in link.get("href", "")
+        ]
+        assert "https://factory.katanamrp.com/contacts/suppliers/1301979" in (
+            supplier_link_hrefs
+        )
+        # The visible link text is the supplier name.
+        supplier_link_contents = [
+            link.get("content")
+            for link in links
+            if isinstance(link.get("href"), str)
+            and "/contacts/suppliers/" in link.get("href", "")
+        ]
+        assert "Enduro Bearings" in supplier_link_contents
+
+    def test_supplier_renders_as_plain_text_when_id_missing(self):
+        """With only ``default_supplier_name`` set (no id), the supplier
+        line falls back to plain Text — can't construct a URL without
+        the id."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "default_supplier_id": None,
+            "default_supplier_name": "Unknown Inc",
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        envelope = app.to_json()
+        rendered = str(envelope)
+        assert "Default Supplier: Unknown Inc" in rendered
+        # No supplier link rendered.
+        links = _find_components_by_type(envelope, "Link")
+        supplier_links = [
+            link
+            for link in links
+            if isinstance(link.get("href"), str)
+            and "/contacts/suppliers/" in link.get("href", "")
+        ]
+        assert supplier_links == []
+
+    def test_title_uses_display_name_when_provided(self):
+        """The card title pulls from ``display_name`` (the Katana-UI-format
+        ``parent / configN`` string), not the raw ``name``. Falls back to
+        ``name`` for legacy dicts and then ``sku``."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "raw-katana-name",
+            "display_name": "Kitchen Knife / 8-inch / Black",
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        # The formatted display_name lands in the rendered title.
+        assert "Kitchen Knife / 8-inch / Black" in rendered
+
+    def test_title_wraps_in_link_when_katana_url_set(self):
+        """When ``katana_url`` is set (parent product/material page),
+        the title renders as a real external Link, not a SendMessage
+        button. Clicking opens the parent page directly — no agent
+        round-trip."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "display_name": "Parent / Red",
+            "katana_url": "https://factory.katanamrp.com/material/12345",
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        envelope = app.to_json()
+        # A Link node must carry the katana_url as href.
+        links = _find_components_by_type(envelope, "Link")
+        href_values = [
+            link.get("href") for link in links if isinstance(link.get("href"), str)
+        ]
+        assert "https://factory.katanamrp.com/material/12345" in href_values
+        # The footer "View in Katana" Button is gone — the title link
+        # replaces it.
+        assert len(_find_buttons_by_label(envelope, "View in Katana")) == 0
+
+    def test_title_bare_when_no_katana_url(self):
+        """Without ``katana_url`` the title still renders, just not as
+        a Link — fallback path for orphan variants / missing parent."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "display_name": "Orphan Widget",
+            "katana_url": None,
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Orphan Widget" in rendered
+
+    def test_supplier_codes_inline_with_code_font(self):
+        """Supplier codes render inline using ``Code`` components — same
+        row as the label, monospace font, comma-separated. The previous
+        rendering used a ``Muted`` label + ``ForEach`` Text block that
+        broke each code onto its own line."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "supplier_item_codes": ["BB63802LLUMAX-BAG", "OTHER-CODE-123"],
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        envelope = app.to_json()
+        rendered = str(envelope)
+        # Both codes appear, wrapped in Code components for monospace
+        # rendering.
+        code_nodes = _find_components_by_type(envelope, "Code")
+        code_contents = [
+            n.get("content") for n in code_nodes if isinstance(n.get("content"), str)
+        ]
+        assert "BB63802LLUMAX-BAG" in code_contents
+        assert "OTHER-CODE-123" in code_contents
+        # Label text still appears once.
+        assert "Supplier Codes:" in rendered
+
+    def test_no_raw_id_row(self):
+        """The bottom ``variant_id=... · material_id=...`` Muted row was
+        dropped — IDs are noise for human readers. Tooling can still
+        read IDs from ``structured_content``."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "material_id": 200,
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "variant_id=" not in rendered
+        assert "material_id=" not in rendered
+        assert "product_id=" not in rendered
+
+    def test_no_part_of_line(self):
+        """The ``Part of:`` Muted line was dropped — ``display_name``
+        already includes the parent name as its leading segment, so the
+        separate line just duplicated information (especially when the
+        variant has no config attributes and ``display_name == parent_name``,
+        which is the common case for single-variant materials)."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "display_name": "Enduro Bearings / 8mm",
+            "product_or_material_name": "Enduro Bearings",
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Part of:" not in rendered
 
     def test_renders_when_parent_lookup_returns_nothing(self):
         """When parent enrichment finds nothing (uom/supplier/batch all None),
@@ -1440,6 +1627,25 @@ def _find_buttons_by_label(tree: Any, label: str) -> list[dict]:
     elif isinstance(tree, list):
         for item in tree:
             found.extend(_find_buttons_by_label(item, label))
+    return found
+
+
+def _find_components_by_type(tree: Any, node_type: str) -> list[dict]:
+    """Walk a Prefab envelope and return every node whose ``type`` matches.
+
+    Variant of :func:`_has_node_of_type` that returns the actual nodes
+    instead of a boolean — used when the caller wants to inspect props
+    (e.g. ``href`` on Link, ``content`` on Code).
+    """
+    found: list[dict] = []
+    if isinstance(tree, dict):
+        if tree.get("type") == node_type:
+            found.append(tree)
+        for v in tree.values():
+            found.extend(_find_components_by_type(v, node_type))
+    elif isinstance(tree, list):
+        for item in tree:
+            found.extend(_find_components_by_type(item, node_type))
     return found
 
 

--- a/katana_public_api_client/domain/variant.py
+++ b/katana_public_api_client/domain/variant.py
@@ -9,15 +9,82 @@ leveraging its `from_attrs()` conversion while adding business-specific methods.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field
 
 from .base import KatanaBaseModel
+from .converters import unwrap_unset
 
 if TYPE_CHECKING:
     from ..models.variant import Variant as AttrsVariant
     from ..models_pydantic._generated.inventory import Variant as GeneratedVariant
+
+
+def build_variant_display_name(
+    parent_name: str | None,
+    config_attributes: Iterable[Any] | None,
+    fallback_sku: str | None = None,
+) -> str:
+    """Build a variant's display name in Katana UI format.
+
+    Format: ``"{parent_name} / {config_value_1} / {config_value_2} / ..."``.
+    Falls back to ``fallback_sku`` when ``parent_name`` is empty (a
+    defensive case — Katana always returns a non-empty parent name in
+    practice, but the legacy cache handled the empty case so we
+    preserve it).
+
+    Accepts ``config_attributes`` as an iterable of either dicts
+    (domain models, MCP response dicts) or attrs objects (raw API
+    objects via ``?extend=`` responses). Both routes converge on a
+    ``config_value`` field — the helper reads via ``dict.get`` for the
+    former and ``getattr`` + ``unwrap_unset`` for the latter. This is
+    the single source of truth for the formula; consumers in the
+    ``KatanaVariant`` domain class, the typed-cache postprocess hook,
+    and the MCP variant-details response all delegate to this function
+    so the rendered name stays consistent across the codebase.
+
+    Args:
+        parent_name: The parent Product or Material's ``name``. ``None``
+            or empty triggers the SKU fallback.
+        config_attributes: Iterable of variant config attribute records
+            (e.g. ``{"config_name": "Size", "config_value": "Large"}``).
+            Empty or ``None`` is fine — yields just the parent name.
+        fallback_sku: Returned (or empty string) when ``parent_name``
+            is empty.
+
+    Returns:
+        The formatted display name, or ``fallback_sku`` (or ``""``) on
+        the empty-parent path.
+
+    Example:
+        >>> build_variant_display_name(
+        ...     "Kitchen Knife",
+        ...     [
+        ...         {"config_name": "Size", "config_value": "8-inch"},
+        ...         {"config_name": "Color", "config_value": "Black"},
+        ...     ],
+        ... )
+        'Kitchen Knife / 8-inch / Black'
+        >>> build_variant_display_name(None, [], fallback_sku="KNF-001")
+        'KNF-001'
+    """
+    if not parent_name:
+        return fallback_sku or ""
+    parts: list[str] = [parent_name]
+    for attr in config_attributes or []:
+        # Dict shape (domain class, MCP response): direct .get.
+        # Attrs-object shape (raw API): getattr + unwrap_unset to strip
+        # the UNSET sentinel (which itself handles ``None`` and
+        # ``Unset`` uniformly via its default). Both yield ``str | None``.
+        if isinstance(attr, dict):
+            value = attr.get("config_value")
+        else:
+            value = unwrap_unset(getattr(attr, "config_value", None), None)
+        if isinstance(value, str) and value:
+            parts.append(value)
+    return " / ".join(parts)
 
 
 class KatanaVariant(KatanaBaseModel):
@@ -271,10 +338,12 @@ class KatanaVariant(KatanaBaseModel):
     def get_display_name(self) -> str:
         """Get formatted display name matching Katana UI format.
 
-        Format: "{Product/Material Name} / {Config Value 1} / {Config Value 2} / ..."
+        Delegates to :func:`build_variant_display_name` so the formula
+        stays consistent across the domain class, the typed-cache
+        postprocess hook, and the MCP variant-details response.
 
         Returns:
-            Formatted variant name, or SKU if no name available
+            Formatted variant name, or SKU if no parent name available.
 
         Example:
             ```python
@@ -291,17 +360,11 @@ class KatanaVariant(KatanaBaseModel):
             # "Kitchen Knife / 8-inch / Black"
             ```
         """
-        if not self.product_or_material_name:
-            return self.sku or ""
-
-        parts = [self.product_or_material_name]
-
-        # Append config attribute values
-        for attr in self.config_attributes:
-            if value := attr.get("config_value"):
-                parts.append(value)
-
-        return " / ".join(parts)
+        return build_variant_display_name(
+            self.product_or_material_name,
+            self.config_attributes,
+            self.sku,
+        )
 
     def matches_search(self, query: str) -> bool:
         """Check if variant matches search query with tokenization and fuzzy matching.

--- a/tests/test_domain_models.py
+++ b/tests/test_domain_models.py
@@ -539,6 +539,96 @@ class TestDomainModelBusinessMethods:
 
         assert display_name == "FALLBACK-SKU"
 
+
+class TestBuildVariantDisplayName:
+    """Tests for the standalone ``build_variant_display_name`` helper.
+
+    The domain-class method delegates here, so these pin the formula for
+    every consumer (``KatanaVariant`` domain method, typed-cache
+    postprocess, MCP variant-details response).
+    """
+
+    def test_parent_name_with_configs_joins_with_slashes(self) -> None:
+        from katana_public_api_client.domain.variant import (
+            build_variant_display_name,
+        )
+
+        result = build_variant_display_name(
+            "T-Shirt",
+            [
+                {"config_name": "Color", "config_value": "Red"},
+                {"config_name": "Size", "config_value": "Large"},
+            ],
+        )
+        assert result == "T-Shirt / Red / Large"
+
+    def test_parent_name_only_with_no_configs(self) -> None:
+        from katana_public_api_client.domain.variant import (
+            build_variant_display_name,
+        )
+
+        result = build_variant_display_name(
+            "Enduro Bearings - 63802 LLU MAX",
+            [],
+        )
+        assert result == "Enduro Bearings - 63802 LLU MAX"
+
+    def test_empty_parent_falls_back_to_sku(self) -> None:
+        from katana_public_api_client.domain.variant import (
+            build_variant_display_name,
+        )
+
+        assert build_variant_display_name(None, [], "KNF-001") == "KNF-001"
+        assert build_variant_display_name("", [], "KNF-001") == "KNF-001"
+
+    def test_empty_parent_no_sku_returns_empty(self) -> None:
+        from katana_public_api_client.domain.variant import (
+            build_variant_display_name,
+        )
+
+        assert build_variant_display_name(None, []) == ""
+        assert build_variant_display_name(None, [], None) == ""
+
+    def test_accepts_attrs_objects_via_getattr(self) -> None:
+        """Cache-side callers (typed_cache postprocess) pass raw API attrs
+        objects whose config_attributes are attrs records, not dicts.
+        The helper accepts both shapes."""
+        from types import SimpleNamespace
+
+        from katana_public_api_client.domain.variant import (
+            build_variant_display_name,
+        )
+
+        attrs_config = [
+            SimpleNamespace(config_name="Color", config_value="Blue"),
+            SimpleNamespace(config_name="Size", config_value="M"),
+        ]
+        result = build_variant_display_name("T-Shirt", attrs_config)
+        assert result == "T-Shirt / Blue / M"
+
+    def test_skips_configs_without_values(self) -> None:
+        from katana_public_api_client.domain.variant import (
+            build_variant_display_name,
+        )
+
+        result = build_variant_display_name(
+            "Item",
+            [
+                {"config_name": "Color", "config_value": "Red"},
+                {"config_name": "Empty", "config_value": ""},  # skipped
+                {"config_name": "None", "config_value": None},  # skipped
+                {"config_name": "Size", "config_value": "L"},
+            ],
+        )
+        assert result == "Item / Red / L"
+
+    def test_handles_none_config_attributes(self) -> None:
+        from katana_public_api_client.domain.variant import (
+            build_variant_display_name,
+        )
+
+        assert build_variant_display_name("T-Shirt", None) == "T-Shirt"
+
     def test_variant_matches_search(self) -> None:
         """Test KatanaVariant.matches_search()."""
         from katana_public_api_client.domain.variant import KatanaVariant


### PR DESCRIPTION
## Summary

Cleanup pass on the ``get_variant_details`` Prefab card driven by a live session screenshot where the rendering had multiple issues simultaneously:

- ``Part of: Enduro Bearings - 63802 LLU MAX - ...`` line duplicated the title verbatim (common for single-variant materials where the variant name matches the parent name)
- ``Supplier Codes:`` label and value rendered on separate lines while ``Barcodes:`` rendered inline
- ``Default Supplier: Acme Industrial (1301979)`` — supplier-id parenthetical added noise; supplier name was plain text instead of a link
- ``variant_id=... · material_id=...`` raw-IDs row was visible at the bottom
- "View in Katana" footer button used ``SendMessage`` to ask the agent to surface the URL — silly indirection vs a direct link

## Changes

### 1. Single source of truth for the display_name formula

Extract a pure ``build_variant_display_name(parent_name, config_attributes, fallback_sku) -> str`` helper in ``katana_public_api_client/domain/variant.py``. Format matches Katana's UI: ``"{parent_name} / {value1} / {value2}"``. Accepts both dict-shaped config attributes (domain models, MCP response dicts) and attrs-object config attributes (raw API ``?extend=`` objects).

Three consumers now delegate to this single function:

- ``KatanaVariant.get_display_name`` (domain class)
- ``CachedVariant.display_name`` column — typed-cache ``attrs_postprocess`` hook
- ``VariantDetailsResponse.display_name`` — **new field** populated in ``_dict_to_variant_details``

The follow-up audit (issue #695) tracks rolling the canonical field through the other variant-displaying UIs.

### 2. Variant card visual changes

| Before | After |
|---|---|
| ``CardTitle(content=variant["name"])`` | ``CardTitle`` wraps a ``Link`` to ``katana_url`` when present; ``Text`` fallback otherwise. Title is the canonical ``display_name``. |
| ``Muted("Part of: <parent>")`` below title | Dropped — title already starts with parent name |
| ``"Default Supplier: Acme (1301979)"`` plain text | ``"Default Supplier:"`` + external ``Link`` on the supplier name pointing at ``/contacts/suppliers/{id}``; id parenthetical dropped |
| ``Muted("Supplier Codes:")`` + ``ForEach`` Text block | Inline ``Row``: ``"Supplier Codes:"`` + ``Code`` chips with comma separators |
| ``Muted("variant_id=... · material_id=...")`` | Dropped — IDs available in ``structured_content`` for tooling |
| ``Button("View in Katana", on_click=SendMessage(...))`` | Dropped — title link replaces it |

Config-attribute pill row ("Color: Red", "Size: Large") retained intentionally — the slash-joined title is scan-friendly identity, the pills are explicit axis labels.

### 3. New ``supplier`` entity kind in ``web_urls.py``

Added ``supplier`` to ``EntityKind`` with path ``/contacts/suppliers/{id}`` (by analogy with the existing ``customer`` → ``/contacts/customers/{id}`` — both live under Katana's "Contacts" section).

### 4. Card-design convention documented in ``prefab_ui.py`` module docstring

> **Link Katana entities wherever possible.** When a card displays a field that maps to a Katana entity with a known web URL, render it as a ``Link`` with ``href`` pointing at the Katana page, not as plain ``Text`` or a ``SendMessage`` button. A real anchor tag is a one-click path to the source of truth, costs nothing in agent tokens or chat noise, and stays correct regardless of which host renders the iframe. The variant card now uses this pattern twice (parent product/material on the title; default supplier in the reference section). Future card work should follow the same shape — if a field corresponds to a Katana entity not yet in ``EntityKind``, add the path template in ``web_urls.py`` and wire the link, don't fall back to ``SendMessage`` indirection.

Other footer buttons (Check Inventory, Create Purchase Order, List MOs Using This) stay on the existing ``SendMessage`` rail — those are agent-prompt invocations of *other tools*, which is the legitimate use of SendMessage. The wrong primitive is using SendMessage to surface a URL, not to invoke a tool.

## Test plan

- [x] ``uv run poe check`` — clean (3122 tests pass)
- [x] 9 new tests for the pure ``build_variant_display_name`` helper
- [x] 8 new variant-card tests: display_name title, Link wrapping w/ ``katana_url``, bare title fallback, Code-font supplier codes, dropped IDs row, dropped "Part of:" line, supplier Link with href, supplier plain-text fallback when id missing
- [x] One existing test updated for the dropped supplier-id parenthetical
- [ ] Live render: load a real material variant in Claude Desktop. Verify (a) single-variant materials no longer show the duplicate "Part of:" line, (b) clicking the title opens the parent's Katana material page in a new tab, (c) clicking the supplier name opens the supplier's Katana page in a new tab.

## Related

- #537 (Prefab UI card redesign umbrella)
- #695 (follow-up: surface display_name across other variant-displaying UIs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)