### PR TITLE
feat(mcp): surface canonical variant display_name across UIs (closes #695)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -534,10 +534,27 @@ class ItemVariantSummary(BaseModel):
     """Brief variant summary embedded in the product/material/service detail."""
 
     id: int
-    sku: str
+    sku: str | None = None
+    """Variant SKU. ``None``-able to match Katana's wire contract — the
+    platform allows variants without a SKU (legacy NetSuite imports are
+    a common source, and there's no DB-level constraint that forces it
+    non-null). Display-side consumers should coalesce to ``""`` when
+    rendering; ``display_name`` below already provides a non-empty
+    title in the rare SKU-less case.
+    """
     sales_price: float | None = None
     purchase_price: float | None = None
     type: str | None = None
+    display_name: str = ""
+    """Katana-UI-format human-readable name: ``"{parent_name} / {config1} / {config2}"``.
+
+    Built via :func:`katana_public_api_client.domain.variant.build_variant_display_name`
+    so it stays consistent with every other variant-displaying surface
+    (typed-cache ``CachedVariant.display_name``, ``KatanaVariant.get_display_name``,
+    ``VariantDetailsResponse.display_name``). The summary is embedded in the parent
+    ``ItemDetailsResponse`` so the parent name is known at build time — that means
+    ``display_name`` is always populated when the parent has variants.
+    """
 
 
 class ItemDetailsResponse(BaseModel):
@@ -631,14 +648,32 @@ def _config_to_info(raw: Any) -> ItemConfigInfo | None:
     )
 
 
-def _variant_to_summary(raw: Any) -> ItemVariantSummary | None:
-    """Convert a nested Variant/ServiceVariant attrs (or dict) to summary."""
+def _variant_to_summary(
+    raw: Any, *, parent_name: str | None = None
+) -> ItemVariantSummary | None:
+    """Convert a nested Variant/ServiceVariant attrs (or dict) to summary.
+
+    When ``parent_name`` is supplied, the helper computes the canonical
+    ``display_name`` (Katana-UI format ``"{parent_name} / {config1} / ..."``)
+    via :func:`build_variant_display_name` so the embedded summary is
+    consistent with every other variant-displaying surface. The summary
+    is built inside :func:`_get_item_impl`, where the parent's ``name``
+    is always available; callers in that path always pass it.
+    """
     d = raw.to_dict() if hasattr(raw, "to_dict") else raw
     if not isinstance(d, dict) or "id" not in d or "sku" not in d:
         return None
+    # ``sku`` may legitimately be ``None`` on the wire; coalesce only
+    # for the display-name fallback. The model field accepts ``None``.
+    raw_sku = d["sku"]
+    display_name = build_variant_display_name(
+        parent_name,
+        d.get("config_attributes") or [],
+        raw_sku or "",
+    )
     return ItemVariantSummary(
         id=d["id"],
-        sku=d["sku"],
+        sku=raw_sku,
         sales_price=d.get("sales_price"),
         # ServiceVariant uses default_cost; Variant uses purchase_price.
         # Explicit None-check — `or` would shadow a legitimate 0.0 price
@@ -649,6 +684,7 @@ def _variant_to_summary(raw: Any) -> ItemVariantSummary | None:
             else d.get("default_cost")
         ),
         type=d.get("type") or d.get("type_"),
+        display_name=display_name,
     )
 
 
@@ -744,8 +780,19 @@ async def _get_item_impl(
     item = await _fetch_item_attrs(services, request.id, request.type)
     d = _item_attrs_to_dict(item)
 
+    # Lift the parent's name into the variant summary builder so each
+    # variant's ``display_name`` follows the canonical Katana-UI format
+    # (parent / value1 / value2). Without this every nested variant
+    # would fall back to its SKU (the empty-parent branch in
+    # ``build_variant_display_name``).
+    parent_name = d.get("name") or ""
     variants = [
-        v for v in (_variant_to_summary(raw) for raw in d.get("variants") or []) if v
+        v
+        for v in (
+            _variant_to_summary(raw, parent_name=parent_name)
+            for raw in d.get("variants") or []
+        )
+        if v
     ]
     configs = [c for c in (_config_to_info(raw) for raw in d.get("configs") or []) if c]
     supplier = _supplier_to_info(d.get("supplier"))

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -631,13 +631,23 @@ class RecipeRowBatchTransactionInfo(BaseModel):
 class RecipeRowInfo(BaseModel):
     """Full manufacturing-order recipe row. Exhaustive — every field on
     ``ManufacturingOrderRecipeRow`` is surfaced, plus the resolved SKU
-    for display convenience.
+    and canonical ``display_name`` for display convenience.
     """
 
     id: int
     manufacturing_order_id: int | None = None
     variant_id: int | None = None
     sku: str | None = None
+    display_name: str | None = None
+    """Katana-UI-format human-readable name for this row's variant.
+
+    Lifted from the typed-cache ``CachedVariant.display_name`` column
+    (which itself delegates to
+    :func:`katana_public_api_client.domain.variant.build_variant_display_name`)
+    so the rendered name stays consistent with every other variant-displaying
+    surface. ``None`` when the variant can't be resolved (cache miss + no
+    API fallback for this read path).
+    """
     notes: str | None = None
     planned_quantity_per_unit: float | None = None
     total_actual_quantity: float | None = None
@@ -821,8 +831,15 @@ class GetManufacturingOrderResponse(BaseModel):
     )
 
 
-def _recipe_row_info_from_attrs(row: Any, sku: str | None) -> RecipeRowInfo:
-    """Build RecipeRowInfo from a ManufacturingOrderRecipeRow attrs model."""
+def _recipe_row_info_from_attrs(
+    row: Any, sku: str | None, display_name: str | None = None
+) -> RecipeRowInfo:
+    """Build RecipeRowInfo from a ManufacturingOrderRecipeRow attrs model.
+
+    ``sku`` and ``display_name`` are looked up upstream in
+    :func:`_fetch_mo_recipe_rows` from the typed cache so each row carries
+    the canonical Katana-UI name without an extra API call per row.
+    """
     raw_batch = unwrap_unset(row.batch_transactions, []) or []
     batch_infos = [
         RecipeRowBatchTransactionInfo(
@@ -836,6 +853,7 @@ def _recipe_row_info_from_attrs(row: Any, sku: str | None) -> RecipeRowInfo:
         manufacturing_order_id=unwrap_unset(row.manufacturing_order_id, None),
         variant_id=unwrap_unset(row.variant_id, None),
         sku=sku,
+        display_name=display_name,
         notes=unwrap_unset(row.notes, None),
         planned_quantity_per_unit=unwrap_unset(row.planned_quantity_per_unit, None),
         total_actual_quantity=unwrap_unset(row.total_actual_quantity, None),
@@ -1024,19 +1042,23 @@ async def _fetch_mo_recipe_rows(
         CachedVariant, variant_ids, include_deleted=True
     )
 
-    def _sku_for(v: Any) -> Any:
+    def _field_for(v: Any, field_name: str) -> Any:
         if v is None:
             return None
         if isinstance(v, dict):
-            return v.get("sku")
-        return getattr(v, "sku", None)
+            return v.get(field_name)
+        return getattr(v, field_name, None)
+
+    def _resolved(v_id: int | None) -> tuple[str | None, str | None]:
+        if v_id is None:
+            return None, None
+        v = variants.get(v_id)
+        return _field_for(v, "sku"), _field_for(v, "display_name")
 
     return [
         _recipe_row_info_from_attrs(
             row,
-            _sku_for(variants.get(v_id))
-            if (v_id := unwrap_unset(row.variant_id, None)) is not None
-            else None,
+            *_resolved(unwrap_unset(row.variant_id, None)),
         )
         for row in raw_rows
     ]
@@ -1277,6 +1299,7 @@ def _render_recipe_row_md(row: RecipeRowInfo, *, verbose: bool = True) -> str:
         "manufacturing_order_id",
         "variant_id",
         "sku",
+        "display_name",
         "notes",
         "planned_quantity_per_unit",
         "total_actual_quantity",

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -1799,6 +1799,17 @@ class ManufacturingOrderSummary(BaseModel):
     status: str | None
     ingredient_availability: str | None
     variant_id: int | None
+    sku: str | None = None
+    """SKU of the MO's finished-good variant, lifted from the typed cache
+    in a batched IN-clause read across the result set. ``None`` on cache
+    miss (matches the SO/PO list convention).
+    """
+    display_name: str | None = None
+    """Katana-UI-format human-readable name for the MO's finished good
+    (``parent / value1 / value2``). Surfaces what's actually being
+    manufactured without a follow-up variant lookup. Cache-only — same
+    resolution path as ``sku`` above.
+    """
     planned_quantity: float | None
     actual_quantity: float | None
     location_id: int | None
@@ -1947,8 +1958,26 @@ async def _list_manufacturing_orders_impl(
                 last_page=request.page >= total_pages,
             )
 
+    # Resolve SKU + canonical display_name for every MO's finished-good
+    # variant in one batched cache read. MOs reference one variant (the
+    # finished good); the lookup is one IN-clause across the result set.
+    variant_ids = {mo.variant_id for mo in cached_orders if mo.variant_id is not None}
+    variant_lookup: dict[int, Any] = {}
+    if variant_ids:
+        variant_lookup = await services.typed_cache.catalog.get_many_by_ids(
+            CachedVariant, variant_ids, include_deleted=True
+        )
+
+    def _variant_field(v: Any, name: str) -> Any:
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return v.get(name)
+        return getattr(v, name, None)
+
     summaries: list[ManufacturingOrderSummary] = []
     for mo in cached_orders:
+        variant = variant_lookup.get(mo.variant_id) if mo.variant_id else None
         summaries.append(
             ManufacturingOrderSummary(
                 id=mo.id,
@@ -1956,6 +1985,8 @@ async def _list_manufacturing_orders_impl(
                 status=enum_to_str(mo.status),
                 ingredient_availability=enum_to_str(mo.ingredient_availability),
                 variant_id=mo.variant_id,
+                sku=_variant_field(variant, "sku"),
+                display_name=_variant_field(variant, "display_name"),
                 planned_quantity=mo.planned_quantity,
                 actual_quantity=mo.actual_quantity,
                 location_id=mo.location_id,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -158,12 +158,20 @@ async def _fulfill_manufacturing_order(
     variant_id = unwrap_unset(mo.variant_id, None)
     actual_quantity = unwrap_unset(mo.actual_quantity, None)
 
-    is_serial_tracked, sku = await _resolve_variant_serial_info(services, variant_id)
+    is_serial_tracked, sku, display_name = await _resolve_variant_serial_info(
+        services, variant_id
+    )
 
+    # The MO header carries one variant — surface the canonical display
+    # name in the inventory-updates summary so the rendered fulfillment
+    # card matches the variant-naming convention used by every other
+    # surface. Falls back to SKU when the typed cache hasn't resolved a
+    # display name yet (cold cache / API fallback with no parent).
+    finished_good_label = display_name or sku
     inventory_updates = [
-        "Manufacturing order completion will update inventory based on BOM",
+        f"Manufacturing order completion will produce {finished_good_label}",
         "Finished goods will be added to stock",
-        "Raw materials will be consumed from inventory",
+        "Raw materials will be consumed from inventory based on BOM",
     ]
     if is_serial_tracked and request.serial_numbers:
         inventory_updates.append(
@@ -351,8 +359,9 @@ def _attr(obj: Any, name: str, default: Any = None) -> Any:
 
 async def _resolve_row_serial_info(
     services: Any, so_rows: list[Any]
-) -> tuple[dict[int, bool], dict[int, str]]:
-    """Return ``(serial_tracked_by_row, sku_by_row)`` from cache + API fallback.
+) -> tuple[dict[int, bool], dict[int, str], dict[int, str]]:
+    """Return ``(serial_tracked_by_row, sku_by_row, display_name_by_row)``
+    from cache + API fallback.
 
     The ``serial_tracked`` flag lives on the parent Product/Material, not on
     Variant — so we fan out variant-by-id, then group parent IDs by type
@@ -363,12 +372,20 @@ async def _resolve_row_serial_info(
     ``serial_tracked=False`` and ``"variant {id}"`` for SKUs (best-effort,
     same as if the entity didn't exist). The two parent maps are kept
     separate per CLAUDE.md "Cache IDs are not globally unique".
+
+    ``display_name_by_row`` lifts the typed cache's pre-computed
+    ``CachedVariant.display_name`` column (which delegates to
+    :func:`build_variant_display_name`). API-fallback rows don't carry the
+    column, so the helper computes it fresh from the parent name + config
+    attributes. Empty string when neither resolves (matches the
+    ``MISSING_IN_PO`` convention on the verify path).
     """
     if not so_rows:
-        return {}, {}
+        return {}, {}, {}
     from katana_public_api_client.api.material import get_material
     from katana_public_api_client.api.product import get_product
     from katana_public_api_client.api.variant import get_variant
+    from katana_public_api_client.domain.variant import build_variant_display_name
 
     variant_ids = {row.variant_id for row in so_rows if row.variant_id is not None}
     catalog = services.typed_cache.catalog
@@ -400,12 +417,14 @@ async def _resolve_row_serial_info(
 
     serial_tracked: dict[int, bool] = {}
     skus: dict[int, str] = {}
+    display_names: dict[int, str] = {}
     for row in so_rows:
         variant = variants_by_id.get(row.variant_id)
         sku = _attr(variant, "sku") if variant is not None else None
         skus[row.id] = sku or f"variant {row.variant_id}"
         if variant is None:
             serial_tracked[row.id] = False
+            display_names[row.id] = ""
             continue
         product_id = _attr(variant, "product_id")
         material_id = _attr(variant, "material_id")
@@ -416,27 +435,46 @@ async def _resolve_row_serial_info(
         else:
             parent = None
         serial_tracked[row.id] = bool(parent and _attr(parent, "serial_tracked"))
-    return serial_tracked, skus
+        # Prefer the typed cache's pre-computed display_name when present
+        # (cache hit). On the API-fallback path the attrs variant has no
+        # such column, so compute fresh from the resolved parent name +
+        # config_attributes — same formula every other surface uses.
+        cached_display = _attr(variant, "display_name")
+        if cached_display:
+            display_names[row.id] = cached_display
+        else:
+            parent_name = _attr(parent, "name") if parent is not None else None
+            display_names[row.id] = build_variant_display_name(
+                parent_name,
+                _attr(variant, "config_attributes") or [],
+                sku,
+            )
+    return serial_tracked, skus, display_names
 
 
 async def _resolve_variant_serial_info(
     services: Any, variant_id: int | None
-) -> tuple[bool, str]:
-    """Return ``(is_serial_tracked, sku)`` for a single variant.
+) -> tuple[bool, str, str]:
+    """Return ``(is_serial_tracked, sku, display_name)`` for a single variant.
 
     Single-variant counterpart to ``_resolve_row_serial_info`` used by the
     manufacturing-order path (MOs reference one variant, not per-row). Cache
     misses fall back to a per-ID API fetch so a cold / stale cache doesn't
     silently mis-classify a serial-tracked MO as "OK to mark DONE without
     serials" and surface the original Katana 422 on apply. If the variant
-    can't be resolved at all, returns ``(False, f"variant {id}")`` —
+    can't be resolved at all, returns ``(False, f"variant {id}", "")`` —
     best-effort, same as if the entity didn't exist.
+
+    ``display_name`` is the canonical Katana-UI-format name lifted from
+    the typed cache's ``CachedVariant.display_name`` column, or computed
+    fresh from the parent name + config attributes on the API-fallback path.
     """
     if variant_id is None:
-        return False, "variant ?"
+        return False, "variant ?", ""
     from katana_public_api_client.api.material import get_material
     from katana_public_api_client.api.product import get_product
     from katana_public_api_client.api.variant import get_variant
+    from katana_public_api_client.domain.variant import build_variant_display_name
 
     catalog = services.typed_cache.catalog
     variants_by_id: dict[int, Any] = await catalog.get_many_by_ids(
@@ -447,7 +485,7 @@ async def _resolve_variant_serial_info(
     sku_val = _attr(variant, "sku") if variant is not None else None
     sku = sku_val or f"variant {variant_id}"
     if variant is None:
-        return False, sku
+        return False, sku, ""
 
     product_id = _attr(variant, "product_id")
     material_id = _attr(variant, "material_id")
@@ -464,7 +502,18 @@ async def _resolve_variant_serial_info(
         )
         await _fetch_missing_from_api(services, materials, {material_id}, get_material)
         parent = materials.get(material_id)
-    return bool(parent and _attr(parent, "serial_tracked")), sku
+
+    cached_display = _attr(variant, "display_name")
+    if cached_display:
+        display_name = cached_display
+    else:
+        parent_name = _attr(parent, "name") if parent is not None else None
+        display_name = build_variant_display_name(
+            parent_name,
+            _attr(variant, "config_attributes") or [],
+            sku_val,
+        )
+    return bool(parent and _attr(parent, "serial_tracked")), sku, display_name
 
 
 def _build_mo_serial_warnings(
@@ -620,10 +669,17 @@ async def _fulfill_sales_order(
         if ovr.serial_numbers is not None
     }
 
-    serial_tracked_by_row, sku_by_row = await _resolve_row_serial_info(
-        services, so_rows
-    )
+    (
+        serial_tracked_by_row,
+        sku_by_row,
+        display_name_by_row,
+    ) = await _resolve_row_serial_info(services, so_rows)
 
+    # Inventory-update lines lead with the canonical Katana-UI display
+    # name (parent / value1 / value2) when the typed cache resolved the
+    # variant, falling back through SKU to ``variant {id}`` so each line
+    # always says something more useful than a bare numeric ID. Matches
+    # the resolution order used by the batch recipe update card.
     inventory_updates: list[str] = []
     for row in so_rows:
         rid = row.id
@@ -631,8 +687,9 @@ async def _fulfill_sales_order(
         qty = row.quantity
         serials = overrides_by_row.get(rid)
         suffix = f" with serials {serials}" if serials else ""
+        label = display_name_by_row.get(rid) or sku_by_row.get(rid) or f"variant {vid}"
         inventory_updates.append(
-            f"Row {rid}: ship {qty} of variant {vid} (full ordered quantity){suffix}"
+            f"Row {rid}: ship {qty} of {label} (full ordered quantity){suffix}"
         )
     if not inventory_updates:
         inventory_updates.append("(no rows on this sales order)")

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -1517,6 +1517,18 @@ class MatchResult(BaseModel):
     """Result of matching a document item to a PO line."""
 
     sku: str = Field(..., description="Item SKU")
+    display_name: str = Field(
+        default="",
+        description=(
+            "Katana-UI-format human-readable name "
+            "(``{parent_name} / {config1} / ...``) — built via "
+            ":func:`build_variant_display_name` from the PO row's variant + "
+            "parent product/material lookup so the verification card shows "
+            "the same canonical name as every other variant-displaying "
+            "surface. Empty string when the variant can't be resolved "
+            "(rare — would mean the PO row references a deleted variant)."
+        ),
+    )
     quantity: float = Field(..., description="Matched quantity")
     unit_price: float | None = Field(default=None, description="Matched price")
     status: str = Field(
@@ -1537,6 +1549,16 @@ class Discrepancy(BaseModel):
     """A discrepancy found during verification."""
 
     sku: str = Field(..., description="Item SKU")
+    display_name: str = Field(
+        default="",
+        description=(
+            "Katana-UI-format human-readable name "
+            "(``{parent_name} / {config1} / ...``). Empty string for "
+            "``MISSING_IN_PO`` discrepancies (the document item's SKU "
+            "didn't match any PO row, so there's no variant to resolve "
+            "against)."
+        ),
+    )
     type: DiscrepancyType = Field(..., description="Type of discrepancy")
     expected: float | None = Field(default=None, description="Expected value (from PO)")
     actual: float | None = Field(
@@ -1680,29 +1702,132 @@ async def _verify_order_document_impl(
         po_rows = po_rows_raw
 
         # Collect all variant IDs from PO rows using unwrap_unset
-        variant_ids = []
+        variant_ids: list[int] = []
         for row in po_rows:
             variant_id = unwrap_unset(row.variant_id, None)
             if variant_id is not None:
                 variant_ids.append(variant_id)
 
-        # Fetch only the needed variants by ID (API-level filtering)
-        try:
-            filtered_variants = await services.client.variants.list(ids=variant_ids)
-            variant_by_id = {v.id: v for v in filtered_variants}
-        except Exception as e:
-            logger.error(f"Failed to fetch variants: {e}")
-            raise
+        # Resolve SKU + canonical display_name in one cache read instead of
+        # an API call per row. The typed cache pre-computes
+        # ``CachedVariant.display_name`` via the variant postprocess hook
+        # (same Katana-UI formula used by every other surface — see
+        # ``build_variant_display_name``). API fallback covers cold-cache
+        # gaps so a fresh install doesn't silently lose verification rows.
+        from katana_mcp.tools.foundation.items import _fetch_variant_by_id
+        from katana_public_api_client.domain.variant import (
+            build_variant_display_name,
+        )
+        from katana_public_api_client.models_pydantic._generated import (
+            CachedMaterial,
+            CachedProduct,
+            CachedVariant,
+        )
 
-        # Build a map of SKU -> PO row for matching
-        sku_to_row: dict[str, Any] = {}
+        cached_variants: dict[
+            int, Any
+        ] = await services.typed_cache.catalog.get_many_by_ids(
+            CachedVariant, set(variant_ids), include_deleted=True
+        )
+
+        # Cold-cache fallback: any variant_id not in the cache gets a
+        # fresh API fetch. Dedup first (a PO can reference the same
+        # variant on multiple rows) and fire all fetches in parallel —
+        # the previous serial-await pattern added avoidable latency on
+        # POs with many cache misses.
+        missing_ids = list({vid for vid in variant_ids if vid not in cached_variants})
+        if missing_ids:
+            fallback_variants = await asyncio.gather(
+                *(_fetch_variant_by_id(services, vid) for vid in missing_ids)
+            )
+            # API-fallback ``Variant`` attrs don't carry the
+            # ``display_name`` field (the typed-cache postprocess
+            # computes it during sync, but cold-cache paths skip that).
+            # Bulk-resolve parents from the cache so each fallback can
+            # get a canonical display_name via the same helper every
+            # other surface uses — keeps verification rows readable
+            # without re-fetching at render time.
+            present_fallbacks = [v for v in fallback_variants if v is not None]
+            parent_product_ids = {
+                pid
+                for v in present_fallbacks
+                if (pid := unwrap_unset(getattr(v, "product_id", None), None))
+            }
+            parent_material_ids = {
+                mid
+                for v in present_fallbacks
+                if (mid := unwrap_unset(getattr(v, "material_id", None), None))
+            }
+            products_by_id, materials_by_id = await asyncio.gather(
+                services.typed_cache.catalog.get_many_by_ids(
+                    CachedProduct,
+                    parent_product_ids,
+                    include_archived=True,
+                    include_deleted=True,
+                ),
+                services.typed_cache.catalog.get_many_by_ids(
+                    CachedMaterial,
+                    parent_material_ids,
+                    include_archived=True,
+                    include_deleted=True,
+                ),
+            )
+            for vid, fallback in zip(missing_ids, fallback_variants, strict=True):
+                if fallback is None:
+                    continue
+                pid = unwrap_unset(getattr(fallback, "product_id", None), None)
+                mid = unwrap_unset(getattr(fallback, "material_id", None), None)
+                parent = None
+                if pid is not None:
+                    parent = products_by_id.get(pid)
+                elif mid is not None:
+                    parent = materials_by_id.get(mid)
+                parent_name = (
+                    getattr(parent, "name", None) if parent is not None else None
+                )
+                sku_value = unwrap_unset(getattr(fallback, "sku", None), None)
+                config_attrs = unwrap_unset(
+                    getattr(fallback, "config_attributes", None), []
+                )
+                display_name = build_variant_display_name(
+                    parent_name, config_attrs, sku_value
+                )
+                # Normalize to a dict so ``_sku_of`` / ``_display_name_of``
+                # below read uniformly — they already key off the
+                # ``isinstance(v, dict)`` branch for the cache-miss case.
+                cached_variants[vid] = {
+                    "sku": sku_value,
+                    "display_name": display_name,
+                    "product_id": pid,
+                    "material_id": mid,
+                }
+
+        def _sku_of(v: Any) -> str | None:
+            if v is None:
+                return None
+            if isinstance(v, dict):
+                return v.get("sku")
+            return getattr(v, "sku", None)
+
+        def _display_name_of(v: Any) -> str | None:
+            if v is None:
+                return None
+            if isinstance(v, dict):
+                return v.get("display_name")
+            return getattr(v, "display_name", None)
+
+        # Build a map of SKU -> (PO row, display_name) for matching. The
+        # display_name is cached alongside the row so each MatchResult /
+        # Discrepancy can surface the canonical name without re-resolving.
+        sku_to_row: dict[str, tuple[Any, str]] = {}
         for row in po_rows:
             variant_id = unwrap_unset(row.variant_id, None)
             if variant_id is None:
                 continue
-            variant = variant_by_id.get(variant_id)
-            if variant and variant.sku:
-                sku_to_row[variant.sku] = row
+            variant = cached_variants.get(variant_id)
+            sku = _sku_of(variant)
+            if sku:
+                sku_to_row[sku] = (row, _display_name_of(variant) or "")
 
         # Now match document items to PO rows
         matches: list[MatchResult] = []
@@ -1714,6 +1839,8 @@ async def _verify_order_document_impl(
                 discrepancies.append(
                     Discrepancy(
                         sku=doc_item.sku,
+                        # MISSING_IN_PO has no variant to resolve against
+                        # — leave display_name empty (the model default).
                         type=DiscrepancyType.MISSING_IN_PO,
                         expected=None,
                         actual=doc_item.quantity,
@@ -1722,7 +1849,7 @@ async def _verify_order_document_impl(
                 )
                 continue
 
-            row = sku_to_row[doc_item.sku]
+            row, display_name = sku_to_row[doc_item.sku]
             row_qty = unwrap_unset(row.quantity, 0.0)
             row_price = unwrap_unset(row.price_per_unit, 0.0)
 
@@ -1738,6 +1865,7 @@ async def _verify_order_document_impl(
                 discrepancies.append(
                     Discrepancy(
                         sku=doc_item.sku,
+                        display_name=display_name,
                         type=DiscrepancyType.QUANTITY_MISMATCH,
                         expected=row_qty,
                         actual=doc_item.quantity,
@@ -1754,6 +1882,7 @@ async def _verify_order_document_impl(
                 discrepancies.append(
                     Discrepancy(
                         sku=doc_item.sku,
+                        display_name=display_name,
                         type=DiscrepancyType.PRICE_MISMATCH,
                         expected=row_price,
                         actual=doc_item.unit_price,
@@ -1775,6 +1904,7 @@ async def _verify_order_document_impl(
             matches.append(
                 MatchResult(
                     sku=doc_item.sku,
+                    display_name=display_name,
                     quantity=doc_item.quantity,
                     unit_price=doc_item.unit_price,
                     status=status,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -814,6 +814,17 @@ class PurchaseOrderRowInfo(BaseModel):
     deleted_at: str | None = None
     quantity: float | None = None
     variant_id: int | None = None
+    sku: str | None = None
+    """SKU lifted from the typed cache via the row's ``variant_id``. Adds no
+    cost over the existing variant lookup ``_get_purchase_order_impl`` already
+    does for ``display_name``.
+    """
+    display_name: str | None = None
+    """Katana-UI-format human-readable name for this row's variant.
+
+    Lifted from the typed-cache ``CachedVariant.display_name`` column.
+    ``None`` when the variant can't be resolved (rare — deleted variant).
+    """
     tax_rate_id: int | None = None
     price_per_unit: float | None = None
     price_per_unit_in_base_currency: float | None = None
@@ -947,8 +958,19 @@ def _iso_optional(value: datetime | str | None) -> str | None:
     return value
 
 
-def _po_row_info(row: Any) -> PurchaseOrderRowInfo:
-    """Extract full row info from an attrs ``PurchaseOrderRow``."""
+def _po_row_info(
+    row: Any,
+    *,
+    sku: str | None = None,
+    display_name: str | None = None,
+) -> PurchaseOrderRowInfo:
+    """Extract full row info from an attrs ``PurchaseOrderRow``.
+
+    ``sku`` and ``display_name`` are looked up upstream in
+    ``_get_purchase_order_impl`` from the typed cache (one batched read for
+    every row's variant); pass them in so each rendered row carries the
+    canonical name without an extra API call per row.
+    """
     # batch_transactions items are attrs models — serialize them to dicts so
     # Pydantic can validate the list shape without cross-model coupling.
     raw_batch = unwrap_unset(row.batch_transactions, None) or []
@@ -966,6 +988,8 @@ def _po_row_info(row: Any) -> PurchaseOrderRowInfo:
         deleted_at=_iso_optional(unwrap_unset(row.deleted_at, None)),
         quantity=unwrap_unset(row.quantity, None),
         variant_id=unwrap_unset(row.variant_id, None),
+        sku=sku,
+        display_name=display_name,
         tax_rate_id=unwrap_unset(row.tax_rate_id, None),
         price_per_unit=unwrap_unset(row.price_per_unit, None),
         price_per_unit_in_base_currency=unwrap_unset(
@@ -1133,10 +1157,40 @@ def _build_get_purchase_order_response(
     *,
     additional_cost_rows: list[PurchaseOrderAdditionalCostRowInfo],
     accounting_metadata: list[PurchaseOrderAccountingMetadataInfo],
+    variants_by_id: dict[int, Any] | None = None,
 ) -> GetPurchaseOrderResponse:
-    """Build an exhaustive response from an attrs PO plus fetched side data."""
+    """Build an exhaustive response from an attrs PO plus fetched side data.
+
+    ``variants_by_id`` is the result of a batched typed-cache lookup for
+    every row's variant — passing it in lets each ``PurchaseOrderRowInfo``
+    carry the canonical SKU and Katana-UI ``display_name`` without any
+    extra API calls per row. Optional for callers that don't need the
+    enrichment (legacy code paths, fixture-driven tests); rows then surface
+    ``sku=None`` / ``display_name=None``.
+    """
+    variants_by_id = variants_by_id or {}
+
+    def _attr_or_none(v: Any, name: str) -> Any:
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return v.get(name)
+        return getattr(v, name, None)
+
     raw_rows = unwrap_unset(po.purchase_order_rows, None) or []
-    rows = [_po_row_info(r) for r in raw_rows]
+    rows = [
+        _po_row_info(
+            r,
+            sku=_attr_or_none(
+                variants_by_id.get(unwrap_unset(r.variant_id, None)), "sku"
+            ),
+            display_name=_attr_or_none(
+                variants_by_id.get(unwrap_unset(r.variant_id, None)),
+                "display_name",
+            ),
+        )
+        for r in raw_rows
+    ]
     supplier = _supplier_info(unwrap_unset(po.supplier, None))
 
     return GetPurchaseOrderResponse(
@@ -1224,10 +1278,31 @@ async def _get_purchase_order_impl(
         _fetch_po_accounting_metadata(services, po.id),
     )
 
+    # Enrich each row with its variant's SKU + canonical display_name from
+    # the typed cache — one batched IN-clause read instead of an API call
+    # per row. Cache misses simply yield ``None`` for both fields
+    # (consistent with the surface convention).
+    raw_rows = unwrap_unset(po.purchase_order_rows, None) or []
+    variant_ids: set[int] = {
+        vid
+        for vid in (unwrap_unset(r.variant_id, None) for r in raw_rows)
+        if vid is not None
+    }
+    from katana_public_api_client.models_pydantic._generated import CachedVariant
+
+    variants_by_id: dict[int, Any] = (
+        await services.typed_cache.catalog.get_many_by_ids(
+            CachedVariant, variant_ids, include_deleted=True
+        )
+        if variant_ids
+        else {}
+    )
+
     return _build_get_purchase_order_response(
         po,
         additional_cost_rows=additional_cost_rows,
         accounting_metadata=accounting_metadata,
+        variants_by_id=variants_by_id,
     )
 
 
@@ -1262,6 +1337,8 @@ _PO_SCALAR_FIELDS: tuple[str, ...] = (
 _PO_ROW_FIELDS: tuple[str, ...] = (
     "id",
     "variant_id",
+    "sku",
+    "display_name",
     "quantity",
     "price_per_unit",
     "price_per_unit_in_base_currency",
@@ -1671,16 +1748,15 @@ async def _verify_order_document_impl(
         # Build the exhaustive PO structured view — same shape as
         # get_purchase_order — so callers have full context on what was
         # compared against. Side-data fetches run concurrently via gather
-        # to avoid doubling latency on the verify path.
+        # to avoid doubling latency on the verify path. ``variants_by_id``
+        # is plumbed in below (built right after we have ``po_rows``) so
+        # each row in the embedded ``purchase_order`` response carries the
+        # canonical SKU + display_name from the same cache read the verify
+        # path already does.
         default_group_id = unwrap_unset(po.default_group_id, None)
         additional_cost_rows, accounting_metadata = await asyncio.gather(
             _fetch_po_additional_cost_rows(services, default_group_id),
             _fetch_po_accounting_metadata(services, po.id),
-        )
-        exhaustive_po = _build_get_purchase_order_response(
-            po,
-            additional_cost_rows=additional_cost_rows,
-            accounting_metadata=accounting_metadata,
         )
 
         # Extract order number safely using unwrap_unset
@@ -1688,32 +1764,17 @@ async def _verify_order_document_impl(
 
         # Get PO rows - use unwrap_unset for UNSET check
         po_rows_raw = unwrap_unset(po.purchase_order_rows, None)
-        if not po_rows_raw:
-            return VerifyOrderDocumentResponse(
-                order_id=request.order_id,
-                purchase_order=exhaustive_po,
-                matches=[],
-                discrepancies=[],
-                suggested_actions=["Verify purchase order data in Katana"],
-                overall_status="no_match",
-                message=f"Purchase order {order_no} has no line items",
-            )
+        po_rows = po_rows_raw or []
 
-        po_rows = po_rows_raw
-
-        # Collect all variant IDs from PO rows using unwrap_unset
-        variant_ids: list[int] = []
-        for row in po_rows:
-            variant_id = unwrap_unset(row.variant_id, None)
-            if variant_id is not None:
-                variant_ids.append(variant_id)
-
-        # Resolve SKU + canonical display_name in one cache read instead of
-        # an API call per row. The typed cache pre-computes
-        # ``CachedVariant.display_name`` via the variant postprocess hook
-        # (same Katana-UI formula used by every other surface — see
-        # ``build_variant_display_name``). API fallback covers cold-cache
-        # gaps so a fresh install doesn't silently lose verification rows.
+        # Collect variant IDs and resolve SKU + canonical display_name in
+        # one batched cache read instead of an API call per row. The typed
+        # cache pre-computes ``CachedVariant.display_name`` via the variant
+        # postprocess hook (same Katana-UI formula used by every other
+        # surface — see ``build_variant_display_name``). API fallback covers
+        # cold-cache gaps so a fresh install doesn't silently lose
+        # verification rows. ``cached_variants`` also flows into
+        # ``_build_get_purchase_order_response`` so the embedded
+        # ``purchase_order`` response carries the same canonical names.
         from katana_mcp.tools.foundation.items import _fetch_variant_by_id
         from katana_public_api_client.domain.variant import (
             build_variant_display_name,
@@ -1723,6 +1784,12 @@ async def _verify_order_document_impl(
             CachedProduct,
             CachedVariant,
         )
+
+        variant_ids: list[int] = [
+            vid
+            for vid in (unwrap_unset(row.variant_id, None) for row in po_rows)
+            if vid is not None
+        ]
 
         cached_variants: dict[
             int, Any
@@ -1801,6 +1868,24 @@ async def _verify_order_document_impl(
                     "product_id": pid,
                     "material_id": mid,
                 }
+
+        exhaustive_po = _build_get_purchase_order_response(
+            po,
+            additional_cost_rows=additional_cost_rows,
+            accounting_metadata=accounting_metadata,
+            variants_by_id=cached_variants,
+        )
+
+        if not po_rows_raw:
+            return VerifyOrderDocumentResponse(
+                order_id=request.order_id,
+                purchase_order=exhaustive_po,
+                matches=[],
+                discrepancies=[],
+                suggested_actions=["Verify purchase order data in Katana"],
+                overall_status="no_match",
+                message=f"Purchase order {order_no} has no line items",
+            )
 
         def _sku_of(v: Any) -> str | None:
             if v is None:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -2189,6 +2189,18 @@ class PurchaseOrderRowSummary(BaseModel):
 
     id: int | None = None
     variant_id: int | None = None
+    sku: str | None = None
+    """SKU from the variant, populated when the typed cache resolves the
+    row's ``variant_id``. ``None`` on cache miss — matches the convention
+    used by ``SalesOrderRowInfo``.
+    """
+    display_name: str | None = None
+    """Katana-UI-format human-readable name. Like ``sku``, lifted from
+    the typed cache when the row's variant is present. ``None`` on cache
+    miss. The list-tool path uses ``ensure_purchase_orders_synced`` so
+    these are typically populated in steady state; cold-cache callers may
+    see ``None`` until the next variant sync runs.
+    """
     quantity: float | None = None
     price_per_unit: float | None = None
     arrival_date: str | None = None
@@ -2382,6 +2394,34 @@ async def _list_purchase_orders_impl(
                 last_page=request.page >= total_pages,
             )
 
+    # When ``include_rows`` is set, collect every row's variant_id and do
+    # one batched cache read to lift SKU + canonical display_name onto each
+    # row summary. Adds one extra IN-clause read regardless of result-set
+    # size — much cheaper than the per-row API fallback the get path uses
+    # (the list path explicitly stays cache-only by design to keep the
+    # ``ensure_purchase_orders_synced`` + single-query win intact).
+    variant_lookup: dict[int, Any] = {}
+    if request.include_rows:
+        from katana_public_api_client.models_pydantic._generated import CachedVariant
+
+        variant_ids = {
+            r.variant_id
+            for po, _ in orders_with_counts
+            for r in po.purchase_order_rows
+            if r.variant_id is not None
+        }
+        if variant_ids:
+            variant_lookup = await services.typed_cache.catalog.get_many_by_ids(
+                CachedVariant, variant_ids, include_deleted=True
+            )
+
+    def _row_attr(v: Any, name: str) -> Any:
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return v.get(name)
+        return getattr(v, name, None)
+
     summaries: list[PurchaseOrderSummary] = []
     for po, row_count in orders_with_counts:
         rows: list[PurchaseOrderRowSummary] | None = None
@@ -2390,6 +2430,10 @@ async def _list_purchase_orders_impl(
                 PurchaseOrderRowSummary(
                     id=r.id,
                     variant_id=r.variant_id,
+                    sku=_row_attr(variant_lookup.get(r.variant_id), "sku"),
+                    display_name=_row_attr(
+                        variant_lookup.get(r.variant_id), "display_name"
+                    ),
                     quantity=r.quantity,
                     price_per_unit=r.price_per_unit,
                     arrival_date=iso_or_none(r.arrival_date),

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -1177,17 +1177,20 @@ def _build_get_purchase_order_response(
             return v.get(name)
         return getattr(v, name, None)
 
+    def _variant_for(row: Any) -> Any:
+        # ``variant_id`` may be ``None`` on stub rows; the typed-cache map
+        # only ever stores int keys, so guard against ``None`` lookups to
+        # keep ty/pyright satisfied (``dict.get(None)`` widens the value
+        # type and silently shadows hits).
+        vid = unwrap_unset(row.variant_id, None)
+        return variants_by_id.get(vid) if vid is not None else None
+
     raw_rows = unwrap_unset(po.purchase_order_rows, None) or []
     rows = [
         _po_row_info(
             r,
-            sku=_attr_or_none(
-                variants_by_id.get(unwrap_unset(r.variant_id, None)), "sku"
-            ),
-            display_name=_attr_or_none(
-                variants_by_id.get(unwrap_unset(r.variant_id, None)),
-                "display_name",
-            ),
+            sku=_attr_or_none(_variant_for(r), "sku"),
+            display_name=_attr_or_none(_variant_for(r), "display_name"),
         )
         for r in raw_rows
     ]
@@ -2422,6 +2425,13 @@ async def _list_purchase_orders_impl(
             return v.get(name)
         return getattr(v, name, None)
 
+    def _variant_for_row(row: Any) -> Any:
+        # Guard ``None`` lookups so the dict-get type stays narrow and
+        # ``CachedVariant`` rows without a variant_id don't silently shadow
+        # the empty-map default.
+        vid = row.variant_id
+        return variant_lookup.get(vid) if vid is not None else None
+
     summaries: list[PurchaseOrderSummary] = []
     for po, row_count in orders_with_counts:
         rows: list[PurchaseOrderRowSummary] | None = None
@@ -2430,10 +2440,8 @@ async def _list_purchase_orders_impl(
                 PurchaseOrderRowSummary(
                     id=r.id,
                     variant_id=r.variant_id,
-                    sku=_row_attr(variant_lookup.get(r.variant_id), "sku"),
-                    display_name=_row_attr(
-                        variant_lookup.get(r.variant_id), "display_name"
-                    ),
+                    sku=_row_attr(_variant_for_row(r), "sku"),
+                    display_name=_row_attr(_variant_for_row(r), "display_name"),
                     quantity=r.quantity,
                     price_per_unit=r.price_per_unit,
                     arrival_date=iso_or_none(r.arrival_date),

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -677,12 +677,12 @@ class SalesOrderRowInfo(BaseModel):
     variant_id: int | None
     sku: str | None
     display_name: str | None = None
-    """Katana-UI-format human-readable name. Unpopulated by ``list_sales_orders``
-    today — resolving requires a per-row variant lookup that would defeat
-    the single-query win. Use ``get_sales_order`` for SKU- and display-name-
-    enriched rows on a specific order. Left in the model for forward-compat
-    so a future cache-side denormalization can fill it without bumping the
-    response shape.
+    """Katana-UI-format human-readable name lifted from the typed cache
+    in a single batched IN-clause read (one query regardless of result-set
+    size). ``None`` on cache miss; the list path stays cache-only by design
+    so the variant must be present in ``CachedVariant`` for the field to
+    populate. Matches the convention used by every other variant-displaying
+    surface (search_items, check_inventory, recipe rows, verify card).
     """
     quantity: float | None
     price_per_unit: float | None
@@ -876,8 +876,33 @@ async def _list_sales_orders_impl(
                 last_page=request.page >= total_pages,
             )
 
-    # ``sku`` stays None — resolving it would require a variant lookup
-    # per row and defeat the single-query win.
+    # When ``include_rows`` is set, lift SKU + canonical display_name from
+    # the typed cache in one batched IN-clause read. Adds one extra query
+    # — much cheaper than the per-row API fallback the get path uses, and
+    # keeps the ``ensure_sales_orders_synced`` cache-only win for everything
+    # else.
+    variant_lookup: dict[int, Any] = {}
+    if request.include_rows:
+        from katana_public_api_client.models_pydantic._generated import CachedVariant
+
+        variant_ids = {
+            r.variant_id
+            for so, _ in orders_with_counts
+            for r in so.sales_order_rows
+            if r.variant_id is not None
+        }
+        if variant_ids:
+            variant_lookup = await services.typed_cache.catalog.get_many_by_ids(
+                CachedVariant, variant_ids, include_deleted=True
+            )
+
+    def _row_attr(v: Any, name: str) -> Any:
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return v.get(name)
+        return getattr(v, name, None)
+
     orders: list[SalesOrderSummary] = []
     for so, row_count in orders_with_counts:
         row_infos: list[SalesOrderRowInfo] | None = None
@@ -886,7 +911,10 @@ async def _list_sales_orders_impl(
                 SalesOrderRowInfo(
                     id=r.id,
                     variant_id=r.variant_id,
-                    sku=None,
+                    sku=_row_attr(variant_lookup.get(r.variant_id), "sku"),
+                    display_name=_row_attr(
+                        variant_lookup.get(r.variant_id), "display_name"
+                    ),
                     quantity=r.quantity,
                     price_per_unit=r.price_per_unit,
                     linked_manufacturing_order_id=r.linked_manufacturing_order_id,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -903,6 +903,13 @@ async def _list_sales_orders_impl(
             return v.get(name)
         return getattr(v, name, None)
 
+    def _variant_for_row(row: Any) -> Any:
+        # Guard ``None`` lookups — keeps the dict-get type narrow and
+        # avoids silently shadowing the empty-map default for rows that
+        # legitimately carry ``variant_id=None``.
+        vid = row.variant_id
+        return variant_lookup.get(vid) if vid is not None else None
+
     orders: list[SalesOrderSummary] = []
     for so, row_count in orders_with_counts:
         row_infos: list[SalesOrderRowInfo] | None = None
@@ -911,10 +918,8 @@ async def _list_sales_orders_impl(
                 SalesOrderRowInfo(
                     id=r.id,
                     variant_id=r.variant_id,
-                    sku=_row_attr(variant_lookup.get(r.variant_id), "sku"),
-                    display_name=_row_attr(
-                        variant_lookup.get(r.variant_id), "display_name"
-                    ),
+                    sku=_row_attr(_variant_for_row(r), "sku"),
+                    display_name=_row_attr(_variant_for_row(r), "display_name"),
                     quantity=r.quantity,
                     price_per_unit=r.price_per_unit,
                     linked_manufacturing_order_id=r.linked_manufacturing_order_id,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -676,6 +676,14 @@ class SalesOrderRowInfo(BaseModel):
     id: int
     variant_id: int | None
     sku: str | None
+    display_name: str | None = None
+    """Katana-UI-format human-readable name. Unpopulated by ``list_sales_orders``
+    today — resolving requires a per-row variant lookup that would defeat
+    the single-query win. Use ``get_sales_order`` for SKU- and display-name-
+    enriched rows on a specific order. Left in the model for forward-compat
+    so a future cache-side denormalization can fill it without bumping the
+    response shape.
+    """
     quantity: float | None
     price_per_unit: float | None
     linked_manufacturing_order_id: int | None
@@ -1009,6 +1017,14 @@ class SalesOrderRowDetail(BaseModel):
     id: int
     variant_id: int | None = None
     sku: str | None = None
+    display_name: str | None = None
+    """Katana-UI-format human-readable name for this row's variant.
+
+    Lifted from the typed-cache ``CachedVariant.display_name`` column
+    (built via :func:`build_variant_display_name`) so the rendered name
+    stays consistent with every other variant-displaying surface. ``None``
+    when the variant can't be resolved from the cache.
+    """
     quantity: float | None = None
     sales_order_id: int | None = None
     tax_rate_id: int | None = None
@@ -1287,6 +1303,14 @@ async def _get_sales_order_impl(
             return v.get("sku")
         return getattr(v, "sku", None)
 
+    def _display_name_for(v: Any) -> str | None:
+        """Lift the typed cache's pre-computed display_name when available."""
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return v.get("display_name")
+        return getattr(v, "display_name", None)
+
     row_details: list[SalesOrderRowDetail] = []
     for r in raw_rows:
         v_id = unwrap_unset(r.variant_id, None)
@@ -1296,6 +1320,7 @@ async def _get_sales_order_impl(
                 id=r.id,
                 variant_id=v_id,
                 sku=_sku_for(variant),
+                display_name=_display_name_for(variant),
                 quantity=unwrap_unset(r.quantity, None),
                 sales_order_id=unwrap_unset(r.sales_order_id, None),
                 tax_rate_id=unwrap_unset(r.tax_rate_id, None),
@@ -1433,8 +1458,11 @@ _ADDRESS_FIELDS: tuple[str, ...] = (
 )
 
 # Per-row fields rendered under a ``rows`` block. ``id`` + ``variant_id`` /
-# ``sku`` are emitted first as the row header; the rest are indented beneath.
-_ROW_HEADER_FIELDS: tuple[str, ...] = ("variant_id", "sku")
+# ``sku`` / ``display_name`` are emitted first as the row header; the rest
+# are indented beneath. ``display_name`` carries the canonical Katana-UI
+# name (parent / value1 / value2) so each row in the rendered output
+# matches the convention used by every other variant-displaying surface.
+_ROW_HEADER_FIELDS: tuple[str, ...] = ("variant_id", "sku", "display_name")
 _ROW_BODY_FIELDS: tuple[str, ...] = (
     "sales_order_id",
     "quantity",

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -2189,12 +2189,19 @@ def build_batch_recipe_update_ui(
         label = op.get("group_label") or "Other"
         groups.setdefault(label, []).append(op)
 
-    # Augment each row with display-friendly fields (flatten nested structure)
+    # Augment each row with display-friendly fields (flatten nested structure).
+    # ``item`` column prefers the canonical ``display_name`` (Katana-UI format
+    # ``parent / value1 / value2`` built upstream via
+    # ``build_variant_display_name``), then SKU, then a ``variant {id}``
+    # fallback so the row always renders something meaningful even on
+    # cold-cache calls where neither is resolved.
     flat_rows: list[dict[str, Any]] = []
     for label, ops in groups.items():
         for op in ops:
-            sku_or_variant = op.get("sku") or (
-                f"variant {op['variant_id']}" if op.get("variant_id") else ""
+            display = (
+                op.get("display_name")
+                or op.get("sku")
+                or (f"variant {op['variant_id']}" if op.get("variant_id") else "")
             )
             flat_rows.append(
                 {
@@ -2202,7 +2209,8 @@ def build_batch_recipe_update_ui(
                     "mo_id": op.get("manufacturing_order_id"),
                     "action": (op.get("op_type") or "").upper(),
                     "row_id": op.get("recipe_row_id") or "(new)",
-                    "sku": sku_or_variant,
+                    "sku": op.get("sku") or "",
+                    "item": display,
                     "qty": op.get("planned_quantity_per_unit") or "",
                     "status": (op.get("status") or "pending").upper(),
                     "error": op.get("error") or "",
@@ -2257,13 +2265,17 @@ def build_batch_recipe_update_ui(
                 Metric(label="Failed", value=str(failed))
                 Metric(label="Skipped", value=str(skipped))
 
-        # One big table with all ops, grouped visually by the group column
+        # One big table with all ops, grouped visually by the group column.
+        # ``Item`` shows the canonical Katana-UI display name (parent / value1
+        # / value2) when the upstream caller resolved a variant; ``SKU`` keeps
+        # the raw SKU as a secondary identity column for ops + scripts.
         DataTable(
             columns=[
                 DataTableColumn(key="group", header="Group", sortable=True),
                 DataTableColumn(key="mo_id", header="MO", sortable=True),
                 DataTableColumn(key="action", header="Action"),
                 DataTableColumn(key="row_id", header="Row ID"),
+                DataTableColumn(key="item", header="Item"),
                 DataTableColumn(key="sku", header="SKU"),
                 DataTableColumn(key="qty", header="Qty", align="right"),
                 DataTableColumn(key="status", header="Status", sortable=True),

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -1623,11 +1623,15 @@ def build_verification_ui(
                 label=overall_status.replace("_", " ").title(), variant=status_variant
             )
 
-        # Matches table
+        # Matches table — ``Item`` column shows the canonical
+        # Katana-UI-format display name (parent / config1 / config2),
+        # ``SKU`` remains as a secondary identity column for ops + scripts.
+        # Same column ordering used by the batch recipe update card.
         if matches:
             Muted(content="Matched Items:")
             DataTable(
                 columns=[
+                    DataTableColumn(key="display_name", header="Item", sortable=True),
                     DataTableColumn(key="sku", header="SKU", sortable=True),
                     DataTableColumn(key="quantity", header="Quantity", align="right"),
                     DataTableColumn(key="unit_price", header="Price", align="right"),
@@ -1636,11 +1640,13 @@ def build_verification_ui(
                 rows="{{ matches }}",
             )
 
-        # Discrepancies table
+        # Discrepancies table — same ``Item`` / ``SKU`` ordering for
+        # visual consistency with the matches table above.
         if discrepancies:
             Muted(content="Discrepancies:")
             DataTable(
                 columns=[
+                    DataTableColumn(key="display_name", header="Item"),
                     DataTableColumn(key="sku", header="SKU"),
                     DataTableColumn(key="type", header="Type"),
                     DataTableColumn(key="message", header="Details"),

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -720,6 +720,46 @@ class TestBuildVerificationUI:
         app = build_verification_ui(response)
         _assert_valid_prefab(app)
 
+    def test_match_and_discrepancy_tables_include_item_column(self):
+        """Both tables expose ``Item`` as the leading sortable column so the
+        rendered card shows the canonical Katana-UI display name ahead of
+        the raw SKU — matching every other variant-displaying surface
+        (search_items, check_inventory, batch recipe update card).
+        """
+        response = {
+            "overall_status": "partial_match",
+            "order_id": 789,
+            "matches": [
+                {
+                    "sku": "WIDGET-001",
+                    "display_name": "Acme Widget / Large / Red",
+                    "quantity": 10,
+                    "unit_price": 5.0,
+                    "status": "perfect",
+                }
+            ],
+            "discrepancies": [
+                {
+                    "sku": "WIDGET-002",
+                    "display_name": "Acme Widget / Small / Blue",
+                    "type": "quantity_mismatch",
+                    "message": "Quantity off by 2",
+                }
+            ],
+        }
+        app = build_verification_ui(response)
+        envelope = app.to_json()
+
+        # Both DataTable nodes must have ``Item`` (display_name) as the
+        # first column, with ``SKU`` immediately after.
+        tables = _find_components_by_type(envelope, "DataTable")
+        assert len(tables) == 2  # matches + discrepancies
+        for table in tables:
+            cols = table.get("columns", [])
+            assert cols[0]["key"] == "display_name"
+            assert cols[0]["header"] == "Item"
+            assert cols[1]["key"] == "sku"
+
 
 class TestBuildItemMutationUI:
     @pytest.mark.parametrize("action", ["Created", "Updated", "Deleted"])

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -880,6 +880,88 @@ class TestBuildBatchRecipeUpdateUI:
         app = build_batch_recipe_update_ui(response)
         _assert_valid_prefab(app)
 
+    def test_rows_carry_canonical_display_name_when_supplied(self):
+        """Each result op may carry ``display_name`` — the Katana-UI-format
+        ``parent / value1 / value2`` name built upstream via
+        ``build_variant_display_name``. The flattened ``rows`` state slot
+        surfaces it via the ``item`` column so the rendered DataTable shows
+        the same canonical name as every other variant-displaying surface
+        (search_items, check_inventory, variant card).
+        """
+        response = {
+            "is_preview": True,
+            "total_ops": 1,
+            "success_count": 0,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "op_type": "add",
+                    "manufacturing_order_id": 9999,
+                    "variant_id": 200,
+                    "sku": "NEW-FORK",
+                    "display_name": "Fox Float / 36mm / Black",
+                    "planned_quantity_per_unit": 1.0,
+                    "status": "pending",
+                    "group_label": "OLD-FORK → [NEW-FORK]",
+                },
+            ],
+            "warnings": [],
+            "message": "Preview: 1 sub-op planned",
+        }
+        app = build_batch_recipe_update_ui(response)
+        envelope = app.to_json()
+
+        # The flattened state slot the DataTable binds to must carry the
+        # canonical display name on its ``item`` column.
+        state_rows = envelope["state"]["rows"]
+        assert len(state_rows) == 1
+        assert state_rows[0]["item"] == "Fox Float / 36mm / Black"
+        # SKU still flows through as its own column for ops/scripts.
+        assert state_rows[0]["sku"] == "NEW-FORK"
+
+    def test_rows_fall_back_to_sku_when_display_name_absent(self):
+        """Backward-compat: ops emitted by older code paths (or test fixtures
+        that don't compute display_name) fall through to SKU, then to the
+        ``variant {id}`` sentinel. Pins the resolution order: display_name >
+        sku > 'variant {id}' > empty string.
+        """
+        response = {
+            "is_preview": True,
+            "total_ops": 2,
+            "success_count": 0,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "op_type": "add",
+                    "manufacturing_order_id": 9999,
+                    "variant_id": 300,
+                    "sku": "FALLBACK-SKU",
+                    "planned_quantity_per_unit": 1.0,
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+                {
+                    "op_type": "add",
+                    "manufacturing_order_id": 9999,
+                    "variant_id": 301,
+                    "planned_quantity_per_unit": 1.0,
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+            ],
+            "warnings": [],
+            "message": "Preview: 2 sub-ops planned",
+        }
+        app = build_batch_recipe_update_ui(response)
+        envelope = app.to_json()
+
+        state_rows = envelope["state"]["rows"]
+        assert state_rows[0]["item"] == "FALLBACK-SKU"
+        # Neither display_name nor sku — falls through to ``variant {id}``.
+        assert state_rows[1]["item"] == "variant 301"
+
 
 def _confirm_button_on_click(envelope: dict, label: str) -> list[dict]:
     """Return the on_click action list for the Confirm button matching ``label``.

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -512,6 +512,10 @@ _FULL_PRODUCT_DICT = {
             "type": "product",
             "sales_price": 299.99,
             "purchase_price": 150.0,
+            "config_attributes": [
+                {"config_name": "Piece Count", "config_value": "8-piece"},
+                {"config_name": "Handle Material", "config_value": "Steel"},
+            ],
         }
     ],
     "configs": [
@@ -646,6 +650,14 @@ async def test_get_item_product_surfaces_every_field():
     assert len(result.variants) == 1
     assert result.variants[0].sku == "KNF-PRO-8PC-STL"
     assert result.variants[0].sales_price == 299.99
+    # display_name follows the Katana-UI canonical format
+    # ``"{parent_name} / {config1} / {config2}"`` via
+    # ``build_variant_display_name`` — same formula as the typed cache's
+    # ``CachedVariant.display_name`` column and ``VariantDetailsResponse``.
+    assert (
+        result.variants[0].display_name
+        == "Professional Kitchen Knife Set / 8-piece / Steel"
+    )
     assert len(result.configs) == 1
     assert result.configs[0].name == "Piece Count"
     assert result.configs[0].values == ["8-piece", "12-piece"]
@@ -799,6 +811,49 @@ def test_variant_to_summary_falls_back_to_default_cost_when_purchase_price_absen
 
     assert summary is not None
     assert summary.purchase_price == 50.0
+
+
+def test_variant_to_summary_builds_canonical_display_name_with_parent_and_configs():
+    """``_variant_to_summary`` populates ``display_name`` via the canonical
+    helper (``parent / value1 / value2``) when a ``parent_name`` is supplied.
+    Mirrors how every other variant-displaying surface formats the name —
+    typed-cache ``CachedVariant.display_name``, ``VariantDetailsResponse.display_name``,
+    and ``KatanaVariant.get_display_name`` all delegate to
+    ``build_variant_display_name``, and the embedded variant summary must
+    match.
+    """
+    from katana_mcp.tools.foundation.items import _variant_to_summary
+
+    summary = _variant_to_summary(
+        {
+            "id": 7001,
+            "sku": "KNF-PRO-8PC-STL",
+            "sales_price": 299.99,
+            "type": "product",
+            "config_attributes": [
+                {"config_name": "Piece Count", "config_value": "8-piece"},
+                {"config_name": "Handle Material", "config_value": "Steel"},
+            ],
+        },
+        parent_name="Professional Kitchen Knife Set",
+    )
+
+    assert summary is not None
+    assert summary.display_name == "Professional Kitchen Knife Set / 8-piece / Steel"
+
+
+def test_variant_to_summary_display_name_falls_back_to_sku_without_parent():
+    """When no ``parent_name`` is supplied (helper called bare), the
+    Katana-UI display falls back to the SKU — matches
+    ``build_variant_display_name(None, [], sku)`` behaviour.
+    """
+    from katana_mcp.tools.foundation.items import _variant_to_summary
+
+    summary = _variant_to_summary({"id": 7002, "sku": "ORPHAN-1"})
+
+    assert summary is not None
+    # Empty parent → falls back to the SKU (canonical helper contract).
+    assert summary.display_name == "ORPHAN-1"
 
 
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -619,8 +619,12 @@ async def test_get_manufacturing_order_recipe():
     context, lifespan_ctx = create_mock_context()
     lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
         return_value={
-            101: {"id": 101, "sku": "FORK-001"},
-            102: {"id": 102, "sku": "BOLT-004"},
+            101: {
+                "id": 101,
+                "sku": "FORK-001",
+                "display_name": "Fox Float / 36mm / Black",
+            },
+            102: {"id": 102, "sku": "BOLT-004", "display_name": "M5 Bolt / 12mm"},
         }
     )
 
@@ -662,7 +666,12 @@ async def test_get_manufacturing_order_recipe():
     assert result.total_count == 2
     assert result.rows[0].id == 5001
     assert result.rows[0].sku == "FORK-001"
+    # ``display_name`` is lifted from CachedVariant so each rendered row
+    # carries the canonical Katana-UI-format name, matching every other
+    # variant-displaying surface (search_items, check_inventory, variant card).
+    assert result.rows[0].display_name == "Fox Float / 36mm / Black"
     assert result.rows[1].sku == "BOLT-004"
+    assert result.rows[1].display_name == "M5 Bolt / 12mm"
 
 
 @pytest.mark.asyncio
@@ -1561,7 +1570,11 @@ async def test_get_manufacturing_order_recipe_full_field_coverage():
         total_remaining_quantity=25.0,
     )
 
-    info = _recipe_row_info_from_attrs(attrs_row, sku="STEEL-304")
+    info = _recipe_row_info_from_attrs(
+        attrs_row,
+        sku="STEEL-304",
+        display_name="Stainless Steel Sheet 304 / 1.5mm",
+    )
 
     # Previously-dropped fields:
     assert info.manufacturing_order_id == 3001
@@ -1578,6 +1591,10 @@ async def test_get_manufacturing_order_recipe_full_field_coverage():
     assert info.id == 4001
     assert info.variant_id == 3201
     assert info.sku == "STEEL-304"
+    # ``display_name`` is the canonical Katana-UI-format name — surfaced on
+    # every recipe row so the rendered card matches search_items / variant
+    # detail / inventory card naming.
+    assert info.display_name == "Stainless Steel Sheet 304 / 1.5mm"
     assert info.notes == "Use only grade 304 material"
     assert info.planned_quantity_per_unit == 2.5
     assert info.total_actual_quantity == 125.0

--- a/katana_mcp_server/tests/tools/test_orders.py
+++ b/katana_mcp_server/tests/tools/test_orders.py
@@ -265,11 +265,125 @@ async def test_fulfill_sales_order_preview():
     assert result.status == "NOT_SHIPPED"
     assert result.is_preview is True
     # Preview now lists the rows that will ship — one entry per SO row.
+    # On cold cache (no display_name resolved) the line falls back to the
+    # ``variant {id}`` sentinel, same as the legacy contract.
     assert len(result.inventory_updates) == 2
     assert any("variant 100" in u for u in result.inventory_updates)
     assert any("variant 200" in u for u in result.inventory_updates)
     # Last next_action should mention preview=false.
     assert any("preview=false" in a for a in result.next_actions)
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_preview_lifts_display_name():
+    """When the typed cache resolves each row's variant, the inventory-
+    update line leads with the canonical Katana-UI display name
+    (parent / value1 / value2) — matching every other variant-displaying
+    surface. Falls back to the ``variant {id}`` sentinel only on cache
+    miss + no parent.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-DISPLAY"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [
+        _make_so_row(1, 100, 2.0),
+        _make_so_row(2, 200, 5.0),
+    ]
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    # Seed the typed cache so each variant resolves to a canonical
+    # display_name (avoiding the parent-lookup branch — which is exercised
+    # by the verify-card test path instead).
+    def _mk_cached(vid, sku, display_name):
+        m = MagicMock()
+        m.id = vid
+        m.sku = sku
+        m.display_name = display_name
+        m.product_id = None
+        m.material_id = None
+        m.config_attributes = []
+        return m
+
+    async def _get_many(model_cls, ids, **_kw):
+        # Variant lookup: return per-variant cache rows. Product/Material
+        # lookups: empty (variants don't have parents in this fixture, so
+        # serial-tracked stays False, which is fine).
+        from katana_public_api_client.models_pydantic._generated import CachedVariant
+
+        if model_cls is CachedVariant:
+            data = {
+                100: _mk_cached(100, "WIDGET-100", "Big Widget / Red"),
+                200: _mk_cached(200, "WIDGET-200", "Small Widget / Blue"),
+            }
+            return {vid: data[vid] for vid in ids if vid in data}
+        return {}
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(side_effect=_get_many)
+
+    request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=True)
+    result = await _fulfill_order_impl(request, context)
+
+    # Both lines lead with the canonical display name (parent / config1).
+    assert len(result.inventory_updates) == 2
+    assert any("Big Widget / Red" in u for u in result.inventory_updates)
+    assert any("Small Widget / Blue" in u for u in result.inventory_updates)
+
+
+@pytest.mark.asyncio
+async def test_fulfill_manufacturing_order_preview_lifts_display_name():
+    """The MO fulfillment summary surfaces the finished-good's canonical
+    display name in the "will produce X" line, matching the SO sibling.
+    Cold-cache fallback returns ``variant {id}`` (default behaviour pinned
+    by ``test_fulfill_manufacturing_order_preview``).
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    mock_mo = MagicMock(spec=ManufacturingOrder)
+    mock_mo.order_no = "MO-DISPLAY"
+    mock_mo.status = ManufacturingOrderStatus.IN_PROGRESS
+    mock_mo.variant_id = 555
+    mock_mo.actual_quantity = 2
+
+    mock_response = MagicMock(status_code=200, parsed=mock_mo)
+    from katana_public_api_client.api.manufacturing_order import get_manufacturing_order
+
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_response
+    )
+
+    cached_variant = MagicMock()
+    cached_variant.id = 555
+    cached_variant.sku = "BIKE-MAYHEM"
+    cached_variant.display_name = "Mayhem Bike / Large / Black"
+    cached_variant.product_id = None
+    cached_variant.material_id = None
+    cached_variant.config_attributes = []
+
+    async def _get_many(model_cls, ids, **_kw):
+        from katana_public_api_client.models_pydantic._generated import CachedVariant
+
+        if model_cls is CachedVariant and 555 in set(ids):
+            return {555: cached_variant}
+        return {}
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(side_effect=_get_many)
+
+    request = FulfillOrderRequest(
+        order_id=9876, order_type="manufacturing", preview=True
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.is_preview is True
+    # Lead line surfaces the canonical display name (the prior line said
+    # only "Manufacturing order completion will update inventory based on BOM",
+    # which gave the user no signal what was being made).
+    assert any("Mayhem Bike / Large / Black" in u for u in result.inventory_updates)
 
 
 @pytest.mark.asyncio

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -98,12 +98,33 @@ def create_mock_po_row(variant_id, quantity, price):
     )
 
 
-def create_mock_variant(variant_id: int, sku: str):
-    """Create a mock variant."""
+def create_mock_variant(variant_id: int, sku: str, display_name: str | None = None):
+    """Create a mock variant cache row carrying the canonical display name.
+
+    Mirrors the shape of a ``CachedVariant`` row — id, sku, and the
+    pre-computed Katana-UI display name. The verify path reads
+    ``display_name`` to surface the canonical name on each MatchResult /
+    Discrepancy, so test fixtures must populate the field. When
+    ``display_name`` is omitted, the helper synthesizes a sensible default
+    (``"Item / {sku}"``) so existing tests keep passing.
+    """
     variant = MagicMock()
     variant.id = variant_id
     variant.sku = sku
+    variant.display_name = display_name if display_name is not None else f"Item / {sku}"
     return variant
+
+
+def stub_variant_cache(lifespan_ctx, variants: list) -> None:
+    """Stub the typed cache's variant-by-id lookup used by the verify path.
+
+    Returns a ``{variant_id: variant_mock}`` dict for the typed cache's
+    ``get_many_by_ids(CachedVariant, ids)`` call. The verify impl falls
+    back to ``_fetch_variant_by_id`` on cache miss; this helper pins the
+    cache-hit branch.
+    """
+    by_id = {v.id: v for v in variants}
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(return_value=by_id)
 
 
 def create_mock_po(order_id: int, order_no: str, rows: list):
@@ -618,7 +639,7 @@ async def test_verify_order_document_perfect_match():
     cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_po_response
     )
-    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+    stub_variant_cache(lifespan_ctx, mock_variants)
 
     # Document items matching PO perfectly
     request = VerifyOrderDocumentRequest(
@@ -670,7 +691,7 @@ async def test_verify_order_document_quantity_mismatch():
     cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_po_response
     )
-    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+    stub_variant_cache(lifespan_ctx, mock_variants)
 
     # Document with different quantity
     request = VerifyOrderDocumentRequest(
@@ -727,7 +748,7 @@ async def test_verify_order_document_price_mismatch():
     cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_po_response
     )
-    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+    stub_variant_cache(lifespan_ctx, mock_variants)
 
     # Document with different price
     request = VerifyOrderDocumentRequest(
@@ -782,7 +803,7 @@ async def test_verify_order_document_missing_in_po():
     cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_po_response
     )
-    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+    stub_variant_cache(lifespan_ctx, mock_variants)
 
     # Document includes WIDGET-002 which is not in PO
     request = VerifyOrderDocumentRequest(
@@ -839,7 +860,7 @@ async def test_verify_order_document_extra_in_document():
     cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_po_response
     )
-    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+    stub_variant_cache(lifespan_ctx, mock_variants)
 
     # Document only has WIDGET-001 (missing WIDGET-002 from PO)
     request = VerifyOrderDocumentRequest(
@@ -887,7 +908,7 @@ async def test_verify_order_document_mixed_discrepancies():
     cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_po_response
     )
-    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+    stub_variant_cache(lifespan_ctx, mock_variants)
 
     # Document with: perfect match, quantity mismatch, missing item
     request = VerifyOrderDocumentRequest(
@@ -1024,7 +1045,7 @@ async def test_verify_order_document_unset_values():
     cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_po_response
     )
-    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+    stub_variant_cache(lifespan_ctx, mock_variants)
 
     request = VerifyOrderDocumentRequest(
         order_id=1234,
@@ -1064,7 +1085,7 @@ async def test_verify_order_document_no_price_in_document():
     cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_po_response
     )
-    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+    stub_variant_cache(lifespan_ctx, mock_variants)
 
     # Document without price
     request = VerifyOrderDocumentRequest(
@@ -1100,21 +1121,29 @@ async def test_verify_order_document_variant_not_found():
     mock_po_response.parsed = mock_po
 
     # Variants list doesn't include variant_id=1
-    mock_variants = []
+    mock_variants: list = []
 
     cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_po_response
     )
-    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+    stub_variant_cache(lifespan_ctx, mock_variants)
 
-    request = VerifyOrderDocumentRequest(
-        order_id=1234,
-        document_items=[
-            DocumentItem(sku="WIDGET-001", quantity=100.0, unit_price=25.50),
-        ],
-    )
+    # Verify path falls back to ``_fetch_variant_by_id`` on cache miss —
+    # patch it to ``None`` so the test exercises the "variant truly absent"
+    # branch (PO row points at a deleted/missing variant).
+    with patch(
+        "katana_mcp.tools.foundation.items._fetch_variant_by_id",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        request = VerifyOrderDocumentRequest(
+            order_id=1234,
+            document_items=[
+                DocumentItem(sku="WIDGET-001", quantity=100.0, unit_price=25.50),
+            ],
+        )
 
-    result = await _verify_order_document_impl(request, context)
+        result = await _verify_order_document_impl(request, context)
 
     # Should handle gracefully - SKU won't be found in mapping
     assert result.order_id == 1234
@@ -1125,6 +1154,117 @@ async def test_verify_order_document_variant_not_found():
     ]
     assert len(missing_disc) == 1
     assert missing_disc[0].sku == "WIDGET-001"
+
+
+@pytest.mark.asyncio
+async def test_verify_order_document_carries_canonical_display_name():
+    """Every MatchResult and Discrepancy on the verify response carries
+    the canonical Katana-UI ``display_name``, lifted from the typed cache's
+    ``CachedVariant.display_name`` column (which itself delegates to
+    :func:`build_variant_display_name`). The verification card surfaces it
+    as the leading ``Item`` column so the rendered table matches every other
+    variant-displaying surface (search_items, check_inventory, batch recipe
+    update card).
+
+    Pins both the match branch (display_name lifted) and the discrepancy
+    branches (qty / price mismatch — display_name carried through to the
+    discrepancy entry). MISSING_IN_PO is exercised separately below.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    po_rows = [
+        create_mock_po_row(variant_id=1, quantity=100.0, price=25.50),
+        create_mock_po_row(variant_id=2, quantity=50.0, price=30.00),
+    ]
+    mock_po = create_mock_po(order_id=1234, order_no="PO-001", rows=po_rows)
+
+    mock_po_response = MagicMock()
+    mock_po_response.status_code = 200
+    mock_po_response.parsed = mock_po
+
+    mock_variants = [
+        create_mock_variant(
+            variant_id=1,
+            sku="WIDGET-001",
+            display_name="Acme Widget / Large / Red",
+        ),
+        create_mock_variant(
+            variant_id=2,
+            sku="WIDGET-002",
+            display_name="Acme Widget / Small / Blue",
+        ),
+    ]
+
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
+    stub_variant_cache(lifespan_ctx, mock_variants)
+
+    # WIDGET-001 matches perfectly; WIDGET-002 has a quantity mismatch.
+    request = VerifyOrderDocumentRequest(
+        order_id=1234,
+        document_items=[
+            DocumentItem(sku="WIDGET-001", quantity=100.0, unit_price=25.50),
+            DocumentItem(sku="WIDGET-002", quantity=45.0, unit_price=30.00),
+        ],
+    )
+
+    result = await _verify_order_document_impl(request, context)
+
+    # Both matches carry the canonical Katana-UI display name.
+    assert {(m.sku, m.display_name) for m in result.matches} == {
+        ("WIDGET-001", "Acme Widget / Large / Red"),
+        ("WIDGET-002", "Acme Widget / Small / Blue"),
+    }
+    # The quantity-mismatch discrepancy also carries display_name.
+    qty_disc = next(
+        d for d in result.discrepancies if d.type == DiscrepancyType.QUANTITY_MISMATCH
+    )
+    assert qty_disc.sku == "WIDGET-002"
+    assert qty_disc.display_name == "Acme Widget / Small / Blue"
+
+
+@pytest.mark.asyncio
+async def test_verify_order_document_missing_in_po_has_empty_display_name():
+    """MISSING_IN_PO discrepancies have no variant to resolve against —
+    ``display_name`` defaults to an empty string (the field default).
+    Pins the no-resolve branch so a future refactor can't silently make
+    this field required.
+    """
+    context, lifespan_ctx = create_mock_context()
+    po_rows = [create_mock_po_row(variant_id=1, quantity=100.0, price=25.50)]
+    mock_po = create_mock_po(order_id=1234, order_no="PO-001", rows=po_rows)
+
+    mock_po_response = MagicMock()
+    mock_po_response.status_code = 200
+    mock_po_response.parsed = mock_po
+
+    mock_variants = [
+        create_mock_variant(
+            variant_id=1, sku="WIDGET-001", display_name="Acme Widget / Large / Red"
+        ),
+    ]
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_po_response
+    )
+    stub_variant_cache(lifespan_ctx, mock_variants)
+
+    request = VerifyOrderDocumentRequest(
+        order_id=1234,
+        document_items=[
+            DocumentItem(sku="WIDGET-001", quantity=100.0, unit_price=25.50),
+            DocumentItem(sku="UNKNOWN-SKU", quantity=5.0, unit_price=10.0),
+        ],
+    )
+
+    result = await _verify_order_document_impl(request, context)
+
+    missing = next(
+        d for d in result.discrepancies if d.type == DiscrepancyType.MISSING_IN_PO
+    )
+    assert missing.sku == "UNKNOWN-SKU"
+    # No variant resolved → empty string (the field default).
+    assert missing.display_name == ""
 
 
 @pytest.mark.asyncio
@@ -1148,7 +1288,7 @@ async def test_verify_order_document_unset_order_no():
     cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_po_response
     )
-    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+    stub_variant_cache(lifespan_ctx, mock_variants)
 
     request = VerifyOrderDocumentRequest(
         order_id=1234,
@@ -1210,7 +1350,7 @@ async def test_verify_order_document_no_match():
     cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
         return_value=mock_po_response
     )
-    lifespan_ctx.client.variants.list = AsyncMock(return_value=mock_variants)
+    stub_variant_cache(lifespan_ctx, mock_variants)
 
     # Document with completely different items
     request = VerifyOrderDocumentRequest(

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -2612,6 +2612,42 @@ async def test_get_purchase_order_full_field_coverage():
 
 
 @pytest.mark.asyncio
+async def test_get_purchase_order_row_carries_canonical_display_name():
+    """Each row in the exhaustive ``get_purchase_order`` response surfaces
+    the canonical Katana-UI display name lifted from CachedVariant via a
+    single batched cache read. Matches the convention used by every other
+    variant-displaying surface (search_items, check_inventory, recipe
+    rows, verification card).
+    """
+    context, lifespan_ctx = create_mock_context()
+    mock_po = _make_exhaustive_mock_po()
+
+    # Seed the typed cache so the row's variant_id=100 resolves to a
+    # canonical SKU + display_name.
+    cached_variant = MagicMock()
+    cached_variant.id = 100
+    cached_variant.sku = "WIDGET-100"
+    cached_variant.display_name = "Acme Widget / Large / Red"
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        return_value={100: cached_variant}
+    )
+
+    with (
+        patch(f"{_PO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP, return_value=mock_po),
+    ):
+        request = GetPurchaseOrderRequest(order_id=12345)
+        result = await _get_purchase_order_impl(request, context)
+
+    assert len(result.purchase_order_rows) == 1
+    row = result.purchase_order_rows[0]
+    assert row.variant_id == 100
+    # Both SKU and display_name lifted from the same cache read.
+    assert row.sku == "WIDGET-100"
+    assert row.display_name == "Acme Widget / Large / Red"
+
+
+@pytest.mark.asyncio
 async def test_get_purchase_order_fetches_additional_costs_and_accounting_metadata():
     """Side-data fetches run on the PO's default_group_id / id and surface
     into the exhaustive response (#346)."""

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -1357,7 +1357,12 @@ async def test_get_sales_order_enriches_row_sku_from_cache():
         result = await _get_sales_order_impl(GetSalesOrderRequest(order_id=9), context)
 
     assert result.rows[0].sku == "BIKE-A"  # cache hit
+    # display_name is lifted from the same cache row, so each rendered
+    # row carries the canonical Katana-UI name — matching the convention
+    # used by every other variant-displaying surface.
+    assert result.rows[0].display_name == "Bike A"
     assert result.rows[1].sku is None  # cache miss
+    assert result.rows[1].display_name is None  # cache miss → no name
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Walks the audit list from #695 and surfaces the canonical Katana-UI display name
(``"{parent_name} / {value1} / {value2}"``, built via
``build_variant_display_name`` from PR #696) on every variant-displaying surface
the tool emits. Every consumer now reads from the same formula — the typed-cache
``CachedVariant.display_name`` column when possible, falling back to a
single-row computation on cache miss.

## Surfaces touched

| Surface | Status | What changed |
|---|---|---|
| `search_items` results | Verified | Already used ``CachedVariant.display_name`` for the row's ``name`` field — no change needed |
| `check_inventory` rows | Verified | Already used ``display_name`` — no change needed |
| `list_low_stock_items` rows | Verified | Already used ``display_name`` — no change needed |
| `get_item` nested variants | **Added** | ``ItemVariantSummary.display_name`` populated from parent name + config_attributes via the canonical helper |
| MO recipe rows (`get_manufacturing_order_recipe`) | **Added** | ``RecipeRowInfo.display_name`` lifted from ``CachedVariant.display_name`` in the existing batched cache lookup; markdown rendering surfaces it in the row header |
| Batch recipe update card (``build_batch_recipe_update_ui``) | **Added** | New ``Item`` column ahead of ``SKU``, prefers ``display_name`` → ``sku`` → ``variant {id}`` |
| `verify_order_document` | **Added** | ``MatchResult.display_name`` + ``Discrepancy.display_name`` (for matched rows; empty for MISSING_IN_PO). Card adds ``Item`` as the leading sortable column on both Matched and Discrepancies tables |
| `fulfill_order` (sales) | **Added** | ``inventory_updates`` lines lead with the canonical display name; ``_resolve_row_serial_info`` now returns ``display_name`` alongside SKU |
| `fulfill_order` (manufacturing) | **Added** | "will produce X" line surfaces the finished-good's display name |
| `get_purchase_order` rows | **Added** | ``PurchaseOrderRowInfo.sku`` + ``display_name`` lifted from one batched cache read; ``_PO_ROW_FIELDS`` markdown order updated. Verify path plumbs the same lookup into the embedded ``purchase_order`` response |
| `get_sales_order` rows | **Added** | ``SalesOrderRowDetail.display_name`` lifted alongside SKU |
| `list_purchase_orders` | **Added** | ``PurchaseOrderRowSummary.sku`` + ``display_name`` populated when ``include_rows=True`` (one extra batched cache read across the result set) |
| `list_sales_orders` | **Added** | ``SalesOrderRowInfo.sku`` was already populated for the list path; ``display_name`` now lifted from the same lookup (replaces the prior ``sku=None`` deferred-comment) |
| `list_manufacturing_orders` | **Added** | ``ManufacturingOrderSummary.sku`` + ``display_name`` for the MO's finished-good variant, lifted in one batched cache read |
| Modification preview / result cards | **No-op** | Cards render Operation / Target / Changes — they don't render variant names directly. Documented as not requiring change |
| `receive_purchase_order` (`build_receipt_ui`) | **No-op** | Receipt card renders order header + total, not individual line items. No variant-name rendering today |
| Stock-adjustment cards | **No-op** | Already render ``display_name`` from ``StockAdjustmentRowSummary`` (predates this audit) |

## Test plan

- [x] ``uv run poe agent-check`` — lint + ruff + ty all clean
- [x] ``uv run poe test`` — 3132 passed, 2 skipped
- [x] ``uv run poe check`` (incl. headless browser tests for Prefab rendering) — 16 passed
- [x] New focused tests:
  - ``test_variant_to_summary_builds_canonical_display_name_with_parent_and_configs`` — ``_variant_to_summary`` helper
  - ``test_variant_to_summary_display_name_falls_back_to_sku_without_parent`` — empty-parent fallback
  - ``test_rows_carry_canonical_display_name_when_supplied`` — batch recipe update UI
  - ``test_rows_fall_back_to_sku_when_display_name_absent`` — fallback ordering
  - ``test_verify_order_document_carries_canonical_display_name`` — MatchResult + Discrepancy
  - ``test_verify_order_document_missing_in_po_has_empty_display_name`` — MISSING_IN_PO branch
  - ``test_match_and_discrepancy_tables_include_item_column`` — verification UI column ordering
  - ``test_fulfill_sales_order_preview_lifts_display_name`` — SO inventory updates
  - ``test_fulfill_manufacturing_order_preview_lifts_display_name`` — MO inventory updates
  - ``test_get_purchase_order_row_carries_canonical_display_name`` — PO get rows
  - ``test_get_manufacturing_order_recipe`` updated to assert ``display_name``
  - ``test_get_sales_order_enriches_row_sku_from_cache`` extended to assert ``display_name``

## Notes for review

- Every surface that exposes ``display_name`` defaults it to ``None`` (or ``""`` where the field is required) so adding the column never breaks an existing fixture. Resolution order on rendered cards is consistently ``display_name → sku → "variant {id}"`` — matching the convention the variant-card and stock-adjustment cards established before this PR.
- ``verify_order_document`` was rewritten to read variants from the typed cache instead of ``services.client.variants.list()`` — the API path returned ``KatanaVariant`` domain objects without ``product_or_material_name`` (would require an ``extend=`` call), whereas the typed cache pre-computes ``display_name``. Net: one batched cache read replaces a network round trip and the field becomes free. ``test_purchase_orders.py`` was updated to stub the cache instead of ``client.variants.list``.
- List tools (``list_purchase_orders`` / ``list_sales_orders`` / ``list_manufacturing_orders``) stay cache-only — variant resolution is one extra IN-clause read across the entire result set, regardless of batch size. Cache miss yields ``None``; matches the existing convention for ``SalesOrderRowInfo.sku``.
- No generator/spec changes; this is purely MCP-side rendering of fields the cache already populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)