### PR TITLE
chore: scrub second-pass Spot Bikes leakage (Mayhem, Rocker, Liquid Black, real IDs)

### DIFF
--- a/docs/sessions/2026-05-05-mcp-fulfillment-and-card-redesign.md
+++ b/docs/sessions/2026-05-05-mcp-fulfillment-and-card-redesign.md
@@ -13,7 +13,7 @@ Two parallel objectives:
 1. Ship the first card-redesign delivery (#538 — `get_variant_details`) as a working
    template for the rest of the umbrella (#537).
 1. Test the MCP-backed shop-floor agent on a real Shopify→Katana sales-order fulfillment
-   flow (SO #WEB20387, Carbon Rocker v2 / variant 33331882).
+   flow (SO #WEB1001, Premium Widget v2 / variant 1001).
 
 ## What happened (chronological)
 
@@ -48,7 +48,7 @@ now in CLAUDE.md "Known Pitfalls."
 
 ### Afternoon: live fulfillment session — bugs cascade
 
-User ran a real fulfillment for SO #WEB20387 against the dev MCP server. The session
+User ran a real fulfillment for SO #WEB1001 against the dev MCP server. The session
 produced a chain of issues, each compounding the next:
 
 1. **`search_items` iframe stuck on "Waiting for content…"** — happens both during AND
@@ -67,14 +67,14 @@ produced a chain of issues, each compounding the next:
    the user takes. Filed as #544.
 
 1. **Confirm-button apply errors are opaque** — user clicked Confirm, apply failed with
-   a 422, toast said only "Fulfillment for #WEB20387 failed" with no reason. The actual
+   a 422, toast said only "Fulfillment for #WEB1001 failed" with no reason. The actual
    `UnprocessableEntityError: sum of serial number quantity (current: 0) must match fulfillment row quantity (expected: 1)`
    was visible only via tooltip on a small warning icon. Filed as #545.
 
-1. **`fulfill_order` can't ship serial-tracked variants** — Rocker v2 is serial-tracked;
-   tool has no `serial_numbers` parameter; agent diagnosed correctly and bailed to the
-   browser. Filed as #547 with a 2-phase fix proposal (preview-time block warning +
-   per-row override).
+1. **`fulfill_order` can't ship serial-tracked variants** — Premium Widget v2 is
+   serial-tracked; tool has no `serial_numbers` parameter; agent diagnosed correctly and
+   bailed to the browser. Filed as #547 with a 2-phase fix proposal (preview-time block
+   warning + per-row override).
 
 ### Evening: backlog groom
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -1032,7 +1032,7 @@ async def _fetch_mo_recipe_rows(
     raw_rows = await _fetch_mo_recipe_row_attrs(services, manufacturing_order_id)
 
     # One batched IN-clause SQLite read instead of one read per recipe row —
-    # a Mayhem MO has ~30 rows, all looked up by variant_id.
+    # a multi-component MO has ~30 rows, all looked up by variant_id.
     variant_ids = {
         v_id
         for v_id in (unwrap_unset(row.variant_id, None) for row in raw_rows)

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -2652,7 +2652,7 @@ def build_apply_success_ui(
 ) -> PrefabApp:
     """Generic success card for an applied (non-preview) write operation.
 
-    ``title`` is the card title (e.g. ``"Sales order #WEB20387 fulfilled"``).
+    ``title`` is the card title (e.g. ``"Sales order #WEB1001 fulfilled"``).
     ``summary_lines`` are rendered verbatim as ``Text`` rows in the card
     body. ``katana_url``, when set, surfaces a "View in Katana" link button
     in the footer.
@@ -2687,7 +2687,7 @@ def build_apply_error_ui(
     Surfaces the actual error reason verbatim — closes #545 by ensuring
     the apply error is never swallowed by a static "failed" string.
     ``operation`` is a human-readable phrase like
-    ``"Fulfilling sales order #WEB20387"``. ``hint``, when set, renders
+    ``"Fulfilling sales order #WEB1001"``. ``hint``, when set, renders
     a remediation suggestion (e.g. ``"Check the supplier ID"``).
     """
     with PrefabApp(state={}, css_class="p-4") as app, Card():

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -231,7 +231,7 @@ class TestBuildVariantDetailsUI:
         variant = {
             "id": 100,
             "sku": "SEAL-250",
-            "name": "Tubeless Sealant",
+            "name": "General Sealant",
             "uom": "ml",
             "sales_price": 12.99,
         }
@@ -2044,12 +2044,12 @@ class TestBuildApplyResultUIs:
         from katana_mcp.tools.prefab_ui import build_apply_success_ui
 
         app = build_apply_success_ui(
-            title="Sales order #WEB20387 fulfilled",
+            title="Sales order #WEB1001 fulfilled",
             summary_lines=[
-                "Item: Carbon Rocker v2 (RGRD24LG5AXSTBK) qty 1",
-                "Inventory: -1 of variant 33331882",
+                "Item: Premium Widget v2 (WDG-LG-BK-001) qty 1",
+                "Inventory: -1 of variant 1001",
             ],
-            katana_url="https://factory.katanamrp.com/salesorder/43264353",
+            katana_url="https://factory.katanamrp.com/salesorder/1234",
         )
         envelope = app.to_json()
         # Title appears verbatim somewhere in the rendered card
@@ -2067,17 +2067,17 @@ class TestBuildApplyResultUIs:
 
         collect(envelope)
         joined = "\n".join(text_nodes)
-        assert "Sales order #WEB20387 fulfilled" in joined
-        assert "Carbon Rocker v2" in joined
-        assert "Inventory: -1 of variant 33331882" in joined
+        assert "Sales order #WEB1001 fulfilled" in joined
+        assert "Premium Widget v2" in joined
+        assert "Inventory: -1 of variant 1001" in joined
 
     def test_apply_error_surfaces_actual_error_message(self):
         """Closes #545 — the actual error string is not swallowed."""
         from katana_mcp.tools.prefab_ui import build_apply_error_ui
 
         app = build_apply_error_ui(
-            operation="Fulfilling sales order #WEB20387",
-            error_message="Katana API 422: row 108462734 already shipped",
+            operation="Fulfilling sales order #WEB1001",
+            error_message="Katana API 422: row 5001 already shipped",
             hint="Check the SO's current production_status before retrying.",
         )
         envelope = app.to_json()
@@ -2095,11 +2095,11 @@ class TestBuildApplyResultUIs:
 
         collect(envelope)
         joined = "\n".join(text_nodes)
-        assert "Fulfilling sales order #WEB20387 failed" in joined
+        assert "Fulfilling sales order #WEB1001 failed" in joined
         # The actual error string must be visible — the whole point of
         # this builder vs. the static-string toast/SendMessage from the
         # old preview→apply codepath.
-        assert "Katana API 422: row 108462734 already shipped" in joined
+        assert "Katana API 422: row 5001 already shipped" in joined
         assert "Check the SO's current production_status" in joined
 
 

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -1632,7 +1632,7 @@ def _mk_recipe_row(
 async def test_get_manufacturing_order_default_filters_to_blocking_rows():
     """Default include_rows='blocking' drops IN_STOCK and other non-blocking rows.
 
-    Procurement triage view: a Mayhem-140 build has dozens of IN_STOCK rows,
+    Procurement triage view: a multi-row build has dozens of IN_STOCK rows,
     a few NOT_AVAILABLE/EXPECTED rows. Only the blocking ones survive.
     """
     from katana_mcp.tools.foundation.manufacturing_orders import (

--- a/katana_mcp_server/tests/tools/test_orders.py
+++ b/katana_mcp_server/tests/tools/test_orders.py
@@ -359,8 +359,8 @@ async def test_fulfill_manufacturing_order_preview_lifts_display_name():
 
     cached_variant = MagicMock()
     cached_variant.id = 555
-    cached_variant.sku = "WIDGET-MAYHEM"
-    cached_variant.display_name = "Mayhem Widget / Large / Black"
+    cached_variant.sku = "WIDGET-X1"
+    cached_variant.display_name = "Premium Widget / Large / Black"
     cached_variant.product_id = None
     cached_variant.material_id = None
     cached_variant.config_attributes = []
@@ -383,7 +383,7 @@ async def test_fulfill_manufacturing_order_preview_lifts_display_name():
     # Lead line surfaces the canonical display name (the prior line said
     # only "Manufacturing order completion will update inventory based on BOM",
     # which gave the user no signal what was being made).
-    assert any("Mayhem Widget / Large / Black" in u for u in result.inventory_updates)
+    assert any("Premium Widget / Large / Black" in u for u in result.inventory_updates)
 
 
 @pytest.mark.asyncio
@@ -625,7 +625,7 @@ def _wire_serial_tracked_cache(
 async def test_fulfill_sales_order_preview_blocks_serial_tracked_without_override():
     """Serial-tracked variant + no rows override → BLOCK warning naming the SKU."""
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_so = MagicMock(spec=SalesOrder)
     mock_so.order_no = "SO-SN-1"
@@ -643,7 +643,7 @@ async def test_fulfill_sales_order_preview_blocks_serial_tracked_without_overrid
     block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
     assert len(block_warnings) == 1
     assert "serial-tracked" in block_warnings[0]
-    assert "ROCKER-V2" in block_warnings[0]
+    assert "WIDGET-V2" in block_warnings[0]
     assert "Resolve the issue" in result.next_actions[0]
 
 
@@ -651,7 +651,7 @@ async def test_fulfill_sales_order_preview_blocks_serial_tracked_without_overrid
 async def test_fulfill_sales_order_preview_accepts_serial_override():
     """Serial-tracked variant + matching override → no BLOCK warning, serials in preview."""
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_so = MagicMock(spec=SalesOrder)
     mock_so.order_no = "SO-SN-2"
@@ -679,7 +679,7 @@ async def test_fulfill_sales_order_preview_accepts_serial_override():
 async def test_fulfill_sales_order_apply_passes_serials_to_api():
     """Apply with override → POST body row carries serial_numbers."""
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_so = MagicMock(spec=SalesOrder)
     mock_so.order_no = "SO-SN-3"
@@ -726,7 +726,7 @@ async def test_fulfill_sales_order_apply_passes_serials_to_api():
 async def test_fulfill_sales_order_apply_refuses_serial_tracked_without_override():
     """Direct apply (preview=False) without override → refusal, no API call."""
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_so = MagicMock(spec=SalesOrder)
     mock_so.order_no = "SO-SN-4"
@@ -758,7 +758,7 @@ async def test_fulfill_sales_order_apply_refuses_serial_tracked_without_override
 async def test_fulfill_sales_order_blocks_quantity_serials_mismatch():
     """len(serial_numbers) != quantity → BLOCK warning."""
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_so = MagicMock(spec=SalesOrder)
     mock_so.order_no = "SO-SN-5"
@@ -838,7 +838,7 @@ async def test_fulfill_sales_order_serial_tracked_detection_falls_back_to_api():
     # of the legacy ``to_dict`` shim.
     variant_obj = MagicMock()
     variant_obj.id = 100
-    variant_obj.sku = "ROCKER-V2"
+    variant_obj.sku = "WIDGET-V2"
     variant_obj.product_id = 9100
     variant_obj.material_id = None
     mock_get_variant_response = MagicMock(status_code=200, parsed=variant_obj)
@@ -866,7 +866,7 @@ async def test_fulfill_sales_order_serial_tracked_detection_falls_back_to_api():
     result = await _fulfill_order_impl(request, context)
 
     block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
-    assert any("serial-tracked" in w and "ROCKER-V2" in w for w in block_warnings)
+    assert any("serial-tracked" in w and "WIDGET-V2" in w for w in block_warnings)
     # Verify both API endpoints were hit.
     cast(Any, get_variant.asyncio_detailed).assert_called_once()
     cast(Any, get_product.asyncio_detailed).assert_called_once()
@@ -880,7 +880,7 @@ async def test_fulfill_sales_order_blocks_duplicate_row_override():
     override (last-key-wins), hiding conflicting input from the caller.
     """
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_so = MagicMock(spec=SalesOrder)
     mock_so.order_no = "SO-SN-DUP"
@@ -918,7 +918,7 @@ async def test_fulfill_sales_order_blocks_serial_tracked_non_integer_quantity():
     truncated 1.5 → 1 and could mask genuine mismatches.
     """
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_so = MagicMock(spec=SalesOrder)
     mock_so.order_no = "SO-SN-FRAC"
@@ -1035,7 +1035,7 @@ def _make_serial_tracked_mo(
 async def test_fulfill_manufacturing_order_preview_blocks_serial_tracked_without_serials():
     """Serial-tracked MO + no serial_numbers → BLOCK warning naming the SKU."""
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_mo = _make_serial_tracked_mo(order_no="MO-SN-1", actual_quantity=1.0)
     mock_response = MagicMock(status_code=200, parsed=mock_mo)
@@ -1054,7 +1054,7 @@ async def test_fulfill_manufacturing_order_preview_blocks_serial_tracked_without
     block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
     assert len(block_warnings) == 1
     assert "serial-tracked" in block_warnings[0]
-    assert "ROCKER-V2" in block_warnings[0]
+    assert "WIDGET-V2" in block_warnings[0]
     assert "Resolve the issue" in result.next_actions[0]
 
 
@@ -1062,7 +1062,7 @@ async def test_fulfill_manufacturing_order_preview_blocks_serial_tracked_without
 async def test_fulfill_manufacturing_order_preview_accepts_serial_numbers():
     """Serial-tracked MO + matching serial_numbers → no BLOCK, serials in preview."""
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_mo = _make_serial_tracked_mo(order_no="MO-SN-2", actual_quantity=1.0)
     mock_response = MagicMock(status_code=200, parsed=mock_mo)
@@ -1091,7 +1091,7 @@ async def test_fulfill_manufacturing_order_preview_accepts_serial_numbers():
 async def test_fulfill_manufacturing_order_apply_passes_serials_to_api():
     """Apply with serial_numbers → update_manufacturing_order body carries them."""
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_mo = _make_serial_tracked_mo(order_no="MO-SN-3", actual_quantity=2.0)
     mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
@@ -1132,7 +1132,7 @@ async def test_fulfill_manufacturing_order_apply_passes_serials_to_api():
 async def test_fulfill_manufacturing_order_apply_refuses_serial_tracked_without_serials():
     """Direct apply (preview=False) without serial_numbers → refusal, no API call."""
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_mo = _make_serial_tracked_mo(order_no="MO-SN-4", actual_quantity=1.0)
     mock_response = MagicMock(status_code=200, parsed=mock_mo)
@@ -1164,7 +1164,7 @@ async def test_fulfill_manufacturing_order_apply_refuses_serial_tracked_without_
 async def test_fulfill_manufacturing_order_blocks_quantity_serials_mismatch():
     """len(serial_numbers) != actual_quantity → BLOCK warning."""
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     # actual_quantity=2 but only 1 serial provided.
     mock_mo = _make_serial_tracked_mo(order_no="MO-SN-5", actual_quantity=2.0)
@@ -1198,7 +1198,7 @@ async def test_fulfill_manufacturing_order_blocks_serial_tracked_non_integer_qua
     is incompatible with serial tracking.
     """
     context, lifespan_ctx = create_mock_context()
-    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="ROCKER-V2")
+    _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_mo = _make_serial_tracked_mo(order_no="MO-SN-FRAC", actual_quantity=1.5)
     mock_response = MagicMock(status_code=200, parsed=mock_mo)
@@ -1250,7 +1250,7 @@ async def test_fulfill_manufacturing_order_serial_tracked_detection_falls_back_t
     # of the legacy ``to_dict`` shim.
     variant_obj = MagicMock()
     variant_obj.id = 100
-    variant_obj.sku = "ROCKER-V2"
+    variant_obj.sku = "WIDGET-V2"
     variant_obj.product_id = 9100
     variant_obj.material_id = None
     mock_get_variant_response = MagicMock(status_code=200, parsed=variant_obj)
@@ -1280,7 +1280,7 @@ async def test_fulfill_manufacturing_order_serial_tracked_detection_falls_back_t
     result = await _fulfill_order_impl(request, context)
 
     block_warnings = [w for w in result.warnings if w.startswith("BLOCK:")]
-    assert any("serial-tracked" in w and "ROCKER-V2" in w for w in block_warnings)
+    assert any("serial-tracked" in w and "WIDGET-V2" in w for w in block_warnings)
     # Verify both API endpoints were hit.
     cast(Any, get_variant.asyncio_detailed).assert_called_once()
     cast(Any, get_product.asyncio_detailed).assert_called_once()

--- a/katana_public_api_client/utils.py
+++ b/katana_public_api_client/utils.py
@@ -616,7 +616,7 @@ def get_variant_display_name(variant: "VariantResponse") -> str:
 
     Format: "{Product/Material Name} / {Config Value 1} / {Config Value 2} / ..."
 
-    Example: "Mayhem 140 / Liquid Black / Large / 5 Star"
+    Example: "Premium 140 / Glossy Black / Large / Type A"
 
     Takes a `VariantResponse` (the discriminated-union variant schema with
     typed `product_or_material: Material | Product | Unset`). Variants returned
@@ -648,7 +648,7 @@ def get_variant_display_name(variant: "VariantResponse") -> str:
             )
             for variant in unwrap_data(response):
                 print(get_variant_display_name(variant))
-                # e.g. "Mayhem 140 / Liquid Black / Large / 5 Star"
+                # e.g. "Premium 140 / Glossy Black / Large / Type A"
         ```
     """
     product_or_material = unwrap_unset(variant.product_or_material, None)

--- a/uv.lock
+++ b/uv.lock
@@ -1278,7 +1278,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.75.0"
+version = "0.75.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Follow-up to [#715](https://github.com/dougborg/katana-openapi-client/pull/715). The initial sweep missed customer-specific product names that read generically out of context but are Spot Bikes model / component / SKU identifiers. The user reviewed the merged PR and flagged "Mayhem" specifically; a second-pass audit picked up the rest of the trail.

- **Product line names**:
  - `Mayhem` (Spot bike model) → `Premium` / `multi-component` in `test_orders.py` SKU/display_name, `test_manufacturing_orders.py` comment, production `manufacturing_orders.py:1035` comment, and `utils.py` docstring example.
  - `Carbon Rocker v2` (Spot suspension component) → `Premium Widget v2` in `test_prefab_ui.py` + `2026-05-05` session retrospective + the production `prefab_ui.py` docstring examples.
  - `Rocker v2` → `Widget v2` in serial-tracked fulfillment tests (`ROCKER-V2` SKU → `WIDGET-V2`).
- **Variant attributes**:
  - `Liquid Black` (Spot paint color) → `Glossy Black` and `5 Star` (Spot component bundle) → `Type A` in `utils.py`'s `get_variant_display_name` docstring.
- **Real customer-system IDs**:
  - SO `order_no #WEB20387` → `#WEB1001`
  - `variant 33331882` → `variant 1001`
  - `/salesorder/43264353` URL ID → `/salesorder/1234`
  - `row 108462734` → `row 5001`
  - All appeared in `test_prefab_ui.py` apply-success/apply-error fixtures and the `2026-05-05` session retrospective.
- **Real Spot SKU**: `RGRD24LG5AXSTBK` → `WDG-LG-BK-001` in `test_prefab_ui.py`.
- **Bike vocabulary**: `Tubeless Sealant` → `General Sealant` in `test_prefab_ui.py` variant-details fixture.

Also bundles incidental `uv.lock` drift from `mcp v0.75.1` release on main during the session.

Refs #711.

## Test plan

- [x] `uv run poe test` — 3170 passed, 2 skipped
- [x] Comprehensive grep audit returns no remaining Spot identifiers, model names, paint colors, real SKUs, or system IDs.
- [x] All test setup/assertion renames stay paired (e.g., SKU `ROCKER-V2` → `WIDGET-V2` updated in both the cache stub and the warning-string assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)