### PR TITLE
docs: Tier 2 process-doc sweep — CONTRIBUTING + MCP architecture (closes #701 #702 #703)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -69,9 +69,12 @@ uv run poe test-integration
 
 ### Code Style
 
-- We use [Ruff](https://docs.astral.sh/ruff/) for code formatting and linting
-- [ty](https://astral.sh/blog/ty) for type checking (Astral's fast Rust-based type
-  checker)
+- [Ruff](https://docs.astral.sh/ruff/) for code formatting and linting
+- [pyright](https://microsoft.github.io/pyright/) for type checking — **canonical**, per
+  [`pyrightconfig.json`](../pyrightconfig.json) and the LSP integration. Run via
+  `uv run pyright <path>` (the LSP can be stale; the CLI is the source of truth).
+- [ty](https://astral.sh/blog/ty) for type checking — secondary fast checker (Astral's
+  Rust-based). Both run in CI via `uv run poe lint`; both must pass.
 - [mdformat](https://mdformat.readthedocs.io/) for Markdown formatting
 
 All formatting is automated via `uv run poe format`.
@@ -158,22 +161,12 @@ See [docs/RELEASE.md](RELEASE.md) for complete release documentation
 
 ## Project Structure
 
-```text
-katana-openapi-client/
-├── katana_public_api_client/    # Main package
-│   ├── __init__.py
-│   ├── katana_client.py         # Main client implementation
-│   ├── client.py                # Base client classes
-│   ├── client_types.py          # Type definitions
-│   ├── errors.py                # Exception classes
-│   ├── log_setup.py             # Logging configuration
-│   ├── api/                     # Generated API methods (flattened)
-│   └── models/                  # Generated models (flattened)
-├── tests/                       # Test suite
-├── docs/                        # Documentation
-├── scripts/                     # Development scripts
-└── .github/                     # GitHub workflows
-```
+The repo is a 3-package monorepo (Python client, MCP server, TypeScript client). The
+canonical tree lives in the root
+[README.md → Project Structure](../README.md#project-structure); see also the linked
+package READMEs from that section. The structure isn't reproduced here — keeping the
+tree in two places is exactly the kind of drift-prone hand-maintained reference the rule
+below forbids.
 
 ## Architecture Guidelines
 

--- a/katana_mcp_server/docs/architecture.md
+++ b/katana_mcp_server/docs/architecture.md
@@ -21,12 +21,14 @@ calls with its own retry / rate-limit logic.
 │  FastMCP entry (server.py)                                 │
 │   - registers tools / resources / prompts                  │
 │   - hot-reload + HTTP/STDIO transports                     │
+│   - middleware/ (request-side coercion shims)              │
 ├────────────────────────────────────────────────────────────┤
 │  Tools           Resources         Prompts                 │
 │  tools/          resources/        prompts/                │
 │   foundation/     help.py           workflows.py           │
 │   workflows/      inventory.py                             │
-│                   reference.py                             │
+│   prefab_ui.py                                             │
+│   decorators.py                                            │
 ├────────────────────────────────────────────────────────────┤
 │  Services / dependencies (services/dependencies.py)        │
 │   get_services(context) → KatanaClient + caches            │
@@ -48,17 +50,30 @@ calls with its own retry / rate-limit logic.
 Tools live under `katana_mcp/tools/` and split into two sublayers:
 
 - **Foundation tools** (`tools/foundation/`) — thin, single-purpose tools organized by
-  Katana domain: `catalog.py`, `customers.py`, `inventory.py`, `items.py`,
-  `manufacturing_orders.py`, `orders.py`, `purchase_orders.py`, `reporting.py`,
-  `sales_orders.py`, `stock_transfers.py`. Each module exposes the `get_*` / `list_*` /
-  `create_*` / `update_*` operations for its domain and follows the conventions in
+  Katana domain. Each module exposes the `get_*` / `list_*` / `create_*` / `modify_*` /
+  `delete_*` / `correct_*` operations for its domain and follows the conventions in
   [ADR-0016](adr/0016-tool-interface-pattern.md) and
-  [ADR-0019](adr/0019-tool-description-batch-conventions.md).
+  [ADR-0019](adr/0019-tool-description-batch-conventions.md). The canonical list of
+  modules is the directory itself
+  ([`tools/foundation/`](../src/katana_mcp/tools/foundation/)) and the live tool surface
+  is exposed at the `katana://help/tools` resource — both stay current; this doc does
+  not enumerate.
 - **Workflows** (`tools/workflows/`) — a planned extension layer for future multi-step
   compositions built on top of foundation tools. This directory is currently a stub:
   `register_all_workflow_tools` is a no-op and there are no concrete workflow tool
   modules yet. Add fulfilment / production-planning examples here only once real
   workflow tools exist.
+
+Cross-cutting tool infrastructure also lives directly under `tools/`:
+
+- `prefab_ui.py` — Prefab card builders + `register_preview_tool` helper (preview/apply
+  pattern). See [Prefab UI — Rendering Pitfalls](prefab/README.md) for the contracts the
+  JS renderer enforces.
+- `tool_result_utils.py` — `make_tool_result(...)` and the `UI_META` opt-in marker that
+  links a tool to the auto-registered widget.
+- `decorators.py` — `@cache_read(CachedEntity, ...)` for typed-cache-aware reads.
+- `_modification.py` / `_modification_dispatch.py` / `_reopen.py` / `_derived_fields.py`
+  / `list_coercion.py` — internal helpers consumed by the foundation tools.
 
 ### Tool interface pattern (ADR-0016)
 
@@ -95,12 +110,19 @@ or modified entity is picked up automatically by the next read. The legacy `cach
 
 ## Resources
 
-Resources expose read-only context to the AI:
+Resources expose read-only context to the AI. The current set is small:
 
-- `resources/help.py` — tool reference and conventions
+- `resources/help.py` — tool reference and conventions, registered at `katana://help`,
+  `katana://help/workflows`, `katana://help/tools`, `katana://help/resources`
   ([ADR-0019](adr/0019-tool-description-batch-conventions.md))
-- `resources/inventory.py` — current inventory snapshots
-- `resources/reference.py` — Katana taxonomy and lookup tables
+- `resources/inventory.py` — full catalog snapshot at `katana://inventory/items`
+  (products, materials, services), backed by the typed cache
+
+Reference data (suppliers, locations, tax rates, operators, additional costs) is
+**tools-only** — see `tools/foundation/reference.py`. The previous bulk-list resources
+for those entities dumped every row as a single JSON blob and flooded agent context;
+parameterized tools (FTS-backed `query` + bounded `limit`) replaced them. Transactional
+data (sales / manufacturing / purchase orders, stock movements) is also tools-only.
 
 ## Prompts
 
@@ -135,18 +157,26 @@ SQLModel-backed per-entity tables for every cached type. Each entity has its own
 with proper FK relationships and JSON columns; nested rows (sales-order rows, MO recipe
 rows, ...) become child tables with FKs back to the parent.
 
-**Catalog tier** (11 entity types): variants, products, materials, services, suppliers,
-customers, locations, tax rates, operators, factories, additional costs. Search via
-per-entity FTS5 sidecar tables (`<entity>_fts`) wired through a `CatalogQueries` adapter
-exposed at `services.typed_cache.catalog`. The adapter provides typed `get_by_id` /
-`get_by_sku` / `get_many_by_ids` / `get_all` / `smart_search` / `search_fuzzy` methods
-that return `Cached*` SQLModel instances directly (not dict shims), with default
-`include_archived=False` / `include_deleted=False` filters.
+The cache is split into two tiers:
 
-**Transactional tier** (10 entity types counting child rows): sales orders,
-manufacturing orders (+ recipe rows), purchase orders (+ rows), stock adjustments (+
-rows), stock transfers (+ rows). Searched via SQL `WHERE` clauses; no FTS sidecar —
-these tables don't carry free-text fields.
+- **Catalog tier** — variants, products, materials, services, and the per-domain
+  reference taxonomies. Search via per-entity FTS5 sidecar tables (`<entity>_fts`) wired
+  through a `CatalogQueries` adapter exposed at `services.typed_cache.catalog`. The
+  adapter provides typed `get_by_id` / `get_by_sku` / `get_many_by_ids` / `get_all` /
+  `smart_search` / `search_fuzzy` methods that return `Cached*` SQLModel instances
+  directly (not dict shims), with default `include_archived=False` /
+  `include_deleted=False` filters.
+- **Transactional tier** — sales orders, manufacturing orders (+ recipe rows), purchase
+  orders (+ rows), stock adjustments (+ rows), stock transfers (+ rows). Searched via
+  SQL `WHERE` clauses; no FTS sidecar — these tables don't carry free-text fields.
+
+The canonical entity list lives in
+[`typed_cache/sync.py`](../src/katana_mcp/typed_cache/sync.py) (the `EntitySpec`
+literals); enumerating it here would drift on every new entity. For the soft-state
+filtering rules (`include_archived` / `include_deleted` opt-ins, `is_archived` /
+`is_deleted` derived bools, cross-entity ID collision pitfalls) and the `Cached<Entity>`
+/ API-pydantic-don't-pollute contract, see
+[Typed Cache — Patterns and Pitfalls](typed_cache/README.md).
 
 ### EntitySpec — the generic sync driver
 
@@ -228,16 +258,31 @@ bugs at the client/generator layer").
 1. **Add tests:** unit tests for the request/response shape; integration tests if cache
    sync is involved.
 
+## Subsystem deep-dives
+
+This doc is the map; the deep-dives live alongside the code:
+
+- [Prefab UI — Rendering Pitfalls](prefab/README.md) — JSON-envelope contracts the JS
+  renderer enforces (`DataTable.rows` mustache binding, `register_preview_tool` +
+  `meta=UI_META` symmetry, browser-test wire-shape parity, help-resource drift).
+- [Typed Cache — Patterns and Pitfalls](typed_cache/README.md) — soft-state filtering
+  (`include_archived` / `include_deleted` + `is_archived` / `is_deleted` derived bools),
+  cross-entity ID-collision pitfall, and the API-pydantic / `Cached<Entity>` separation
+  contract.
+- [Spec Authoring](../../katana_public_api_client/docs/spec-authoring.md) — OpenAPI 3.1
+  conventions, the generator/spec regen lockstep, breaking-change marker rules, and the
+  "fix bugs at the client/generator layer" rule that decides where a sync.py symptom
+  should actually be fixed.
+
 ## References
 
-- [ADR-0010](adr/0010-katana-mcp-server.md) — original MCP server scope
-- [ADR-0016](adr/0016-tool-interface-pattern.md) — tool interface pattern
-- [ADR-0017](adr/0017-automated-tool-documentation.md) — automated tool documentation
-- [ADR-0018](adr/0018-sqlmodel-typed-cache.md) — SQLModel typed cache
-- [ADR-0019](adr/0019-tool-description-batch-conventions.md) — tool description and
-  batch-field conventions
+The canonical, current list of MCP server ADRs is the [ADR index](adr/README.md) — this
+section does not enumerate (drift surface). Adjacent references that aren't in the ADR
+index:
+
 - [Client ADR-0001](../../katana_public_api_client/docs/adr/0001-transport-layer-resilience.md)
-  — transport-layer resilience pattern
+  — transport-layer resilience pattern (read this once if you've never touched the
+  client retry/pagination layer)
 - [CLAUDE.md](../../CLAUDE.md) — repo-level conventions for AI assistants
 - [Development guide](development.md) — local hot-reload workflow
 - [Deployment guide](deployment.md) — production deployment


### PR DESCRIPTION
## Summary

Three Tier 2 follow-ups from the #569 documentation sweep, bundled into one PR. Closes #701, #702, #703.

Same drift-resistance philosophy as #697 / #699 — every fix that *can* remove a hand-maintained drift-prone reference, does. CONTRIBUTING.md got two surgical fixes; `architecture.md` got six concrete drift fixes plus cross-links to the new subsystem docs.

## Per-file

### `docs/CONTRIBUTING.md` (closes #701, #702)

- **Project Structure tree** (the issue from #701): the 14-line hand-maintained tree showed only `katana_public_api_client/`, but the repo is now a 3-package monorepo. Replaced with a one-paragraph link to the canonical tree in the root README, with explicit acknowledgement that "keeping the tree in two places is exactly the kind of drift-prone hand-maintained reference the rule below forbids" — self-referentially closes the loop with the rule the same file just codified in #699.
- **Code Style section** (the issue from #702): mentioned only \`ty\`. Now documents both pyright and ty: pyright marked **canonical** (per \`pyrightconfig.json\` and the LSP integration), ty as the secondary fast checker, both run in CI via \`uv run poe lint\`, both must pass.

### \`katana_mcp_server/docs/architecture.md\` (closes #703)

Six concrete drift fixes:

1. **Layered-structure box** — added \`prefab_ui.py\`, \`decorators.py\`, and \`middleware/\` (all exist in the tree, all were missing from the diagram); removed \`resources/reference.py\` (doesn't exist — reference data is tools-only).
2. **Foundation tools enumeration** — replaced the 9-module hand-typed list with a link to the [\`tools/foundation/\`](katana_mcp_server/src/katana_mcp/tools/foundation/) directory and a pointer to the \`katana://help/tools\` resource. Drift-resistant per #569.
3. **Cross-cutting tool infrastructure** — new section documenting \`prefab_ui.py\`, \`tool_result_utils.py\`, \`decorators.py\`, and the \`_modification\` / \`_reopen\` / \`_derived_fields\` / \`list_coercion\` helpers that foundation tools consume. None were mentioned previously.
4. **Resources section** — spelled out the four \`katana://help/*\` URIs, corrected the inventory resource description (it's a full catalog snapshot, not just stock levels), and added the explanation for why reference + transactional data are tools-only (the previous bulk-list resources flooded agent context).
5. **Cache section** — removed the entity-count claims (\"11 catalog\", \"10 transactional\") in favor of pointing at \`typed_cache/sync.py\`'s \`EntitySpec\` literals — the canonical source.
6. **References list** — replaced the hand-curated 5-ADR list (which had already drifted — ADR-0020 was missing) with a link to the ADR index README. Added a new **Subsystem deep-dives** section linking the three new docs from #697: [\`prefab/README.md\`](katana_mcp_server/docs/prefab/README.md), [\`typed_cache/README.md\`](katana_mcp_server/docs/typed_cache/README.md), and [\`spec-authoring.md\`](katana_public_api_client/docs/spec-authoring.md).

## Out of scope (recommended follow-up issues)

The agent flagged these while auditing:

- \`docs/CONTRIBUTING.md\` \"Submitting Changes\" section still recommends \`git checkout -b feature/your-feature-name\` — doesn't surface the \`HEAD:refs/heads/<name>\` first-push safety pattern that CLAUDE.md and the pre-push hook now enforce.
- \`docs/CONTRIBUTING.md\` \"What Gets Regenerated\" enumerates \`client.py\`, \`client_types.py\`, etc. — same drift class. Could be replaced with \"see \`scripts/regenerate_client.py\` for the canonical list.\"
- \`katana_mcp_server/src/katana_mcp/tools/__init__.py\` module docstring is stale — only mentions \`items.py\` and \`inventory.py\` as if foundation Phase 3 hasn't happened (it has 13+ modules now). Source-code-side mirror of the same README/architecture drift this PR cleans up.

I'll file these as additional follow-up issues if you want to chain another pass.

## Test plan

- [x] \`uv run poe check\` passed (3122 unit tests + 16 browser tests, ~3 min total)
- [x] All cross-reference targets verified to exist (subsystem docs, ADR index, foundation directory)
- [x] Architecture diagram boxes accurately reflect the current \`src/katana_mcp/\` tree
- [x] CONTRIBUTING's pyright/ty section matches actual \`poe lint\` behavior
- [ ] Reviewer: confirm the architecture.md \"why reference + transactional are tools-only\" rationale matches your design intent
- [ ] Reviewer: agree with the choice to remove the hand-typed module list rather than auto-generate it (consistent with #699's \"remove drift surface > add a sync task\" call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)