### PR TITLE
fix(mcp): _dump_list supports attrs models on API-fallback variant path

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -1813,14 +1813,32 @@ def _dict_to_variant_details(
     parent_url = katana_web_url("product", product_id) or katana_web_url(
         "material", material_id
     )
-    type_val = _attr(v, "type")
+    # Cache rows / dicts use ``type``; the generated attrs ``Variant``
+    # uses ``type_`` (trailing underscore — Python keyword collision in
+    # the OpenAPI generator's name-mangling). Read both so cache-hit and
+    # API-fallback paths produce the same response shape; otherwise the
+    # API-fallback response would carry ``type=None`` and the Prefab UI
+    # would silently drop the type badge.
+    type_val = _attr(v, "type") or _attr(v, "type_")
     type_str = type_val.value if hasattr(type_val, "value") else type_val
 
     def _dump_list(items: Any) -> list[Any]:
+        # Cache rows carry pydantic items (``ConfigAttribute`` /
+        # ``CustomField``); API-fallback variants carry attrs items
+        # (``VariantConfigAttributesItem`` / ``VariantCustomFieldsItem``).
+        # Both need to land as plain dicts on the response so the
+        # pydantic ``VariantDetailsResponse`` validator accepts them
+        # — attrs models expose ``to_dict()``, pydantic models expose
+        # ``model_dump()``.
         if not items:
             return []
         return [
-            item.model_dump() if hasattr(item, "model_dump") else item for item in items
+            item.model_dump()
+            if hasattr(item, "model_dump")
+            else item.to_dict()
+            if hasattr(item, "to_dict")
+            else item
+            for item in items
         ]
 
     parent_name_value = _attr(v, "parent_name") or _attr(parent, "name")

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -299,6 +299,157 @@ async def test_get_variant_details_lifts_purchase_uom_from_parent():
 
 
 @pytest.mark.asyncio
+async def test_get_variant_details_api_fallback_derives_display_name_and_parent_name():
+    """API-fallback path (variant absent from cache, fetched fresh from
+    ``GET /variants/{id}``) still produces a complete response.
+
+    The raw ``Variant`` attrs model has neither ``display_name`` nor
+    ``parent_name`` — those are cache-only synthesized fields written
+    by the typed-cache sync postprocess hook. Without explicit fallback
+    logic the response would render with just a bare SKU and no
+    "Part of: …" line. ``_dict_to_variant_details`` handles this via:
+
+    - ``parent_name_value = _attr(v, 'parent_name') or _attr(parent, 'name')``
+      — falls back to the enriched parent's ``name`` when the variant
+      itself has no precomputed field
+    - ``display_name_value = _attr(v, 'display_name') or
+      build_variant_display_name(parent_name_value, configs, sku)`` —
+      recomputes the canonical display name from parent + configs
+
+    This test exercises the path with an actual ``Variant`` attrs
+    model (no cache-only fields) plus a parent product in the enriched
+    cache, and asserts both names land correctly on the response.
+    Regression test for #564.
+    """
+    from katana_public_api_client.client_types import UNSET
+    from katana_public_api_client.models.variant import Variant
+    from katana_public_api_client.models.variant_config_attributes_item import (
+        VariantConfigAttributesItem,
+    )
+    from katana_public_api_client.models.variant_custom_fields_item import (
+        VariantCustomFieldsItem,
+    )
+    from katana_public_api_client.models.variant_type import VariantType
+
+    context, lifespan_ctx = create_mock_context()
+    # The variant lookup misses the cache and falls through to the API.
+    # The API returns a generated attrs ``Variant`` — no ``display_name``
+    # or ``parent_name`` keys, because those are cache-synthesized fields.
+    # NB: the attrs model's discriminator is ``type_`` (trailing underscore
+    # — Python keyword collision in the generator), NOT ``type``. Pin
+    # that in the fixture so the read-side fallback (``_attr(v, "type")
+    # or _attr(v, "type_")``) gets exercised end-to-end.
+    #
+    # ``custom_fields`` is also populated alongside ``config_attributes``
+    # so both attrs-item shapes round-trip through ``_dump_list``. The
+    # ``_dump_list`` ``to_dict`` branch handles both lists, but only
+    # exercising one would leave the other path uncovered.
+    api_variant = Variant(
+        id=9001,
+        sku="KNF-PRO-8PC-STL",
+        product_id=101,
+        material_id=None,
+        sales_price=299.99,
+        purchase_price=150.0,
+        type_=VariantType.PRODUCT,
+        config_attributes=[
+            VariantConfigAttributesItem(
+                config_name="Piece Count", config_value="8-piece"
+            ),
+            VariantConfigAttributesItem(
+                config_name="Handle Material", config_value="Steel"
+            ),
+        ],
+        custom_fields=[
+            VariantCustomFieldsItem(
+                field_name="Warranty Period", field_value="5 years"
+            ),
+        ],
+    )
+    # The fixture deliberately leaves ``lead_time`` unset on the attrs
+    # model so the test verifies optional-field omission round-trips
+    # cleanly (UNSET on the attrs side → ``None`` on the response).
+    # Mirrors a real API response shape where the seller hasn't
+    # populated lead_time.
+    assert api_variant.lead_time is UNSET, (
+        "Fixture must leave lead_time as UNSET to mimic an API response "
+        "where the optional field wasn't populated. If this fails the "
+        "fixture has drifted, not the prod code."
+    )
+
+    # Cache miss for the variant; parent product + supplier ARE in cache
+    # (the @cache_read decorator synced them before the call).
+    lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(return_value=None)
+    parent_product = {
+        "id": 101,
+        "name": "Professional Kitchen Knife Set",
+        "uom": "set",
+        "default_supplier_id": 555,
+        "batch_tracked": False,
+    }
+    supplier = {"id": 555, "name": "Acme Cutlery Co"}
+
+    async def _get_many_by_ids(entity_type, ids, **_kw):
+        from katana_public_api_client.models_pydantic._generated import (
+            CachedProduct,
+            CachedSupplier,
+        )
+
+        if entity_type == CachedProduct:
+            return {101: parent_product} if 101 in set(ids) else {}
+        if entity_type == CachedSupplier:
+            return {555: supplier} if 555 in set(ids) else {}
+        return {}
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        side_effect=_get_many_by_ids
+    )
+
+    with patch(
+        "katana_mcp.tools.foundation.items._fetch_variant_by_id",
+        new_callable=AsyncMock,
+        return_value=api_variant,
+    ):
+        request = GetVariantDetailsRequest(variant_id=9001)
+        [result] = (await _get_variant_details_impl(request, context)).found
+
+    # parent_name lifted from the enriched parent product
+    assert result.product_or_material_name == "Professional Kitchen Knife Set"
+    # display_name recomputed from parent_name + configs (parent + Piece
+    # Count + Handle Material). Confirms ``build_variant_display_name``
+    # is called on the API-fallback path, not just the cache-hit path.
+    assert result.display_name is not None
+    assert "Professional Kitchen Knife Set" in result.display_name
+    assert "8-piece" in result.display_name
+    assert "Steel" in result.display_name
+    # Lifted parent context — the bits that would silently null on a
+    # broken fallback path.
+    assert result.uom == "set"
+    assert result.default_supplier_id == 555
+    assert result.default_supplier_name == "Acme Cutlery Co"
+    # Variant-level fields still surface from the attrs model.
+    assert result.sku == "KNF-PRO-8PC-STL"
+    assert result.sales_price == 299.99
+    # Both attrs-item lists ``_dump_list`` handles — config_attributes
+    # AND custom_fields — round-trip into plain dicts on the response.
+    # Pre-fix this assertion would have failed with a pydantic
+    # ValidationError when ``_dump_list`` left the attrs items
+    # unconverted.
+    assert result.config_attributes == [
+        {"config_name": "Piece Count", "config_value": "8-piece"},
+        {"config_name": "Handle Material", "config_value": "Steel"},
+    ]
+    assert result.custom_fields == [
+        {"field_name": "Warranty Period", "field_value": "5 years"},
+    ]
+    # ``type`` comes through the ``type_`` → ``type`` rename — pinned
+    # because attrs models name the discriminator ``type_`` to avoid the
+    # Python keyword collision, and a naive ``_attr(v, "type")`` would
+    # silently return None on this path.
+    assert result.type == "product"
+
+
+@pytest.mark.asyncio
 async def test_get_variant_details_no_purchase_uom_when_parent_omits_it():
     """The common case (purchase_uom == stock uom) — parent omits the fields,
     response surfaces them as None so the Prefab UI card stays quiet."""

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -450,6 +450,181 @@ async def test_get_variant_details_api_fallback_derives_display_name_and_parent_
 
 
 @pytest.mark.asyncio
+async def test_get_variant_details_cache_hit_and_api_fallback_paths_match():
+    """The same logical variant must produce structurally identical
+    ``VariantDetailsResponse`` whether resolved via the cache-hit path
+    (``CachedVariant`` shape) or the API-fallback path (attrs ``Variant``
+    shape). Every field surfaced through ``_dict_to_variant_details``
+    needs to read off both shapes consistently.
+
+    This is the divergence-protection contract that #564 and the Copilot
+    review on PR #717 exposed two facets of:
+
+    - ``_dump_list`` only handled ``model_dump`` (pydantic), not
+      ``to_dict`` (attrs) — API-fallback variants with non-empty
+      ``config_attributes`` would fail pydantic validation
+    - ``_attr(v, "type")`` returned None on attrs because the field is
+      named ``type_`` (Python-keyword rename), dropping the type badge
+
+    Both bugs share the same root: cache rows and attrs models have
+    subtly divergent field shapes, and any helper that reads them with
+    a single attribute name will silently lose data on one side. The
+    only practical defense is exercising both paths with the same
+    logical input and asserting the responses match — catching a
+    broader class of latent divergence without enumerating every
+    possible field-shape difference.
+
+    Adding new fields to ``VariantDetailsResponse`` that read from the
+    variant: if the field's source differs between cache and attrs
+    shapes (different name, different type), this test will fail and
+    point at the divergence.
+    """
+    from katana_public_api_client.models.variant import Variant
+    from katana_public_api_client.models.variant_config_attributes_item import (
+        VariantConfigAttributesItem,
+    )
+    from katana_public_api_client.models.variant_custom_fields_item import (
+        VariantCustomFieldsItem,
+    )
+    from katana_public_api_client.models.variant_type import VariantType
+
+    # Logical variant + parent — same data, used to build both shapes.
+    # Pinned values rather than the existing ``_FULL_VARIANT_DICT`` so
+    # the test stays self-contained and the assertions read top-to-bottom.
+    parent_product = {
+        "id": 101,
+        "name": "Professional Kitchen Knife Set",
+        "uom": "set",
+        "default_supplier_id": 555,
+        "batch_tracked": False,
+        "purchase_uom": None,
+        "purchase_uom_conversion_rate": None,
+    }
+    supplier = {"id": 555, "name": "Acme Cutlery Co"}
+
+    # CachedVariant shape: dict with cache-only synthesized fields
+    # (``display_name``, ``parent_name``) precomputed at sync time.
+    cache_row = {
+        "id": 9001,
+        "sku": "KNF-PRO-8PC-STL",
+        "product_id": 101,
+        "material_id": None,
+        "sales_price": 299.99,
+        "purchase_price": 150.0,
+        "type": "product",
+        "internal_barcode": "INT-KNF-001",
+        "registered_barcode": "789123456789",
+        "supplier_item_codes": ["SUP-KNF-8PC-001"],
+        "lead_time": 7,
+        "minimum_order_quantity": 1,
+        "config_attributes": [
+            {"config_name": "Piece Count", "config_value": "8-piece"},
+            {"config_name": "Handle Material", "config_value": "Steel"},
+        ],
+        "custom_fields": [
+            {"field_name": "Warranty Period", "field_value": "5 years"},
+        ],
+        "display_name": ("Professional Kitchen Knife Set / 8-piece / Steel"),
+        "parent_name": "Professional Kitchen Knife Set",
+        "created_at": None,
+        "updated_at": None,
+        "deleted_at": None,
+    }
+
+    # attrs Variant shape: same logical data, no cache-only fields,
+    # ``type_`` trailing-underscore rename, attrs items for configs /
+    # custom fields. The fields ``Variant`` doesn't carry
+    # (display_name, parent_name) get recomputed at read time by
+    # ``_dict_to_variant_details`` from the enriched parent.
+    api_variant = Variant(
+        id=9001,
+        sku="KNF-PRO-8PC-STL",
+        product_id=101,
+        material_id=None,
+        sales_price=299.99,
+        purchase_price=150.0,
+        type_=VariantType.PRODUCT,
+        internal_barcode="INT-KNF-001",
+        registered_barcode="789123456789",
+        supplier_item_codes=["SUP-KNF-8PC-001"],
+        lead_time=7,
+        minimum_order_quantity=1,
+        config_attributes=[
+            VariantConfigAttributesItem(
+                config_name="Piece Count", config_value="8-piece"
+            ),
+            VariantConfigAttributesItem(
+                config_name="Handle Material", config_value="Steel"
+            ),
+        ],
+        custom_fields=[
+            VariantCustomFieldsItem(
+                field_name="Warranty Period", field_value="5 years"
+            ),
+        ],
+    )
+    # Sanity: the attrs shape genuinely lacks cache-only fields. If
+    # this changes the test stops proving what it claims to prove.
+    assert api_variant.lead_time == 7  # actually-set field surfaces
+    assert not hasattr(api_variant, "display_name")
+    assert not hasattr(api_variant, "parent_name")
+
+    async def _get_many_by_ids(entity_type, ids, **_kw):
+        from katana_public_api_client.models_pydantic._generated import (
+            CachedProduct,
+            CachedSupplier,
+        )
+
+        if entity_type == CachedProduct:
+            return {101: parent_product} if 101 in set(ids) else {}
+        if entity_type == CachedSupplier:
+            return {555: supplier} if 555 in set(ids) else {}
+        return {}
+
+    async def _run_path(variant_lookup_returns: object) -> dict:
+        """Drive the impl with a single mocked variant return value; return
+        the response as a plain dict for cross-path comparison."""
+        context, lifespan_ctx = create_mock_context()
+        lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(
+            return_value=variant_lookup_returns
+        )
+        lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+            side_effect=_get_many_by_ids
+        )
+        # API path: cache_by_id returns None, _fetch_variant_by_id falls
+        # through to its API call. Patch the inner call to return the
+        # attrs Variant directly without round-tripping through httpx.
+        if variant_lookup_returns is None:
+            with patch(
+                "katana_mcp.tools.foundation.items._fetch_variant_by_id",
+                new_callable=AsyncMock,
+                return_value=api_variant,
+            ):
+                request = GetVariantDetailsRequest(variant_id=9001)
+                response = (await _get_variant_details_impl(request, context)).found[0]
+        else:
+            request = GetVariantDetailsRequest(variant_id=9001)
+            response = (await _get_variant_details_impl(request, context)).found[0]
+        return response.model_dump()
+
+    cache_response = await _run_path(cache_row)
+    api_response = await _run_path(None)
+
+    # Path equivalence — every user-facing field on
+    # ``VariantDetailsResponse`` must produce the same value from either
+    # path. A diff here is a divergence bug.
+    assert cache_response == api_response, (
+        "Cache-hit and API-fallback paths produced different responses. "
+        "Diff (cache - api):\n"
+        + "\n".join(
+            f"  {k}: cache={cache_response.get(k)!r} api={api_response.get(k)!r}"
+            for k in sorted(set(cache_response) | set(api_response))
+            if cache_response.get(k) != api_response.get(k)
+        )
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_variant_details_no_purchase_uom_when_parent_omits_it():
     """The common case (purchase_uom == stock uom) — parent omits the fields,
     response surfaces them as None so the Prefab UI card stays quiet."""


### PR DESCRIPTION
## Summary

Closes #564.

The issue as written hypothesized that `_fetch_variant_by_id`'s API-fallback path drops `display_name` and `parent_name`. Investigation shows that *specific* symptom was already fixed in PR #542's `_dict_to_variant_details` via the `_attr(v, 'parent_name') or _attr(parent, 'name')` fallback. But writing a real regression test exposed a *latent* bug from the same fallback path: `_dump_list` only handles pydantic items (`model_dump`), not attrs items (`to_dict`).

## The latent bug

When `get_variant_details(variant_id=...)` misses the cache and falls through to `GET /variants/{id}`, the returned attrs `Variant` carries `config_attributes` and `custom_fields` as `VariantConfigAttributesItem` / `VariantCustomFieldsItem` instances. `_dict_to_variant_details` calls `_dump_list` on them:

```python
def _dump_list(items: Any) -> list[Any]:
    if not items:
        return []
    return [
        item.model_dump() if hasattr(item, 'model_dump') else item
        for item in items
    ]
```

Attrs models don't have `model_dump`, so they pass through unchanged. Pydantic then rejects the response model:

```
ValidationError: 2 validation errors for VariantDetailsResponse
config_attributes.0
  Input should be a valid dictionary
  [input_type=VariantConfigAttributesItem]
```

The bug stays silent until you actually hit it — cache miss + a variant with non-empty configs / custom_fields. Existing tests shimmed in plain dicts via `_fetch_variant_by_id` mocks, so the real attrs shape was never exercised.

## Fix

Teach `_dump_list` to handle three shapes:

| Shape | Method | Source |
|---|---|---|
| pydantic | `model_dump()` | cache rows (`ConfigAttribute`, `CustomField`) |
| attrs | `to_dict()` | API-fallback (`Variant*Item`) |
| raw dict | identity | legacy test fixtures |

One-line conditional chain. No behavior change for the cache-hit path.

## Regression test

`test_get_variant_details_api_fallback_derives_display_name_and_parent_name` exercises the full API-fallback path with a real `Variant` attrs model carrying real `VariantConfigAttributesItem` instances. Asserts that all the parent-derived fields (`display_name`, `product_or_material_name`, `uom`, `default_supplier_id`, `default_supplier_name`) resolve correctly AND that the configs/custom_fields don't blow up the pydantic validation.

Pre-fix this test fails on the pydantic ValidationError. Post-fix it passes cleanly.

## Test plan

- [x] `uv run poe check` — clean (3171 unit + 19 browser tests)
- [x] New regression test fails before the fix, passes after
- [ ] Live verification on a real Katana instance: invoke `get_variant_details(variant_id=<uncached>)` on a variant with non-empty `config_attributes`; confirm the full card renders with parent name, display name, and config rows

## Related

- #566 — Closed as already-fixed (the multi-cache decorator landed in #472 Phase C). Investigating that ticket led directly into this one — both were filed as PR #542 follow-ups, both ended up resolved on main but with different completeness levels: #566 had the regression test already, #564 was missing the test and had the latent attrs-shape bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)