### PR TITLE
docs: slim CLAUDE.md to a spine + topical pointer table

### DIFF
--- a/.claude/agents/domain-advisor.md
+++ b/.claude/agents/domain-advisor.md
@@ -53,7 +53,7 @@ items = unwrap_data(response, default=[])              # 200 list (.data envelop
 if is_success(response): ...                           # 201/204
 ```
 
-Anti-pattern: `if response.status_code == 200`. Source: `CLAUDE.md` API Response Handling Best Practices.
+Anti-pattern: `if response.status_code == 200`. Source: `katana_public_api_client/docs/guide.md` — Response Handling section.
 
 ### "How do I handle UNSET attrs fields?"
 
@@ -64,7 +64,7 @@ status = unwrap_unset(order.status, None)        # read attrs field; default if 
 payload_value = to_unset(maybe_optional)         # write attrs field; UNSET if None
 ```
 
-Never `isinstance(value, type(UNSET))`, never `hasattr(order, 'status')` for attrs-defined fields. Source: `CLAUDE.md` Anti-Patterns.
+Never `isinstance(value, type(UNSET))`, never `hasattr(order, 'status')` for attrs-defined fields. Source: `katana_public_api_client/docs/guide.md` — Response Handling section (anti-patterns).
 
 ### "Where do retries go?"
 
@@ -72,7 +72,7 @@ Transport layer (`katana_client.py`). All 100+ endpoints get retries, rate-limit
 
 ### "How are list responses shaped?"
 
-Katana wraps every list in `{"data": [...]}`. Test mocks must reflect this — never define raw arrays. Source: `CLAUDE.md` Known Pitfalls.
+Katana wraps every list in `{"data": [...]}`. Test mocks must reflect this — never define raw arrays. Source: `katana_public_api_client/docs/spec-authoring.md` — "List responses must use a `ListResponse` schema".
 
 ### "Which exceptions can `unwrap_as` raise?"
 
@@ -84,11 +84,11 @@ Katana wraps every list in `{"data": [...]}`. Test mocks must reflect this — n
 | 5xx | `ServerError` |
 | Other 4xx | `APIError` |
 
-Source: `CLAUDE.md` Exception Hierarchy.
+Source: `katana_public_api_client/docs/guide.md` — Response Handling section, "Exception hierarchy".
 
 ### "When do I need to update the help resource?"
 
-When you add or change MCP tool parameters. The help resource at `katana_mcp_server/.../resources/help.py` has hardcoded tool documentation that drifts silently. Source: `CLAUDE.md` Known Pitfalls.
+When you add or change MCP tool parameters. The help resource at `katana_mcp_server/.../resources/help.py` has hardcoded tool documentation that drifts silently. Source: `katana_mcp_server/docs/prefab/README.md` — "Help resource drift".
 
 ## EDGE CASES
 

--- a/.claude/skills/pre-commit/SKILL.md
+++ b/.claude/skills/pre-commit/SKILL.md
@@ -46,7 +46,7 @@ git diff --cached
 Look for:
 
 - Generated-file edits (`api/**/*.py`, `models/**/*.py`, `client.py`) without spec change
-- Anti-patterns from `CLAUDE.md` "Known Pitfalls" and "Anti-Patterns to Avoid"
+- Anti-patterns from `CLAUDE.md` "Known Pitfalls" and `katana_public_api_client/docs/guide.md` "Response Handling" section
 
 ### 3. Verify test coverage
 

--- a/.claude/skills/techdebt/SKILL.md
+++ b/.claude/skills/techdebt/SKILL.md
@@ -35,7 +35,7 @@ uv run poe quick-check
 Categories:
 
 1. **Dead code** — unused imports/vars/functions/classes; unreachable paths; commented-out blocks. Confirm with `LSP findReferences` before flagging.
-2. **Outdated patterns** — anti-patterns from `CLAUDE.md` Known Pitfalls / Anti-Patterns sections (UNSET misuse, manual status checks, retry wrapping, hasattr on attrs models, raw list mocks).
+2. **Outdated patterns** — anti-patterns from `katana_public_api_client/docs/guide.md` "Response Handling" section and `CLAUDE.md` "Known Pitfalls" (UNSET misuse, manual status checks, retry wrapping, hasattr on attrs models, raw list mocks).
 3. **Code duplication** — repeated logic that should be a helper, copy-pasted test setup that should be a fixture.
 4. **Code smells** — broad `except Exception`, missing type annotations on public functions, parameter explosions, name shadowing, circular imports.
 5. **Missing best practices** — public functions without docstrings, async tests missing `@pytest.mark.asyncio`, fixtures that should be `scope="session"`.

--- a/.github/agents/guides/shared/COMMIT_STANDARDS.md
+++ b/.github/agents/guides/shared/COMMIT_STANDARDS.md
@@ -215,28 +215,27 @@ Before version 1.0.0, breaking changes still bump MINOR (not MAJOR):
 ## Schema and Generator Changes
 
 Edits to the OpenAPI spec (`docs/katana-openapi.yaml`) or to the generator scripts
-(`scripts/generate_pydantic_models.py`, `scripts/regenerate_client.py`) can ripple
-into the **public client surface** in ways that break consumers — even when each
-individual change reads as a "fix" or "chore". Those ripples must be captured in
-the commit message so the auto-generated changelog flags them.
+(`scripts/generate_pydantic_models.py`, `scripts/regenerate_client.py`) can ripple into
+the **public client surface** in ways that break consumers — even when each individual
+change reads as a "fix" or "chore". Those ripples must be captured in the commit message
+so the auto-generated changelog flags them.
 
 ### What counts as a breaking schema change
 
-Use `feat(client)!:` (or `fix(client)!:`) **with a `BREAKING CHANGE:` footer**
-whenever a spec or generator edit causes any of the following in the regenerated
-client output:
+Use `feat(client)!:` (or `fix(client)!:`) **with a `BREAKING CHANGE:` footer** whenever
+a spec or generator edit causes any of the following in the regenerated client output:
 
-- A previously-exported class **disappears** (e.g., a `StrEnum` was deduped into
-  a structurally identical sibling — see #414 / `OutsourcedRecipeIngredientAvailability`
+- A previously-exported class **disappears** (e.g., a `StrEnum` was deduped into a
+  structurally identical sibling — see #414 / `OutsourcedRecipeIngredientAvailability`
   collapsed into `OutsourcedPurchaseOrderIngredientAvailability`)
-- A field **type narrows** in a way that makes previously-valid values raise
-  (e.g., `type: string` → `$ref` to a `StrEnum` — see #410)
+- A field **type narrows** in a way that makes previously-valid values raise (e.g.,
+  `type: string` → `$ref` to a `StrEnum` — see #410)
 - A field is **renamed** or **removed** on a response or request schema
 - An endpoint path is **removed**
 - A required field becomes **optional** (changes parse semantics) or vice versa
 
-The footer must list the affected name(s) so a consumer searching the
-changelog for the broken import or attribute can find the change:
+The footer must list the affected name(s) so a consumer searching the changelog for the
+broken import or attribute can find the change:
 
 ```
 fix(client)!: dedupe collapses OutsourcedRecipeIngredientAvailability
@@ -256,24 +255,79 @@ Refs #409
 
 - Adding a new endpoint or field (purely additive)
 - Adding a value to an existing enum (parse stays tolerant; old values still work)
-- Generated-file diff is byte-identical (e.g., a docstring tweak in the generator
-  that doesn't change emitted code)
-- Internal-only refactors that don't change the surface (e.g., consolidating
-  generator config dicts — see #407)
+- Generated-file diff is byte-identical (e.g., a docstring tweak in the generator that
+  doesn't change emitted code)
+- Internal-only refactors that don't change the surface (e.g., consolidating generator
+  config dicts — see #407)
 
 ### Why this matters pre-1.0
 
-The package is pre-1.0, so breaking changes bump MINOR (per the
-"Pre-1.0 Special Rules" section above) — *not* MAJOR. That's a smaller
-version-number signal than a 1.x → 2.x bump, so the **changelog entry** carries
-the discoverability for affected consumers. Without the breaking-change footer,
-the change shows up in the changelog as a normal `fix:` line and consumers hit
-an `ImportError` (or `ValueError`, etc.) without a breadcrumb to follow.
+The package is pre-1.0, so breaking changes bump MINOR (per the "Pre-1.0 Special Rules"
+section above) — *not* MAJOR. That's a smaller version-number signal than a 1.x → 2.x
+bump, so the **changelog entry** carries the discoverability for affected consumers.
+Without the breaking-change footer, the change shows up in the changelog as a normal
+`fix:` line and consumers hit an `ImportError` (or `ValueError`, etc.) without a
+breadcrumb to follow.
 
-When in doubt, run `uv run poe regenerate-client && uv run poe generate-pydantic`
-and inspect `git diff katana_public_api_client/`. If the diff removes any
-top-level class, removes any `__all__` entry, or changes a field's type
-annotation in a non-additive way, use `!` and `BREAKING CHANGE:`.
+When in doubt, run `uv run poe regenerate-client && uv run poe generate-pydantic` and
+inspect `git diff katana_public_api_client/`. If the diff removes any top-level class,
+removes any `__all__` entry, or changes a field's type annotation in a non-additive way,
+use `!` and `BREAKING CHANGE:`.
+
+### Generator/spec edits must commit the regen in the same PR
+
+Whenever you edit a generator script or the OpenAPI spec, run the regen, run
+`uv run poe check` (or at minimum `agent-check` + `uv run poe test`), and commit the
+regenerated output **in the same PR**. The input and its output stay locked together at
+every commit so the cause-and-effect chain is reviewable.
+
+- Pushing a generator/spec change **without** its regen leaves CI green-but-stale until
+  the next time someone runs the generator.
+- Pushing regen output **without** the input change drifts in the other direction.
+
+Note the generated-file impact in the PR description (e.g., "byte-identical except X" or
+list affected files). Before editing the spec, audit upstream drift via the workflow in
+[`docs/upstream-specs/README.md`](../../../docs/upstream-specs/README.md)
+(`poe refresh-upstream-spec` → `poe audit-spec` → `poe validate-response-examples` →
+`poe validate-examples`).
+
+## Lockfile Drift
+
+When `uv.lock` shows up modified but you didn't touch dependencies (e.g., a
+sibling-package release on `main` bumped a workspace version), `git add uv.lock` and
+bundle it into your current commit.
+
+**Don't `git checkout -- uv.lock` to drop it**: pre-commit's auto-stash/restore fights
+with the lockfile being regenerated mid-hook (pytest's `uv run` re-syncs it), producing
+confusing "files were modified by this hook" failures where nothing was actually wrong
+with the staged content. The lockfile must stay in sync with `pyproject.toml` at every
+commit anyway, so bundling is always the right call.
+
+## First-Push Safety
+
+When a local branch was created via `git checkout -b <name> origin/main`, its upstream
+is set to `origin/main`. A subsequent `git push -u origin <name>` then resolves to its
+tracked upstream and **pushes the local tip straight to `main`** — bypassing PR review
+and triggering semantic-release.
+
+This actually happened: commit `30f3fd86` reached main + tagged `mcp-v0.44.1` +
+published to PyPI before the pipeline could be cancelled.
+
+**Always use the explicit destination ref for first-time pushes:**
+
+```bash
+# Wrong — pushes to whatever the local branch tracks (may be main)
+git push -u origin chore/foo
+
+# Right — explicit destination, creates the remote branch
+git push -u origin HEAD:refs/heads/chore/foo
+```
+
+A `pre-push` hook at `.pre-commit-config.yaml`'s `pre-push` stage enforces this for
+contributors who run pre-commit; **do not bypass with `--no-verify`**. The
+`Protect Main` ruleset has `bypass_mode: always` for the Admin role (required by
+semantic-release's PAT-based pushes); tightening that bypass is tracked in #429 (GitHub
+App migration). Until #429 lands, the local hook is the only mechanical guardrail.
 
 ## Multi-Package Changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,297 +147,56 @@ or misleading, fix them as part of your current work rather than leaving them fo
 
 ## Known Pitfalls
 
-**This is a living document.** When you discover a new recurring mistake, surprising API
-behavior, or gotcha during development, add it here so future sessions don't repeat it.
+**This is a living document.** When you discover a recurring mistake, add it where it
+fits topically — to one of the linked docs below if it's subsystem-scoped, or to the
+**Cross-cutting** list here if it's genuinely repo-wide.
 
-Common mistakes to avoid:
+### Cross-cutting
 
-- **Variants can have null SKUs — never assume `Variant.sku` is non-null** - Katana
-  allows users to create variants without a SKU (legacy NetSuite imports are a common
-  source — items that came across with a "Display Name" but no Item Name). The wire
+- **Variants can have null SKUs — never assume `Variant.sku` is non-null.** Katana
+  allows variants without SKUs (legacy NetSuite imports are a common source). The wire
   contract reflects this: `Variant.sku` is `str | None` in both the attrs and pydantic
-  models. The bug that prompted the spec relaxation was a typed-cache sync crash —
-  `get_all_variants(extend=PRODUCT_OR_MATERIAL)` nests each parent's full `variants[]`
-  array, and a single null-sku sibling raised pydantic `ValidationError` during
-  `Variant.from_attrs` recursion, aborting the whole sync batch and leaving the cache
-  empty. Pinned by tests in `tests/test_models_pydantic.py::TestVariantNullSku` and
+  models. **Downstream consumers must coalesce** — render with `variant.sku or ""`,
+  score with `(variant.sku or "", weight)`. The `KatanaVariant` domain model and
+  `CachedVariant` table both accept null SKU; `get_by_sku` won't match these rows (NULL
+  ≠ string), so they're effectively unreachable by SKU lookup but still surface in
+  ID-based reads and FTS fuzzy search. Pinned by tests in
+  `tests/test_models_pydantic.py::TestVariantNullSku` and
   `katana_mcp_server/tests/test_typed_cache_catalog.py::TestVariantPostprocess::test_sync_tolerates_null_sku_in_nested_variants`.
-  **Downstream consumers must coalesce** — render with `variant.sku or ""`, score with
-  `(variant.sku or "", weight)`, etc. The `KatanaVariant` domain model and the typed
-  cache's `CachedVariant` table both accept null SKU; `get_by_sku` won't match these
-  rows (NULL ≠ string), so they're effectively unreachable by SKU lookup but still
-  surface in ID-based reads and FTS fuzzy search.
 
-- **Editing generated files** - `api/**/*.py`, `models/**/*.py`, and `client.py` are
-  generated. Run `uv run poe regenerate-client` instead of editing them directly.
+- **Editing generated files** — `api/**/*.py`, `models/**/*.py`, `client.py`,
+  `models_pydantic/_generated/**`, and `models_pydantic/_auto_registry.py` are
+  generated. Other modules in `models_pydantic/` (e.g. `_base.py`, `_mapped_shim.py`,
+  `_pydantic_json.py`, `_registry.py`, `converters.py`) are hand-maintained. Run
+  `uv run poe regenerate-client` **and** `uv run poe generate-pydantic` instead of
+  editing the generated paths directly; they must stay in sync.
 
-- **Forgetting pydantic regeneration** - After `uv run poe regenerate-client`, always
-  run `uv run poe generate-pydantic` too. They must stay in sync.
+- **Raw list responses in tests** — Katana wraps every list endpoint in
+  `{"data": [...]}`. Never put raw arrays in mocks.
 
-- **uv.lock drift during pre-commit** - When `uv.lock` shows up modified but you didn't
-  touch dependencies (e.g., a sibling-package release on `main` bumped a workspace
-  version), `git add uv.lock` and bundle it into your current commit. Don't
-  `git checkout -- uv.lock` to drop it: pre-commit's auto-stash/restore fights with the
-  lockfile being regenerated mid-hook (pytest's `uv run` re-syncs it), producing
-  confusing "files were modified by this hook" failures where nothing was actually wrong
-  with the staged content. The lockfile must stay in sync with `pyproject.toml` at every
-  commit anyway, so bundling is always the right call.
+- **Always call functions with keyword arguments** — `func(param=value)`, not
+  `func(value)`, for all calls. Especially `prefab_ui` components, which only accept
+  kwargs.
 
-- **Generator/schema edits without committing the regen** - Whenever you edit a
-  generator script (`scripts/generate_pydantic_models.py`,
-  `scripts/regenerate_client.py`) **or** the OpenAPI spec (`docs/katana-openapi.yaml`),
-  run the regen, run `uv run poe check` (or at minimum `agent-check` +
-  `uv run poe test`), and commit the regenerated output **in the same PR**. The input
-  and its output stay locked together at every commit so the cause-and-effect chain is
-  reviewable. Pushing a generator/spec change without its regen leaves CI
-  green-but-stale until the next time someone runs the generator; pushing regen output
-  without the input change drifts in the other direction. Note the generated-file impact
-  in the PR description (e.g., "byte-identical except X" or list affected files). When
-  the regen drops a previously-public class (e.g., a `StrEnum` deduped into a sibling)
-  or narrows a field's type, the commit must use the breaking-change marker
-  (`feat(client)!:` / `fix(client)!:`) with a `BREAKING CHANGE:` footer naming the
-  affected symbol — see
-  [`.github/agents/guides/shared/COMMIT_STANDARDS.md`](.github/agents/guides/shared/COMMIT_STANDARDS.md)
-  "Schema and Generator Changes" for the full rule. Before editing the spec, audit
-  upstream drift via the workflow in
-  [`docs/upstream-specs/README.md`](docs/upstream-specs/README.md)
-  (`poe refresh-upstream-spec` → `poe audit-spec` → `poe validate-response-examples` →
-  `poe validate-examples`).
+- **Never delete `.claude/worktrees/`** — other agents may be working inside them. If a
+  worktree causes tool noise (e.g., `ty` scanning into it), exclude the path in the
+  tool's config — never `rm -rf`.
 
-- **OpenAPI spec is 3.1 — use 3.1 conventions** - `docs/katana-openapi.yaml` declares
-  `openapi: 3.1.0`. Use 3.1 features rather than 3.0 work-arounds. Specifically:
-  **`$ref` siblings are legal in 3.1**, so attach property metadata (especially
-  `description`) directly alongside `$ref` rather than wrapping the ref in
-  `allOf: [{$ref: ...}]` (the 3.0 idiom — usually unnecessary for new edits here, though
-  the spec still has a few legacy cases). Use `allOf` only for real composition
-  (combining a `$ref` with additional properties), not as a description-attacher.
+### Topical — load the linked doc when working in that area
 
-- **Property descriptions live at the use-site, not the schema-definition site** - When
-  a property references a shared schema via `$ref`, put the property's `description` as
-  a sibling of the `$ref` so the description describes the *role of this field on this
-  object*. The shared schema's own `description` should describe the type/enum's general
-  meaning. The two serve different audiences: schema-definition describes what the type
-  *is*; use-site describes what the field's value *means in context* (e.g.,
-  `ManufacturingOrder.status` references `ManufacturingOrderStatus` and adds "Current
-  production status of the manufacturing order"; the schema itself just says "Status of
-  a manufacturing order"). The pydantic generator only emits
-  `Annotated[..., Field(description=...)]` when the description is at the use-site, so
-  use-site descriptions are also what surfaces in the generated client's IDE hovertext /
-  generated docs. Bare `$ref` drops the description from generated pydantic — avoid
-  except when the schema's own description is enough context for every caller (rare).
+Each row keys the topic and lists the most-greppable terms inside, so a `grep` of this
+file for "DataTable" or "archive" or "ListResponse" lands you on the right pointer. Open
+the linked doc when you're working in that subsystem; agents loading CLAUDE.md don't
+need to pay for the full content of every topic.
 
-- **UNSET vs None confusion** - attrs model fields that are unset use a sentinel value,
-  not `None`. Use `unwrap_unset(field, default)` from
-  `katana_public_api_client.domain.converters`, not `isinstance` or `hasattr` checks.
-
-- **Manual status code checks** - Don't write `if response.status_code == 200`. Use
-  `unwrap_as()`, `unwrap_data()`, or `is_success()` from
-  `katana_public_api_client.utils`.
-
-- **Wrapping API methods for retries** - Resilience (retries, rate limiting) is at the
-  transport layer. All 100+ endpoints get it automatically via `KatanaClient`.
-
-- **Raw list responses in tests** - Katana wraps ALL list responses in
-  `{"data": [...]}`. Never define raw arrays in mocks.
-
-- **Help resource drift** - `katana_mcp_server/.../resources/help.py` contains hardcoded
-  tool documentation. When adding or modifying tool parameters, also update the help
-  resource content to stay in sync.
-
-- **None-to-UNSET conversion** - When building attrs API request models from optional
-  fields, use `to_unset(value)` from `katana_public_api_client.domain.converters`
-  instead of `value if value is not None else UNSET`.
-
-- **Archive / deleted state — opt-in flags + derived booleans** - Katana represents
-  soft-state as nullable timestamps on the wire: `archived_at` (the user-toggleable
-  archive lifecycle — exposed on catalog items, inventory rows, and a few other
-  archivable entities) and `deleted_at` (soft-delete, exposed on most entities including
-  catalog items *and* transactional entities like POs, SOs, MOs, stock transfers, stock
-  adjustments). The two are independent — an entity can be both archived and
-  soft-deleted. Two MCP-side conventions surface this; keep them symmetric:
-
-  - **Query-param flags** for opting into surfacing soft-state rows. **Default
-    `False`.** Items use `include_archived` (`search_items`, catalog cache); after #472
-    Phase D the canonical wiring is the typed cache's `CatalogQueries` adapter —
-    `parent_archived_at` is denormalized onto `CachedVariant` at sync time (via the
-    variant `attrs_postprocess` hook in `typed_cache/sync.py`) and the adapter's default
-    `include_archived=False` / `include_deleted=False` filters push the
-    `archived_at IS NULL` / `deleted_at IS NULL` predicates down to SQL. Transactional
-    entities use `include_deleted` on `list_purchase_orders` / `list_sales_orders` /
-    `list_manufacturing_orders` / `list_stock_adjustments`, filtering at the same
-    typed-cache query layer.
-  - **Response-side derived booleans**: every response model that exposes `archived_at`
-    / `deleted_at` should also expose a convenience `is_archived` / `is_deleted` bool
-    derived from `<timestamp> is not None`, saving callers from the timestamp/null
-    inspection. **Note the asymmetry**: `is_archived` mirrors Katana's *write*
-    convention (`update_<entity>` request bodies accept `is_archived: bool`, so
-    round-tripping through `modify_<entity>` with
-    `{"update_header": {"is_archived": false}}` works). `is_deleted`, by contrast, is
-    *read-side only* — Katana exposes deletion through DELETE endpoints, not as a
-    writable boolean on update bodies. Items expose `is_archived` on `ItemInfo` and
-    `ItemDetailsResponse` as of #526.
-
-  Don't add a new opt-in flag without the matching derived bool, and vice versa. **Known
-  gaps** (filed for follow-up): `list_stock_transfers` lacks `include_deleted` parity
-  (#484); `check_inventory` and the inventory reporting tools lack `include_archived`
-  and the `is_archived` row field (#539); transactional response models lack the
-  `is_deleted` derived bool (#540).
-
-- **Polluting the API spec/models with cache-only fields** - The OpenAPI spec at
-  `docs/katana-openapi.yaml` and the generated pydantic models in
-  `katana_public_api_client/models_pydantic/_generated/*.py` reflect Katana's actual
-  wire contract. **Never** add fields to the spec or inject fields into the API pydantic
-  classes to satisfy cache-schema, MCP-tool, or other consumer needs. Cache schemas live
-  on sibling `Cached<Name>` classes emitted by the same generator pass — the API class
-  stays pure pydantic, the cache class carries `table=True`, foreign keys,
-  relationships, JSON columns, and any cache-only fields. See
-  `scripts/generate_pydantic_models.py::duplicate_cache_tables_as_cached_siblings` and
-  `katana_mcp_server/src/katana_mcp/typed_cache/sync.py::_attrs_<entity>_to_cached` for
-  the conversion pattern: attrs → API pydantic (via the registry) → cache pydantic (via
-  `model_dump`/`model_validate`), with relationship fields set after construction since
-  SQLModel `Relationship` descriptors don't accept input via `__init__`.
-
-- **Fix bugs at the client/generator layer when the root cause lives there** - The
-  Katana client (`katana_public_api_client`) is a published, standalone package.
-  Third-party Python users hit the same bugs we hit in MCP. When a bug surfaces in
-  `katana_mcp_server/.../typed_cache/sync.py`, in a foundation tool, or in a helper but
-  originates in generated client code (attrs, pydantic, `from_attrs`, `Cached*`
-  schemas), apply the fix to the **generator or spec** — not the consumer. Test: *"would
-  a standalone client user hit this bug?"* If yes, fix it in the client. Examples:
-  `Pydantic*.from_attrs` raising on `{}` from Katana → fix `from_attrs` codegen, not
-  `_attrs_*_to_cached`. `Column(JSON)` failing to serialize a pydantic instance → fix
-  `inject_json_columns` in `scripts/generate_pydantic_models.py`, not `sync.py`. Missing
-  enum value → patch spec + regenerate, not enum-tolerant deserialization downstream.
-
-- **List responses must use a `ListResponse` schema with `data` array property** -
-  Katana wraps every GET list endpoint in `{"data": [...]}`. If the OpenAPI spec defines
-  a 200 response as `type: array`, the generated parser iterates `response.json()`
-  directly — when the API returns the dict wrapper, iteration yields keys (strings) and
-  `Model.from_dict("data")` raises
-  `ValueError: dictionary update sequence element #0 has length 1; 2 is required`.
-  Always define a proper `MyListResponse` schema (`type: object`,
-  `properties.data: {type: array, items: {$ref: ...}}`) and reference it from the
-  operation. The only documented exception is `/user_info`, which returns a flat object,
-  not wrapped.
-
-- **Real names and emails from live API responses must never enter the repo** - When
-  testing against the live Katana API and incorporating response data into the spec,
-  examples, or test fixtures, replace real names/emails with generic placeholders
-  (`Jane Doe`, `jane.doe@example.com`, etc.). Privacy concern — real user data from
-  production accounts should not be committed.
-
-- **Always call functions with named/keyword arguments** - Use `func(param=value)`, not
-  `func(value)`, for all calls — including third-party constructors (especially
-  `prefab_ui` components, which only accept keyword args), API methods, and cache
-  helpers. Caught by review when positional args caused runtime errors with
-  `prefab_ui.Metric`. Explicitness > brevity.
-
-- **Never delete `.claude/worktrees/` directories or their contents** - Other agents may
-  be actively working inside them; deleting destroys their in-progress context. If a
-  worktree causes downstream issues (e.g., `ty` type checker scanning into it),
-  **exclude the path in tool config** — never `rm -rf` the directory. Treat
-  `.claude/worktrees/` as off-limits for destructive operations.
-
-- **Cache IDs are not globally unique — never merge cross-entity maps by numeric ID
-  alone** - The typed cache stores each entity type in its own table (`product`,
-  `material`, `supplier`, ...), so a product with `id=42` and a material with `id=42`
-  are both legal. When enriching a list of variants with parent context (or any other
-  cross-entity batch fetch), keep separate per-type maps (`products`, `materials`) and
-  select based on which ID the variant carries (`v.product_id` vs `v.material_id`).
-  Merging into a single dict via `{**products, **materials}` mis-attaches parents on
-  collision — Python dict-unpack iterates left-to-right and later keys win, so the
-  material entry silently overwrites the product entry on shared IDs. The bug is
-  symmetric in practice: every product variant whose ID also exists as a material ID
-  looks up the material's data instead (and vice versa if you reorder the unpack).
-  Caught in #542 (variant card redesign) by Copilot review; regression test pins the
-  case in
-  `test_items.py::test_enrich_variants_keeps_product_and_material_maps_separate`.
-
-- **First push of a feature branch — use `HEAD:refs/heads/<name>`, not bare branch
-  name** - When a local branch was created via `git checkout -b <name> origin/main`, its
-  upstream is set to `origin/main`. A subsequent `git push -u origin <name>` then
-  resolves to its tracked upstream and pushes the local tip **straight to `main`** —
-  bypassing PR review and triggering semantic-release. This actually happened: commit
-  `30f3fd86` reached main + tagged `mcp-v0.44.1` + published to PyPI before we could
-  cancel the pipeline. **Always use the explicit destination ref** for first-time
-  pushes:
-
-  ```bash
-  # Wrong — pushes to whatever the local branch tracks (may be main)
-  git push -u origin chore/foo
-
-  # Right — explicit destination, creates the remote branch
-  git push -u origin HEAD:refs/heads/chore/foo
-  ```
-
-  A `pre-push` hook at `.pre-commit-config.yaml`'s `pre-push` stage enforces this for
-  contributors who run pre-commit; do not bypass with `--no-verify`. The `Protect Main`
-  ruleset has `bypass_mode: always` for the Admin role (required by semantic-release's
-  PAT-based pushes); tightening that bypass is tracked in #429 (GitHub App migration).
-  Until #429 lands, the local hook is the only mechanical guardrail.
-
-- **Rebase on the target branch before opening a PR or addressing review** - A branch
-  that's behind the target produces a chain of compounding problems: CI runs against a
-  stale base (green checks here don't prove the code works on `main`'s actual current
-  state); reviewers see merge artifacts that aren't yours; `uv.lock` drift from
-  sibling-package releases shows up mid-pre-commit (this happened ~5 times in one
-  session before the rule was codified); GitHub auto-merge gets stuck on
-  `mergeStateStatus=BEHIND` and can't fire even when CI is green and all threads are
-  resolved (this trapped PR #690 mid-cycle). The `/open-pr` and `/review-pr` skills'
-  CRITICAL sections enforce this — always
-  `git fetch origin <base> && git log HEAD..origin/<base>` before opening or before each
-  fixup push. If anything appears, `git rebase origin/<base>` first, bundle any
-  `uv.lock` drift, then push.
-
-- **Prefab `DataTable.rows` requires mustache `{{ key }}` for state binding, not bare
-  string** - The Python pydantic field type accepts `rows: str` either way, but the JS
-  renderer crashes the entire iframe with `t.some is not a function` if it sees a bare
-  state-key string — it treats the string as the rows array itself, calls `.some()` on a
-  string, and the React tree never mounts. Use mustache form everywhere:
-  `rows="{{ items }}"`, `rows="{{ stock.by_location }}"` (dotted paths supported).
-  `_assert_state_bindings_resolve` in `katana_mcp_server/tests/test_prefab_ui.py`
-  enforces this on every state-bound DataTable. The browser-render harness in
-  `katana_mcp_server/tests/browser/` proves cards actually render in headless Chromium —
-  the prior unit-test contract (`to_json()` returns a dict with `$prefab`) was
-  insufficient because the wire envelope can be "valid but unrenderable." Discovered
-  while investigating #629; bit every state-bound DataTable in the repo (search,
-  inventory, verification, batch_recipe, modification card). Run
-  `uv run poe test-browser` to exercise the JS renderer locally; needs one-time
-  `uv run playwright install chromium`.
-
-- **MCP tool stubs in browser tests must mirror production wire shape via
-  `make_tool_result`** - When stubbing an MCP tool in
-  `katana_mcp_server/tests/browser/render_test_server.py`, return
-  `make_tool_result(response_pydantic, ui=ui_card)` exactly like real tool code in
-  `katana_mcp_server/src/katana_mcp/tools/foundation/`. A hand-built
-  `ToolResult(content="ok", structured_content=raw_dict)` silently passes browser tests
-  but misses production-shape bugs: in particular, `$result` in the on_success Rx
-  context resolves to the apply tool's `structured_content` (a PrefabApp wire envelope
-  keyed by `$prefab` / `view` / `state` — **not** the raw `ModificationResponse` shape,
-  so it has no `actions` field), not to the pydantic response model the stub might
-  construct directly. A stub with the wrong-but-convenient shape gives false green: it
-  looks like the apply rail's `Rx("$result.actions")` resolves correctly when in
-  production it does not. Discovered via Copilot review on #634; the broken live-tick
-  that "passed" against the bad stub is tracked for proper fix in #645. Rule: **a stub
-  that doesn't match production wire shape is worse than no stub.**
-
-- **A tool's docstring promises must match the UI it actually emits** -
-  `register_preview_tool` auto-appends "Preview→apply: ... returns a Prefab card with
-  Confirm/Cancel buttons" to the tool's docstring. Hosts (Claude Desktop, Cowork) read
-  that promise and look for a widget. If the tool was registered with
-  `register_preview_tool` but **without** `meta=UI_META` (or it returns via
-  `make_simple_result` with no Prefab envelope), the host's widget-fetch fails — Claude
-  Desktop crashes its internal `read_widget_context` with `tool_name=undefined` because
-  no widget exists for the tool the host believed was emitting one. The actual tool
-  result still returns successfully, but the iframe renders nothing. Rule: every
-  `register_preview_tool` call must pair `meta=UI_META` with a real Prefab card (built
-  via `make_tool_result(response, ui=...)`) — never the docstring without the card.
-  Conversely, tools that emit no UI must use plain `mcp.tool(...)`, not
-  `register_preview_tool`. Caught via a live Claude Desktop session against
-  `create_stock_adjustment` (fixed in #649); the same misregistration still applies to
-  `create_stock_transfer` — tracked in #639. (`fulfill_order` is correctly wired with
-  `meta=UI_META`; its remaining work is the direct-apply rail migration in #638, not
-  this misregistration.)
+| Area                                            | Keywords inside                                                                                                                                                                                                 | Where to read                                                                                                  |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| **Prefab UI**                                   | DataTable mustache `{{ key }}`, browser-test wire shape via `make_tool_result`, `register_preview_tool` + `meta=UI_META` contract, help resource drift                                                          | [katana_mcp_server/docs/prefab/README.md](katana_mcp_server/docs/prefab/README.md)                             |
+| **Typed cache**                                 | archive/deleted opt-in flags (`include_archived` / `include_deleted`), `is_archived` / `is_deleted` derived bools, cross-entity ID collisions (per-type maps), `Cached<Name>` siblings (don't pollute API spec) | [katana_mcp_server/docs/typed_cache/README.md](katana_mcp_server/docs/typed_cache/README.md)                   |
+| **OpenAPI spec authoring**                      | OpenAPI 3.1 (`$ref` siblings legal), use-site descriptions, `ListResponse` schema for arrays, generator/spec regen lockstep + breaking-change markers, privacy (no real names/emails), fix-at-source rule       | [katana_public_api_client/docs/spec-authoring.md](katana_public_api_client/docs/spec-authoring.md)             |
+| **API response handling**                       | `unwrap_as`, `unwrap_data`, `is_success`, `unwrap_unset`, `to_unset`, transport-layer retries, exception hierarchy (`AuthenticationError`, `ValidationError`, `RateLimitError`, `ServerError`, `APIError`)      | [katana_public_api_client/docs/guide.md](katana_public_api_client/docs/guide.md) — "Response Handling" section |
+| **Commit / push safety**                        | first-push `HEAD:refs/heads/<name>` form, `uv.lock` drift bundling, generator regen lockstep, breaking-change marker (`feat(client)!:` + `BREAKING CHANGE:` footer)                                             | [.github/agents/guides/shared/COMMIT_STANDARDS.md](.github/agents/guides/shared/COMMIT_STANDARDS.md)           |
+| **Rebase before PR / before addressing review** | `git fetch origin <base> && git log HEAD..origin/<base>`, `mergeStateStatus=BEHIND` auto-merge stall                                                                                                            | Enforced by `/open-pr` and `/review-pr` CRITICAL sections — no separate doc needed                             |
 
 ## Using the LSP tool
 
@@ -529,73 +288,6 @@ docs: update README          # No release
 
 Use `!` for breaking changes: `feat(client)!: breaking change`
 
-## API Response Handling Best Practices
-
-Use the helper utilities in `katana_public_api_client/utils.py` for consistent response
-handling:
-
-### Response Unwrapping
-
-```python
-from katana_public_api_client.utils import unwrap, unwrap_as, unwrap_data, is_success
-from katana_public_api_client.domain.converters import unwrap_unset
-
-# For single-object responses (200 OK with parsed model)
-order = unwrap_as(response, ManufacturingOrder)  # Type-safe with validation
-
-# For list responses (200 OK with data array)
-items = unwrap_data(response, default=[])  # Extracts .data field
-
-# For success-only responses (201 Created, 204 No Content)
-if is_success(response):
-    # Handle success case
-
-# For attrs model fields that may be UNSET
-status = unwrap_unset(order.status, None)  # Returns None if UNSET
-```
-
-### When to Use Each Pattern
-
-| Scenario            | Pattern                             | Example               |
-| ------------------- | ----------------------------------- | --------------------- |
-| Single object (200) | `unwrap_as(response, Type)`         | Get/update operations |
-| List endpoint (200) | `unwrap_data(response, default=[])` | List operations       |
-| Create (201)        | `is_success(response)`              | POST with no body     |
-| Delete/action (204) | `is_success(response)`              | DELETE, fulfill       |
-| attrs UNSET field   | `unwrap_unset(field, default)`      | Optional API fields   |
-
-### Anti-Patterns to Avoid
-
-```python
-# ❌ DON'T: Manual status code checks
-if response.status_code == 200:
-    result = response.parsed
-# ✅ DO: Use helpers
-result = unwrap_as(response, ExpectedType)
-
-# ❌ DON'T: isinstance with UNSET
-if not isinstance(value, type(UNSET)):
-    use(value)
-# ✅ DO: Use unwrap_unset
-use(unwrap_unset(value, default))
-
-# ❌ DON'T: hasattr for attrs-defined fields
-if hasattr(order, "status"):
-    status = order.status
-# ✅ DO: Use unwrap_unset (attrs fields always exist, may be UNSET)
-status = unwrap_unset(order.status, None)
-```
-
-### Exception Hierarchy
-
-`unwrap()` and `unwrap_as()` raise typed exceptions:
-
-- `AuthenticationError` - 401 Unauthorized
-- `ValidationError` - 422 Unprocessable Entity
-- `RateLimitError` - 429 Too Many Requests
-- `ServerError` - 5xx server errors
-- `APIError` - Other errors (400, 403, 404, etc.)
-
 ## Claude Code Harness
 
 The harness lives in `.claude/skills/` (workflows) and `.claude/agents/` (delegated
@@ -676,13 +368,16 @@ Configured in `.claude/settings.local.json` (gitignored):
 
 **Discover on-demand** - read these when working on specific areas:
 
-| Topic             | File                                                                                                             |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------- |
-| Validation tiers  | [.github/agents/guides/shared/VALIDATION_TIERS.md](.github/agents/guides/shared/VALIDATION_TIERS.md)             |
-| Commit standards  | [.github/agents/guides/shared/COMMIT_STANDARDS.md](.github/agents/guides/shared/COMMIT_STANDARDS.md)             |
-| File organization | [.github/agents/guides/shared/FILE_ORGANIZATION.md](.github/agents/guides/shared/FILE_ORGANIZATION.md)           |
-| Architecture      | [.github/agents/guides/shared/ARCHITECTURE_QUICK_REF.md](.github/agents/guides/shared/ARCHITECTURE_QUICK_REF.md) |
-| Client guide      | [katana_public_api_client/docs/guide.md](katana_public_api_client/docs/guide.md)                                 |
-| MCP docs          | [katana_mcp_server/docs/README.md](katana_mcp_server/docs/README.md)                                             |
-| TypeScript client | [packages/katana-client/README.md](packages/katana-client/README.md)                                             |
-| ADRs              | [docs/adr/README.md](docs/adr/README.md)                                                                         |
+| Topic                  | File                                                                                                             |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Validation tiers       | [.github/agents/guides/shared/VALIDATION_TIERS.md](.github/agents/guides/shared/VALIDATION_TIERS.md)             |
+| Commit standards       | [.github/agents/guides/shared/COMMIT_STANDARDS.md](.github/agents/guides/shared/COMMIT_STANDARDS.md)             |
+| File organization      | [.github/agents/guides/shared/FILE_ORGANIZATION.md](.github/agents/guides/shared/FILE_ORGANIZATION.md)           |
+| Architecture           | [.github/agents/guides/shared/ARCHITECTURE_QUICK_REF.md](.github/agents/guides/shared/ARCHITECTURE_QUICK_REF.md) |
+| Client guide           | [katana_public_api_client/docs/guide.md](katana_public_api_client/docs/guide.md)                                 |
+| OpenAPI spec authoring | [katana_public_api_client/docs/spec-authoring.md](katana_public_api_client/docs/spec-authoring.md)               |
+| MCP docs               | [katana_mcp_server/docs/README.md](katana_mcp_server/docs/README.md)                                             |
+| Prefab UI pitfalls     | [katana_mcp_server/docs/prefab/README.md](katana_mcp_server/docs/prefab/README.md)                               |
+| Typed cache patterns   | [katana_mcp_server/docs/typed_cache/README.md](katana_mcp_server/docs/typed_cache/README.md)                     |
+| TypeScript client      | [packages/katana-client/README.md](packages/katana-client/README.md)                                             |
+| ADRs                   | [docs/adr/README.md](docs/adr/README.md)                                                                         |

--- a/katana_mcp_server/docs/prefab/README.md
+++ b/katana_mcp_server/docs/prefab/README.md
@@ -1,0 +1,99 @@
+# Prefab UI — Rendering Pitfalls and Contracts
+
+Prefab cards are emitted by MCP tools as JSON envelopes that the host (Claude Desktop,
+Cowork, the browser-render harness) hydrates into a React tree inside an iframe. The
+JSON wire is forgiving (it accepts most pydantic shapes); the JS renderer is not. The
+rules below come from real production failures — cards that passed unit tests but
+crashed in the host, or tools that promised a widget in their docstring and silently
+emitted none.
+
+When you change anything that emits a Prefab card, run `uv run poe test-browser` (needs
+one-time `uv run playwright install chromium`) — the browser-render harness in
+`katana_mcp_server/tests/browser/` is the only thing that exercises the real JS
+renderer.
+
+Related tests:
+
+- `katana_mcp_server/tests/test_prefab_ui.py` — unit tests on the wire envelope.
+- `katana_mcp_server/tests/browser/` — headless Chromium harness that proves cards
+  actually mount.
+
+______________________________________________________________________
+
+## `DataTable.rows` requires mustache `{{ key }}`, never a bare string
+
+The Python pydantic field type accepts `rows: str` either way, but the JS renderer
+**crashes the entire iframe** with `t.some is not a function` if it sees a bare
+state-key string — it treats the string as the rows array itself, calls `.some()` on a
+string, and the React tree never mounts.
+
+Always use the mustache form for state-bound rows:
+
+```python
+DataTable(rows="{{ items }}")
+DataTable(rows="{{ stock.by_location }}")  # dotted paths supported
+```
+
+`_assert_state_bindings_resolve` in `tests/test_prefab_ui.py` enforces this on every
+state-bound `DataTable`. The browser-render harness then proves the rendered card
+actually mounts in headless Chromium — the prior unit-test contract (`to_json()` returns
+a dict with `$prefab`) was insufficient because the wire envelope can be "valid but
+unrenderable."
+
+Discovered while investigating #629; bit every state-bound DataTable in the repo
+(search, inventory, verification, batch_recipe, modification card).
+
+______________________________________________________________________
+
+## Browser-test tool stubs must mirror production wire shape via `make_tool_result`
+
+When stubbing an MCP tool in `tests/browser/render_test_server.py`, return
+`make_tool_result(response_pydantic, ui=ui_card)` — exactly like real tool code in
+`src/katana_mcp/tools/foundation/`. A hand-built
+`ToolResult(content="ok", structured_content=raw_dict)` silently passes browser tests
+but misses production-shape bugs.
+
+In particular, `$result` in the `on_success` Rx context resolves to the apply tool's
+`structured_content` — a `PrefabApp` wire envelope keyed by `$prefab` / `view` / `state`
+— **not** the raw `ModificationResponse` shape. A stub that returns a raw
+`ModificationResponse` therefore exposes an `actions` field that doesn't exist in
+production, so the rail's `Rx("$result.actions")` looks like it resolves correctly in
+test but doesn't in real life.
+
+Rule: **a stub that doesn't match production wire shape is worse than no stub.**
+Discovered via Copilot review on #634; the broken live-tick that "passed" against the
+bad stub is tracked for proper fix in #645.
+
+______________________________________________________________________
+
+## A tool's docstring promises must match the UI it actually emits
+
+`register_preview_tool` auto-appends "Preview→apply: ... returns a Prefab card with
+Confirm/Cancel buttons" to the tool's docstring. Hosts read that promise and look for a
+widget. If the tool is registered with `register_preview_tool` but **without**
+`meta=UI_META` (or it returns via `make_simple_result` with no Prefab envelope), the
+host's widget-fetch fails — Claude Desktop crashes its internal `read_widget_context`
+with `tool_name=undefined` because no widget exists for the tool the host believed was
+emitting one. The tool result still returns successfully, but the iframe renders
+nothing.
+
+The contract is bidirectional:
+
+- Every `register_preview_tool` call **must** pair `meta=UI_META` with a real Prefab
+  card (built via `make_tool_result(response, ui=...)`) — never the docstring without
+  the card.
+- Conversely, tools that emit no UI must use plain `mcp.tool(...)`, **not**
+  `register_preview_tool` — the docstring promise has to match reality.
+
+Caught via a live Claude Desktop session against `create_stock_adjustment` (fixed in
+#649); the same misregistration still applies to `create_stock_transfer` — tracked in
+#639. (`fulfill_order` is correctly wired with `meta=UI_META`; its remaining work is the
+direct-apply rail migration in #638, not this misregistration.)
+
+______________________________________________________________________
+
+## Help resource drift
+
+`katana_mcp_server/.../resources/help.py` contains hardcoded tool documentation. When
+adding or modifying tool parameters, also update the help resource content to stay in
+sync. The `pr-preparer` agent flags this on PR readiness.

--- a/katana_mcp_server/docs/typed_cache/README.md
+++ b/katana_mcp_server/docs/typed_cache/README.md
@@ -1,0 +1,110 @@
+# Typed Cache — Patterns and Pitfalls
+
+The typed cache is a SQLite-backed mirror of Katana's wire state, with per-entity tables
+(`product`, `material`, `supplier`, `manufacturing_order`, …) generated from the same
+pydantic models the API client uses. It exists so MCP tools can serve queries without
+round-tripping to Katana for every read, and so FTS5 fuzzy search has something to
+index.
+
+The rules below are about how the cache layer relates to the API layer (the spec, the
+generated pydantic, the attrs models) — what belongs where, and what surprises bite when
+those layers blur.
+
+Related code:
+
+- `katana_mcp_server/src/katana_mcp/typed_cache/sync.py` — attrs → API pydantic → cache
+  pydantic conversion.
+- `scripts/generate_pydantic_models.py` — emits both the API pydantic class and the
+  sibling `Cached<Name>` class with `table=True` per entity. See
+  `duplicate_cache_tables_as_cached_siblings`.
+
+______________________________________________________________________
+
+## Archive / deleted state — opt-in flags + derived booleans
+
+Katana represents soft-state as nullable timestamps on the wire: `archived_at` (the
+user-toggleable archive lifecycle — exposed on catalog items, inventory rows, and a few
+other archivable entities) and `deleted_at` (soft-delete, exposed on most entities
+including catalog items *and* transactional entities like POs, SOs, MOs, stock
+transfers, stock adjustments). The two are independent — an entity can be both archived
+and soft-deleted.
+
+Two MCP-side conventions surface this; **keep them symmetric**:
+
+### Query-param flags for opting into soft-state rows (default `False`)
+
+Items use `include_archived` (`search_items`, catalog cache). After #472 Phase D the
+canonical wiring is the typed cache's `CatalogQueries` adapter — `parent_archived_at` is
+denormalized onto `CachedVariant` at sync time (via the variant `attrs_postprocess` hook
+in `typed_cache/sync.py`) and the adapter's default `include_archived=False` /
+`include_deleted=False` filters push the `archived_at IS NULL` / `deleted_at IS NULL`
+predicates down to SQL.
+
+Transactional entities use `include_deleted` on `list_purchase_orders` /
+`list_sales_orders` / `list_manufacturing_orders` / `list_stock_adjustments`, filtering
+at the same typed-cache query layer.
+
+### Response-side derived booleans
+
+Every response model that exposes `archived_at` / `deleted_at` should also expose a
+convenience `is_archived` / `is_deleted` bool derived from `<timestamp> is not None`,
+saving callers from the timestamp/null inspection.
+
+**Note the asymmetry**: `is_archived` mirrors Katana's *write* convention
+(`update_<entity>` request bodies accept `is_archived: bool`, so round-tripping through
+`modify_<entity>` with `{"update_header": {"is_archived": false}}` works). `is_deleted`,
+by contrast, is *read-side only* — Katana exposes deletion through DELETE endpoints, not
+as a writable boolean on update bodies. Items expose `is_archived` on `ItemInfo` and
+`ItemDetailsResponse` as of #526.
+
+Don't add a new opt-in flag without the matching derived bool, and vice versa.
+
+**Known gaps** (filed for follow-up):
+
+- `list_stock_transfers` lacks `include_deleted` parity (#484).
+- `check_inventory` and the inventory reporting tools lack `include_archived` and the
+  `is_archived` row field (#539).
+- Transactional response models lack the `is_deleted` derived bool (#540).
+
+______________________________________________________________________
+
+## Cache IDs are not globally unique — never merge cross-entity maps by numeric ID alone
+
+The typed cache stores each entity type in its own table (`product`, `material`,
+`supplier`, …), so a product with `id=42` and a material with `id=42` are both legal.
+When enriching a list of variants with parent context (or any other cross-entity batch
+fetch), keep separate per-type maps (`products`, `materials`) and select based on which
+ID the variant carries (`v.product_id` vs `v.material_id`).
+
+Merging into a single dict via `{**products, **materials}` mis-attaches parents on
+collision — Python dict-unpack iterates left-to-right and later keys win, so the
+material entry silently overwrites the product entry on shared IDs. The bug is symmetric
+in practice: every product variant whose ID also exists as a material ID looks up the
+material's data instead (and vice versa if you reorder the unpack).
+
+Caught in #542 (variant card redesign) by Copilot review; regression test pins the case
+in `test_items.py::test_enrich_variants_keeps_product_and_material_maps_separate`.
+
+______________________________________________________________________
+
+## Don't pollute the API spec/models with cache-only fields
+
+The OpenAPI spec at `docs/katana-openapi.yaml` and the generated pydantic models in
+`katana_public_api_client/models_pydantic/_generated/*.py` reflect Katana's actual wire
+contract. **Never** add fields to the spec or inject fields into the API pydantic
+classes to satisfy cache-schema, MCP-tool, or other consumer needs.
+
+Cache schemas live on sibling `Cached<Name>` classes emitted by the same generator pass
+— the API class stays pure pydantic, the cache class carries `table=True`, foreign keys,
+relationships, JSON columns, and any cache-only fields. See
+`scripts/generate_pydantic_models.py::duplicate_cache_tables_as_cached_siblings` and
+`katana_mcp_server/src/katana_mcp/typed_cache/sync.py::_attrs_<entity>_to_cached` for
+the conversion pattern: attrs → API pydantic (via the registry) → cache pydantic (via
+`model_dump`/`model_validate`), with relationship fields set after construction since
+SQLModel `Relationship` descriptors don't accept input via `__init__`.
+
+If a bug surfaces in `sync.py` but originates in generated client code (attrs, pydantic,
+`from_attrs`, `Cached*` schemas), fix it at the generator/spec layer — not in `sync.py`.
+See
+[Fix bugs at the client/generator layer](../../../katana_public_api_client/docs/spec-authoring.md#fix-bugs-at-the-clientgenerator-layer-when-the-root-cause-lives-there)
+in the spec-authoring guide.

--- a/katana_public_api_client/docs/guide.md
+++ b/katana_public_api_client/docs/guide.md
@@ -33,6 +33,7 @@ import asyncio
 
 from katana_public_api_client import KatanaClient
 from katana_public_api_client.api.product import get_all_products
+from katana_public_api_client.utils import unwrap_data
 
 async def main():
     # Automatic configuration from .env file
@@ -43,12 +44,90 @@ async def main():
             limit=50
         )
 
-        if response.status_code == 200:
-            products = response.parsed.data
-            print(f"Retrieved {len(products)} products")
+        products = unwrap_data(response, default=[])
+        print(f"Retrieved {len(products)} products")
 
 asyncio.run(main())
 ```
+
+## 📥 Response Handling
+
+Use the helper utilities in `katana_public_api_client.utils` for consistent response
+handling. They replace manual status-code checks, give you typed errors, and handle the
+`{"data": [...]}` wrapping that Katana applies to every list endpoint.
+
+### Helpers at a glance
+
+```python
+from katana_public_api_client.utils import unwrap, unwrap_as, unwrap_data, is_success
+from katana_public_api_client.domain.converters import unwrap_unset
+
+# Single-object responses (200 OK with parsed model)
+order = unwrap_as(response, ManufacturingOrder)  # type-safe, raises on error
+
+# List responses (200 OK with `data` array)
+items = unwrap_data(response, default=[])  # extracts the .data field
+
+# Success-only responses (201 Created, 204 No Content)
+if is_success(response):
+    ...
+
+# attrs model fields that may be UNSET
+status = unwrap_unset(order.status, None)  # returns None if UNSET
+```
+
+### When to use each
+
+| Scenario            | Pattern                             | Example               |
+| ------------------- | ----------------------------------- | --------------------- |
+| Single object (200) | `unwrap_as(response, Type)`         | Get/update operations |
+| List endpoint (200) | `unwrap_data(response, default=[])` | List operations       |
+| Create (201)        | `is_success(response)`              | POST with no body     |
+| Delete/action (204) | `is_success(response)`              | DELETE, fulfill       |
+| attrs UNSET field   | `unwrap_unset(field, default)`      | Optional API fields   |
+
+### Anti-patterns
+
+```python
+# ❌ DON'T: manual status code checks
+if response.status_code == 200:
+    result = response.parsed
+# ✅ DO: use helpers
+result = unwrap_as(response, ExpectedType)
+
+# ❌ DON'T: isinstance with UNSET
+if not isinstance(value, type(UNSET)):
+    use(value)
+# ✅ DO: use unwrap_unset
+use(unwrap_unset(value, default))
+
+# ❌ DON'T: hasattr for attrs-defined fields
+if hasattr(order, "status"):
+    status = order.status
+# ✅ DO: use unwrap_unset (attrs fields always exist, may be UNSET)
+status = unwrap_unset(order.status, None)
+
+# ❌ DON'T: wrap API methods to add retries / rate limiting
+# ✅ DO: nothing — resilience is at the transport layer; every endpoint inherits it.
+
+# ❌ DON'T: build attrs request bodies with conditional UNSET
+optional_field = value if value is not None else UNSET
+# ✅ DO: use to_unset
+from katana_public_api_client.domain.converters import to_unset
+optional_field = to_unset(value)
+```
+
+### Exception hierarchy
+
+`unwrap()` and `unwrap_as()` raise typed exceptions on non-2xx responses:
+
+- `AuthenticationError` — 401 Unauthorized
+- `ValidationError` — 422 Unprocessable Entity
+- `RateLimitError` — 429 Too Many Requests (retries exhausted)
+- `ServerError` — 5xx server errors
+- `APIError` — other errors (400, 403, 404, …)
+
+`is_success(response)` returns `True` for any 2xx status without raising.
 
 ## 🛡️ Automatic Resilience
 
@@ -493,7 +572,7 @@ async def process_products_in_batches(product_ids, batch_size=10):
 
 ```python
 import httpx
-from katana_public_api_client.errors import UnexpectedStatus
+from katana_public_api_client.utils import unwrap_data, APIError
 
 async with KatanaClient() as client:
     try:
@@ -501,18 +580,14 @@ async with KatanaClient() as client:
             client=client,
             limit=50
         )
-
-        if response.status_code == 200:
-            products = response.parsed.data
-            print(f"Success: {len(products)} products")
-        else:
-            print(f"API returned: {response.status_code}")
+        products = unwrap_data(response, default=[])
+        print(f"Success: {len(products)} products")
 
     except httpx.TimeoutException:
         print("Request timed out after retries")
     except httpx.ConnectError:
         print("Connection failed after retries")
-    except UnexpectedStatus as e:
+    except APIError as e:
         print(f"Unexpected API response: {e.status_code}")
 ```
 
@@ -581,20 +656,22 @@ while True:  # Could run forever!
 ### 4. Handle Different Response Types
 
 ```python
+from katana_public_api_client.utils import unwrap_data, AuthenticationError, APIError
+
 async with KatanaClient() as client:
     response = await get_all_products.asyncio_detailed(
         client=client,
         limit=50
     )
 
-    # ✅ Good: Check status before accessing data
-    if response.status_code == 200:
-        products = response.parsed.data
+    # ✅ Good: use unwrap helpers + typed exceptions
+    try:
+        products = unwrap_data(response, default=[])
         print(f"Retrieved {len(products)} products")
-    elif response.status_code == 401:
+    except AuthenticationError:
         print("Authentication failed")
-    else:
-        print(f"Unexpected status: {response.status_code}")
+    except APIError as e:
+        print(f"Unexpected status: {e.status_code}")
 ```
 
 ### 5. Use Direct API Calls
@@ -608,8 +685,7 @@ async with KatanaClient() as client:
         client=client,
         is_sellable=True
     )
-    if response.status_code == 200:
-        products = response.parsed.data
+    products = unwrap_data(response, default=[])
 ```
 
 ## 🚀 Performance Tips

--- a/katana_public_api_client/docs/spec-authoring.md
+++ b/katana_public_api_client/docs/spec-authoring.md
@@ -1,0 +1,132 @@
+# OpenAPI Spec Authoring — Conventions and Pitfalls
+
+The Katana client's source of truth is `docs/katana-openapi.yaml`. Two generator passes
+turn the spec into Python:
+
+1. `scripts/regenerate_client.py` — emits the attrs models, API methods, and `client.py`
+   under `katana_public_api_client/`.
+1. `scripts/generate_pydantic_models.py` — emits the pydantic mirrors (and the sibling
+   `Cached<Name>` cache tables used by MCP).
+
+A spec edit is therefore not just a doc change — it directly shapes the public client
+surface and the cache schema. The rules below come from real failures where spec choices
+broke downstream consumers.
+
+Before editing the spec, audit upstream drift via the workflow in
+[`docs/upstream-specs/README.md`](../../docs/upstream-specs/README.md):
+`poe refresh-upstream-spec` → `poe audit-spec` → `poe validate-response-examples` →
+`poe validate-examples`.
+
+______________________________________________________________________
+
+## The spec is OpenAPI 3.1 — use 3.1 conventions
+
+`docs/katana-openapi.yaml` declares `openapi: 3.1.0`. Use 3.1 features rather than 3.0
+work-arounds.
+
+**`$ref` siblings are legal in 3.1.** Attach property metadata (especially
+`description`) directly alongside `$ref`, **not** wrapped in `allOf: [{$ref: ...}]` (the
+3.0 idiom — still legal but unnecessary; the spec has a few legacy cases).
+
+Use `allOf` only for real composition (combining a `$ref` with additional properties),
+not as a description-attacher.
+
+______________________________________________________________________
+
+## Property descriptions belong at the use-site, not the schema-definition site
+
+When a property references a shared schema via `$ref`, put the property's `description`
+as a sibling of the `$ref` so the description describes the *role of this field on this
+object*. The shared schema's own `description` should describe the type/enum's general
+meaning.
+
+The two serve different audiences:
+
+- **Schema-definition** describes what the type *is*.
+- **Use-site** describes what the field's value *means in context*.
+
+Example: `ManufacturingOrder.status` references `ManufacturingOrderStatus` and adds
+"Current production status of the manufacturing order"; the schema itself just says
+"Status of a manufacturing order."
+
+The pydantic generator only emits `Annotated[..., Field(description=...)]` when the
+description is at the use-site, so use-site descriptions are also what surfaces in the
+generated client's IDE hovertext and generated docs. **A bare `$ref` drops the
+description from generated pydantic** — avoid except when the schema's own description
+is enough context for every caller (rare).
+
+______________________________________________________________________
+
+## List responses must use a `ListResponse` schema with a `data` array property
+
+Katana wraps every GET list endpoint in `{"data": [...]}`. If the OpenAPI spec defines a
+200 response as `type: array`, the generated parser iterates `response.json()` directly
+— when the API returns the dict wrapper, iteration yields keys (strings) and
+`Model.from_dict("data")` raises:
+
+```
+ValueError: dictionary update sequence element #0 has length 1; 2 is required
+```
+
+Always define a proper `MyListResponse` schema (`type: object`,
+`properties.data: {type: array, items: {$ref: ...}}`) and reference it from the
+operation. The only documented exception is `/user_info`, which returns a flat object,
+not wrapped.
+
+Test fixtures and mocks must also honor this — never put a raw array in a list mock.
+
+______________________________________________________________________
+
+## Generator/schema edits must commit the regen in the same PR
+
+Whenever you edit a generator script (`scripts/generate_pydantic_models.py`,
+`scripts/regenerate_client.py`) **or** the OpenAPI spec (`docs/katana-openapi.yaml`),
+run the regen, run `uv run poe check` (or at minimum `agent-check` + `uv run poe test`),
+and commit the regenerated output **in the same PR**. The input and its output stay
+locked together at every commit so the cause-and-effect chain is reviewable.
+
+- Pushing a generator/spec change without its regen leaves CI green-but-stale until the
+  next time someone runs the generator.
+- Pushing regen output without the input change drifts in the other direction.
+
+Note the generated-file impact in the PR description (e.g., "byte-identical except X" or
+list affected files).
+
+### Breaking-change marker
+
+When the regen drops a previously-public class (e.g., a `StrEnum` deduped into a
+sibling) or narrows a field's type, the commit must use the breaking-change marker
+(`feat(client)!:` / `fix(client)!:`) with a `BREAKING CHANGE:` footer naming the
+affected symbol — see
+[`.github/agents/guides/shared/COMMIT_STANDARDS.md`](../../.github/agents/guides/shared/COMMIT_STANDARDS.md)
+"Schema and Generator Changes" for the full rule.
+
+______________________________________________________________________
+
+## Real names and emails from live API responses must never enter the repo
+
+When testing against the live Katana API and incorporating response data into the spec,
+examples, or test fixtures, replace real names/emails with generic placeholders
+(`Jane Doe`, `jane.doe@example.com`, etc.). Privacy concern — real user data from
+production accounts should not be committed.
+
+______________________________________________________________________
+
+## Fix bugs at the client/generator layer when the root cause lives there
+
+The Katana client (`katana_public_api_client`) is a published, standalone package.
+Third-party Python users hit the same bugs we hit in MCP. When a bug surfaces in
+`katana_mcp_server/.../typed_cache/sync.py`, in a foundation tool, or in a helper but
+originates in generated client code (attrs, pydantic, `from_attrs`, `Cached*` schemas),
+apply the fix to the **generator or spec** — not the consumer.
+
+Test: *"would a standalone client user hit this bug?"* If yes, fix it in the client.
+
+Examples:
+
+- `Pydantic*.from_attrs` raising on `{}` from Katana → fix `from_attrs` codegen, not
+  `_attrs_*_to_cached`.
+- `Column(JSON)` failing to serialize a pydantic instance → fix `inject_json_columns` in
+  `scripts/generate_pydantic_models.py`, not `sync.py`.
+- Missing enum value → patch spec + regenerate, not enum-tolerant deserialization
+  downstream.

--- a/uv.lock
+++ b/uv.lock
@@ -1278,7 +1278,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.71.0"
+version = "0.71.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

`CLAUDE.md` was 688L / 40KB and injected into every session — most of its bulk was topical pitfalls only relevant when working on a specific subsystem (Prefab UI, typed cache, OpenAPI spec, API helpers). Every session paid the context tax even for topics never touched.

This PR refactors CLAUDE.md to use **progressive discovery**: a short scannable spine + a keyword-dense topical pointer table that lets agents land on the right subsystem doc via `grep`. Final size: **381L / 22KB (–45%)**.

## What moved where

- **New** `katana_mcp_server/docs/prefab/README.md` — DataTable mustache binding, browser-test wire shape via `make_tool_result`, `register_preview_tool` + `meta=UI_META` contract, help.py drift.
- **New** `katana_mcp_server/docs/typed_cache/README.md` — archive/deleted opt-in flags + derived bools, cross-entity ID collisions (per-type maps), `Cached<Name>` siblings.
- **New** `katana_public_api_client/docs/spec-authoring.md` — OpenAPI 3.1 conventions, use-site descriptions, `ListResponse` schema, generator/spec regen lockstep, privacy, fix-at-source.
- **Extended** `katana_public_api_client/docs/guide.md` with a new "Response Handling" section (unwrap helpers, when-to-use table, anti-patterns, exception hierarchy). Also fixed four stale `status_code == 200` example blocks in this file to use `unwrap_as` / `unwrap_data` / `is_success`.
- **Extended** `.github/agents/guides/shared/COMMIT_STANDARDS.md` with First-Push Safety (`HEAD:refs/heads/<name>` rule), Lockfile Drift (uv.lock bundling), and Generator/spec regen lockstep sections.

## What stayed in `CLAUDE.md`

- **Cross-cutting** pitfalls that genuinely apply repo-wide: null SKUs (15L), editing generated files, raw list mocks, kwargs, never delete `.claude/worktrees/`.
- **Topical pointer table** with keyword-dense rows (DataTable, archive, ListResponse, uv.lock, HEAD:refs/heads, …) so an agent grepping CLAUDE.md still lands on the right pointer.
- Quick Start, Essential Commands, CRITICAL, Project Backlog, LSP tool guide, Architecture, File Rules, Commit Standards header, Harness section, Detailed Documentation table.
- Deleted the duplicate "API Response Handling Best Practices" section — content lives in `guide.md`.

## Cross-link integrity

Updated stale section pointers in three harness files:

- `.claude/agents/domain-advisor.md` — 4 citations now point at `guide.md` / `spec-authoring.md` / `prefab/README.md`.
- `.claude/skills/techdebt/SKILL.md` and `.claude/skills/pre-commit/SKILL.md` — anti-pattern source citations updated.

## Commit structure

Two reviewable commits + one mechanical lockfile bundle:

1. `docs: add subsystem-local docs for progressive-discovery refactor` — additive only; new docs created and existing docs extended. Content exists in two places after this commit.
2. `docs: slim CLAUDE.md to a spine + topical pointer table` — removes the duplicated content from CLAUDE.md and updates stale cross-refs.
3. `chore: bundle uv.lock drift from rebase onto main` — picked up `katana-mcp-server` 0.71.0 → 0.71.1 from the release on main during rebase.

## Test plan

- [x] `uv run poe check` passes (3107 + 16 browser tests, format/lint/typecheck/mdformat clean)
- [x] Discoverability spot-check: `grep CLAUDE.md` for `DataTable`, `ListResponse`, `uv.lock`, `archive`, `register_preview_tool`, `HEAD:refs/heads` — all land on the right topical row
- [x] Content integrity: distinctive keywords from each moved pitfall grep cleanly in their destination file
- [x] No remaining stale references to deleted sections (`grep -r "API Response Handling Best Practices" .` is empty)
- [ ] Reviewer eyeballs the topical pointer table for keyword coverage — would an agent searching for "Cached<Name>" or "is_archived" find the typed-cache row?

🤖 Generated with [Claude Code](https://claude.com/claude-code)