### PR TITLE
feat(mcp): expose item-level purchase_uom on catalog create tools

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/catalog.py
@@ -11,18 +11,19 @@ from typing import Annotated
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.foundation.items import (
     VariantConfigAttributePatch,
+    _validate_purchase_uom_pair,
     coerce_variant_config_attributes,
 )
 from katana_mcp.tools.tool_result_utils import UI_META, make_tool_result
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
-from katana_public_api_client.domain.converters import to_unset
+from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     CreateMaterialRequest as ApiCreateMaterialRequest,
     CreateProductRequest as ApiCreateProductRequest,
@@ -59,6 +60,23 @@ class CreateProductRequest(BaseModel):
     default_supplier_id: int | None = Field(
         default=None,
         description=("Default supplier ID. Look up via `list_suppliers`."),
+    )
+    purchase_uom: str | None = Field(
+        default=None,
+        description=(
+            "Purchase unit of measure when buying in a different unit than the "
+            "stock ``uom`` (e.g. ``kit`` / ``box`` / ``case``). Pair with "
+            "``purchase_uom_conversion_rate`` to set the kit-size. Leave None "
+            "when purchased and stocked in the same unit."
+        ),
+    )
+    purchase_uom_conversion_rate: float | None = Field(
+        default=None,
+        description=(
+            "How many stock-``uom`` units are received per one ``purchase_uom`` "
+            "unit (e.g. 4 for a 4-pcs kit, 100 for a box of 100). Required "
+            "when ``purchase_uom`` is set."
+        ),
     )
     additional_info: str | None = Field(default=None, description="Additional notes")
 
@@ -98,6 +116,13 @@ class CreateProductRequest(BaseModel):
         ),
     )
 
+    @model_validator(mode="after")
+    def _check_purchase_uom_pair(self) -> CreateProductRequest:
+        _validate_purchase_uom_pair(
+            self.purchase_uom, self.purchase_uom_conversion_rate
+        )
+        return self
+
 
 class CreateProductResponse(BaseModel):
     """Response from creating a product."""
@@ -106,6 +131,9 @@ class CreateProductResponse(BaseModel):
     name: str
     sku: str
     type: str = "product"
+    uom: str | None = None
+    purchase_uom: str | None = None
+    purchase_uom_conversion_rate: float | None = None
     success: bool = True
     message: str = "Product created successfully"
     katana_url: str | None = None
@@ -167,6 +195,8 @@ async def _create_product_impl(
             is_producible=request.is_producible,
             is_purchasable=request.is_purchasable,
             default_supplier_id=to_unset(request.default_supplier_id),
+            purchase_uom=to_unset(request.purchase_uom),
+            purchase_uom_conversion_rate=to_unset(request.purchase_uom_conversion_rate),
             additional_info=to_unset(request.additional_info),
             variants=[variant],
         )
@@ -182,11 +212,17 @@ async def _create_product_impl(
             duration_ms=duration_ms,
         )
 
+        product_name = product.name or request.name
         return CreateProductResponse(
             id=product.id,
-            name=product.name or "",
+            name=product_name,
             sku=request.sku,
-            message=f"Product '{product.name}' created successfully with SKU {request.sku}",
+            uom=unwrap_unset(product.uom),
+            purchase_uom=unwrap_unset(product.purchase_uom),
+            purchase_uom_conversion_rate=unwrap_unset(
+                product.purchase_uom_conversion_rate
+            ),
+            message=f"Product '{product_name}' created successfully with SKU {request.sku}",
             katana_url=katana_web_url("product", product.id),
         )
 
@@ -248,6 +284,23 @@ class CreateMaterialRequest(BaseModel):
         default=None,
         description=("Default supplier ID. Look up via `list_suppliers`."),
     )
+    purchase_uom: str | None = Field(
+        default=None,
+        description=(
+            "Purchase unit of measure when buying in a different unit than the "
+            "stock ``uom`` (e.g. ``kit`` / ``box`` / ``case``). Pair with "
+            "``purchase_uom_conversion_rate`` to set the kit-size. Leave None "
+            "when purchased and stocked in the same unit."
+        ),
+    )
+    purchase_uom_conversion_rate: float | None = Field(
+        default=None,
+        description=(
+            "How many stock-``uom`` units are received per one ``purchase_uom`` "
+            "unit (e.g. 4 for a 4-pcs kit, 100 for a box of 100). Required "
+            "when ``purchase_uom`` is set."
+        ),
+    )
     additional_info: str | None = Field(default=None, description="Additional notes")
 
     # Variant-level fields — forwarded to the embedded CreateVariantRequest.
@@ -286,6 +339,13 @@ class CreateMaterialRequest(BaseModel):
         ),
     )
 
+    @model_validator(mode="after")
+    def _check_purchase_uom_pair(self) -> CreateMaterialRequest:
+        _validate_purchase_uom_pair(
+            self.purchase_uom, self.purchase_uom_conversion_rate
+        )
+        return self
+
 
 class CreateMaterialResponse(BaseModel):
     """Response from creating a material."""
@@ -294,6 +354,9 @@ class CreateMaterialResponse(BaseModel):
     name: str
     sku: str
     type: str = "material"
+    uom: str | None = None
+    purchase_uom: str | None = None
+    purchase_uom_conversion_rate: float | None = None
     success: bool = True
     message: str = "Material created successfully"
     katana_url: str | None = None
@@ -353,6 +416,8 @@ async def _create_material_impl(
             category_name=to_unset(request.category_name),
             is_sellable=request.is_sellable,
             default_supplier_id=to_unset(request.default_supplier_id),
+            purchase_uom=to_unset(request.purchase_uom),
+            purchase_uom_conversion_rate=to_unset(request.purchase_uom_conversion_rate),
             additional_info=to_unset(request.additional_info),
             variants=[variant],
         )
@@ -368,11 +433,17 @@ async def _create_material_impl(
             duration_ms=duration_ms,
         )
 
+        material_name = material.name or request.name
         return CreateMaterialResponse(
             id=material.id,
-            name=material.name or "",
+            name=material_name,
             sku=request.sku,
-            message=f"Material '{material.name}' created successfully with SKU {request.sku}",
+            uom=unwrap_unset(material.uom),
+            purchase_uom=unwrap_unset(material.purchase_uom),
+            purchase_uom_conversion_rate=unwrap_unset(
+                material.purchase_uom_conversion_rate
+            ),
+            message=f"Material '{material_name}' created successfully with SKU {request.sku}",
             katana_url=katana_web_url("material", material.id),
         )
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -72,7 +72,7 @@ from katana_public_api_client.api.variant import (
     update_variant as api_update_variant,
 )
 from katana_public_api_client.client_types import UNSET
-from katana_public_api_client.domain.converters import to_unset
+from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.domain.variant import build_variant_display_name
 from katana_public_api_client.models import (
     CreateMaterialRequest,
@@ -280,6 +280,29 @@ async def search_items(
 # ============================================================================
 
 
+def _validate_purchase_uom_pair(
+    purchase_uom: str | None,
+    purchase_uom_conversion_rate: float | None,
+) -> None:
+    """Enforce the purchase_uom / conversion-rate co-dependency.
+
+    Both fields must be set together (or both omitted) and the rate must be
+    positive. Raises ``ValueError`` so callers get a clear validation error
+    at the MCP boundary instead of a 422 from Katana. Shared by
+    ``CreateProductRequest`` / ``CreateMaterialRequest`` / ``CreateItemRequest``.
+    """
+    if purchase_uom is not None and purchase_uom_conversion_rate is None:
+        raise ValueError(
+            "purchase_uom_conversion_rate is required when purchase_uom is set"
+        )
+    if purchase_uom_conversion_rate is not None and purchase_uom is None:
+        raise ValueError(
+            "purchase_uom is required when purchase_uom_conversion_rate is set"
+        )
+    if purchase_uom_conversion_rate is not None and purchase_uom_conversion_rate <= 0:
+        raise ValueError("purchase_uom_conversion_rate must be greater than 0")
+
+
 class CreateItemRequest(BaseModel):
     """Create a new item (product, material, or service).
 
@@ -315,6 +338,24 @@ class CreateItemRequest(BaseModel):
     default_supplier_id: int | None = Field(
         default=None,
         description=("Default supplier ID. Look up via `list_suppliers`."),
+    )
+    purchase_uom: str | None = Field(
+        default=None,
+        description=(
+            "Purchase unit of measure when buying in a different unit than the "
+            "stock ``uom`` (e.g. ``kit`` / ``box`` / ``case``). Pair with "
+            "``purchase_uom_conversion_rate`` to set the kit-size. Leave None "
+            "when purchased and stocked in the same unit. Ignored for "
+            "type=service."
+        ),
+    )
+    purchase_uom_conversion_rate: float | None = Field(
+        default=None,
+        description=(
+            "How many stock-``uom`` units are received per one ``purchase_uom`` "
+            "unit (e.g. 4 for a 4-pcs kit, 100 for a box of 100). Required "
+            "when ``purchase_uom`` is set. Ignored for type=service."
+        ),
     )
     additional_info: str | None = Field(default=None, description="Additional notes")
 
@@ -359,6 +400,13 @@ class CreateItemRequest(BaseModel):
         ),
     )
 
+    @model_validator(mode="after")
+    def _check_purchase_uom_pair(self) -> CreateItemRequest:
+        _validate_purchase_uom_pair(
+            self.purchase_uom, self.purchase_uom_conversion_rate
+        )
+        return self
+
 
 def _item_katana_url(item_type: ItemType, id: int | None) -> str | None:
     """Web URL for a product or material. Services have no URL pattern."""
@@ -376,6 +424,9 @@ class CreateItemResponse(BaseModel):
     type: ItemType
     variant_id: int | None = None
     sku: str | None = None
+    uom: str | None = None
+    purchase_uom: str | None = None
+    purchase_uom_conversion_rate: float | None = None
     success: bool = True
     message: str = "Item created successfully"
     katana_url: str | None = None
@@ -431,6 +482,10 @@ async def _create_item_impl(
                 is_producible=request.is_producible,
                 is_purchasable=request.is_purchasable,
                 default_supplier_id=to_unset(request.default_supplier_id),
+                purchase_uom=to_unset(request.purchase_uom),
+                purchase_uom_conversion_rate=to_unset(
+                    request.purchase_uom_conversion_rate
+                ),
                 additional_info=to_unset(request.additional_info),
                 variants=[variant],
             )
@@ -442,6 +497,10 @@ async def _create_item_impl(
                 category_name=to_unset(request.category_name),
                 is_sellable=request.is_sellable,
                 default_supplier_id=to_unset(request.default_supplier_id),
+                purchase_uom=to_unset(request.purchase_uom),
+                purchase_uom_conversion_rate=to_unset(
+                    request.purchase_uom_conversion_rate
+                ),
                 additional_info=to_unset(request.additional_info),
                 variants=[variant],
             )
@@ -454,12 +513,23 @@ async def _create_item_impl(
     # call, so the next ``search_items`` / ``get_variant_details`` sees
     # the new row without a manual dirty bit.
 
+    # Service items don't carry purchase_uom — Product/Material do.
+    result_uom = unwrap_unset(getattr(result, "uom", None))
+    result_purchase_uom = unwrap_unset(getattr(result, "purchase_uom", None))
+    result_conversion_rate = unwrap_unset(
+        getattr(result, "purchase_uom_conversion_rate", None)
+    )
+
+    result_name = result.name or request.name
     return CreateItemResponse(
         id=result.id,
-        name=result.name or "",
+        name=result_name,
         type=request.type,
         sku=request.sku,
-        message=f"{request.type.value.title()} '{result.name}' created successfully with SKU {request.sku}",
+        uom=result_uom,
+        purchase_uom=result_purchase_uom,
+        purchase_uom_conversion_rate=result_conversion_rate,
+        message=f"{request.type.value.title()} '{result_name}' created successfully with SKU {request.sku}",
         katana_url=_item_katana_url(request.type, result.id),
     )
 
@@ -1570,6 +1640,8 @@ class VariantDetailsResponse(BaseModel):
     default_supplier_id: int | None = None
     default_supplier_name: str | None = None
     is_batch_tracked: bool | None = None
+    purchase_uom: str | None = None
+    purchase_uom_conversion_rate: float | None = None
 
     # Deep-link to the parent product or material — variants don't have
     # their own page in Katana's web app, so callers click through to the
@@ -1733,6 +1805,8 @@ def _dict_to_variant_details(
         default_supplier_id=_attr(parent, "default_supplier_id"),
         default_supplier_name=_attr(supplier, "name"),
         is_batch_tracked=_attr(parent, "batch_tracked"),
+        purchase_uom=_attr(parent, "purchase_uom"),
+        purchase_uom_conversion_rate=_attr(parent, "purchase_uom_conversion_rate"),
         katana_url=parent_url,
         internal_barcode=_attr(v, "internal_barcode"),
         registered_barcode=_attr(v, "registered_barcode"),

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -642,6 +642,30 @@ def _variant_barcode_line(variant: dict[str, Any]) -> None:
         Text(content=f"Barcodes: {', '.join(parts)}")
 
 
+def _variant_purchase_uom_line(variant: dict[str, Any]) -> None:
+    """Render the purchase-UoM conversion row when it differs from the stock UoM.
+
+    Stays quiet in the common case (purchase and stock UoM match) so the
+    card doesn't carry a noisy redundant row. Surfaces ``"Purchase UoM:
+    kit (x4 pcs)"`` when an item is purchased in packs (kits, boxes,
+    cases) and stocked as individual units — the conversion factor is
+    the actionable bit for anyone drafting a PO.
+    """
+    purchase_uom = variant.get("purchase_uom")
+    if not purchase_uom:
+        return
+    stock_uom = variant.get("uom")
+    if purchase_uom == stock_uom:
+        return
+    rate = variant.get("purchase_uom_conversion_rate")
+    if rate is None:
+        Text(content=f"Purchase UoM: {purchase_uom}")
+        return
+    rate_str = f"{rate:g}"
+    suffix = f" {stock_uom}" if stock_uom else ""
+    Text(content=f"Purchase UoM: {purchase_uom} (x{rate_str}{suffix})")
+
+
 def _variant_supplier_codes_line(variant: dict[str, Any]) -> None:
     """Render supplier codes inline using monospace ``Code`` chips.
 
@@ -674,6 +698,7 @@ def _variant_reference_section(variant: dict[str, Any]) -> None:
     """
     if variant.get("uom"):
         Text(content=f"UoM: {variant['uom']}")
+    _variant_purchase_uom_line(variant)
     _variant_supplier_line(variant)
     if variant.get("lead_time") is not None:
         Text(content=f"Lead Time: {variant['lead_time']} days")
@@ -766,6 +791,7 @@ def build_item_detail_ui(
             Text(content=f"ID: {item.get('id', 'N/A')}")
             if item.get("uom"):
                 Text(content=f"Unit of Measure: {item['uom']}")
+            _variant_purchase_uom_line(item)
             if item.get("category_name"):
                 Text(content=f"Category: {item['category_name']}")
 
@@ -2050,6 +2076,7 @@ def build_item_mutation_ui(
             Text(content=f"Name: {item.get('name', 'N/A')}")
             if item.get("sku"):
                 Text(content=f"SKU: {item['sku']}")
+            _variant_purchase_uom_line(item)
             if item.get("message"):
                 Text(content=item["message"])
 

--- a/katana_mcp_server/tests/conftest.py
+++ b/katana_mcp_server/tests/conftest.py
@@ -131,6 +131,29 @@ def create_mock_context():
     return context, mock_lifespan_context
 
 
+def mock_item(*, id: int, name: str | None) -> MagicMock:
+    """Build a Product/Material/Service MagicMock for create-tool tests.
+
+    The MCP create-tool impls read item-header fields off the returned attrs
+    entity to populate their response models. A bare ``MagicMock()``
+    auto-vivifies those attributes to nested MagicMocks, which then fail
+    pydantic validation — so this helper sets ``uom``, ``purchase_uom``, and
+    ``purchase_uom_conversion_rate`` to ``UNSET`` (the typical wire shape
+    when Katana omits a field), matching real-API behavior. Override the
+    sentinels by reassigning after the call when a test needs specific
+    values.
+    """
+    from katana_public_api_client.client_types import UNSET
+
+    mock = MagicMock()
+    mock.id = id
+    mock.name = name
+    mock.uom = UNSET
+    mock.purchase_uom = UNSET
+    mock.purchase_uom_conversion_rate = UNSET
+    return mock
+
+
 @pytest.fixture
 def mock_context():
     """Fixture providing a mock FastMCP context.

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -258,6 +258,71 @@ class TestBuildVariantDetailsUI:
         # No `/ <uom>` suffix on the bare price.
         assert "$10.00 /" not in rendered
 
+    def test_includes_purchase_uom_when_set_and_different_from_stock(self):
+        """Purchase UoM row renders the kit-size conversion when the item is
+        purchased in a different unit than it's stocked in (SP0502 case: stock
+        in pcs, buy as 4-pcs kits)."""
+        variant = {
+            "id": 100,
+            "sku": "SP0502",
+            "name": "Spoke (kit)",
+            "uom": "pcs",
+            "purchase_uom": "kit",
+            "purchase_uom_conversion_rate": 4.0,
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Purchase UoM: kit (x4 pcs)" in rendered
+
+    def test_omits_purchase_uom_when_unset(self):
+        """The common case (purchase == stock UoM) leaves the row absent."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "uom": "pcs",
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Purchase UoM:" not in rendered
+
+    def test_omits_purchase_uom_when_equals_stock_uom(self):
+        """Even if both fields are populated, omit the redundant row when
+        purchase and stock UoM match — the row would just say the same thing
+        twice."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "uom": "pcs",
+            "purchase_uom": "pcs",
+            "purchase_uom_conversion_rate": 1.0,
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Purchase UoM:" not in rendered
+
+    def test_purchase_uom_without_conversion_rate_renders_label_only(self):
+        """If purchase_uom is set but conversion_rate is None, surface the
+        label without the ``(xN stock)`` parenthetical — better than dropping
+        the row entirely."""
+        variant = {
+            "id": 100,
+            "sku": "SKU-001",
+            "name": "Widget",
+            "uom": "pcs",
+            "purchase_uom": "kit",
+        }
+        app = build_variant_details_ui(variant)
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Purchase UoM: kit" in rendered
+        # No conversion-factor parenthetical when rate is missing.
+        assert "Purchase UoM: kit (" not in rendered
+
     def test_includes_config_attributes_as_badges(self):
         """Config attributes should appear inline so the variant axes are visible."""
         variant = {

--- a/katana_mcp_server/tests/tools/test_catalog.py
+++ b/katana_mcp_server/tests/tools/test_catalog.py
@@ -11,6 +11,7 @@ from katana_mcp.tools.foundation.catalog import (
     _create_product_impl,
 )
 from katana_mcp.tools.foundation.items import VariantConfigAttributePatch
+from katana_mcp_server.tests.conftest import mock_item as _mock_item
 
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.models import (
@@ -46,9 +47,7 @@ async def test_create_product_minimal():
     context, lifespan_ctx = create_mock_context()
 
     # Mock Product response
-    mock_product = MagicMock()
-    mock_product.id = 123
-    mock_product.name = "Test Product"
+    mock_product = _mock_item(id=123, name="Test Product")
 
     lifespan_ctx.client.products.create = AsyncMock(return_value=mock_product)
 
@@ -75,9 +74,7 @@ async def test_create_product_full_fields():
     context, lifespan_ctx = create_mock_context()
 
     # Mock Product response
-    mock_product = MagicMock()
-    mock_product.id = 456
-    mock_product.name = "Widget Pro"
+    mock_product = _mock_item(id=456, name="Widget Pro")
 
     lifespan_ctx.client.products.create = AsyncMock(return_value=mock_product)
 
@@ -121,9 +118,7 @@ async def test_create_product_default_values():
     context, lifespan_ctx = create_mock_context()
 
     # Mock Product response
-    mock_product = MagicMock()
-    mock_product.id = 789
-    mock_product.name = "Default Product"
+    mock_product = _mock_item(id=789, name="Default Product")
 
     lifespan_ctx.client.products.create = AsyncMock(return_value=mock_product)
 
@@ -145,13 +140,13 @@ async def test_create_product_default_values():
 
 @pytest.mark.asyncio
 async def test_create_product_handles_none_name():
-    """Test create_product handles None product name in response."""
+    """Test create_product handles None product name in response by falling
+    back to the request name — keeps the success message readable instead
+    of showing literal ``None``."""
     context, lifespan_ctx = create_mock_context()
 
     # Mock Product with None name
-    mock_product = MagicMock()
-    mock_product.id = 999
-    mock_product.name = None
+    mock_product = _mock_item(id=999, name=None)
 
     lifespan_ctx.client.products.create = AsyncMock(return_value=mock_product)
 
@@ -161,8 +156,12 @@ async def test_create_product_handles_none_name():
     )
     result = await _create_product_impl(request, context)
 
-    assert result.name == ""  # Converts None to empty string
+    # Falls back to the request-supplied name so neither the response field
+    # nor the message string carries a literal "None".
+    assert result.name == "Test"
     assert result.id == 999
+    assert "None" not in result.message
+    assert "Test" in result.message
 
 
 @pytest.mark.asyncio
@@ -197,9 +196,7 @@ async def test_create_product_forwards_variant_fields():
     """
     context, lifespan_ctx = create_mock_context()
 
-    mock_product = MagicMock()
-    mock_product.id = 700
-    mock_product.name = "Variant Pro"
+    mock_product = _mock_item(id=700, name="Variant Pro")
     lifespan_ctx.client.products.create = AsyncMock(return_value=mock_product)
 
     request = CreateProductRequest(
@@ -244,9 +241,7 @@ async def test_create_product_omits_unset_variant_fields():
     """
     context, lifespan_ctx = create_mock_context()
 
-    mock_product = MagicMock()
-    mock_product.id = 701
-    mock_product.name = "Plain"
+    mock_product = _mock_item(id=701, name="Plain")
     lifespan_ctx.client.products.create = AsyncMock(return_value=mock_product)
 
     request = CreateProductRequest(name="Plain", sku="PLN-001")
@@ -266,9 +261,7 @@ async def test_create_material_forwards_variant_fields():
     """Mirror of test_create_product_forwards_variant_fields for materials."""
     context, lifespan_ctx = create_mock_context()
 
-    mock_material = MagicMock()
-    mock_material.id = 800
-    mock_material.name = "Steel Rod"
+    mock_material = _mock_item(id=800, name="Steel Rod")
     lifespan_ctx.client.materials.create = AsyncMock(return_value=mock_material)
 
     request = CreateMaterialRequest(
@@ -301,9 +294,7 @@ async def test_create_material_omits_unset_variant_fields():
     """Mirror of test_create_product_omits_unset_variant_fields for materials."""
     context, lifespan_ctx = create_mock_context()
 
-    mock_material = MagicMock()
-    mock_material.id = 801
-    mock_material.name = "Plain Material"
+    mock_material = _mock_item(id=801, name="Plain Material")
     lifespan_ctx.client.materials.create = AsyncMock(return_value=mock_material)
 
     request = CreateMaterialRequest(name="Plain Material", sku="PLN-MAT-001")
@@ -318,6 +309,110 @@ async def test_create_material_omits_unset_variant_fields():
     assert variant.config_attributes is UNSET
 
 
+@pytest.mark.asyncio
+async def test_create_product_forwards_purchase_uom():
+    """purchase_uom + purchase_uom_conversion_rate must land on the parent-level
+    CreateProductRequest (item-header fields, not variant fields). The reporter's
+    SP0502 case: stock in pcs, purchased in 4-pcs kits.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    mock_product = _mock_item(id=720, name="SP0502")
+    mock_product.uom = "pcs"
+    mock_product.purchase_uom = "kit"
+    mock_product.purchase_uom_conversion_rate = 4.0
+    lifespan_ctx.client.products.create = AsyncMock(return_value=mock_product)
+
+    request = CreateProductRequest(
+        name="SP0502",
+        sku="SP0502",
+        uom="pcs",
+        purchase_uom="kit",
+        purchase_uom_conversion_rate=4.0,
+    )
+    response = await _create_product_impl(request, context)
+
+    api_request = lifespan_ctx.client.products.create.call_args[0][0]
+    assert api_request.purchase_uom == "kit"
+    assert api_request.purchase_uom_conversion_rate == 4.0
+    # Response mirrors the created entity so the mutation card can render it.
+    assert response.uom == "pcs"
+    assert response.purchase_uom == "kit"
+    assert response.purchase_uom_conversion_rate == 4.0
+
+
+@pytest.mark.asyncio
+async def test_create_product_omits_unset_purchase_uom():
+    """Without purchase_uom/conversion_rate, the API request must keep them
+    UNSET so the wire body omits the keys (preventing null serialization).
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    mock_product = _mock_item(id=721, name="Plain Product")
+    mock_product.uom = "pcs"
+    mock_product.purchase_uom = UNSET
+    mock_product.purchase_uom_conversion_rate = UNSET
+    lifespan_ctx.client.products.create = AsyncMock(return_value=mock_product)
+
+    request = CreateProductRequest(name="Plain Product", sku="PLN-001")
+    response = await _create_product_impl(request, context)
+
+    api_request = lifespan_ctx.client.products.create.call_args[0][0]
+    assert api_request.purchase_uom is UNSET
+    assert api_request.purchase_uom_conversion_rate is UNSET
+    assert response.purchase_uom is None
+    assert response.purchase_uom_conversion_rate is None
+
+
+@pytest.mark.asyncio
+async def test_create_material_forwards_purchase_uom():
+    """purchase_uom flow for materials — e.g. "Box of 100" spoke nipples."""
+    context, lifespan_ctx = create_mock_context()
+
+    mock_material = _mock_item(id=820, name="Spoke Nipples")
+    mock_material.uom = "pcs"
+    mock_material.purchase_uom = "box"
+    mock_material.purchase_uom_conversion_rate = 100.0
+    lifespan_ctx.client.materials.create = AsyncMock(return_value=mock_material)
+
+    request = CreateMaterialRequest(
+        name="Spoke Nipples",
+        sku="SP7025",
+        uom="pcs",
+        purchase_uom="box",
+        purchase_uom_conversion_rate=100.0,
+    )
+    response = await _create_material_impl(request, context)
+
+    api_request = lifespan_ctx.client.materials.create.call_args[0][0]
+    assert api_request.purchase_uom == "box"
+    assert api_request.purchase_uom_conversion_rate == 100.0
+    assert response.uom == "pcs"
+    assert response.purchase_uom == "box"
+    assert response.purchase_uom_conversion_rate == 100.0
+
+
+@pytest.mark.asyncio
+async def test_create_material_omits_unset_purchase_uom():
+    """Materials without purchase_uom must keep the API fields UNSET."""
+    context, lifespan_ctx = create_mock_context()
+
+    mock_material = _mock_item(id=821, name="Plain Material")
+    mock_material.uom = "pcs"
+    mock_material.purchase_uom = UNSET
+    mock_material.purchase_uom_conversion_rate = UNSET
+    lifespan_ctx.client.materials.create = AsyncMock(return_value=mock_material)
+
+    request = CreateMaterialRequest(name="Plain Material", sku="PLN-MAT-001")
+    response = await _create_material_impl(request, context)
+
+    api_request = lifespan_ctx.client.materials.create.call_args[0][0]
+    assert api_request.purchase_uom is UNSET
+    assert api_request.purchase_uom_conversion_rate is UNSET
+    assert response.purchase_uom is None
+    assert response.purchase_uom_conversion_rate is None
+
+
 # ============================================================================
 # Unit Tests (with mocks) - create_material
 # ============================================================================
@@ -329,9 +424,7 @@ async def test_create_material_minimal():
     context, lifespan_ctx = create_mock_context()
 
     # Mock Material response
-    mock_material = MagicMock()
-    mock_material.id = 200
-    mock_material.name = "Steel Rod"
+    mock_material = _mock_item(id=200, name="Steel Rod")
 
     lifespan_ctx.client.materials.create = AsyncMock(return_value=mock_material)
 
@@ -358,9 +451,7 @@ async def test_create_material_full_fields():
     context, lifespan_ctx = create_mock_context()
 
     # Mock Material response
-    mock_material = MagicMock()
-    mock_material.id = 201
-    mock_material.name = "Aluminum Sheet"
+    mock_material = _mock_item(id=201, name="Aluminum Sheet")
 
     lifespan_ctx.client.materials.create = AsyncMock(return_value=mock_material)
 
@@ -399,9 +490,7 @@ async def test_create_material_default_values():
     context, lifespan_ctx = create_mock_context()
 
     # Mock Material response
-    mock_material = MagicMock()
-    mock_material.id = 202
-    mock_material.name = "Basic Material"
+    mock_material = _mock_item(id=202, name="Basic Material")
 
     lifespan_ctx.client.materials.create = AsyncMock(return_value=mock_material)
 
@@ -421,13 +510,12 @@ async def test_create_material_default_values():
 
 @pytest.mark.asyncio
 async def test_create_material_handles_none_name():
-    """Test create_material handles None material name in response."""
+    """Test create_material handles None material name by falling back to
+    the request name — same readability contract as create_product."""
     context, lifespan_ctx = create_mock_context()
 
     # Mock Material with None name
-    mock_material = MagicMock()
-    mock_material.id = 203
-    mock_material.name = None
+    mock_material = _mock_item(id=203, name=None)
 
     lifespan_ctx.client.materials.create = AsyncMock(return_value=mock_material)
 
@@ -437,7 +525,9 @@ async def test_create_material_handles_none_name():
     )
     result = await _create_material_impl(request, context)
 
-    assert result.name == ""  # Converts None to empty string
+    assert result.name == "Test Material"
+    assert "None" not in result.message
+    assert "Test Material" in result.message
     assert result.id == 203
 
 
@@ -487,6 +577,50 @@ def test_create_material_requires_sku():
     """Test create_material requires sku field."""
     with pytest.raises(ValueError):
         CreateMaterialRequest.model_validate({"name": "Test Material"})
+
+
+def test_create_product_purchase_uom_requires_conversion_rate():
+    """purchase_uom without purchase_uom_conversion_rate is ambiguous —
+    callers must supply both. Catch at the MCP boundary so the validation
+    error is clear instead of hitting Katana's 422."""
+    with pytest.raises(ValueError, match="purchase_uom_conversion_rate is required"):
+        CreateProductRequest(name="X", sku="X-1", purchase_uom="kit")
+
+
+def test_create_product_conversion_rate_requires_purchase_uom():
+    """Setting only conversion_rate is equally meaningless without a UoM."""
+    with pytest.raises(ValueError, match="purchase_uom is required"):
+        CreateProductRequest(name="X", sku="X-1", purchase_uom_conversion_rate=4.0)
+
+
+def test_create_product_purchase_uom_rate_must_be_positive():
+    """Zero or negative conversion rate has no meaningful interpretation."""
+    with pytest.raises(ValueError, match="must be greater than 0"):
+        CreateProductRequest(
+            name="X", sku="X-1", purchase_uom="kit", purchase_uom_conversion_rate=0
+        )
+    with pytest.raises(ValueError, match="must be greater than 0"):
+        CreateProductRequest(
+            name="X", sku="X-1", purchase_uom="kit", purchase_uom_conversion_rate=-1.0
+        )
+
+
+def test_create_material_purchase_uom_requires_conversion_rate():
+    """Mirror of the product validator on materials."""
+    with pytest.raises(ValueError, match="purchase_uom_conversion_rate is required"):
+        CreateMaterialRequest(name="X", sku="MAT-1", purchase_uom="box")
+
+
+def test_create_material_conversion_rate_requires_purchase_uom():
+    with pytest.raises(ValueError, match="purchase_uom is required"):
+        CreateMaterialRequest(name="X", sku="MAT-1", purchase_uom_conversion_rate=100.0)
+
+
+def test_create_material_purchase_uom_rate_must_be_positive():
+    with pytest.raises(ValueError, match="must be greater than 0"):
+        CreateMaterialRequest(
+            name="X", sku="MAT-1", purchase_uom="box", purchase_uom_conversion_rate=0
+        )
 
 
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -23,7 +23,10 @@ from katana_mcp.tools.foundation.items import (
     get_item,
     get_variant_details,
 )
-from katana_mcp_server.tests.conftest import create_mock_context
+from katana_mcp_server.tests.conftest import (
+    create_mock_context,
+    mock_item as _mock_item,
+)
 from pydantic import ValidationError
 
 
@@ -247,6 +250,87 @@ async def test_get_variant_details_lifts_default_supplier_from_parent():
     assert result.default_supplier_name == "Acme Cutlery Co"
     assert result.uom == "set"
     assert result.is_batch_tracked is False
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_lifts_purchase_uom_from_parent():
+    """``purchase_uom`` and ``purchase_uom_conversion_rate`` live on the parent
+    product/material (item-header fields), not on the variant attrs model.
+    ``_dict_to_variant_details`` must lift them through so a single
+    ``get_variant_details`` call carries enough context to draft an accurate
+    PO without a follow-up parent lookup.
+    """
+    context, lifespan_ctx = create_mock_context()
+    variant = dict(_FULL_VARIANT_DICT)
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=variant)
+
+    parent_product = {
+        "id": 101,
+        "uom": "pcs",
+        "purchase_uom": "kit",
+        "purchase_uom_conversion_rate": 4.0,
+        "default_supplier_id": 555,
+        "batch_tracked": False,
+    }
+    supplier = {"id": 555, "name": "Industry Nine"}
+
+    async def _get_many_by_ids(entity_type, ids, **_kw):
+        from katana_public_api_client.models_pydantic._generated import (
+            CachedProduct,
+            CachedSupplier,
+        )
+
+        if entity_type == CachedProduct:
+            return {101: parent_product} if 101 in set(ids) else {}
+        if entity_type == CachedSupplier:
+            return {555: supplier} if 555 in set(ids) else {}
+        return {}
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        side_effect=_get_many_by_ids
+    )
+
+    request = GetVariantDetailsRequest(sku="KNF-PRO-8PC-STL")
+    [result] = (await _get_variant_details_impl(request, context)).found
+
+    assert result.uom == "pcs"
+    assert result.purchase_uom == "kit"
+    assert result.purchase_uom_conversion_rate == 4.0
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_no_purchase_uom_when_parent_omits_it():
+    """The common case (purchase_uom == stock uom) — parent omits the fields,
+    response surfaces them as None so the Prefab UI card stays quiet."""
+    context, lifespan_ctx = create_mock_context()
+    variant = dict(_FULL_VARIANT_DICT)
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=variant)
+
+    parent_product = {
+        "id": 101,
+        "uom": "pcs",
+        "default_supplier_id": None,
+        "batch_tracked": False,
+    }
+
+    async def _get_many_by_ids(entity_type, ids, **_kw):
+        from katana_public_api_client.models_pydantic._generated import (
+            CachedProduct,
+        )
+
+        if entity_type == CachedProduct:
+            return {101: parent_product} if 101 in set(ids) else {}
+        return {}
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        side_effect=_get_many_by_ids
+    )
+
+    request = GetVariantDetailsRequest(sku="KNF-PRO-8PC-STL")
+    [result] = (await _get_variant_details_impl(request, context)).found
+
+    assert result.purchase_uom is None
+    assert result.purchase_uom_conversion_rate is None
 
 
 # ============================================================================
@@ -945,9 +1029,7 @@ async def test_create_item_product_forwards_variant_fields():
     )
 
     context, lifespan_ctx = create_mock_context()
-    mock_product = MagicMock()
-    mock_product.id = 900
-    mock_product.name = "Variant Item"
+    mock_product = _mock_item(id=900, name="Variant Item")
     lifespan_ctx.client.products.create = AsyncMock(return_value=mock_product)
 
     request = CreateItemRequest(
@@ -986,9 +1068,7 @@ async def test_create_item_material_forwards_variant_fields():
     )
 
     context, lifespan_ctx = create_mock_context()
-    mock_material = MagicMock()
-    mock_material.id = 901
-    mock_material.name = "Variant Material"
+    mock_material = _mock_item(id=901, name="Variant Material")
     lifespan_ctx.client.materials.create = AsyncMock(return_value=mock_material)
 
     request = CreateItemRequest(
@@ -1020,9 +1100,7 @@ async def test_create_item_omits_unset_variant_fields():
     from katana_public_api_client.client_types import UNSET
 
     context, lifespan_ctx = create_mock_context()
-    mock_product = MagicMock()
-    mock_product.id = 902
-    mock_product.name = "Plain Item"
+    mock_product = _mock_item(id=902, name="Plain Item")
     lifespan_ctx.client.products.create = AsyncMock(return_value=mock_product)
 
     request = CreateItemRequest(type=ItemType.PRODUCT, name="Plain Item", sku="PI-001")
@@ -1038,6 +1116,106 @@ async def test_create_item_omits_unset_variant_fields():
 
 
 @pytest.mark.asyncio
+async def test_create_item_forwards_purchase_uom_for_product():
+    """purchase_uom + conversion_rate must land on the parent-level
+    CreateProductRequest, and be mirrored back on CreateItemResponse so the
+    mutation card can render the kit-size."""
+    from katana_mcp.tools.foundation.items import (
+        CreateItemRequest,
+        _create_item_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    mock_product = _mock_item(id=910, name="Spoke (kit-purchased)")
+    mock_product.uom = "pcs"
+    mock_product.purchase_uom = "kit"
+    mock_product.purchase_uom_conversion_rate = 4.0
+    lifespan_ctx.client.products.create = AsyncMock(return_value=mock_product)
+
+    request = CreateItemRequest(
+        type=ItemType.PRODUCT,
+        name="Spoke (kit-purchased)",
+        sku="SP0502",
+        uom="pcs",
+        purchase_uom="kit",
+        purchase_uom_conversion_rate=4.0,
+    )
+    response = await _create_item_impl(request, context)
+
+    api_request = lifespan_ctx.client.products.create.call_args[0][0]
+    assert api_request.purchase_uom == "kit"
+    assert api_request.purchase_uom_conversion_rate == 4.0
+    assert response.uom == "pcs"
+    assert response.purchase_uom == "kit"
+    assert response.purchase_uom_conversion_rate == 4.0
+
+
+@pytest.mark.asyncio
+async def test_create_item_forwards_purchase_uom_for_material():
+    """Material flow — "box of 100" spoke nipples case."""
+    from katana_mcp.tools.foundation.items import (
+        CreateItemRequest,
+        _create_item_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    mock_material = _mock_item(id=911, name="Spoke Nipples")
+    mock_material.uom = "pcs"
+    mock_material.purchase_uom = "box"
+    mock_material.purchase_uom_conversion_rate = 100.0
+    lifespan_ctx.client.materials.create = AsyncMock(return_value=mock_material)
+
+    request = CreateItemRequest(
+        type=ItemType.MATERIAL,
+        name="Spoke Nipples",
+        sku="SP7025",
+        uom="pcs",
+        purchase_uom="box",
+        purchase_uom_conversion_rate=100.0,
+    )
+    response = await _create_item_impl(request, context)
+
+    api_request = lifespan_ctx.client.materials.create.call_args[0][0]
+    assert api_request.purchase_uom == "box"
+    assert api_request.purchase_uom_conversion_rate == 100.0
+    assert response.purchase_uom == "box"
+    assert response.purchase_uom_conversion_rate == 100.0
+
+
+@pytest.mark.asyncio
+async def test_create_item_service_ignores_purchase_uom():
+    """Services don't model purchase_uom — the field must be silently dropped,
+    not crash, and not appear on the CreateServiceRequest. Response surfaces
+    None so the mutation card stays quiet for services.
+    """
+    from katana_mcp.tools.foundation.items import (
+        CreateItemRequest,
+        _create_item_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    mock_service = MagicMock(spec=["id", "name"])
+    mock_service.id = 912
+    mock_service.name = "Consulting Service"
+    lifespan_ctx.client.services.create = AsyncMock(return_value=mock_service)
+
+    request = CreateItemRequest(
+        type=ItemType.SERVICE,
+        name="Consulting Service",
+        sku="SVC-002",
+        sales_price=150.0,
+        purchase_uom="kit",
+        purchase_uom_conversion_rate=4.0,
+    )
+    response = await _create_item_impl(request, context)
+
+    api_request = lifespan_ctx.client.services.create.call_args[0][0]
+    assert not hasattr(api_request, "purchase_uom")
+    assert response.purchase_uom is None
+    assert response.purchase_uom_conversion_rate is None
+
+
+@pytest.mark.asyncio
 async def test_create_item_service_ignores_variant_fields():
     """Services don't have variants in the same sense — pricing lives on the
     header. Variant-level fields supplied with type=service must not crash and
@@ -1048,7 +1226,10 @@ async def test_create_item_service_ignores_variant_fields():
     )
 
     context, lifespan_ctx = create_mock_context()
-    mock_service = MagicMock()
+    # spec= constrains attrs so getattr(result, "uom", None) returns None
+    # instead of auto-vivifying a MagicMock — services don't carry uom /
+    # purchase_uom, so this mirrors real-API behavior.
+    mock_service = MagicMock(spec=["id", "name"])
     mock_service.id = 903
     mock_service.name = "Consulting Service"
     lifespan_ctx.client.services.create = AsyncMock(return_value=mock_service)
@@ -1073,6 +1254,52 @@ async def test_create_item_service_ignores_variant_fields():
         or not getattr(service_variant, "internal_barcode", None)
         or service_variant.internal_barcode is None
     )
+
+
+# ============================================================================
+# CreateItemRequest — purchase_uom validator
+# ============================================================================
+
+
+def test_create_item_purchase_uom_requires_conversion_rate():
+    """Setting purchase_uom without a conversion rate is ambiguous and must
+    be caught at the MCP boundary, not silently forwarded to Katana."""
+    from katana_mcp.tools.foundation.items import CreateItemRequest
+
+    with pytest.raises(ValueError, match="purchase_uom_conversion_rate is required"):
+        CreateItemRequest(
+            type=ItemType.PRODUCT,
+            name="Spoke",
+            sku="SP-1",
+            purchase_uom="kit",
+        )
+
+
+def test_create_item_conversion_rate_requires_purchase_uom():
+    """Setting only the conversion rate is equally meaningless without a UoM."""
+    from katana_mcp.tools.foundation.items import CreateItemRequest
+
+    with pytest.raises(ValueError, match="purchase_uom is required"):
+        CreateItemRequest(
+            type=ItemType.PRODUCT,
+            name="Spoke",
+            sku="SP-1",
+            purchase_uom_conversion_rate=4.0,
+        )
+
+
+def test_create_item_purchase_uom_rate_must_be_positive():
+    """Zero or negative conversion rate has no meaningful interpretation."""
+    from katana_mcp.tools.foundation.items import CreateItemRequest
+
+    with pytest.raises(ValueError, match="must be greater than 0"):
+        CreateItemRequest(
+            type=ItemType.MATERIAL,
+            name="Box",
+            sku="BX-1",
+            purchase_uom="box",
+            purchase_uom_conversion_rate=0,
+        )
 
 
 # ============================================================================
@@ -1195,9 +1422,7 @@ async def test_modify_item_material_header_dispatches_to_materials_endpoint():
     )
 
     context, _ = create_mock_context()
-    mock_material = MagicMock()
-    mock_material.id = 99
-    mock_material.name = "Renamed Material"
+    mock_material = _mock_item(id=99, name="Renamed Material")
     with (
         patch(
             "katana_public_api_client.api.material.update_material.asyncio_detailed",


### PR DESCRIPTION
## Summary

Adds `purchase_uom` + `purchase_uom_conversion_rate` to the catalog create tools so items purchased in packs (kits, boxes, cases) but stocked / sold loose can be modeled end-to-end via MCP — no more "create in MCP, finish in the Katana web UI" round-trip.

Closes the immediate gap reported for SP0502-style SKUs (spokes bought in 4-piece kits, sold individually) and SP7025-style SKUs (spoke nipples bought as "box of 100"). The modify_item flow already supported these fields via `ItemHeaderPatch`; this brings the create surface to parity.

**What changed:**

- `CreateProductRequest` / `CreateMaterialRequest` / `CreateItemRequest` (catalog.py, items.py) accept `purchase_uom: str | None` + `purchase_uom_conversion_rate: float | None`; impls forward via `to_unset(...)`. Services ignore the fields (upstream Service model doesn't carry them).
- Matching response models surface the resulting values via `unwrap_unset()` so the mutation card can render the configured kit-size.
- `VariantDetailsResponse` lifts the fields from the parent product/material — same pattern as the existing `uom` / `default_supplier_id` / `is_batch_tracked` lift in `_dict_to_variant_details`.
- New `_variant_purchase_uom_line` Prefab UI helper renders `"Purchase UoM: kit (x4 pcs)"` only when configured and the purchase UoM differs from the stock UoM. Wired into variant-detail, item-detail, and item-mutation cards. Quiet in the common case (purchase == stock).
- New `mock_item` helper in `tests/conftest.py` consolidates 22 ad-hoc `MagicMock()` constructions so existing tests still pass after the response models started reading the new fields.

**Out of scope:**

Per-supplier-divergent UoM (different conversion factors per supplier on the same item) — neither the live-gateway nor readme-portal upstream spec exposes a `/variant_suppliers` resource, so the truly per-supplier case isn't reachable via the public Katana REST API today. The Katana web UI's "Item → Suppliers" tab is where this is *edited*, but the underlying record is one-per-item. Worth a follow-up if Katana exposes the resource upstream.

## Test plan

- [x] `uv run poe check` — 3135 tests + 16 browser tests pass; pyright clean; ruff clean.
- [x] New unit tests cover: forward to API request (kit-of-4, box-of-100 cases), UNSET defaults when omitted, service route ignores the fields, parent-lift round-trip on `get_variant_details`, conditional UI rendering (shows when set + different, omits when matching or unset, label-only when conversion is None).
- [ ] Live smoke (reviewer): `create_material` with `name="Test spoke kit", sku="TEST-KIT-1", uom="pcs", purchase_uom="kit", purchase_uom_conversion_rate=4, purchase_price=4.55` → returned variant ID; follow up with `get_variant_details` and confirm `purchase_uom == "kit"`, `purchase_uom_conversion_rate == 4.0`; cross-check via Katana web UI → Item → Suppliers tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)