### PR TITLE
feat(mcp): per-entity create-order Prefab cards (PO/SO/MO) — #551

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -77,12 +77,12 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **delete_stock_transfer** - Delete a transfer
 
 ### Reference Data
-- **list_locations** - List or fuzzy-search warehouses and facilities (id, name, address, primary flag). Use for `location_id` lookups on orders and inventory queries. Supports `query`, `limit`, `format`.
-- **list_suppliers** - List or fuzzy-search suppliers by name/code (id, name, email, phone, currency, code). Use for `supplier_id` / `default_supplier_id` on POs and materials. Supports `query`, `limit`, `format`.
+- **list_locations** - List or fuzzy-search warehouses and facilities (id, name, address, primary flag). Use for `location_id` lookups on orders and inventory queries. Supports `query`, `limit`
+- **list_suppliers** - List or fuzzy-search suppliers by name/code (id, name, email, phone, currency, code). Use for `supplier_id` / `default_supplier_id` on POs and materials. Supports `query`, `limit`
 - **get_supplier** - Full-detail supplier record by id (contact info, address, payment terms). Pair with `list_suppliers(query=...)`.
-- **list_tax_rates** - List or fuzzy-search configured tax rates (id, rate, defaults). Use for `tax_rate_id` on order line items. Supports `query`, `limit`, `format`.
-- **list_operators** - List or fuzzy-search manufacturing operators (id, name). Use for `operator_id` / `packer_id` on MO operations and SO fulfillments. Supports `query`, `limit`, `format`.
-- **list_additional_costs** - List or fuzzy-search the additional-cost catalog (freight, duties, handling). Use for `additional_cost_id` on `modify_purchase_order`. Supports `query`, `limit`, `format`.
+- **list_tax_rates** - List or fuzzy-search configured tax rates (id, rate, defaults). Use for `tax_rate_id` on order line items. Supports `query`, `limit`
+- **list_operators** - List or fuzzy-search manufacturing operators (id, name). Use for `operator_id` / `packer_id` on MO operations and SO fulfillments. Supports `query`, `limit`
+- **list_additional_costs** - List or fuzzy-search the additional-cost catalog (freight, duties, handling). Use for `additional_cost_id` on `modify_purchase_order`. Supports `query`, `limit`
 
 ### Cache Administration
 - **rebuild_cache** - Force-rebuild the local typed cache for one or more cached entity types. Covers transactional entities (PO, SO, MO, stock adjustment, stock transfer) and catalog entities (variant, product, material, service, customer, supplier, location, tax_rate, operator, factory, additional_cost). Truncates the cache table(s), clears the sync watermark, and re-fetches from Katana. Use when the cache has phantom rows (entities present locally but missing from Katana). Destructive; preview/apply.
@@ -238,14 +238,23 @@ RECEIVED transfers as-is).
 
 ## Output Format
 
-Every list/get/search and reporting tool accepts a shared `format` parameter:
+**Always read `content` for the response payload.** It carries the tool's
+JSON response on every tool. Programmatic consumers can `json.loads(...)`
+the content text directly; LLM consumers read the JSON natively without a
+markdown rendering layer in between.
 
-- `format="markdown"` (default) — human-readable markdown tables / sections.
-- `format="json"` — structured JSON matching the tool's Pydantic response,
-  for programmatic consumers that would otherwise have to re-parse markdown.
+`structured_content` carries different shapes depending on the tool:
 
-Default behavior is unchanged. Pass `format="json"` when chaining tool calls
-or feeding output into downstream aggregation / filtering.
+- **Plain tools** (most read-only `list_*` / `get_*` / `search_*`) —
+  `structured_content` is the same response dict as `content`. Either
+  surface works for programmatic consumers.
+
+- **UI tools** (the `meta={"ui": True}` set — `get_variant_details`,
+  `check_inventory` single-item, `inventory_velocity` single-variant,
+  modification previews, etc.) — `structured_content` carries a Prefab
+  card envelope rendered by MCP-Apps hosts. The response payload lives
+  *only* in `content` on these tools; programmatic consumers must read
+  `content` (don't expect response-shaped JSON in `structured_content`).
 
 ## Linking to Katana
 
@@ -533,7 +542,6 @@ you can unarchive it via `modify_item`), pass `include_archived=true`.
 - `include_archived` (optional, default false): When true, archived items
   are included in results. Each row carries an `is_archived` flag so the
   UI / caller can distinguish active vs archived rows.
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Examples:**
 
@@ -583,7 +591,6 @@ invocations.
 - `variant_id` (optional): Single variant ID to look up directly
 - `skus` (optional): Batch — list of SKUs to look up
 - `variant_ids` (optional): Batch — list of variant IDs to look up
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Examples:**
 ```json
@@ -608,12 +615,10 @@ requested.
 (`{"sku": "..."}` / `{"variant_id": ...}`) raise an error if the variant
 isn't found. Batch requests (`{"skus": [...]}` / `{"variant_ids": [...]}`,
 or any mixed form) never short-circuit — the response carries every variant
-that resolved plus a `not_found` list of the missing identifiers. JSON
-payloads expose this as
-`{"variants": [...], "not_found": [{"sku": ...}, ...]}`; markdown appends
-a `**Not found (n):** ...` section after the table when there are
-misses. This makes batching safe for receiving-flow lookups where one
-bad SKU on a packing slip shouldn't lose the rest of the batch.
+that resolved plus a `not_found` list of the missing identifiers. Response
+shape: `{"variants": [...], "not_found": [{"sku": ...}, ...]}`. This makes
+batching safe for receiving-flow lookups where one bad SKU on a packing
+slip shouldn't lose the rest of the batch.
 
 ---
 
@@ -622,7 +627,6 @@ Check current stock levels for one or more SKUs or variant IDs — pass a list f
 
 **Parameters:**
 - `skus_or_variant_ids` (required, min 1): List of SKUs (strings) or variant IDs (integers) — mix freely. Pass one for a stock card, many for a summary table.
-- `format` (optional, default "markdown"): "markdown" | "json"
 
 **Examples:**
 ```json
@@ -641,7 +645,6 @@ Find items that are below their reorder threshold.
 **Parameters:**
 - `threshold` (optional): Stock threshold level (default: 10)
 - `limit` (optional): Maximum items to return (default: 50)
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** List of items needing reorder with current stock vs threshold.
 
@@ -656,7 +659,6 @@ timestamps, and rank) so no follow-up lookups are needed for standard fields.
 **Parameters:**
 - `sku` (required): SKU to get movements for
 - `limit` (optional): Maximum movements to return (default: 50)
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Movement history with `id`, `variant_id`, `location_id`, `resource_type`,
 `resource_id`, `caused_by_order_no`, `caused_by_resource_id`, `movement_date`,
@@ -707,7 +709,6 @@ how many adjustments precede them.
 - `variant_id` (optional): Only adjustments whose rows touch this variant — runs as an EXISTS subquery against the indexed FK on the rows table
 - `reason` (optional): Case-insensitive substring match on the `reason` field (SQL ILIKE)
 - `include_rows` (optional, default false): When true, populate row-level details on each summary
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Summary rows with `id`, `stock_adjustment_number`, `location_id`, dates,
 `reason`, and row count (plus per-row detail when `include_rows=true`), plus optional
@@ -780,7 +781,6 @@ run as indexed SQL against the typed cache.
 - `production_deadline_after` / `production_deadline_before`: bounds on
   `production_deadline_date`
 
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Summary rows with id, order_no, status, ingredient_availability,
 variant_id, planned/actual qty, location_id, order_created_date,
@@ -802,7 +802,6 @@ metadata stripped, operation rows and production records omitted.
 **Parameters:**
 - `order_no` (optional): Order number (e.g., '#WEB20082 / 1')
 - `order_id` (optional): Manufacturing order ID
-- `format` (optional, default "markdown"): "markdown" | "json"
 - `include_rows` (optional, default `"blocking"`): Recipe-row projection.
   - `"blocking"` — only rows with `ingredient_availability` in {NOT_AVAILABLE, EXPECTED}.
   - `"all"` — every recipe row.
@@ -848,14 +847,13 @@ are excluded by design — they don't represent actionable procurement work.
     desc, then total_remaining_quantity desc. The procurement-priority view.
   - `"mo"` — one block per MO, sorted by deadline. Preserves per-row detail.
 - `limit` (optional, default 100, max 500): Max aggregate rows.
-- `format` (optional, default "markdown").
 
 **Returns:** When `group_by="variant"`: rows with variant_id, sku,
-affected_mo_count, affected_mo_order_nos (truncated to 5 in markdown),
-total_planned_quantity (per-unit times MO planned_quantity, summed),
-total_remaining_quantity, earliest_expected_date. When `group_by="mo"`: per-MO
-sections with id, order_no, status, deadline, and the blocking recipe rows
-nested. Top-level `total_blocking_rows` and `total_affected_mos` are always
+affected_mo_count, affected_mo_order_nos, total_planned_quantity
+(per-unit times MO planned_quantity, summed), total_remaining_quantity,
+earliest_expected_date. When `group_by="mo"`: per-MO entries with id,
+order_no, status, deadline, and the blocking recipe rows nested.
+Top-level `total_blocking_rows` and `total_affected_mos` are always
 populated.
 
 **Cache freshness:** every list/rollup tool re-syncs from Katana via an
@@ -905,7 +903,6 @@ polymorphic Product / Material / Service record, plus nested `variants`
 **Parameters:**
 - `id` (required): Item ID
 - `type` (required): "product" | "material" | "service"
-- `format` (optional, default "markdown"): "markdown" | "json"
 
 For per-variant detail (barcodes, supplier codes, custom fields), follow
 up with `get_variant_details`.
@@ -1042,7 +1039,6 @@ Verify a supplier document (invoice, packing slip) against a PO.
 **Parameters:**
 - `order_id` (required): Purchase order ID to verify against
 - `document_items` (required): Array of items from document with sku, quantity, unit_price
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Match status, discrepancies, suggested actions, and the full
 `purchase_order` in the same exhaustive shape as `get_purchase_order` —
@@ -1085,7 +1081,6 @@ field is hoisted onto the row so it's queryable across both subtypes.
 
 - `include_rows` (optional, default false): Populate per-PO line item detail
   (variant_id, quantity, price, arrival).
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Summary rows with id, order_no, status, billing_status,
 entity_type, supplier_id, location_id, currency, created_date,
@@ -1103,7 +1098,6 @@ same filters in a single call.
 **Parameters:**
 - `order_no` (optional): PO number (e.g., "PO-1022")
 - `order_id` (optional): PO ID
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Every field Katana exposes on the PO record — status, billing
 status, supplier, location, totals (including `total_in_base_currency`),
@@ -1233,7 +1227,6 @@ Search customers by name or email.
 **Parameters:**
 - `query` (required): Search term
 - `limit` (optional): Maximum results (default: 20)
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** List of customers with id, name, email, phone, currency.
 
@@ -1244,7 +1237,6 @@ Get full details for a customer by ID.
 
 **Parameters:**
 - `customer_id` (required): Customer ID
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Full customer details (name, email, phone, currency, category, comment).
 
@@ -1257,7 +1249,6 @@ it returns recipe rows inline (there is no batch shape for this tool).
 
 **Parameters:**
 - `manufacturing_order_id` (required): MO ID
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Every field Katana exposes on each `ManufacturingOrderRecipeRow`
 (notes, planned/actual/consumed/remaining quantities, ingredient availability
@@ -1430,7 +1421,6 @@ List sales orders with filters. All filters run as indexed SQL against the typed
   context — use `get_sales_order` for SKU-enriched rows on a specific order.
 
 **Other:**
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Summary rows with order_no, status, production_status, row_count,
 total, currency, created_at, delivery_date. When `page` is set, the response
@@ -1449,7 +1439,6 @@ same filters in a single call.
 **Parameters:**
 - `order_no` (optional): SO number (e.g., "#WEB20394")
 - `order_id` (optional): SO ID
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Every field Katana exposes on the sales order record —
 identifiers (id, order_no, customer_id, location_id, source), status flags
@@ -1701,7 +1690,6 @@ SQL against the typed cache.
 - `created_after` / `created_before` (optional): ISO-8601 datetime bounds on
   created_at — indexed SQL range filter
 - `include_rows` (optional, default false): Populate per-transfer row details
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** Summary rows (id, number, status, source/destination, row_count,
 expected_arrival). `pagination` metadata is populated when `page` is set.
@@ -1749,10 +1737,9 @@ Delete a stock transfer. Destructive — the transfer record is removed.
 ## Reference Data Tools
 
 Parameterized search tools backed by the local cache (FTS5 with difflib
-fallback). Each `list_*` tool accepts `query` (optional fuzzy search),
-`limit` (default 50, max 250), and `format` (`"markdown"` | `"json"`).
-Outputs are bounded — passing `limit` keeps even large reference catalogs
-from flooding agent context.
+fallback). Each `list_*` tool accepts `query` (optional fuzzy search) and
+`limit` (default 50, max 250). Outputs are bounded — passing `limit`
+keeps even large reference catalogs from flooding agent context.
 
 ### list_locations
 List or fuzzy-search warehouses and facilities by name. Returns id, name,
@@ -1763,7 +1750,6 @@ orders or filtering inventory queries.
 **Parameters:**
 - `query` (optional): Fuzzy match by name.
 - `limit` (optional, default 50, max 250): Cap on rows returned.
-- `format` (optional, default "markdown"): "markdown" | "json".
 
 **Returns:** `ListLocationsResponse` with `locations: [{id, name,
 address: {line_1, line_2, city, state, zip, country} | null,
@@ -1780,7 +1766,6 @@ for the full-detail record.
 **Parameters:**
 - `query` (optional): Fuzzy match by name or code.
 - `limit` (optional, default 50, max 250).
-- `format` (optional, default "markdown"): "markdown" | "json".
 
 **Returns:** `ListSuppliersResponse` with `suppliers: [{id, name, email,
 phone, currency, code}]`, `total_count`, `query`.
@@ -1793,7 +1778,6 @@ info, address, currency, payment terms, comment, and timestamps.
 
 **Parameters:**
 - `supplier_id` (required): Supplier id.
-- `format` (optional, default "markdown"): "markdown" | "json".
 
 **Returns:** `GetSupplierResponse` with id, name, email, phone, currency,
 code, comment, default_payment_terms, address fields (line_1, line_2,
@@ -1810,7 +1794,6 @@ with explicit tax assignments.
 **Parameters:**
 - `query` (optional): Fuzzy match by name.
 - `limit` (optional, default 50, max 250).
-- `format` (optional, default "markdown"): "markdown" | "json".
 
 **Returns:** `ListTaxRatesResponse` with `tax_rates: [{id, name, rate,
 display_name, is_default_sales, is_default_purchases}]`, `total_count`,
@@ -1826,7 +1809,6 @@ operation rows or naming the packer on a sales order.
 **Parameters:**
 - `query` (optional): Fuzzy match by name.
 - `limit` (optional, default 50, max 250).
-- `format` (optional, default "markdown"): "markdown" | "json".
 
 **Returns:** `ListOperatorsResponse` with `operators: [{id, name}]`,
 `total_count`, `query`.
@@ -1842,7 +1824,6 @@ Pair with `list_tax_rates` for the matching `tax_rate_id`.
 **Parameters:**
 - `query` (optional): Fuzzy match by name.
 - `limit` (optional, default 50, max 250).
-- `format` (optional, default "markdown"): "markdown" | "json".
 
 **Returns:** `ListAdditionalCostsResponse` with `additional_costs: [{id,
 name}]`, `total_count`, `query`.
@@ -1877,7 +1858,6 @@ For each requested entity type, the rebuild:
 - `preview` (optional, default true): true = report current row counts and
   last-synced timestamps without modifying anything; false = perform the
   destructive rebuild.
-- `format` (optional, default "markdown"): "markdown" | "json".
 
 **Returns:** `RebuildCacheResponse` with `is_preview` and a `results` list
 carrying per-entity `parent_rows_before/after`, `child_rows_before/after`,
@@ -1909,7 +1889,6 @@ aggregates DELIVERED sales orders in memory).
 - `category` (optional): Item category name to filter by (e.g. "widgets")
 - `order_by` (optional, default "units"): "units" or "revenue"
 - `location_id` (optional): Filter to a single location
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** List of `{sku, variant_id, name, units, revenue, order_count}`
 sorted by the `order_by` key descending.
@@ -1924,7 +1903,6 @@ Grouped sales totals for DELIVERED orders in a window.
 - `end_date` (required): ISO-8601 date — window end (inclusive)
 - `group_by` (required): one of `day`, `week`, `month`, `variant`,
   `customer`, `category`
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** List of `{group, units, revenue, order_count}`. Time groups
 (`day`/`week`/`month`) sort ascending; dimension groups sort by revenue
@@ -1945,13 +1923,11 @@ sales-order demand and manufacturing-order ingredient consumption. Use
 - `period_days` (optional, default 90, max 365): Rolling window size
 - `include_mo_consumption` (optional, default true): Include units consumed as
   ingredients on completed MOs. Set false for SO-only numbers (legacy behavior).
-- `format` (optional, default "markdown"): "markdown" | "json" — "json" returns the Pydantic response serialized
 
 **Returns:** `{items: [{sku, variant_id, units_sold, units_consumed_by_mos,
 units_total, avg_daily, stock_on_hand, days_of_cover, period_days,
 window_start, window_end}]}`. `days_of_cover` is `null` when `avg_daily` is 0
-(no demand in window). Single-item calls return a rich card; batch calls return
-a markdown table.
+(no demand in window).
 """
 
 HELP_RESOURCES = """

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -250,11 +250,11 @@ markdown rendering layer in between.
   surface works for programmatic consumers.
 
 - **UI tools** (the `meta={"ui": True}` set — `get_variant_details`,
-  `check_inventory` single-item, `inventory_velocity` single-variant,
-  modification previews, etc.) — `structured_content` carries a Prefab
-  card envelope rendered by MCP-Apps hosts. The response payload lives
-  *only* in `content` on these tools; programmatic consumers must read
-  `content` (don't expect response-shaped JSON in `structured_content`).
+  `check_inventory` single-item, modification previews, etc.) —
+  `structured_content` carries a Prefab card envelope rendered by
+  MCP-Apps hosts. The response payload lives *only* in `content` on
+  these tools; programmatic consumers must read `content` (don't expect
+  response-shaped JSON in `structured_content`).
 
 ## Linking to Katana
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/cache_admin.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/cache_admin.py
@@ -36,7 +36,7 @@ from sqlmodel import SQLModel, func, select
 
 from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
-from katana_mcp.tools.tool_result_utils import format_md_table, make_simple_result
+from katana_mcp.tools.tool_result_utils import make_json_result
 from katana_mcp.typed_cache import (
     ENTITY_SPECS,
     EntitySpec,
@@ -107,13 +107,6 @@ class RebuildCacheRequest(BaseModel):
             "If true (default), reports current cache row counts and last-"
             "synced timestamps without modifying anything. If false, "
             "performs the destructive rebuild."
-        ),
-    )
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data."
         ),
     )
 
@@ -263,34 +256,6 @@ async def _rebuild_cache_impl(
 # ============================================================================
 
 
-def _format_markdown(response: RebuildCacheResponse) -> str:
-    state_label = "PREVIEW" if response.is_preview else "APPLIED"
-    headers = [
-        "Entity",
-        "Parents (before → after)",
-        "Children (before → after)",
-        "Last synced",
-    ]
-    rows = [
-        [
-            r.entity_type,
-            f"{r.parent_rows_before} → {r.parent_rows_after}",
-            f"{r.child_rows_before} → {r.child_rows_after}",
-            r.last_synced_before or "(never)",
-        ]
-        for r in response.results
-    ]
-    table = format_md_table(headers=headers, rows=rows)
-    if response.is_preview:
-        footer = (
-            "\n\nThis is a preview. Re-run with `preview=false` to truncate "
-            "the listed tables, clear watermarks, and re-fetch from Katana."
-        )
-    else:
-        footer = "\n\nRebuild complete."
-    return f"## Rebuild Cache — {state_label}\n\n{table}{footer}"
-
-
 @observe_tool
 @unpack_pydantic_params
 async def rebuild_cache(
@@ -343,16 +308,7 @@ async def rebuild_cache(
       entity A succeeded, A is already rebuilt.
     """
     response = await _rebuild_cache_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    return make_simple_result(
-        _format_markdown(response), structured_data=response.model_dump()
-    )
+    return make_json_result(response)
 
 
 def register_tools(mcp: FastMCP) -> None:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
@@ -7,7 +7,7 @@ rather than exposed as a resource.
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from katana_mcp.logging import observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.decorators import cache_read
-from katana_mcp.tools.tool_result_utils import make_simple_result
+from katana_mcp.tools.tool_result_utils import make_json_result
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.models_pydantic._generated import CachedCustomer
@@ -33,13 +33,6 @@ class SearchCustomersRequest(BaseModel):
 
     query: str = Field(..., description="Search query (name or email)")
     limit: int = Field(default=20, description="Maximum results to return")
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
 
 
 class CustomerInfo(BaseModel):
@@ -119,29 +112,7 @@ async def search_customers(
     Query must not be empty. Default limit is 20 results.
     """
     response = await _search_customers_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    if response.customers:
-        lines = [
-            f"- **{c.name}** (ID: {c.id})"
-            + (f" — {c.email}" if c.email else "")
-            + (f" [{c.currency}]" if c.currency else "")
-            for c in response.customers
-        ]
-        md = (
-            f"## Customer Search Results\n\n"
-            f"Query: `{request.query}` — {response.total_count} results\n\n"
-            + "\n".join(lines)
-        )
-    else:
-        md = f"No customers found matching `{request.query}`."
-
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -155,13 +126,6 @@ class GetCustomerRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     customer_id: int = Field(..., description="Customer ID to look up")
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
 
 
 class CustomerAddressInfo(BaseModel):
@@ -344,33 +308,6 @@ async def _get_customer_impl(
     )
 
 
-def _render_address_md(addr: CustomerAddressInfo) -> str:
-    """Render a single address as a compact multi-line block.
-
-    Uses canonical field names so an LLM consuming the markdown can't mistake
-    a rendered value for a differently-labeled field.
-    """
-    lines = [f"  - **id**: {addr.id}"]
-    for fname in (
-        "entity_type",
-        "default",
-        "first_name",
-        "last_name",
-        "company",
-        "phone",
-        "line_1",
-        "line_2",
-        "city",
-        "state",
-        "zip",
-        "country",
-    ):
-        val = getattr(addr, fname)
-        if val is not None and val != "":
-            lines.append(f"    **{fname}**: {val}")
-    return "\n".join(lines)
-
-
 @observe_tool
 @unpack_pydantic_params
 async def get_customer(
@@ -385,51 +322,7 @@ async def get_customer(
     single-call path to the rest.
     """
     response = await _get_customer_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    # Labels use the canonical Pydantic field names so LLM consumers can't
-    # confuse a section header with the field name (see #346 follow-on).
-    md_lines = [f"## {response.name}"]
-    scalar_fields = (
-        "id",
-        "first_name",
-        "last_name",
-        "company",
-        "email",
-        "phone",
-        "currency",
-        "reference_id",
-        "category",
-        "discount_rate",
-        "default_billing_id",
-        "default_shipping_id",
-        "comment",
-        "created_at",
-        "updated_at",
-        "deleted_at",
-    )
-    for fname in scalar_fields:
-        val = getattr(response, fname)
-        if val is None or val == "":
-            continue
-        md_lines.append(f"**{fname}**: {val}")
-
-    if response.addresses:
-        md_lines.append("")
-        md_lines.append(f"**addresses** ({len(response.addresses)}):")
-        for addr in response.addresses:
-            md_lines.append(_render_address_md(addr))
-    else:
-        md_lines.append("**addresses**: []")
-
-    return make_simple_result(
-        "\n".join(md_lines), structured_data=response.model_dump()
-    )
+    return make_json_result(response)
 
 
 def register_tools(mcp: FastMCP) -> None:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import time
 from datetime import datetime
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
@@ -25,9 +25,8 @@ from katana_mcp.tools.tool_result_utils import (
     UI_META,
     PaginationMeta,
     apply_date_window_filters,
-    format_md_table,
     iso_or_none,
-    make_simple_result,
+    make_json_result,
     make_tool_result,
     parse_request_dates,
 )
@@ -80,7 +79,8 @@ class CheckInventoryRequest(BaseModel):
         description=(
             "JSON array of SKUs (strings) or variant IDs (integers) — mix freely. "
             'E.g., ["WS74001", 12345] or ["WS74001", "WS74002"]. '
-            "Pass one for a detailed stock card; pass many for a summary table. "
+            "Response is always the JSON `{items: [...]}` envelope (single OR batch); "
+            "single-item calls additionally attach a Prefab stock card for UI hosts. "
             "Batching N items in a single call beats N separate invocations. "
             "Output order matches input order."
         ),
@@ -91,13 +91,6 @@ class CheckInventoryRequest(BaseModel):
             "Filter to a single warehouse/facility. When set, the response "
             "totals and `by_location` only include this location. "
             "Look up via `list_locations`."
-        ),
-    )
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
         ),
     )
 
@@ -319,9 +312,11 @@ async def check_inventory(
     """Check current stock levels for one or more SKUs or variant IDs.
 
     Pass a list of SKUs (strings) or variant IDs (integers) — or mix both — to
-    ``skus_or_variant_ids``. A single item returns a rich stock card; multiple
-    items return a summary table. Batching N checks in one call is faster than
-    N separate invocations.
+    ``skus_or_variant_ids``. Returns the JSON ``{items: [...]}`` envelope for
+    every request shape — single OR batch — so programmatic consumers see one
+    stable contract. Single-item requests additionally attach a rich Prefab
+    stock card via ``structured_content`` for MCP-Apps hosts. Batching N
+    checks in one call is faster than N separate invocations.
 
     By default returns totals summed across every location the variant has
     stock at, plus a per-location ``by_location`` breakdown so callers can
@@ -338,73 +333,22 @@ async def check_inventory(
 
     results = await _check_inventory_impl(request, context)
 
-    if request.format == "json":
-        payload = {"items": [r.model_dump() for r in results]}
-        return ToolResult(
-            content=json.dumps(payload, indent=2, default=str),
-            structured_content=payload,
-        )
+    # JSON content always uses the ``{items: [...]}`` envelope — single
+    # OR batch — so programmatic consumers see one stable contract.
+    # Pre-#567 the format="json" branch already returned this envelope;
+    # the single-item bare-StockInfo content was markdown-only.
+    payload = {"items": [r.model_dump(mode="json") for r in results]}
+    content = json.dumps(payload, indent=2, default=str)
 
-    # Single-variant request: preserve the rich Prefab card output, plus
-    # append a per-location breakdown table whenever stock is split across
-    # more than one warehouse (single-location → no extra noise).
+    # Single-variant request: attach the rich Prefab card on top of the
+    # envelope content. The batch Prefab UI (tracked in #562) will read
+    # the same ``items`` key when it ships.
     is_single = len(results) == 1 and len(request.skus_or_variant_ids) == 1
     if is_single:
-        response = results[0]
-        ui = build_inventory_check_ui(response.model_dump())
-        return make_tool_result(response, ui=ui)
+        ui = build_inventory_check_ui(results[0].model_dump())
+        return ToolResult(content=content, structured_content=ui)
 
-    # Batch response: summary table + optional per-location breakdown
-    from katana_mcp.tools.tool_result_utils import format_md_table, make_simple_result
-
-    table = format_md_table(
-        headers=["SKU", "Product", "In Stock", "Committed", "Available", "Expected"],
-        rows=[
-            [
-                r.sku,
-                r.product_name[:40],
-                r.in_stock,
-                r.committed,
-                r.available_stock,
-                r.expected,
-            ]
-            for r in results
-        ],
-    )
-    md_parts = [f"## Inventory Check ({len(results)} items)\n\n{table}"]
-    # Surface per-location breakdown for any item that has stock at >1 location.
-    # Single-location items don't get a redundant breakdown table.
-    multi_location_results = [r for r in results if len(r.by_location) > 1]
-    if multi_location_results:
-        md_parts.append("\n## By Location")
-        for r in multi_location_results:
-            loc_table = format_md_table(
-                headers=[
-                    "Location",
-                    "ID",
-                    "In Stock",
-                    "Committed",
-                    "Available",
-                    "Expected",
-                ],
-                rows=[
-                    [
-                        ls.location_name or "(unknown)",
-                        ls.location_id,
-                        ls.in_stock,
-                        ls.committed,
-                        ls.available,
-                        ls.expected,
-                    ]
-                    for ls in r.by_location
-                ],
-            )
-            md_parts.append(f"\n### {r.sku}\n\n{loc_table}")
-    md = "\n".join(md_parts)
-    return make_simple_result(
-        md,
-        structured_data={"items": [r.model_dump() for r in results]},
-    )
+    return ToolResult(content=content, structured_content=payload)
 
 
 # ============================================================================
@@ -419,13 +363,6 @@ class LowStockRequest(BaseModel):
 
     threshold: int = Field(default=10, description="Stock threshold level")
     limit: int = Field(default=50, description="Maximum items to return")
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
 
 
 class LowStockItem(BaseModel):
@@ -572,12 +509,6 @@ async def list_low_stock_items(
 
     response = await _list_low_stock_items_impl(request, context)
 
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
     items_dicts = [item.model_dump() for item in response.items]
     ui = build_low_stock_ui(items_dicts, request.threshold, response.total_count)
 
@@ -596,13 +527,6 @@ class GetInventoryMovementsRequest(BaseModel):
 
     sku: str = Field(..., description="SKU to get movements for")
     limit: int = Field(default=50, description="Maximum movements to return")
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
 
 
 class MovementInfo(BaseModel):
@@ -777,70 +701,7 @@ async def get_inventory_movements(
     changed over time. Default limit is 50 movements, ordered most recent first.
     """
     response = await _get_inventory_movements_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    # Column headers use the canonical Pydantic field names so LLM consumers
-    # can't confuse a rendered header with a different field (see #346 follow-on).
-    if response.movements:
-        movements_md = format_md_table(
-            headers=[
-                "id",
-                "movement_date",
-                "variant_id",
-                "location_id",
-                "resource_type",
-                "resource_id",
-                "caused_by_order_no",
-                "caused_by_resource_id",
-                "quantity_change",
-                "balance_after",
-                "value_per_unit",
-                "value_in_stock_after",
-                "average_cost_after",
-                "rank",
-                "created_at",
-                "updated_at",
-            ],
-            rows=[
-                [
-                    m.id,
-                    m.movement_date,
-                    m.variant_id,
-                    m.location_id,
-                    m.resource_type,
-                    m.resource_id if m.resource_id is not None else "—",
-                    m.caused_by_order_no or "—",
-                    m.caused_by_resource_id
-                    if m.caused_by_resource_id is not None
-                    else "—",
-                    f"{m.quantity_change:+.4f}",
-                    f"{m.balance_after:.4f}",
-                    f"{m.value_per_unit:.4f}",
-                    f"{m.value_in_stock_after:.4f}",
-                    f"{m.average_cost_after:.4f}",
-                    m.rank if m.rank is not None else "—",
-                    m.created_at or "—",
-                    m.updated_at or "—",
-                ]
-                for m in response.movements
-            ],
-        )
-    else:
-        movements_md = "No movements found."
-
-    md = (
-        f"## Inventory Movements\n\n"
-        f"**sku**: {response.sku}\n"
-        f"**product_name**: {response.product_name}\n"
-        f"**total_count**: {response.total_count}\n\n"
-        f"{movements_md}"
-    )
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -1188,14 +1049,6 @@ class ListStockAdjustmentsRequest(BaseModel):
         description="When true, populate row-level detail on each summary",
     )
 
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
-
 
 class StockAdjustmentRowInfo(BaseModel):
     """Summary of a stock adjustment line item."""
@@ -1460,33 +1313,7 @@ async def list_stock_adjustments(
       bounds on the corresponding columns.
     """
     response = await _list_stock_adjustments_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    if not response.adjustments:
-        md = "No stock adjustments match the given filters."
-    else:
-        table = format_md_table(
-            headers=["ID", "Number", "Location", "Date", "Rows", "Reason"],
-            rows=[
-                [
-                    adj.id,
-                    adj.stock_adjustment_number,
-                    adj.location_id,
-                    adj.stock_adjustment_date or "—",
-                    adj.row_count,
-                    (adj.reason or "—")[:40],
-                ]
-                for adj in response.adjustments
-            ],
-        )
-        md = f"## Stock Adjustments ({response.total_count})\n\n{table}"
-
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 from enum import StrEnum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
@@ -44,8 +44,6 @@ from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.list_coercion import CoercedIntListOpt, CoercedStrListOpt
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
-    format_md_table,
-    make_simple_result,
     make_tool_result,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
@@ -156,13 +154,6 @@ class SearchItemsRequest(BaseModel):
             'with {"update_header": {"is_archived": false}}.'
         ),
     )
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
 
 
 class ItemInfo(BaseModel):
@@ -187,21 +178,30 @@ class SearchItemsResponse(BaseModel):
 def _search_response_to_tool_result(
     response: SearchItemsResponse, query: str
 ) -> ToolResult:
-    """Convert SearchItemsResponse to ToolResult with the Prefab UI."""
+    """Convert SearchItemsResponse to ToolResult with the Prefab UI.
+
+    The Prefab DataTable row-click drill-down requires a SKU (the on-row
+    binding is ``{{ $event.sku }}`` per #714), so SKU-less variants are
+    filtered OUT of the rendered table — clicking them would otherwise
+    invoke ``get_variant_details(sku=None)`` and fail. **But JSON content
+    keeps every variant**, including SKU-less rows. Programmatic consumers
+    deserve the full result set; only the interactive UI hides rows it
+    can't make actionable. The two surfaces diverge intentionally here.
+    """
     from katana_mcp.tools.prefab_ui import build_search_results_ui
 
-    # Drill-down (CallTool on row click) requires a SKU. Filter once and emit
-    # the filtered set to BOTH the LLM (via content JSON) and the UI, so the
-    # model and user see the same data — otherwise the model could reference
-    # an item the user can't see in the table.
-    filtered_items = [item for item in response.items if item.sku]
-    filtered_response = SearchItemsResponse(
-        items=filtered_items, total_count=len(filtered_items)
-    )
-    items_dicts = [item.model_dump() for item in filtered_items]
-    ui = build_search_results_ui(items_dicts, query, len(items_dicts))
+    # UI: filter out SKU-less variants (row-click drill-down needs sku).
+    ui_items = [item.model_dump() for item in response.items if item.sku]
+    ui = build_search_results_ui(ui_items, query, len(ui_items))
 
-    return make_tool_result(filtered_response, ui=ui)
+    # ``content`` carries the full response (every variant, sku or no sku) so
+    # JSON consumers don't silently lose data. ``structured_content`` carries
+    # the Prefab UI envelope with the filtered row set for MCP-Apps hosts —
+    # the two surfaces diverge intentionally per the docstring above.
+    return ToolResult(
+        content=response.model_dump_json(indent=2),
+        structured_content=ui,
+    )
 
 
 @cache_read(CachedVariant)
@@ -267,11 +267,6 @@ async def search_items(
     Query must not be empty. Default limit is 20 results.
     """
     response = await _search_items_impl(request, context)
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
     return _search_response_to_tool_result(response, request.query)
 
 
@@ -567,13 +562,6 @@ class GetItemRequest(BaseModel):
 
     id: int = Field(..., description="Item ID")
     type: ItemType = Field(..., description="Type of item (product, material, service)")
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
 
 
 class ItemSupplierInfo(BaseModel):
@@ -940,13 +928,6 @@ async def get_item(
     codes, custom fields), follow up with ``get_variant_details``.
     """
     response = await _get_item_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
     return _item_details_to_tool_result(response)
 
 
@@ -1626,13 +1607,6 @@ class GetVariantDetailsRequest(BaseModel):
         default=None,
         description="Batch lookup: JSON array of variant IDs, e.g. [12345, 67890].",
     )
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
 
 
 class VariantDetailsResponse(BaseModel):
@@ -1752,22 +1726,6 @@ class GetVariantDetailsResult(BaseModel):
 
     found: list[VariantDetailsResponse] = Field(default_factory=list)
     not_found: list[VariantNotFound] = Field(default_factory=list)
-
-
-def _variant_details_to_tool_result(response: VariantDetailsResponse) -> ToolResult:
-    """Convert VariantDetailsResponse to ToolResult.
-
-    content carries the raw response as JSON for the LLM (no UI tree noise);
-    structured_content carries the Prefab envelope rendered in the iframe on
-    UI-capable hosts (per MCP Apps spec, #422).
-    """
-    from katana_mcp.tools.prefab_ui import build_variant_details_ui
-
-    ui = build_variant_details_ui(response.model_dump())
-    return ToolResult(
-        content=response.model_dump_json(),
-        structured_content=ui,
-    )
 
 
 def _iso_or_none(value: Any) -> str | None:
@@ -2144,23 +2102,28 @@ async def get_variant_details(
     found = result.found
     not_found = result.not_found
 
-    if request.format == "json":
-        payload = {
-            "variants": [r.model_dump() for r in found],
-            "not_found": [n.model_dump(exclude_none=True) for n in not_found],
-        }
-        import json as _json
+    # JSON ``content`` is the stable contract: the ``{variants, not_found}``
+    # envelope is returned for every request shape — single OR batch — so
+    # programmatic consumers see one parseable shape (#567 — no per-tool
+    # markdown). ``structured_content`` then differs by shape: a Prefab card
+    # for single requests (see below), or the envelope dict for batch.
+    # Pre-#567 the format="json" branch already returned this envelope; the
+    # single-item bare-VariantDetailsResponse shape was markdown-only.
+    import json as _json
 
-        return ToolResult(
-            content=_json.dumps(payload, indent=2, default=str),
-            structured_content=payload,
-        )
+    payload = {
+        "variants": [r.model_dump(mode="json") for r in found],
+        "not_found": [n.model_dump(mode="json", exclude_none=True) for n in not_found],
+    }
+    content = _json.dumps(payload, indent=2, default=str)
 
-    # If a single-variant request, return the single-variant markdown + UI.
-    # Treat a single-element batch list (skus=[X] or variant_ids=[X]) the same
-    # as the singular form to honor the docstring's "single item" promise —
-    # but only when there are no misses; with misses we fall through to the
-    # batch renderer so the "Not found" section still surfaces.
+    # Single-variant request → rich Prefab card alongside the envelope.
+    # Treat a single-element batch list (skus=[X] or variant_ids=[X]) the
+    # same as the singular form to honor the docstring's "single item"
+    # promise — but only when there are no misses; with misses we fall
+    # through to the bare envelope so the ``not_found`` array still
+    # surfaces in structured_content without a Prefab card stealing
+    # the slot.
     is_single = (
         len(found) == 1
         and not not_found
@@ -2172,45 +2135,12 @@ async def get_variant_details(
         )
     )
     if is_single:
-        return _variant_details_to_tool_result(found[0])
+        from katana_mcp.tools.prefab_ui import build_variant_details_ui
 
-    # Batch response: summary + table (+ a "Not found" section when the
-    # batch had misses, so callers see the gaps at a glance without
-    # reaching into structured_content).
-    if found:
-        table = format_md_table(
-            headers=["ID", "SKU", "Name", "Sales Price", "Purchase Price"],
-            rows=[
-                [
-                    v.id,
-                    v.sku,
-                    v.name,
-                    f"${v.sales_price:,.2f}" if v.sales_price is not None else "N/A",
-                    f"${v.purchase_price:,.2f}"
-                    if v.purchase_price is not None
-                    else "N/A",
-                ]
-                for v in found
-            ],
-        )
-        markdown = f"## Variant Details ({len(found)} variants)\n\n{table}"
-    else:
-        markdown = "## Variant Details (0 variants)\n\nNo variants resolved."
+        ui = build_variant_details_ui(found[0].model_dump())
+        return ToolResult(content=content, structured_content=ui)
 
-    if not_found:
-        misses = ", ".join(
-            f"`{n.sku}`" if n.sku is not None else f"`#{n.variant_id}`"
-            for n in not_found
-        )
-        markdown += f"\n\n**Not found ({len(not_found)}):** {misses}"
-
-    return make_simple_result(
-        markdown,
-        structured_data={
-            "variants": [v.model_dump() for v in found],
-            "not_found": [n.model_dump(exclude_none=True) for n in not_found],
-        },
-    )
+    return ToolResult(content=content, structured_content=payload)
 
 
 def register_tools(mcp: FastMCP) -> None:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -483,24 +483,15 @@ async def create_manufacturing_order(
 
     Two-step flow: preview=true (default) to preview, preview=false to create.
     """
-    from katana_mcp.tools.prefab_ui import (
-        build_order_created_ui,
-        build_order_preview_ui,
-    )
+    from katana_mcp.tools.prefab_ui import build_mo_create_ui
 
     response = await _create_manufacturing_order_impl(request, context)
 
-    order_dict = response.model_dump()
-    if response.is_preview:
-        ui = build_order_preview_ui(
-            order_dict,
-            "Manufacturing Order",
-            confirm_request=request,
-            confirm_tool="create_manufacturing_order",
-            direct_apply=True,
-        )
-    else:
-        ui = build_order_created_ui(order_dict, "Manufacturing Order")
+    ui = build_mo_create_ui(
+        response.model_dump(mode="json"),
+        confirm_request=request,
+        confirm_tool="create_manufacturing_order",
+    )
 
     return make_tool_result(response, ui=ui)
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -60,9 +60,8 @@ from katana_mcp.tools.tool_result_utils import (
     apply_date_window_filters,
     coerce_enum,
     enum_to_str,
-    format_md_table,
     iso_or_none,
-    make_simple_result,
+    make_json_result,
     make_tool_result,
     none_coro,
     parse_request_dates,
@@ -542,13 +541,6 @@ class GetManufacturingOrderRequest(BaseModel):
         default=None, description="Order number to look up (e.g., '#WEB20082 / 1')"
     )
     order_id: int | None = Field(default=None, description="Manufacturing order ID")
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
     include_rows: Literal["all", "blocking", "none"] = Field(
         default="blocking",
         description=(
@@ -1232,263 +1224,6 @@ async def _get_manufacturing_order_impl(
     return _build_mo_response(mo, recipe_rows, operation_rows, productions)
 
 
-def _render_mo_scalar_lines(
-    response: GetManufacturingOrderResponse, *, verbose: bool = True
-) -> list[str]:
-    """Render every scalar MO field as ``**field_name**: value`` lines.
-
-    Uses canonical Pydantic field names so LLM consumers can't confuse a
-    prettified label with a different field name (see #346 follow-on).
-    """
-    scalar_fields: tuple[str, ...] = (
-        "id",
-        "order_no",
-        "status",
-        "variant_id",
-        "planned_quantity",
-        "actual_quantity",
-        "completed_quantity",
-        "remaining_quantity",
-        "includes_partial_completions",
-        "location_id",
-        "order_created_date",
-        "production_deadline_date",
-        "done_date",
-        "additional_info",
-        "is_linked_to_sales_order",
-        "ingredient_availability",
-        "total_cost",
-        "total_actual_time",
-        "total_planned_time",
-        "sales_order_id",
-        "sales_order_row_id",
-        "sales_order_delivery_deadline",
-        "material_cost",
-        "subassemblies_cost",
-        "operations_cost",
-    )
-    if verbose:
-        scalar_fields += ("created_at", "updated_at", "deleted_at")
-    lines: list[str] = []
-    for fname in scalar_fields:
-        val = getattr(response, fname)
-        if val is None or val == "":
-            continue
-        lines.append(f"**{fname}**: {val}")
-    return lines
-
-
-def _render_list_field(label: str, items: list[Any], renderer: Any) -> list[str]:
-    """Render a list-shaped response field with canonical-name syntax.
-
-    Empty → ``**label**: []`` so presence-vs-absence is unambiguous.
-    Populated → ``**label** (N):`` followed by indented per-item blocks.
-    """
-    if not items:
-        return [f"**{label}**: []"]
-    lines = ["", f"**{label}** ({len(items)}):"]
-    for item in items:
-        lines.append(renderer(item))
-    return lines
-
-
-def _render_recipe_row_md(row: RecipeRowInfo, *, verbose: bool = True) -> str:
-    """Render a single recipe row as a compact multi-line block."""
-    lines = [f"  - **id**: {row.id}"]
-    scalar_fields: tuple[str, ...] = (
-        "manufacturing_order_id",
-        "variant_id",
-        "sku",
-        "display_name",
-        "notes",
-        "planned_quantity_per_unit",
-        "total_actual_quantity",
-        "total_consumed_quantity",
-        "total_remaining_quantity",
-        "ingredient_availability",
-        "ingredient_expected_date",
-        "cost",
-    )
-    if verbose:
-        scalar_fields += ("created_at", "updated_at", "deleted_at")
-    for fname in scalar_fields:
-        val = getattr(row, fname)
-        if val is None or val == "":
-            continue
-        lines.append(f"    **{fname}**: {val}")
-    if row.batch_transactions:
-        lines.append(f"    **batch_transactions** ({len(row.batch_transactions)}):")
-        for bt in row.batch_transactions:
-            lines.append(f"      - batch_id={bt.batch_id}, quantity={bt.quantity}")
-    elif verbose:
-        lines.append("    **batch_transactions**: []")
-    return "\n".join(lines)
-
-
-def _render_operation_row_md(row: OperationRowInfo, *, verbose: bool = True) -> str:
-    """Render a single operation row as a compact multi-line block."""
-    lines = [f"  - **id**: {row.id}"]
-    scalar_fields: tuple[str, ...] = (
-        "manufacturing_order_id",
-        "status",
-        "type_",
-        "rank",
-        "operation_id",
-        "operation_name",
-        "resource_id",
-        "resource_name",
-        "active_operator_id",
-        "planned_time_per_unit",
-        "planned_time_parameter",
-        "total_actual_time",
-        "total_consumed_time",
-        "total_remaining_time",
-        "planned_cost_per_unit",
-        "total_actual_cost",
-        "cost_per_hour",
-        "cost_parameter",
-        "group_boundary",
-        "is_status_actionable",
-        "completed_at",
-    )
-    if verbose:
-        scalar_fields += ("created_at", "updated_at", "deleted_at")
-    for fname in scalar_fields:
-        val = getattr(row, fname)
-        if val is None or val == "":
-            continue
-        lines.append(f"    **{fname}**: {val}")
-    for list_name in ("assigned_operators", "completed_by_operators"):
-        items = getattr(row, list_name)
-        if not items:
-            if verbose:
-                lines.append(f"    **{list_name}**: []")
-            continue
-        lines.append(f"    **{list_name}** ({len(items)}):")
-        for op in items:
-            lines.append(f"      - operator_id={op.operator_id}, name={op.name}")
-    return "\n".join(lines)
-
-
-def _render_production_md(prod: ProductionInfo, *, verbose: bool = True) -> str:
-    """Render a single production record as a compact multi-line block."""
-    lines = [f"  - **id**: {prod.id}"]
-    scalar_fields: tuple[str, ...] = (
-        "manufacturing_order_id",
-        "factory_id",
-        "quantity",
-        "production_date",
-    )
-    if verbose:
-        scalar_fields += ("created_at", "updated_at", "deleted_at")
-    for fname in scalar_fields:
-        val = getattr(prod, fname)
-        if val is None or val == "":
-            continue
-        lines.append(f"    **{fname}**: {val}")
-    lines.append(
-        f"    **ingredients** ({len(prod.ingredients)}):"
-        if prod.ingredients
-        else "    **ingredients**: []"
-    )
-    for ing in prod.ingredients:
-        lines.append(
-            f"      - id={ing.id}, variant_id={ing.variant_id}, "
-            f"quantity={ing.quantity}, cost={ing.cost}"
-        )
-    lines.append(
-        f"    **operations** ({len(prod.operations)}):"
-        if prod.operations
-        else "    **operations**: []"
-    )
-    for op in prod.operations:
-        lines.append(
-            f"      - id={op.id}, operation_id={op.manufacturing_order_operation_id}, "
-            f"time={op.time}, cost={op.cost}"
-        )
-    lines.append(
-        f"    **serial_numbers** ({len(prod.serial_numbers)}):"
-        if prod.serial_numbers
-        else "    **serial_numbers**: []"
-    )
-    for sn in prod.serial_numbers:
-        lines.append(f"      - serial_number={sn.serial_number}")
-    return "\n".join(lines)
-
-
-def _render_mo_list_fields_md(
-    response: GetManufacturingOrderResponse,
-    *,
-    verbose: bool = True,
-    include_rows: Literal["all", "blocking", "none"] = "all",
-    include_operation_rows: bool = True,
-    include_productions: bool = True,
-) -> list[str]:
-    """Render every list-shaped field with canonical names + explicit list syntax.
-
-    Empty lists render as ``**field**: []`` (motivation: #346 follow-on —
-    no bare section headers that could be misread as scalar values) when
-    ``verbose=True``. In compact mode, empty/omitted collections are
-    suppressed entirely so the response stays under inline tool-result
-    limits.
-    """
-    lines: list[str] = []
-    # MO-level batch_transactions
-    if response.batch_transactions:
-        lines.append("")
-        lines.append(f"**batch_transactions** ({len(response.batch_transactions)}):")
-        for bt in response.batch_transactions:
-            lines.append(f"  - batch_id={bt.batch_id}, quantity={bt.quantity}")
-    elif verbose:
-        lines.append("**batch_transactions**: []")
-    # MO-level serial_numbers
-    if response.serial_numbers:
-        lines.append("")
-        lines.append(f"**serial_numbers** ({len(response.serial_numbers)}):")
-        for sn in response.serial_numbers:
-            lines.append(
-                f"  - id={sn.id}, serial_number={sn.serial_number}, "
-                f"transaction_date={sn.transaction_date}"
-            )
-    elif verbose:
-        lines.append("**serial_numbers**: []")
-
-    # Render each collection with the canonical field-name label. In
-    # compact mode, an empty/omitted collection is suppressed entirely
-    # (no ``**field**: []`` placeholder) so the response stays small. The
-    # blocking-filter is surfaced as a sibling annotation rather than
-    # decorating the field name, so consumers parsing the markdown still
-    # see the canonical ``recipe_rows`` header.
-    if include_rows != "none" and (verbose or response.recipe_rows):
-        if include_rows == "blocking":
-            lines.append("")
-            lines.append("_recipe_rows filtered to blocking rows only_")
-        lines.extend(
-            _render_list_field(
-                "recipe_rows",
-                response.recipe_rows,
-                lambda r: _render_recipe_row_md(r, verbose=verbose),
-            )
-        )
-    if include_operation_rows and (verbose or response.operation_rows):
-        lines.extend(
-            _render_list_field(
-                "operation_rows",
-                response.operation_rows,
-                lambda r: _render_operation_row_md(r, verbose=verbose),
-            )
-        )
-    if include_productions and (verbose or response.productions):
-        lines.extend(
-            _render_list_field(
-                "productions",
-                response.productions,
-                lambda p: _render_production_md(p, verbose=verbose),
-            )
-        )
-    return lines
-
-
 @observe_tool
 @unpack_pydantic_params
 async def get_manufacturing_order(
@@ -1551,29 +1286,13 @@ async def get_manufacturing_order(
     if exclude:
         dump_kwargs["exclude"] = exclude
 
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2, **dump_kwargs),
-            structured_content=response.model_dump(**dump_kwargs),
-        )
-
-    # Labels use the canonical Pydantic field names so LLM consumers can't
-    # confuse a section header with the field name (see #346 follow-on).
-    md_lines = [f"## MO {response.order_no or response.id}"]
-    md_lines.extend(_render_mo_scalar_lines(response, verbose=request.verbose))
-    md_lines.extend(
-        _render_mo_list_fields_md(
-            response,
-            verbose=request.verbose,
-            include_rows=request.include_rows,
-            include_operation_rows=request.include_operation_rows,
-            include_productions=request.include_productions,
-        )
-    )
-
-    return make_simple_result(
-        "\n".join(md_lines),
-        structured_data=response.model_dump(**dump_kwargs),
+    # JSON content + dict structured_content (#567 — markdown dropped).
+    # ``dump_kwargs`` carries the field-exclusion logic for verbose=False
+    # and the include_* gates, so the payload shape still respects those
+    # toggles.
+    return ToolResult(
+        content=response.model_dump_json(indent=2, **dump_kwargs),
+        structured_content=response.model_dump(mode="json", **dump_kwargs),
     )
 
 
@@ -1588,13 +1307,6 @@ class GetManufacturingOrderRecipeRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     manufacturing_order_id: int = Field(..., description="Manufacturing order ID")
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
 
 
 class GetManufacturingOrderRecipeResponse(BaseModel):
@@ -1639,30 +1351,8 @@ async def get_manufacturing_order_recipe(
     the resolved SKU. Use this before adding or deleting recipe rows so you
     can identify the rows to modify.
     """
-    from katana_mcp.tools.tool_result_utils import make_simple_result
-
     response = await _get_manufacturing_order_recipe_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    # Labels use the canonical Pydantic field names so LLM consumers can't
-    # confuse a section header with the field name (see #346 follow-on).
-    if not response.rows:
-        md = f"## Recipe for MO {response.manufacturing_order_id}\n**rows**: []"
-    else:
-        md_lines = [
-            f"## Recipe for MO {response.manufacturing_order_id}",
-            f"**rows** ({response.total_count}):",
-        ]
-        for row in response.rows:
-            md_lines.append(_render_recipe_row_md(row))
-        md = "\n".join(md_lines)
-
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -1778,15 +1468,6 @@ class ListManufacturingOrdersRequest(BaseModel):
         description=(
             "ISO-8601 datetime upper bound on production_deadline_date — "
             "indexed SQL range filter against the cache."
-        ),
-    )
-
-    # Output formatting
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
         ),
     )
 
@@ -2043,52 +1724,7 @@ async def list_manufacturing_orders(
     For its recipe rows, use `get_manufacturing_order_recipe`.
     """
     response = await _list_manufacturing_orders_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    if not response.orders:
-        md = "No manufacturing orders match the given filters."
-    else:
-        table = format_md_table(
-            headers=[
-                "Order #",
-                "Status",
-                "Ingredients",
-                "Variant",
-                "Planned",
-                "Actual",
-                "Deadline",
-                "Total Cost",
-            ],
-            rows=[
-                [
-                    o.order_no or o.id,
-                    o.status or "—",
-                    o.ingredient_availability or "—",
-                    o.variant_id if o.variant_id is not None else "—",
-                    o.planned_quantity if o.planned_quantity is not None else "—",
-                    o.actual_quantity if o.actual_quantity is not None else "—",
-                    o.production_deadline_date or "—",
-                    f"{o.total_cost:.2f}" if o.total_cost is not None else "—",
-                ]
-                for o in response.orders
-            ],
-        )
-        md = f"## Manufacturing Orders ({response.total_count})\n\n{table}"
-
-    if response.pagination is not None:
-        p = response.pagination
-        if p.page is not None and p.total_pages is not None:
-            summary = f"\n\nPage {p.page} of {p.total_pages}"
-            if p.total_records is not None:
-                summary += f" (total: {p.total_records} records)"
-            md += summary
-
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -2154,13 +1790,6 @@ class ListBlockingIngredientsRequest(BaseModel):
         ge=1,
         le=500,
         description="Max aggregate rows to return (default 100, max 500).",
-    )
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data."
-        ),
     )
 
 
@@ -2538,101 +2167,12 @@ async def list_blocking_ingredients(
     you need per-row detail (notes, exact remaining qty per row).
     """
     response = await _list_blocking_ingredients_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2, exclude_none=True),
-            structured_content=response.model_dump(exclude_none=True),
-        )
-
-    if request.group_by == "variant":
-        rows = response.by_variant or []
-        if not rows:
-            md = (
-                f"## Blocking Ingredients\n\nNo blocking recipe rows in scope "
-                f"(scanned {response.total_blocking_rows} blocking row(s) across "
-                f"{response.total_affected_mos} MO(s))."
-            )
-        else:
-            table = format_md_table(
-                headers=[
-                    "SKU",
-                    "Variant ID",
-                    "Affected MOs",
-                    "Total Planned",
-                    "Total Remaining",
-                    "Earliest Expected",
-                    "Order #s",
-                ],
-                rows=[
-                    [
-                        v.sku or "—",
-                        v.variant_id,
-                        v.affected_mo_count,
-                        f"{v.total_planned_quantity:g}",
-                        f"{v.total_remaining_quantity:g}",
-                        v.earliest_expected_date or "—",
-                        ", ".join(v.affected_mo_order_nos[:5])
-                        + (
-                            f" (+{len(v.affected_mo_order_nos) - 5} more)"
-                            if len(v.affected_mo_order_nos) > 5
-                            else ""
-                        ),
-                    ]
-                    for v in rows
-                ],
-            )
-            md = (
-                f"## Blocking Ingredients by Variant ({len(rows)} variant(s) "
-                f"across {response.total_affected_mos} affected MO(s), "
-                f"{response.total_blocking_rows} blocking row(s))\n\n{table}"
-            )
-    else:
-        mos = response.by_mo or []
-        if not mos:
-            md = "## Blocking Ingredients\n\nNo blocking recipe rows in scope."
-        else:
-            sections: list[str] = [
-                f"## Blocking Ingredients by MO ({len(mos)} MO(s), "
-                f"{response.total_blocking_rows} blocking row(s))"
-            ]
-            for entry in mos:
-                deadline = entry.production_deadline_date or "—"
-                sections.append(
-                    f"\n### {entry.order_no or entry.manufacturing_order_id} "
-                    f"(status: {entry.status or '—'}, deadline: {deadline})"
-                )
-                sections.append(
-                    format_md_table(
-                        headers=[
-                            "SKU",
-                            "Variant ID",
-                            "Per-Unit",
-                            "Remaining",
-                            "Availability",
-                            "Expected",
-                        ],
-                        rows=[
-                            [
-                                r.sku or "—",
-                                r.variant_id if r.variant_id is not None else "—",
-                                r.planned_quantity_per_unit
-                                if r.planned_quantity_per_unit is not None
-                                else "—",
-                                r.total_remaining_quantity
-                                if r.total_remaining_quantity is not None
-                                else "—",
-                                r.ingredient_availability or "—",
-                                r.ingredient_expected_date or "—",
-                            ]
-                            for r in entry.blocking_rows
-                        ],
-                    )
-                )
-            md = "\n".join(sections)
-
-    return make_simple_result(
-        md, structured_data=response.model_dump(exclude_none=True)
+    # ``exclude_none=True`` matches the prior JSON-branch contract: drop
+    # the unused per-row optional fields from the payload so consumers
+    # only see populated keys.
+    return ToolResult(
+        content=response.model_dump_json(indent=2, exclude_none=True),
+        structured_content=response.model_dump(mode="json", exclude_none=True),
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -246,22 +246,13 @@ def _po_response_to_tool_result(
     result to the agent via ``ui/update-model-context``). This is the spike
     for the rail described in ADR-0016 (forthcoming, supersedes ADR-0015).
     """
-    from katana_mcp.tools.prefab_ui import (
-        build_order_created_ui,
-        build_order_preview_ui,
-    )
+    from katana_mcp.tools.prefab_ui import build_po_create_ui
 
-    order_dict = response.model_dump()
-    if response.is_preview:
-        ui = build_order_preview_ui(
-            order_dict,
-            "Purchase Order",
-            confirm_request=request,
-            confirm_tool="create_purchase_order",
-            direct_apply=True,
-        )
-    else:
-        ui = build_order_created_ui(order_dict, "Purchase Order")
+    ui = build_po_create_ui(
+        response.model_dump(mode="json"),
+        confirm_request=request,
+        confirm_tool="create_purchase_order",
+    )
 
     return make_tool_result(response, ui=ui)
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -54,9 +54,8 @@ from katana_mcp.tools.tool_result_utils import (
     apply_date_window_filters,
     coerce_enum,
     enum_to_str,
-    format_md_table,
     iso_or_none,
-    make_simple_result,
+    make_json_result,
     make_tool_result,
     parse_request_dates,
     resolve_entity_name,
@@ -793,13 +792,6 @@ class GetPurchaseOrderRequest(BaseModel):
         default=None, description="Purchase order number (e.g., 'PO-1022')"
     )
     order_id: int | None = Field(default=None, description="Purchase order ID")
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
 
 
 class PurchaseOrderRowInfo(BaseModel):
@@ -1310,235 +1302,6 @@ async def _get_purchase_order_impl(
 
 
 # ----------------------------------------------------------------------------
-# Markdown rendering — canonical Pydantic field names as labels so an LLM
-# consumer can't misread a section header as a differently-named field
-# (motivation: #346 follow-on).
-# ----------------------------------------------------------------------------
-
-_PO_SCALAR_FIELDS: tuple[str, ...] = (
-    "id",
-    "order_no",
-    "status",
-    "billing_status",
-    "entity_type",
-    "supplier_id",
-    "location_id",
-    "tracking_location_id",
-    "default_group_id",
-    "currency",
-    "total",
-    "total_in_base_currency",
-    "expected_arrival_date",
-    "order_created_date",
-    "last_document_status",
-    "additional_info",
-    "created_at",
-    "updated_at",
-    "deleted_at",
-)
-
-_PO_ROW_FIELDS: tuple[str, ...] = (
-    "id",
-    "variant_id",
-    "sku",
-    "display_name",
-    "quantity",
-    "price_per_unit",
-    "price_per_unit_in_base_currency",
-    "total",
-    "total_in_base_currency",
-    "purchase_uom",
-    "purchase_uom_conversion_rate",
-    "tax_rate_id",
-    "currency",
-    "conversion_rate",
-    "conversion_date",
-    "arrival_date",
-    "received_date",
-    "purchase_order_id",
-    "landed_cost",
-    "group_id",
-    "created_at",
-    "updated_at",
-    "deleted_at",
-)
-
-_PO_ADDITIONAL_COST_FIELDS: tuple[str, ...] = (
-    "id",
-    "additional_cost_id",
-    "group_id",
-    "name",
-    "distribution_method",
-    "price",
-    "price_in_base",
-    "currency",
-    "currency_conversion_rate",
-    "currency_conversion_rate_fix_date",
-    "tax_rate_id",
-    "tax_rate",
-    "created_at",
-    "updated_at",
-    "deleted_at",
-)
-
-_PO_ACCOUNTING_META_FIELDS: tuple[str, ...] = (
-    "id",
-    "purchase_order_id",
-    "received_items_group_id",
-    "integration_type",
-    "bill_id",
-    "created_at",
-)
-
-
-def _render_po_row_md(row: PurchaseOrderRowInfo) -> list[str]:
-    """Render a PO row as a multi-line block under ``purchase_order_rows``."""
-    lines = [f"  - **id**: {row.id}"]
-    for fname in _PO_ROW_FIELDS:
-        if fname == "id":
-            continue
-        val = getattr(row, fname, None)
-        if val is None or val == "":
-            continue
-        lines.append(f"    **{fname}**: {val}")
-    if row.batch_transactions:
-        lines.append(
-            f"    **batch_transactions** ({len(row.batch_transactions)}): "
-            f"{row.batch_transactions}"
-        )
-    else:
-        lines.append("    **batch_transactions**: []")
-    return lines
-
-
-def _render_po_additional_cost_row_md(
-    row: PurchaseOrderAdditionalCostRowInfo,
-) -> list[str]:
-    """Render an additional cost row under ``additional_cost_rows``."""
-    lines = [f"  - **id**: {row.id}"]
-    for fname in _PO_ADDITIONAL_COST_FIELDS:
-        if fname == "id":
-            continue
-        val = getattr(row, fname, None)
-        if val is None or val == "":
-            continue
-        lines.append(f"    **{fname}**: {val}")
-    return lines
-
-
-def _render_po_accounting_metadata_md(
-    meta: PurchaseOrderAccountingMetadataInfo,
-) -> list[str]:
-    """Render an accounting metadata entry under ``accounting_metadata``."""
-    lines = [f"  - **id**: {meta.id}"]
-    for fname in _PO_ACCOUNTING_META_FIELDS:
-        if fname == "id":
-            continue
-        val = getattr(meta, fname, None)
-        if val is None or val == "":
-            continue
-        lines.append(f"    **{fname}**: {val}")
-    return lines
-
-
-_SUPPLIER_FIELDS: tuple[str, ...] = (
-    "id",
-    "name",
-    "email",
-    "phone",
-    "currency",
-    "comment",
-    "default_address_id",
-    "created_at",
-    "updated_at",
-    "deleted_at",
-)
-
-
-def _render_supplier_md(supplier: SupplierInfo) -> list[str]:
-    """Render an embedded supplier under ``**supplier**:`` using canonical
-    field names, matching the scheme used for rows and accounting metadata.
-    """
-    lines: list[str] = []
-    for fname in _SUPPLIER_FIELDS:
-        val = getattr(supplier, fname, None)
-        if val is None or val == "":
-            continue
-        lines.append(f"  **{fname}**: {val}")
-    if supplier.addresses:
-        lines.append(
-            f"  **addresses** ({len(supplier.addresses)}): {supplier.addresses}"
-        )
-    else:
-        lines.append("  **addresses**: []")
-    return lines
-
-
-def _render_get_purchase_order_md(
-    response: GetPurchaseOrderResponse, *, embed: bool = False
-) -> str:
-    """Render an exhaustive PO response as canonical-labeled markdown.
-
-    When ``embed=True`` the top-level ``## PO …`` heading is omitted —
-    used when the PO is rendered as a nested block under another response
-    (e.g., ``verify_order_document``) where an indented markdown heading
-    would still be parsed as a top-level heading and break intended
-    nesting (copilot feedback on #357).
-    """
-    md_lines: list[str] = []
-    if not embed:
-        md_lines.append(f"## PO {response.order_no or response.id}")
-
-    for fname in _PO_SCALAR_FIELDS:
-        val = getattr(response, fname)
-        if val is None or val == "":
-            continue
-        md_lines.append(f"**{fname}**: {val}")
-
-    # supplier: inline block under the canonical key so the LLM can trace
-    # every embedded supplier field without a separate lookup.
-    if response.supplier is not None:
-        md_lines.append("")
-        md_lines.append("**supplier**:")
-        md_lines.extend(_render_supplier_md(response.supplier))
-    else:
-        md_lines.append("**supplier**: null")
-
-    # purchase_order_rows: explicit list syntax so empty lists render as `[]`
-    # rather than a dangling section header an LLM could misread (#346).
-    if response.purchase_order_rows:
-        md_lines.append("")
-        md_lines.append(
-            f"**purchase_order_rows** ({len(response.purchase_order_rows)}):"
-        )
-        for row in response.purchase_order_rows:
-            md_lines.extend(_render_po_row_md(row))
-    else:
-        md_lines.append("**purchase_order_rows**: []")
-
-    if response.additional_cost_rows:
-        md_lines.append("")
-        md_lines.append(
-            f"**additional_cost_rows** ({len(response.additional_cost_rows)}):"
-        )
-        for row in response.additional_cost_rows:
-            md_lines.extend(_render_po_additional_cost_row_md(row))
-    else:
-        md_lines.append("**additional_cost_rows**: []")
-
-    if response.accounting_metadata:
-        md_lines.append("")
-        md_lines.append(
-            f"**accounting_metadata** ({len(response.accounting_metadata)}):"
-        )
-        for meta in response.accounting_metadata:
-            md_lines.extend(_render_po_accounting_metadata_md(meta))
-    else:
-        md_lines.append("**accounting_metadata**: []")
-
-    return "\n".join(md_lines)
-
-
 @observe_tool
 @unpack_pydantic_params
 async def get_purchase_order(
@@ -1565,17 +1328,7 @@ async def get_purchase_order(
     Provide either order_no (e.g., 'PO-1022') or order_id.
     """
     response = await _get_purchase_order_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    return make_simple_result(
-        _render_get_purchase_order_md(response),
-        structured_data=response.model_dump(),
-    )
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -1655,13 +1408,6 @@ class VerifyOrderDocumentRequest(BaseModel):
     order_id: int = Field(..., description="Purchase order ID")
     document_items: list[DocumentItem] = Field(
         ..., description="Items from the document to verify", min_length=1
-    )
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
     )
 
 
@@ -2051,11 +1797,6 @@ async def verify_order_document(
     to validate a delivery. No changes are made to orders or inventory.
     """
     response = await _verify_order_document_impl(request, context)
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
     return _verify_response_to_tool_result(response)
 
 
@@ -2174,15 +1915,6 @@ class ListPurchaseOrdersRequest(BaseModel):
         description=(
             "When true, populate row-level detail (variant_id, quantity, "
             "price, arrival date) on each summary."
-        ),
-    )
-
-    # Output formatting
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
         ),
     )
 
@@ -2509,50 +2241,7 @@ async def list_purchase_orders(
     For full details on a specific PO, use `get_purchase_order`.
     """
     response = await _list_purchase_orders_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    if not response.orders:
-        md = "No purchase orders match the given filters."
-    else:
-        table = format_md_table(
-            headers=[
-                "Order #",
-                "Status",
-                "Supplier",
-                "Location",
-                "Rows",
-                "Total",
-                "Expected Arrival",
-            ],
-            rows=[
-                [
-                    o.order_no or o.id,
-                    o.status or "—",
-                    o.supplier_id if o.supplier_id is not None else "—",
-                    o.location_id if o.location_id is not None else "—",
-                    o.row_count,
-                    f"{o.total:.2f} {o.currency or ''}" if o.total is not None else "—",
-                    o.expected_arrival_date or "—",
-                ]
-                for o in response.orders
-            ],
-        )
-        md = f"## Purchase Orders ({response.total_count})\n\n{table}"
-
-    if response.pagination is not None:
-        p = response.pagination
-        if p.page is not None and p.total_pages is not None:
-            summary = f"\n\nPage {p.page} of {p.total_pages}"
-            if p.total_records is not None:
-                summary += f" (total: {p.total_records} records)"
-            md += summary
-
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
@@ -1,14 +1,13 @@
 """Cache-backed search tools for stable reference data — suppliers,
 locations, tax rates, operators, and the additional-cost catalog. Each
 ``list_*`` tool accepts ``query`` (optional fuzzy name/code search,
-FTS5 with difflib fallback), ``limit`` (default 50, max 250), and
-``format`` (``"markdown"`` | ``"json"``). ``get_supplier(supplier_id)``
-returns the full single-supplier record.
+FTS5 with difflib fallback) and ``limit`` (default 50, max 250).
+``get_supplier(supplier_id)`` returns the full single-supplier record.
 """
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
@@ -18,7 +17,7 @@ from sqlmodel import SQLModel
 from katana_mcp.logging import observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.decorators import cache_read
-from katana_mcp.tools.tool_result_utils import make_simple_result
+from katana_mcp.tools.tool_result_utils import make_json_result
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.models_pydantic._generated import (
     CachedAdditionalCost,
@@ -37,9 +36,9 @@ def _normalize_query(query: str | None) -> str | None:
     """Strip whitespace and treat empty / whitespace-only input as no query.
 
     Caller-side normalization keeps a single canonical form flowing to the
-    cache, the response model, and the markdown header — otherwise
-    ``query="   "`` falls through to the no-query path but still renders
-    "query `   `" in the header because the raw value remains truthy.
+    cache and the response model — otherwise ``query="   "`` would fall
+    through to the no-query path but still surface a non-None ``query``
+    value on the response.
     """
     if query is None:
         return None
@@ -79,18 +78,6 @@ async def _fetch_rows(
     return raw[:limit], total
 
 
-def _list_header(title: str, query: str | None, returned: int, total: int) -> str:
-    if query:
-        return f"## {title} — query `{query}` ({returned} of {total})"
-    return f"## {title} ({returned} of {total})"
-
-
-def _empty_message(entity_label: str, query: str | None) -> str:
-    if query:
-        return f"No {entity_label} found matching `{query}`."
-    return f"No {entity_label} cached."
-
-
 # ============================================================================
 # Suppliers — list_suppliers + get_supplier
 # ============================================================================
@@ -111,13 +98,6 @@ class ListSuppliersRequest(BaseModel):
         ge=1,
         le=250,
         description="Maximum rows to return (default 50, max 250)",
-    )
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable bullets; "
-            "'json' for structured data consumable by downstream tools."
-        ),
     )
 
 
@@ -169,23 +149,6 @@ async def _list_suppliers_impl(
     )
 
 
-def _render_supplier_list_md(response: ListSuppliersResponse) -> str:
-    if not response.suppliers:
-        return _empty_message("suppliers", response.query)
-
-    lines = [
-        f"- **{s.name}** (ID: {s.id})"
-        + (f" — {s.email}" if s.email else "")
-        + (f" [{s.currency}]" if s.currency else "")
-        + (f" code:{s.code}" if s.code else "")
-        for s in response.suppliers
-    ]
-    header = _list_header(
-        "Suppliers", response.query, len(response.suppliers), response.total_count
-    )
-    return header + "\n\n" + "\n".join(lines)
-
-
 @observe_tool
 @unpack_pydantic_params
 async def list_suppliers(
@@ -200,22 +163,13 @@ async def list_suppliers(
     Use ``get_supplier(supplier_id)`` for the full-detail record.
     """
     response = await _list_suppliers_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-    return make_simple_result(
-        _render_supplier_list_md(response), structured_data=response.model_dump()
-    )
+    return make_json_result(response)
 
 
 class GetSupplierRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     supplier_id: int = Field(..., description="Supplier ID to look up")
-    format: Literal["markdown", "json"] = Field(default="markdown")
 
 
 class GetSupplierResponse(BaseModel):
@@ -292,34 +246,6 @@ async def _get_supplier_impl(
     )
 
 
-def _render_supplier_detail_md(response: GetSupplierResponse) -> str:
-    md_lines = [f"## {response.name}"]
-    fields = (
-        "id",
-        "email",
-        "phone",
-        "currency",
-        "code",
-        "default_payment_terms",
-        "address_line_1",
-        "address_line_2",
-        "city",
-        "state",
-        "zip",
-        "country",
-        "comment",
-        "created_at",
-        "updated_at",
-        "deleted_at",
-    )
-    for fname in fields:
-        val = getattr(response, fname)
-        if val is None or val == "":
-            continue
-        md_lines.append(f"**{fname}**: {val}")
-    return "\n".join(md_lines)
-
-
 @observe_tool
 @unpack_pydantic_params
 async def get_supplier(
@@ -333,15 +259,7 @@ async def get_supplier(
     tool is the single-call path to the rest.
     """
     response = await _get_supplier_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-    return make_simple_result(
-        _render_supplier_detail_md(response), structured_data=response.model_dump()
-    )
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -354,7 +272,6 @@ class ListLocationsRequest(BaseModel):
 
     query: str | None = Field(default=None, description="Fuzzy search by location name")
     limit: int = Field(default=50, ge=1, le=250)
-    format: Literal["markdown", "json"] = Field(default="markdown")
 
 
 class AddressInfo(BaseModel):
@@ -439,28 +356,6 @@ async def _list_locations_impl(
     )
 
 
-def _render_location_md(response: ListLocationsResponse) -> str:
-    if not response.locations:
-        return _empty_message("locations", response.query)
-
-    def _city_country(loc: LocationInfo) -> str:
-        if not loc.address:
-            return ""
-        parts = [p for p in (loc.address.city, loc.address.country) if p]
-        return f" — {', '.join(parts)}" if parts else ""
-
-    lines = [
-        f"- **{loc.name}** (ID: {loc.id})"
-        + (" [primary]" if loc.is_primary else "")
-        + _city_country(loc)
-        for loc in response.locations
-    ]
-    header = _list_header(
-        "Locations", response.query, len(response.locations), response.total_count
-    )
-    return header + "\n\n" + "\n".join(lines)
-
-
 @observe_tool
 @unpack_pydantic_params
 async def list_locations(
@@ -476,14 +371,7 @@ async def list_locations(
     caps output at 50 rows.
     """
     response = await _list_locations_impl(request, context)
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-    return make_simple_result(
-        _render_location_md(response), structured_data=response.model_dump()
-    )
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -496,7 +384,6 @@ class ListTaxRatesRequest(BaseModel):
 
     query: str | None = Field(default=None, description="Fuzzy search by tax-rate name")
     limit: int = Field(default=50, ge=1, le=250)
-    format: Literal["markdown", "json"] = Field(default="markdown")
 
 
 class TaxRateInfo(BaseModel):
@@ -538,26 +425,6 @@ async def _list_tax_rates_impl(
     )
 
 
-def _render_tax_rate_md(response: ListTaxRatesResponse) -> str:
-    if not response.tax_rates:
-        return _empty_message("tax rates", response.query)
-    lines = []
-    for tr in response.tax_rates:
-        flags = []
-        if tr.is_default_sales:
-            flags.append("default-sales")
-        if tr.is_default_purchases:
-            flags.append("default-purchases")
-        flag_str = f" [{', '.join(flags)}]" if flags else ""
-        rate_str = f" — {tr.rate}%" if tr.rate is not None else ""
-        display = f" ({tr.display_name})" if tr.display_name else ""
-        lines.append(f"- **{tr.name}** (ID: {tr.id}){display}{rate_str}{flag_str}")
-    header = _list_header(
-        "Tax Rates", response.query, len(response.tax_rates), response.total_count
-    )
-    return header + "\n\n" + "\n".join(lines)
-
-
 @observe_tool
 @unpack_pydantic_params
 async def list_tax_rates(
@@ -571,14 +438,7 @@ async def list_tax_rates(
     Pass ``query`` to fuzzy-match by name; omit to browse.
     """
     response = await _list_tax_rates_impl(request, context)
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-    return make_simple_result(
-        _render_tax_rate_md(response), structured_data=response.model_dump()
-    )
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -591,7 +451,6 @@ class ListOperatorsRequest(BaseModel):
 
     query: str | None = Field(default=None, description="Fuzzy search by operator name")
     limit: int = Field(default=50, ge=1, le=250)
-    format: Literal["markdown", "json"] = Field(default="markdown")
 
 
 class OperatorInfo(BaseModel):
@@ -627,16 +486,6 @@ async def _list_operators_impl(
     )
 
 
-def _render_operator_md(response: ListOperatorsResponse) -> str:
-    if not response.operators:
-        return _empty_message("operators", response.query)
-    lines = [f"- **{op.name}** (ID: {op.id})" for op in response.operators]
-    header = _list_header(
-        "Operators", response.query, len(response.operators), response.total_count
-    )
-    return header + "\n\n" + "\n".join(lines)
-
-
 @observe_tool
 @unpack_pydantic_params
 async def list_operators(
@@ -649,14 +498,7 @@ async def list_operators(
     Pass ``query`` to fuzzy-match by name; omit to browse.
     """
     response = await _list_operators_impl(request, context)
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-    return make_simple_result(
-        _render_operator_md(response), structured_data=response.model_dump()
-    )
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -671,7 +513,6 @@ class ListAdditionalCostsRequest(BaseModel):
         default=None, description="Fuzzy search by additional-cost name"
     )
     limit: int = Field(default=50, ge=1, le=250)
-    format: Literal["markdown", "json"] = Field(default="markdown")
 
 
 class AdditionalCostInfo(BaseModel):
@@ -702,19 +543,6 @@ async def _list_additional_costs_impl(
     )
 
 
-def _render_additional_cost_md(response: ListAdditionalCostsResponse) -> str:
-    if not response.additional_costs:
-        return _empty_message("additional costs", response.query)
-    lines = [f"- **{ac.name}** (ID: {ac.id})" for ac in response.additional_costs]
-    header = _list_header(
-        "Additional Costs",
-        response.query,
-        len(response.additional_costs),
-        response.total_count,
-    )
-    return header + "\n\n" + "\n".join(lines)
-
-
 @observe_tool
 @unpack_pydantic_params
 async def list_additional_costs(
@@ -728,14 +556,7 @@ async def list_additional_costs(
     Pass ``query`` to fuzzy-match by name; omit to browse.
     """
     response = await _list_additional_costs_impl(request, context)
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-    return make_simple_result(
-        _render_additional_cost_md(response), structured_data=response.model_dump()
-    )
+    return make_json_result(response)
 
 
 # ============================================================================

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reporting.py
@@ -52,8 +52,7 @@ from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.list_coercion import CoercedStrIntListOpt
 from katana_mcp.tools.tool_result_utils import (
     apply_date_window_filters,
-    format_md_table,
-    make_simple_result,
+    make_json_result,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.api.inventory import get_all_inventory_point
@@ -284,13 +283,6 @@ class TopSellingVariantsRequest(BaseModel):
             "Optional location ID to filter by. Look up via `list_locations`."
         ),
     )
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
 
 
 class VariantSalesRow(BaseModel):
@@ -417,42 +409,7 @@ async def top_selling_variants(
     instead of paginating through orders client-side.
     """
     response = await _top_selling_variants_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    if not response.rows:
-        md = (
-            f"No DELIVERED sales in window "
-            f"{response.window_start} - {response.window_end}."
-        )
-    else:
-        table = format_md_table(
-            headers=["SKU", "Variant", "Name", "Units", "Revenue", "Orders"],
-            rows=[
-                [
-                    r.sku or "-",
-                    r.variant_id,
-                    r.name or "-",
-                    f"{r.units:g}",
-                    f"{r.revenue:,.2f}",
-                    r.order_count,
-                ]
-                for r in response.rows
-            ],
-        )
-        md = (
-            f"## Top Selling Variants "
-            f"({response.window_start} - {response.window_end})\n\n"
-            f"{table}\n\n"
-            f"_{response.total_variants} variant(s) matched; "
-            f"showing top {len(response.rows)}._"
-        )
-
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -473,13 +430,6 @@ class SalesSummaryRequest(BaseModel):
     group_by: SalesGroupBy = Field(
         ...,
         description="Grouping key: day, week, month, variant, customer, or category",
-    )
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
     )
 
 
@@ -633,37 +583,7 @@ async def sales_summary(
     count.
     """
     response = await _sales_summary_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    if not response.rows:
-        md = (
-            f"No DELIVERED sales in window "
-            f"{response.window_start} - {response.window_end}."
-        )
-    else:
-        table = format_md_table(
-            headers=[response.group_by.title(), "Units", "Revenue", "Orders"],
-            rows=[
-                [
-                    r.group,
-                    f"{r.units:g}",
-                    f"{r.revenue:,.2f}",
-                    r.order_count,
-                ]
-                for r in response.rows
-            ],
-        )
-        md = (
-            f"## Sales Summary by {response.group_by} "
-            f"({response.window_start} - {response.window_end})\n\n{table}"
-        )
-
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -689,8 +609,8 @@ class InventoryVelocityRequest(BaseModel):
         description=(
             "Batch shape: JSON array of SKUs (strings) and/or variant IDs (integers), "
             'e.g. ["WS74001", "WS74002"] or [12345, 67890] (1-100 items). '
-            "Returns one row per item in a markdown table. "
-            "Use this for cross-variant reports."
+            "Returns one ``VelocityStats`` row per item in the JSON "
+            "``InventoryVelocityResponse`` envelope. Use this for cross-variant reports."
         ),
         min_length=1,
         max_length=100,
@@ -707,13 +627,6 @@ class InventoryVelocityRequest(BaseModel):
             "When true (default), units consumed as ingredients on completed "
             "MOs in the window are added to the velocity figure. "
             "Set false to match the legacy SO-only behavior."
-        ),
-    )
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
         ),
     )
 
@@ -1006,65 +919,6 @@ async def _inventory_velocity_impl(
     return InventoryVelocityResponse(items=items)
 
 
-def _format_velocity_card(stats: VelocityStats) -> str:
-    """Render a single variant's velocity as a rich markdown card."""
-    cover = (
-        f"{stats.days_of_cover:.1f} days"
-        if stats.days_of_cover is not None
-        else "N/A (no demand history in window)"
-    )
-    lines = [
-        f"## Inventory Velocity: {stats.sku or stats.variant_id}",
-        f"- **Variant ID**: {stats.variant_id}",
-        f"- **Window**: {stats.window_start} to {stats.window_end} "
-        f"({stats.period_days} days)",
-        f"- **Units Sold (SO)**: {stats.units_sold:g}",
-        f"- **Units Consumed (MO)**: {stats.units_consumed_by_mos:g}",
-        f"- **Total Demand**: {stats.units_total:g}",
-        f"- **Average Daily**: {stats.avg_daily:.2f}",
-        f"- **Stock on Hand**: {stats.stock_on_hand:g}",
-        f"- **Days of Cover**: {cover}",
-    ]
-    return "\n".join(lines)
-
-
-def _format_velocity_table(response: InventoryVelocityResponse) -> str:
-    """Render a batch velocity response as a markdown table."""
-    headers = [
-        "SKU",
-        "Variant ID",
-        "Units Sold (SO)",
-        "Units Consumed (MO)",
-        "Total",
-        "Avg/day",
-        "Stock",
-        "Days Cover",
-    ]
-    rows = []
-    for s in response.items:
-        cover = f"{s.days_of_cover:.1f}" if s.days_of_cover is not None else "N/A"
-        rows.append(
-            [
-                s.sku or "",
-                str(s.variant_id),
-                f"{s.units_sold:g}",
-                f"{s.units_consumed_by_mos:g}",
-                f"{s.units_total:g}",
-                f"{s.avg_daily:.2f}",
-                f"{s.stock_on_hand:g}",
-                cover,
-            ]
-        )
-    first = response.items[0] if response.items else None
-    title = (
-        f"## Inventory Velocity Report "
-        f"({first.window_start} to {first.window_end}, {first.period_days} days)"
-        if first
-        else "## Inventory Velocity Report"
-    )
-    return f"{title}\n\n{format_md_table(headers, rows)}"
-
-
 @observe_tool
 @unpack_pydantic_params
 async def inventory_velocity(
@@ -1077,25 +931,16 @@ async def inventory_velocity(
     divides by the period to get average daily demand, and pairs it with
     current stock-on-hand to produce a ``days_of_cover`` estimate.
 
-    Use ``sku_or_variant_id`` for a single-variant rich card, or
-    ``sku_or_variant_ids`` for a cross-variant batch table.
-    Set ``include_mo_consumption=false`` to use only SO-side numbers (legacy
-    behaviour). ``days_of_cover`` is ``None`` when average daily demand is 0.
+    Response is always the JSON ``InventoryVelocityResponse`` envelope
+    (``{items: [VelocityStats, ...]}``) — one row per requested variant, for
+    both the single-item (``sku_or_variant_id``) and batch
+    (``sku_or_variant_ids``) shapes. Use the batch shape for cross-variant
+    reports. Set ``include_mo_consumption=false`` to use only SO-side numbers
+    (legacy behaviour). ``days_of_cover`` is ``None`` when average daily
+    demand is 0.
     """
     response = await _inventory_velocity_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    if request.is_batch or len(response.items) > 1:
-        md = _format_velocity_table(response)
-    else:
-        md = _format_velocity_card(response.items[0]) if response.items else ""
-
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -55,8 +55,8 @@ from katana_mcp.tools.tool_result_utils import (
     apply_date_window_filters,
     coerce_enum,
     enum_to_str,
-    format_md_table,
     iso_or_none,
+    make_json_result,
     make_tool_result,
     parse_request_dates,
     resolve_entity_name,
@@ -660,15 +660,6 @@ class ListSalesOrdersRequest(BaseModel):
         ),
     )
 
-    # Output formatting
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
-
 
 class SalesOrderRowInfo(BaseModel):
     """Summary of a sales order line item."""
@@ -978,44 +969,8 @@ async def list_sales_orders(
       None in list context; use `get_sales_order` for SKU-enriched rows on a
       specific order.
     """
-    from katana_mcp.tools.tool_result_utils import make_simple_result
-
     response = await _list_sales_orders_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    if not response.orders:
-        md = "No sales orders match the given filters."
-    else:
-        table = format_md_table(
-            headers=["Order #", "Status", "Production", "Rows", "Total", "Created"],
-            rows=[
-                [
-                    o.order_no or o.id,
-                    o.status or "—",
-                    o.production_status or "—",
-                    o.row_count,
-                    f"{o.total:.2f} {o.currency or ''}" if o.total is not None else "—",
-                    o.created_at or "—",
-                ]
-                for o in response.orders
-            ],
-        )
-        md = f"## Sales Orders ({response.total_count})\n\n{table}"
-
-    if response.pagination is not None:
-        p = response.pagination
-        if p.page is not None and p.total_pages is not None:
-            summary = f"\n\nPage {p.page} of {p.total_pages}"
-            if p.total_records is not None:
-                summary += f" (total: {p.total_records} records)"
-            md += summary
-
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -1030,13 +985,6 @@ class GetSalesOrderRequest(BaseModel):
 
     order_no: str | None = Field(default=None, description="Sales order number")
     order_id: int | None = Field(default=None, description="Sales order ID")
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
-    )
 
 
 class SalesOrderRowDetail(BaseModel):
@@ -1432,119 +1380,6 @@ async def _get_sales_order_impl(
     )
 
 
-# Scalar fields rendered in order at the top of the markdown response.
-# Labels use canonical Pydantic names so LLM consumers can't confuse a
-# rendered section header with the field name (see #346 follow-on).
-_GET_SO_SCALAR_FIELDS: tuple[str, ...] = (
-    "id",
-    "order_no",
-    "customer_id",
-    "location_id",
-    "source",
-    "status",
-    "production_status",
-    "invoicing_status",
-    "product_availability",
-    "product_expected_date",
-    "ingredient_availability",
-    "ingredient_expected_date",
-    "order_created_date",
-    "delivery_date",
-    "picked_date",
-    "currency",
-    "total",
-    "total_in_base_currency",
-    "conversion_rate",
-    "conversion_date",
-    "customer_ref",
-    "additional_info",
-    "tracking_number",
-    "tracking_number_url",
-    "billing_address_id",
-    "shipping_address_id",
-    "linked_manufacturing_order_id",
-    "ecommerce_order_type",
-    "ecommerce_store_name",
-    "ecommerce_order_id",
-    "created_at",
-    "updated_at",
-    "deleted_at",
-)
-
-# Per-address fields rendered (in order) under an ``addresses`` block.
-_ADDRESS_FIELDS: tuple[str, ...] = (
-    "sales_order_id",
-    "entity_type",
-    "first_name",
-    "last_name",
-    "company",
-    "phone",
-    "line_1",
-    "line_2",
-    "city",
-    "state",
-    "zip",
-    "country",
-    "created_at",
-    "updated_at",
-    "deleted_at",
-)
-
-# Per-row fields rendered under a ``rows`` block. ``id`` + ``variant_id`` /
-# ``sku`` / ``display_name`` are emitted first as the row header; the rest
-# are indented beneath. ``display_name`` carries the canonical Katana-UI
-# name (parent / value1 / value2) so each row in the rendered output
-# matches the convention used by every other variant-displaying surface.
-_ROW_HEADER_FIELDS: tuple[str, ...] = ("variant_id", "sku", "display_name")
-_ROW_BODY_FIELDS: tuple[str, ...] = (
-    "sales_order_id",
-    "quantity",
-    "price_per_unit",
-    "price_per_unit_in_base_currency",
-    "total",
-    "total_in_base_currency",
-    "total_discount",
-    "tax_rate_id",
-    "tax_rate",
-    "location_id",
-    "product_availability",
-    "product_expected_date",
-    "cogs_value",
-    "linked_manufacturing_order_id",
-    "conversion_rate",
-    "conversion_date",
-    "serial_numbers",
-    "created_at",
-    "updated_at",
-    "deleted_at",
-)
-
-
-def _render_address_md(addr: SalesOrderAddressInfo) -> str:
-    """Render one address as an indented multi-line block with canonical labels."""
-    lines = [f"  - **id**: {addr.id}"]
-    for fname in _ADDRESS_FIELDS:
-        val = getattr(addr, fname)
-        if val is None or val == "":
-            continue
-        lines.append(f"    **{fname}**: {val}")
-    return "\n".join(lines)
-
-
-def _render_row_md(row: SalesOrderRowDetail) -> str:
-    """Render one sales order row as an indented multi-line block with canonical labels."""
-    lines = [f"  - **id**: {row.id}"]
-    for fname in _ROW_HEADER_FIELDS + _ROW_BODY_FIELDS:
-        val = getattr(row, fname)
-        # Empty serial_numbers list is noise — skip it. Non-empty lists render
-        # with explicit [...] syntax so an LLM reading the output can tell
-        # the field is a list.
-        if val is None or val == "" or (isinstance(val, list) and not val):
-            continue
-        lines.append(f"    **{fname}**: {val}")
-    return "\n".join(lines)
-
-
 @observe_tool
 @unpack_pydantic_params
 async def get_sales_order(
@@ -1563,59 +1398,8 @@ async def get_sales_order(
     linked manufacturing order, batch tracking, serial numbers). Use with
     `list_sales_orders` for discovery; this is the single-call path to the rest.
     """
-    from katana_mcp.tools.tool_result_utils import make_simple_result
-
     response = await _get_sales_order_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    # Labels use canonical Pydantic field names so LLM consumers can't
-    # confuse a section header with the field name (see #346 follow-on).
-    header = f"## Sales Order {response.order_no or response.id}"
-    md_lines: list[str] = [header]
-    for fname in _GET_SO_SCALAR_FIELDS:
-        val = getattr(response, fname)
-        if val is None or val == "":
-            continue
-        md_lines.append(f"**{fname}**: {val}")
-
-    # shipping_fee is a nested object — render its canonical fields inline.
-    if response.shipping_fee is not None:
-        md_lines.append("")
-        md_lines.append("**shipping_fee**:")
-        fee = response.shipping_fee
-        md_lines.append(f"  **id**: {fee.id}")
-        for fname in ("sales_order_id", "amount", "tax_rate_id", "description"):
-            fval = getattr(fee, fname)
-            if fval is None or fval == "":
-                continue
-            md_lines.append(f"  **{fname}**: {fval}")
-
-    # Addresses — explicit [] when empty, count + per-address blocks when populated.
-    md_lines.append("")
-    if response.addresses:
-        md_lines.append(f"**addresses** ({len(response.addresses)}):")
-        for addr in response.addresses:
-            md_lines.append(_render_address_md(addr))
-    else:
-        md_lines.append("**addresses**: []")
-
-    # Rows — same shape as addresses (explicit [] / count + per-row blocks).
-    md_lines.append("")
-    if response.rows:
-        md_lines.append(f"**rows** ({len(response.rows)}):")
-        for row in response.rows:
-            md_lines.append(_render_row_md(row))
-    else:
-        md_lines.append("**rows**: []")
-
-    return make_simple_result(
-        "\n".join(md_lines), structured_data=response.model_dump()
-    )
+    return make_json_result(response)
 
 
 # ============================================================================

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -534,24 +534,15 @@ async def create_sales_order(
     variant_id and quantity. Supports optional pricing overrides, discounts,
     delivery dates, and billing/shipping addresses.
     """
-    from katana_mcp.tools.prefab_ui import (
-        build_order_created_ui,
-        build_order_preview_ui,
-    )
+    from katana_mcp.tools.prefab_ui import build_so_create_ui
 
     response = await _create_sales_order_impl(request, context)
 
-    order_dict = response.model_dump()
-    if response.is_preview:
-        ui = build_order_preview_ui(
-            order_dict,
-            "Sales Order",
-            confirm_request=request,
-            confirm_tool="create_sales_order",
-            direct_apply=True,
-        )
-    else:
-        ui = build_order_created_ui(order_dict, "Sales Order")
+    ui = build_so_create_ui(
+        response.model_dump(mode="json"),
+        confirm_request=request,
+        confirm_tool="create_sales_order",
+    )
 
     return make_tool_result(response, ui=ui)
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -47,9 +47,8 @@ from katana_mcp.tools.tool_result_utils import (
     PaginationMeta,
     apply_date_window_filters,
     enum_to_str,
-    format_md_table,
     iso_or_none,
-    make_simple_result,
+    make_json_result,
     parse_request_dates,
     resolve_entity_name,
 )
@@ -458,51 +457,7 @@ async def create_stock_transfer(
     `batch_transactions` on the row.
     """
     response = await _create_stock_transfer_impl(request, context)
-
-    lines = [
-        f"## Stock Transfer ({'PREVIEW' if response.is_preview else 'CREATED'})",
-        f"- **Message**: {response.message}",
-    ]
-    if response.id is not None:
-        lines.append(f"- **ID**: {response.id}")
-    if response.stock_transfer_number:
-        lines.append(f"- **Number**: {response.stock_transfer_number}")
-    if response.source_location_id is not None:
-        src_label = (
-            f"{response.source_location_name} (ID: {response.source_location_id})"
-            if response.source_location_name
-            else str(response.source_location_id)
-        )
-        lines.append(f"- **Source Location**: {src_label}")
-    if response.target_location_id is not None:
-        dst_label = (
-            f"{response.target_location_name} (ID: {response.target_location_id})"
-            if response.target_location_name
-            else str(response.target_location_id)
-        )
-        lines.append(f"- **Destination Location**: {dst_label}")
-    if response.item_count is not None:
-        lines.append(f"- **Rows**: {response.item_count}")
-    if response.expected_arrival_date:
-        lines.append(f"- **Expected Arrival**: {response.expected_arrival_date}")
-    if response.status:
-        lines.append(f"- **Status**: {response.status}")
-    if response.katana_url:
-        lines.append(f"- **Katana URL**: {response.katana_url}")
-    if response.warnings:
-        lines.append("")
-        lines.append("### Warnings")
-        for w in response.warnings:
-            is_block = w.startswith(BLOCK_WARNING_PREFIX)
-            display = w.removeprefix(BLOCK_WARNING_PREFIX).lstrip() if is_block else w
-            prefix = "**[BLOCKED]** " if is_block else ""
-            lines.append(f"- {prefix}{display}")
-    if response.next_actions:
-        lines.append("")
-        lines.append("### Next Actions")
-        lines.extend(f"- {action}" for action in response.next_actions)
-
-    return make_simple_result("\n".join(lines), structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================
@@ -559,15 +514,6 @@ class ListStockTransfersRequest(BaseModel):
     include_rows: bool = Field(
         default=False,
         description="When true, populate row-level detail on each summary.",
-    )
-
-    # Output formatting
-    format: Literal["markdown", "json"] = Field(
-        default="markdown",
-        description=(
-            "Output format: 'markdown' (default) for human-readable tables; "
-            "'json' for structured data consumable by downstream tools/aggregations."
-        ),
     )
 
 
@@ -771,42 +717,7 @@ async def list_stock_transfers(
     Pass `include_rows=True` to populate per-transfer line items.
     """
     response = await _list_stock_transfers_impl(request, context)
-
-    if request.format == "json":
-        return ToolResult(
-            content=response.model_dump_json(indent=2),
-            structured_content=response.model_dump(),
-        )
-
-    if not response.transfers:
-        md = "No stock transfers match the given filters."
-    else:
-        table = format_md_table(
-            headers=[
-                "ID",
-                "Number",
-                "Status",
-                "Source",
-                "Destination",
-                "Rows",
-                "Expected Arrival",
-            ],
-            rows=[
-                [
-                    t.id,
-                    t.stock_transfer_number or "—",
-                    t.status or "—",
-                    t.source_location_id if t.source_location_id is not None else "—",
-                    t.target_location_id if t.target_location_id is not None else "—",
-                    t.row_count,
-                    t.expected_arrival_date or "—",
-                ]
-                for t in response.transfers
-            ],
-        )
-        md = f"## Stock Transfers ({response.total_count})\n\n{table}"
-
-    return make_simple_result(md, structured_data=response.model_dump())
+    return make_json_result(response)
 
 
 # ============================================================================

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -9,8 +9,9 @@ Usage::
     from katana_mcp.tools.prefab_ui import (
         build_search_results_ui,
         build_item_detail_ui,
-        build_order_preview_ui,
-        build_order_created_ui,
+        build_po_create_ui,
+        build_so_create_ui,
+        build_mo_create_ui,
     )
 
     # In a tool's *_to_tool_result function:
@@ -49,6 +50,7 @@ from typing import Any, Literal
 
 from prefab_ui.actions import Action, SetState, ShowToast
 from prefab_ui.actions.mcp import CallTool, SendMessage, UpdateContext
+from prefab_ui.actions.navigation import OpenLink
 from prefab_ui.app import PrefabApp
 from prefab_ui.components import (
     H3,
@@ -79,7 +81,7 @@ from prefab_ui.rx import EVENT, RESULT, Rx
 from pydantic import BaseModel
 
 from katana_mcp.tools.tool_result_utils import BLOCK_WARNING_PREFIX
-from katana_mcp.web_urls import katana_web_url
+from katana_mcp.web_urls import EntityKind, katana_web_url
 
 
 def _split_warnings(
@@ -101,6 +103,68 @@ def _split_warnings(
         else:
             regulars.append(w)
     return blocks, regulars
+
+
+# Status-bucket mapping per entity. Each entity's terminal-success / active
+# (in-progress) / blocked statuses go in their respective sets; statuses
+# absent from every set fall through to "neutral" (the not-started bucket).
+_StatusBucket = Literal["success", "active", "blocked", "neutral"]
+_STATUS_BUCKETS: dict[str, dict[_StatusBucket, set[str]]] = {
+    "purchase_order": {
+        "success": {"RECEIVED"},
+        "active": {"PARTIALLY_RECEIVED"},
+        "blocked": set(),
+        "neutral": set(),
+    },
+    "sales_order": {
+        "success": {"DELIVERED"},
+        "active": {"PARTIALLY_SHIPPED", "PACKED"},
+        "blocked": set(),
+        "neutral": set(),
+    },
+    "manufacturing_order": {
+        "success": {"DONE"},
+        "active": {"IN_PROGRESS", "PARTIALLY_COMPLETED"},
+        "blocked": {"BLOCKED"},
+        "neutral": set(),
+    },
+    "stock_transfer": {
+        "success": {"RECEIVED"},
+        "active": {"IN_TRANSIT"},
+        "blocked": set(),
+        "neutral": set(),
+    },
+}
+_BUCKET_TO_VARIANT: dict[_StatusBucket, str] = {
+    "success": "default",  # green — terminal happy path
+    "active": "secondary",  # gray — in progress
+    "blocked": "destructive",  # red — needs attention
+    "neutral": "outline",  # neutral — not yet started
+}
+
+
+def status_badge_variant(entity: str, status: str | None) -> str:
+    """Return the Prefab ``Badge`` variant string for an entity's status.
+
+    Generic buckets:
+    - ``default`` (green) — terminal-success states (PO RECEIVED, SO DELIVERED,
+      MO DONE).
+    - ``secondary`` (gray) — active / in-progress states (PARTIALLY_*, PACKED,
+      IN_PROGRESS).
+    - ``destructive`` (red) — blocked / problem states (MO BLOCKED).
+    - ``outline`` (neutral) — unstarted / unknown statuses (NOT_RECEIVED,
+      NOT_SHIPPED, NOT_STARTED, ``None``, unknown entity).
+
+    Used by every preview/apply card's Tier 1 status badge. Follow-up card
+    families extend ``_STATUS_BUCKETS`` with their entity's statuses.
+    """
+    if status is None:
+        return "outline"
+    buckets = _STATUS_BUCKETS.get(entity, {})
+    for bucket_name, members in buckets.items():
+        if status in members:
+            return _BUCKET_TO_VARIANT[bucket_name]
+    return "outline"
 
 
 # Coaching text appended to every preview-mode write tool's description.
@@ -342,8 +406,13 @@ def _build_apply_action_direct(
     on_success: list[Action] = [
         *(extra_on_success or []),
         SetState("pending", False),
-        SetState("applied", True),
+        # ``result`` MUST land before ``applied`` flips — the applied-state
+        # tree binds Buttons to ``{{ result.id }}`` / ``{{ result.katana_url }}``
+        # templates (see ``_render_preview_footer``). Setting ``applied=True``
+        # first would let the iframe render the morph with empty bindings
+        # before ``result`` arrives.
         SetState("result", RESULT),
+        SetState("applied", True),
         UpdateContext(content=RESULT),
     ]
     return [
@@ -1270,6 +1339,18 @@ def _format_cost(cost: float | int | None) -> str:
     return f"{cost:.2f}"
 
 
+def _iso_date_only(value: object) -> str:
+    """Trim a serialized ISO datetime to its ``YYYY-MM-DD`` prefix.
+
+    ``model_dump(mode="json")`` renders ``datetime`` fields as ISO strings.
+    The user-facing card surfaces them as dates; the time component is
+    noise.
+    """
+    if isinstance(value, str):
+        return value.split("T")[0]
+    return str(value)
+
+
 # Initial state slots written by the direct-apply rail's Confirm/Cancel
 # action chains. Builders that opt into the rail seed these to ``False`` /
 # ``None`` so the iframe's If/Elif blocks have something to bind to before
@@ -1562,224 +1643,439 @@ def build_stock_adjustment_delete_ui(
 # Order UIs (Preview + Created)
 # ============================================================================
 
-OrderType = Literal["Purchase Order", "Sales Order", "Manufacturing Order"]
+
+def _render_preview_header(
+    *,
+    title_prefix: str,
+    entity: str,
+    order_number: str,
+    status: str | None,
+    extra_badges: tuple[tuple[str, str], ...] = (),
+) -> None:
+    """Tier 1: CardHeader for a preview/apply card.
+
+    Renders the title (toggles ``"X Preview"`` ↔ ``"X Created"`` on
+    ``state.applied``), an order-number Badge, a PREVIEW/CREATED state
+    Badge (toggle on ``state.applied``), the entity status Badge with the
+    bucket-driven variant from ``status_badge_variant``, and any
+    caller-provided extras (e.g. ``[("outsourced", "outline")]`` for PO).
+
+    Must be called inside ``with PrefabApp(...) as app, Card():`` —
+    the helper does NOT open the Card; it only adds the CardHeader row.
+    """
+    with CardHeader(), Row(gap=2):
+        with If("applied"):
+            CardTitle(content=f"{title_prefix} Created")
+        with Else():
+            CardTitle(content=f"{title_prefix} Preview")
+        Badge(label=order_number, variant="outline")
+        with If("applied"):
+            Badge(label="CREATED", variant="default")
+        with Else():
+            Badge(label="PREVIEW", variant="secondary")
+        if status:
+            Badge(label=status, variant=status_badge_variant(entity, status))
+        for label, variant in extra_badges:
+            Badge(label=label, variant=variant)
+
+
+def _render_warnings_block(warnings: list[str] | None) -> list[str]:
+    """Render the warnings section of Tier 3 and return the block-warning list.
+
+    Block warnings render as destructive Badges (the ``BLOCK:`` prefix is
+    stripped); regular warnings render as secondary Badges. A ``Separator``
+    precedes the badges only when at least one warning exists.
+
+    Returns the unprefixed block-warning list so the caller can pass it to
+    ``_render_apply_button_row(disabled=bool(block_warnings))`` — block
+    warnings gate the Confirm button (and the Tier-4 message swaps from
+    "preview" to "cannot proceed" accordingly).
+
+    Must be called inside the ``CardContent`` column block.
+    """
+    block_warnings, regular_warnings = _split_warnings(warnings)
+    if block_warnings or regular_warnings:
+        Separator()
+        for w in block_warnings:
+            Badge(label=w, variant="destructive")
+        for w in regular_warnings:
+            Badge(label=w, variant="secondary")
+    return block_warnings
+
+
+def _render_preview_footer(
+    *,
+    title_prefix: str,
+    block_warnings: list[str],
+    confirm_label: str,
+    apply_action: list[Action] | None,
+    cancel_action: list[Action],
+    next_action_buttons: tuple[tuple[str, str], ...] = (),
+) -> None:
+    """Tier 4: CardFooter for a preview/apply card.
+
+    The applied-state View-in-Katana link and the per-entity next-action
+    SendMessage buttons bind to ``{{ result.<field> }}`` templates so they
+    work in both entry paths:
+
+    - In-place morph: the preview response has no ``id`` / ``katana_url``,
+      but the direct-apply rail's on_success chain writes the apply
+      response into ``state.result`` before flipping ``applied=True``, so
+      the buttons resolve correctly at render time.
+    - Standalone-applied (``is_preview=False``): :func:`_init_create_card_state`
+      pre-seeds ``state.result`` from the response, so the same templates
+      resolve there too.
+
+    The View-in-Katana button is gated by ``If("result.katana_url")`` so
+    it hides when the apply response carries no URL (defensive — every
+    create_* tool sets one today).
+
+    Must be called inside ``with PrefabApp(...) as app, Card():``.
+    """
+    with CardFooter(), Column(gap=2):
+        if block_warnings:
+            Muted(
+                content="Cannot proceed — see warnings above. No changes have been made."
+            )
+            _render_apply_button_row(
+                confirm_label=confirm_label,
+                apply_action=None,
+                cancel_action=cancel_action,
+                disabled=True,
+                direct_apply=True,
+            )
+            return
+        with If("applied"):
+            Muted(content=f"{title_prefix} created.")
+            with Row(gap=2):
+                with If("result.katana_url"):
+                    Button(
+                        label="View in Katana",
+                        variant="outline",
+                        on_click=OpenLink(url="{{ result.katana_url }}"),
+                    )
+                for label, send_text in next_action_buttons:
+                    Button(
+                        label=label,
+                        variant="outline",
+                        on_click=SendMessage(send_text),
+                    )
+        with Elif("error"):
+            Muted(content="Apply failed — see error above.")
+        with Elif("cancelled"):
+            Muted(content="Cancelled. No changes were made.")
+        with Else():
+            Muted(content="This is a preview. No changes have been made.")
+            _render_apply_button_row(
+                confirm_label=confirm_label,
+                apply_action=apply_action,
+                cancel_action=cancel_action,
+                direct_apply=True,
+            )
+
+
 ItemAction = Literal["Created", "Updated", "Deleted"]
 
 
-def _extract_order_fields(order: dict[str, Any]) -> dict[str, Any]:
-    """Extract common display fields from an order dict."""
-    total_cost = order.get("total_cost")
-    return {
-        "order_number": order.get("order_number") or order.get("order_no", "N/A"),
-        "order_id": order.get("id", "N/A"),
-        "total": total_cost if total_cost is not None else order.get("total"),
-        "currency": order.get("currency", "USD"),
-        "status": order.get("status", "CREATED"),
-    }
+def _init_create_card_state(response: dict[str, Any]) -> dict[str, Any]:
+    """Seed iframe state for a create card.
 
+    The direct-apply rail flips ``applied=True`` (and optionally
+    ``error="…"``) on Confirm success/failure; the in-place morph
+    re-renders the same Prefab tree against the new state. When the
+    response enters with ``is_preview=False`` (the standalone post-apply
+    path), we seed ``applied=True`` at construction time so the same
+    builder serves both entry paths.
 
-def _render_order_fields(order: dict[str, Any], *, total: Any, currency: str) -> None:
-    """Render shared order content fields (supplier/customer/location + total).
-
-    Prefers human-readable names when present (``customer_name``,
-    ``supplier_name``, ``location_name``) and falls back to bare IDs. If the
-    order dict carries a non-empty ``notes`` key, it renders below the entity
-    lines so the user can visually verify the value persisted on the apply
-    card — matching the preview's information density (#618). Today only
-    ``create_purchase_order``'s response model surfaces ``notes``; the other
-    order responses expose the field as ``additional_info`` and don't feed it
-    here, so the line is silently skipped for those tools.
+    ``state.result`` carries the apply-response data used by the
+    applied-state Buttons (``{{ result.katana_url }}`` etc.). On the
+    standalone-applied path we seed it from the response here; on the
+    in-place morph path the on_success chain in
+    :func:`_build_apply_action_direct` populates it via
+    ``SetState("result", RESULT)`` before flipping ``applied=True``.
     """
-    if total is not None:
-        Metric(label="Total", value=f"${total:,.2f} {currency}")
-
-    if order.get("supplier_id"):
-        name = order.get("supplier_name")
-        Text(
-            content=f"Supplier: {name} (ID: {order['supplier_id']})"
-            if name
-            else f"Supplier ID: {order['supplier_id']}"
-        )
-    if order.get("customer_id"):
-        name = order.get("customer_name")
-        Text(
-            content=f"Customer: {name} (ID: {order['customer_id']})"
-            if name
-            else f"Customer ID: {order['customer_id']}"
-        )
-    if order.get("location_id"):
-        name = order.get("location_name")
-        Text(
-            content=f"Location: {name} (ID: {order['location_id']})"
-            if name
-            else f"Location ID: {order['location_id']}"
-        )
-    if order.get("item_count") is not None:
-        Text(content=f"Items: {order['item_count']}")
-    notes = order.get("notes")
-    if notes:
-        Text(content=f"Notes: {notes}")
+    applied = not response.get("is_preview", True)
+    state: dict[str, Any] = {
+        "applied": applied,
+        "pending": False,
+        "cancelled": False,
+        "error": None,
+    }
+    if applied:
+        state["result"] = response
+    return state
 
 
-def build_order_preview_ui(
-    order: dict[str, Any],
-    order_type: OrderType,
+def _render_party_line(
+    label: str,
+    *,
+    name: str | None,
+    entity_id: int | None,
+    entity_kind: EntityKind | None = None,
+) -> None:
+    """Render a 'Supplier:' / 'Customer:' / 'Location:' line.
+
+    When ``entity_kind`` resolves to a Katana web URL and a ``name`` is
+    present, renders ``<label>: <Link name>`` so users can click through
+    to the source-of-truth entity (mirrors the variant card's parent and
+    default-supplier link pattern; matches this module's "Link Katana
+    entities wherever possible" convention). Falls back to plain text
+    otherwise. Skips entirely when ``entity_id`` is None.
+    """
+    if entity_id is None:
+        return
+    url = katana_web_url(entity_kind, entity_id) if entity_kind else None
+    if name and url:
+        with Row(gap=1):
+            Text(content=f"{label}:")
+            Link(content=name, href=url, target="_blank")
+    elif name:
+        Text(content=f"{label}: {name} (ID: {entity_id})")
+    else:
+        Text(content=f"{label} ID: {entity_id}")
+
+
+def build_po_create_ui(
+    response: dict[str, Any],
     *,
     confirm_request: BaseModel,
     confirm_tool: str,
-    direct_apply: bool = False,
 ) -> PrefabApp:
-    """Build an order preview card with confirm/cancel buttons.
+    """Build the create-purchase-order card. Handles both preview
+    (``is_preview=True`` → PREVIEW Badge + Confirm/Cancel + direct-apply
+    morph) and applied (``is_preview=False`` → CREATED Badge + View in
+    Katana + next-action buttons) states. Reads
+    ``PurchaseOrderResponse.model_dump()`` directly.
 
-    Pass the original Pydantic ``confirm_request`` and matching
-    ``confirm_tool`` name. Two apply rails:
-
-    - ``direct_apply=False`` (default) — Confirm fires a SendMessage chat
-      hint and the agent re-issues the call. See ADR-0015.
-    - ``direct_apply=True`` — Confirm fires ``tools/call`` directly, the
-      iframe morphs in place to a result view, and the structured response
-      is pushed to the agent via ``ui/update-model-context``. See ADR-0016
-      (forthcoming). Currently opted into by ``create_purchase_order``;
-      rolling out across the rest of the write tools after Cowork
-      verification.
+    Four-tier framework (#537):
+    - Tier 1 — Identity: title, order_number badge, PREVIEW/CREATED state
+      badge, status badge, entity_type badge (regular/outsourced).
+    - Tier 2 — Decision metrics: Total ($X.XX <currency>), Line Items.
+    - Tier 3 — Reference: supplier, location, notes, plus warnings.
+    - Tier 4 — Actions: Confirm + Cancel via the direct-apply rail
+      (Confirm fires ``tools/call`` directly and pushes the structured
+      apply response back via ``ui/update-model-context``); applied state
+      surfaces View in Katana + Receive Items + Verify Document buttons.
     """
-    fields = _extract_order_fields(order)
-    apply_action: list[Action] | CallTool | None
-    if direct_apply:
-        apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
-    else:
-        apply_action = _build_apply_action(confirm_tool, confirm_request)
-    cancel_action = _build_cancel_action(f"that {order_type.lower()}")
-    state: dict[str, Any] = {"order": order, "pending": False, "cancelled": False}
-    if direct_apply:
-        # Initial state for the morph; on apply success the iframe sets
-        # `applied=True` and stashes the structured response in `result`.
-        state["applied"] = False
-        state["error"] = None
-        state["result"] = None
+    order_number = response.get("order_number") or "N/A"
+    status = response.get("status")
+    entity_type = response.get("entity_type")
+    total_cost = response.get("total_cost")
+    currency = response.get("currency") or "USD"
+    item_count = response.get("item_count")
 
-    with PrefabApp(state=state, css_class="p-4") as app, Card():
-        with CardHeader(), Row(gap=2):
-            CardTitle(content=f"{order_type} Preview")
-            Badge(label=fields["order_number"], variant="outline")
-            Badge(label="PREVIEW", variant="secondary")
+    apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    cancel_action = _build_cancel_action("that purchase order")
+    extra_badges: tuple[tuple[str, str], ...] = (
+        ((entity_type, "outline"),) if entity_type and entity_type != "regular" else ()
+    )
 
+    with (
+        PrefabApp(state=_init_create_card_state(response), css_class="p-4") as app,
+        Card(),
+    ):
+        _render_preview_header(
+            title_prefix="Purchase Order",
+            entity="purchase_order",
+            order_number=order_number,
+            status=status,
+            extra_badges=extra_badges,
+        )
         with CardContent(), Column(gap=3):
-            _render_order_fields(
-                order, total=fields["total"], currency=fields["currency"]
+            if total_cost is not None or item_count is not None:
+                with Row(gap=4):
+                    if total_cost is not None:
+                        Metric(label="Total", value=f"${total_cost:,.2f} {currency}")
+                    if item_count is not None:
+                        Metric(label="Line Items", value=str(item_count))
+            _render_party_line(
+                "Supplier",
+                name=response.get("supplier_name"),
+                entity_id=response.get("supplier_id"),
+                entity_kind="supplier",
             )
-            if order.get("variant_id"):
-                Text(content=f"Variant ID: {order['variant_id']}")
-            if order.get("planned_quantity"):
-                Text(content=f"Planned Quantity: {order['planned_quantity']}")
-
-            block_warnings, regular_warnings = _split_warnings(order.get("warnings"))
-            if block_warnings or regular_warnings:
-                Separator()
-                for warning in block_warnings:
-                    Badge(label=warning, variant="destructive")
-                for warning in regular_warnings:
-                    Badge(label=warning, variant="secondary")
-
-            if direct_apply:
-                # Direct-apply morph: success/error blocks render in place
-                # of the preview footer messaging when the iframe state
-                # flips. The agent has already received the structured
-                # result via ui/update-model-context — these blocks are
-                # for the user, not the agent.
-                with If("applied"):
-                    Separator()
-                    Text(content=f"{order_type} created.")
-                    Muted(
-                        content=(
-                            "The structured result has been pushed to the "
-                            "assistant's context."
-                        )
-                    )
-                with Elif("error"):
-                    Separator()
-                    with Alert(variant="destructive", icon="circle-alert"):
-                        AlertTitle(content="Apply failed")
-                        AlertDescription(content="{{ error }}")
-
-        with CardFooter():
-            if block_warnings:
-                Muted(
-                    content="Cannot proceed — see warnings above. No changes have been made."
-                )
-            elif direct_apply:
-                # Footer message tracks the iframe state — once applied or
-                # errored, "This is a preview" is no longer true and would
-                # confuse the user.
-                with If("applied"):
-                    Muted(content=f"{order_type} created.")
-                with Elif("error"):
-                    Muted(content="Apply failed — see error above.")
-                with Elif("cancelled"):
-                    Muted(content="Cancelled. No changes were made.")
-                with Else():
-                    Muted(content="This is a preview. No changes have been made.")
-            else:
-                Muted(content="This is a preview. No changes have been made.")
-
-            _render_apply_button_row(
-                confirm_label=f"Confirm & Create {order_type}",
-                apply_action=apply_action,
-                cancel_action=cancel_action,
-                disabled=bool(block_warnings),
-                direct_apply=direct_apply,
+            _render_party_line(
+                "Location",
+                name=response.get("location_name"),
+                entity_id=response.get("location_id"),
             )
+            notes = response.get("notes")
+            if notes:
+                Text(content=f"Notes: {notes}")
+            block_warnings = _render_warnings_block(response.get("warnings"))
+        _render_preview_footer(
+            title_prefix="Purchase Order",
+            block_warnings=block_warnings,
+            confirm_label="Confirm & Create Purchase Order",
+            apply_action=apply_action,
+            cancel_action=cancel_action,
+            next_action_buttons=(
+                (
+                    "Receive Items",
+                    "Receive items for purchase order {{ result.id }}",
+                ),
+                (
+                    "Verify Document",
+                    "Verify a supplier document against PO {{ result.id }}",
+                ),
+            ),
+        )
     return app
 
 
-def build_order_created_ui(
-    order: dict[str, Any],
-    order_type: OrderType,
+def build_so_create_ui(
+    response: dict[str, Any],
+    *,
+    confirm_request: BaseModel,
+    confirm_tool: str,
 ) -> PrefabApp:
-    """Build a success card for a created order."""
-    fields = _extract_order_fields(order)
-    order_id = fields["order_id"]
+    """Build the create-sales-order card. Handles both preview and
+    applied states (see ``build_po_create_ui`` for the dual-state shape).
+    Reads ``SalesOrderResponse.model_dump()`` directly.
 
-    with PrefabApp(state={"order": order}, css_class="p-4") as app, Card():
-        with CardHeader(), Row(gap=2):
-            CardTitle(content=f"{order_type} Created")
-            Badge(label=fields["order_number"], variant="outline")
-            Badge(label=fields["status"], variant="default")
+    Four-tier content:
+    - Tier 1: title, order_number, PREVIEW/CREATED, status (variant from
+      ``status_badge_variant("sales_order", status)``).
+    - Tier 2: Total, Line Items, Delivery date.
+    - Tier 3: customer, location (ID-only — SO response has no
+      ``location_name``), warnings.
+    - Tier 4: Confirm/Cancel (preview) or View in Katana + Fulfill Order
+      (applied).
+    """
+    order_number = response.get("order_number") or "N/A"
+    status = response.get("status")
+    total = response.get("total")
+    currency = response.get("currency") or "USD"
+    item_count = response.get("item_count")
+    delivery_date = response.get("delivery_date")
 
-        with CardContent(), Column(gap=2):
-            Text(content=f"Order ID: {order_id}")
-            _render_order_fields(
-                order, total=fields["total"], currency=fields["currency"]
+    apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    cancel_action = _build_cancel_action("that sales order")
+
+    with (
+        PrefabApp(state=_init_create_card_state(response), css_class="p-4") as app,
+        Card(),
+    ):
+        _render_preview_header(
+            title_prefix="Sales Order",
+            entity="sales_order",
+            order_number=order_number,
+            status=status,
+        )
+        with CardContent(), Column(gap=3):
+            if total is not None or item_count is not None or delivery_date:
+                with Row(gap=4):
+                    if total is not None:
+                        Metric(label="Total", value=f"${total:,.2f} {currency}")
+                    if item_count is not None:
+                        Metric(label="Line Items", value=str(item_count))
+                    if delivery_date:
+                        Metric(label="Delivery", value=str(delivery_date))
+            _render_party_line(
+                "Customer",
+                name=response.get("customer_name"),
+                entity_id=response.get("customer_id"),
+                entity_kind="customer",
             )
+            _render_party_line(
+                "Location",
+                name=None,  # SalesOrderResponse has no location_name
+                entity_id=response.get("location_id"),
+            )
+            block_warnings = _render_warnings_block(response.get("warnings"))
+        _render_preview_footer(
+            title_prefix="Sales Order",
+            block_warnings=block_warnings,
+            confirm_label="Confirm & Create Sales Order",
+            apply_action=apply_action,
+            cancel_action=cancel_action,
+            next_action_buttons=(
+                ("Fulfill Order", "Fulfill sales order {{ result.id }}"),
+            ),
+        )
+    return app
 
-        with CardFooter(), Row(gap=2):
-            if order_type == "Purchase Order":
-                Button(
-                    label="Receive Items",
-                    variant="outline",
-                    on_click=SendMessage(
-                        f"Receive items for purchase order {order_id}"
-                    ),
-                )
-                Button(
-                    label="Verify Document",
-                    variant="outline",
-                    on_click=SendMessage(
-                        f"Verify a supplier document against PO {order_id}"
-                    ),
-                )
-            elif order_type == "Sales Order":
-                Button(
-                    label="Fulfill Order",
-                    variant="outline",
-                    on_click=SendMessage(f"Fulfill sales order {order_id}"),
-                )
-            elif order_type == "Manufacturing Order":
-                Button(
-                    label="Complete Order",
-                    variant="outline",
-                    on_click=SendMessage(f"Complete manufacturing order {order_id}"),
-                )
+
+def build_mo_create_ui(
+    response: dict[str, Any],
+    *,
+    confirm_request: BaseModel,
+    confirm_tool: str,
+) -> PrefabApp:
+    """Build the create-manufacturing-order card. Handles both preview and
+    applied states. Reads ``ManufacturingOrderResponse.model_dump()`` —
+    note that MO uses ``order_no`` (NOT ``order_number``) and
+    ``additional_info`` (NOT ``notes``).
+
+    Four-tier content:
+    - Tier 1: title, order_no badge, PREVIEW/CREATED, status (variant from
+      ``status_badge_variant("manufacturing_order", status)``).
+    - Tier 2: Planned Qty, Deadline.
+    - Tier 3: variant (sku + id), location ID, created date, notes
+      (additional_info), warnings.
+    - Tier 4: Confirm/Cancel (preview) or View in Katana + Complete Order
+      (applied).
+    """
+    order_number = response.get("order_no") or "N/A"
+    status = response.get("status")
+    variant_id = response.get("variant_id")
+    sku = response.get("sku")
+    planned_quantity = response.get("planned_quantity")
+    location_id = response.get("location_id")
+    order_created_date = response.get("order_created_date")
+    production_deadline_date = response.get("production_deadline_date")
+    additional_info = response.get("additional_info")
+
+    apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    cancel_action = _build_cancel_action("that manufacturing order")
+
+    with (
+        PrefabApp(state=_init_create_card_state(response), css_class="p-4") as app,
+        Card(),
+    ):
+        _render_preview_header(
+            title_prefix="Manufacturing Order",
+            entity="manufacturing_order",
+            order_number=order_number,
+            status=status,
+        )
+        with CardContent(), Column(gap=3):
+            if planned_quantity is not None or production_deadline_date:
+                with Row(gap=4):
+                    if planned_quantity is not None:
+                        Metric(label="Planned Qty", value=str(planned_quantity))
+                    if production_deadline_date:
+                        Metric(
+                            label="Deadline",
+                            value=_iso_date_only(production_deadline_date),
+                        )
+            if variant_id is not None or sku:
+                if sku and variant_id is not None:
+                    Text(content=f"Variant: {sku} (ID: {variant_id})")
+                elif sku:
+                    Text(content=f"Variant: {sku}")
+                else:
+                    Text(content=f"Variant ID: {variant_id}")
+            if location_id is not None:
+                Text(content=f"Location ID: {location_id}")
+            if order_created_date:
+                Text(content=f"Created: {_iso_date_only(order_created_date)}")
+            if additional_info:
+                Text(content=f"Notes: {additional_info}")
+            block_warnings = _render_warnings_block(response.get("warnings"))
+        _render_preview_footer(
+            title_prefix="Manufacturing Order",
+            block_warnings=block_warnings,
+            confirm_label="Confirm & Create Manufacturing Order",
+            apply_action=apply_action,
+            cancel_action=cancel_action,
+            next_action_buttons=(
+                (
+                    "Complete Order",
+                    "Complete manufacturing order {{ result.id }}",
+                ),
+            ),
+        )
     return app
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
+++ b/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
@@ -330,29 +330,6 @@ async def none_coro() -> None:
     return None
 
 
-def format_md_table(
-    headers: list[str],
-    rows: list[list[Any]],
-) -> str:
-    """Format a simple markdown table from headers and row data.
-
-    Each row cell is rendered via str(); use "—" or "" for missing values.
-    Returns an empty string if `rows` is empty.
-
-    Example:
-        format_md_table(
-            ["Name", "Qty"],
-            [["Apple", 3], ["Banana", 5]],
-        )
-    """
-    if not rows:
-        return ""
-    header_line = "| " + " | ".join(headers) + " |"
-    sep_line = "|" + "|".join("---" for _ in headers) + "|"
-    body_lines = ["| " + " | ".join(str(cell) for cell in row) + " |" for row in rows]
-    return "\n".join([header_line, sep_line, *body_lines])
-
-
 def make_tool_result(response: BaseModel, *, ui: PrefabApp) -> ToolResult:
     """Create a ToolResult for a UI-emitting tool.
 
@@ -375,22 +352,31 @@ def make_tool_result(response: BaseModel, *, ui: PrefabApp) -> ToolResult:
     )
 
 
-def make_simple_result(
-    message: str,
-    structured_data: dict[str, Any] | None = None,
-) -> ToolResult:
-    """Create a simple ToolResult with a message.
+def make_json_result(response: BaseModel) -> ToolResult:
+    """Create a ToolResult for a tool with no Prefab UI.
 
-    For simple responses where a full template isn't needed.
+    Use this for tools whose response is purely data — no rich card layer.
+    Sibling of ``make_tool_result(response, ui=...)`` (which handles the
+    UI-emitting case). Historical context: these tools used to maintain a
+    parallel hand-written markdown ``content`` channel plus a
+    ``format: Literal["markdown", "json"]`` parameter; both were dropped
+    in #567 in favor of JSON content matching the MCP-Apps reference
+    servers and structurally eliminating the drift surface (#565).
 
-    Args:
-        message: The message to display
-        structured_data: Optional structured data dict
+    ``content`` carries the response as ``indent=2`` JSON for LLM context
+    and eyeball-debug. ``structured_content`` carries the same payload as
+    a plain dict so programmatic consumers can branch on response shape
+    without re-parsing the content text.
 
-    Returns:
-        ToolResult with message as content
+    **Shape contrast with ``make_tool_result``**: ``make_tool_result``
+    emits the response as compact JSON content (no indent) and puts the
+    ``PrefabApp`` envelope in ``structured_content`` for UI-Apps hosts to
+    render. The two helpers differ in both the ``content`` formatting
+    and the ``structured_content`` payload type, so don't assume the
+    helpers are interchangeable when migrating between UI and non-UI
+    tools.
     """
     return ToolResult(
-        content=message,
-        structured_content=structured_data or {},
+        content=response.model_dump_json(indent=2),
+        structured_content=response.model_dump(mode="json"),
     )

--- a/katana_mcp_server/tests/test_mcp_parameter_passing.py
+++ b/katana_mcp_server/tests/test_mcp_parameter_passing.py
@@ -83,19 +83,20 @@ class TestMCPParameterPassing:
 
         This test verifies that the Unpack decorator successfully transforms the
         signature from nested request objects to individual flat parameters.
+        The ``format`` parameter (markdown/json) was dropped repo-wide in
+        #567 — tools now return JSON content unconditionally.
         """
         # Check list_low_stock_items signature
         sig = inspect.signature(list_low_stock_items)
         params = list(sig.parameters.keys())
 
-        assert params == ["threshold", "limit", "format", "context"], (
-            "list_low_stock_items has flattened params: threshold, limit, format, context"
+        assert params == ["threshold", "limit", "context"], (
+            "list_low_stock_items has flattened params: threshold, limit, context"
         )
         assert sig.parameters["threshold"].annotation is int
         assert sig.parameters["limit"].annotation is int
         assert sig.parameters["threshold"].default == 10
         assert sig.parameters["limit"].default == 50
-        assert sig.parameters["format"].default == "markdown"
 
         # Check check_inventory signature
         sig2 = inspect.signature(check_inventory)
@@ -104,17 +105,15 @@ class TestMCPParameterPassing:
         assert params2 == [
             "skus_or_variant_ids",
             "location_id",
-            "format",
             "context",
         ], (
             "check_inventory has flattened params: "
-            "skus_or_variant_ids, location_id, format, context"
+            "skus_or_variant_ids, location_id, context"
         )
         # skus_or_variant_ids is required (no default) so the MCP schema marks
         # it required; the min_length=1 Pydantic constraint also rejects [].
         assert sig2.parameters["skus_or_variant_ids"].default is inspect.Parameter.empty
         assert sig2.parameters["location_id"].default is None
-        assert sig2.parameters["format"].default == "markdown"
         from katana_mcp.tools.foundation.inventory import CheckInventoryRequest
         from pydantic import ValidationError as PydanticValidationError
 

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 from katana_mcp.tools.prefab_ui import (
@@ -22,14 +22,16 @@ from katana_mcp.tools.prefab_ui import (
     build_item_detail_ui,
     build_item_mutation_ui,
     build_low_stock_ui,
+    build_mo_create_ui,
     build_modification_preview_ui,
     build_modification_result_ui,
-    build_order_created_ui,
-    build_order_preview_ui,
+    build_po_create_ui,
     build_receipt_ui,
     build_search_results_ui,
+    build_so_create_ui,
     build_variant_details_ui,
     build_verification_ui,
+    status_badge_variant,
     with_preview_coaching,
 )
 from prefab_ui.app import PrefabApp
@@ -989,52 +991,305 @@ class TestBuildLowStockUI:
         )
 
 
-class TestBuildOrderPreviewUI:
-    def test_purchase_order(self):
-        order = {
-            "order_number": "PO-001",
-            "status": "PENDING",
-            "supplier_id": 1,
-            "location_id": 2,
-            "total": 1500.0,
-            "currency": "USD",
-        }
-        app = build_order_preview_ui(
-            order,
-            "Purchase Order",
+class TestBuildPOCreateUI:
+    """``build_po_create_ui`` handles both preview and applied states for
+    create_purchase_order. Each test below pins one state's smoke
+    properties; the dual-state nature of the builder means the same
+    Prefab tree handles both — only the initial ``state.applied`` flag
+    seeded in ``_init_create_card_state`` differs."""
+
+    # Preview-shaped fixture: matches what ``_create_purchase_order_impl``
+    # returns on the preview branch — no ``id``, no ``katana_url`` (those
+    # only exist after Katana assigns an ID on apply). Applied-state tests
+    # below merge in ``id`` / ``katana_url`` / ``is_preview=False``.
+    _PO_RESPONSE: ClassVar[dict[str, Any]] = {
+        "order_number": "PO-001",
+        "supplier_id": 1,
+        "supplier_name": "Acme",
+        "location_id": 2,
+        "location_name": "Brooklyn",
+        "status": "NOT_RECEIVED",
+        "entity_type": "regular",
+        "total_cost": 1500.0,
+        "currency": "USD",
+        "item_count": 3,
+        "notes": "Rush order",
+        "is_preview": True,
+        "warnings": [],
+        "next_actions": [],
+        "message": "Preview",
+    }
+
+    _PO_APPLIED: ClassVar[dict[str, Any]] = {
+        "id": 12345,
+        "katana_url": "https://factory.katanamrp.com/purchaseorder/12345",
+        "is_preview": False,
+    }
+
+    def test_smoke_preview(self):
+        app = build_po_create_ui(
+            dict(self._PO_RESPONSE),
             confirm_request=_StubRequest(),
             confirm_tool="create_purchase_order",
         )
         _assert_valid_prefab(app)
 
-    def test_sales_order(self):
-        order = {
-            "order_number": "SO-001",
-            "status": "PENDING",
-            "customer_id": 1,
-            "total": 500.0,
-            "currency": "EUR",
-        }
-        app = build_order_preview_ui(
+    def test_smoke_applied(self):
+        order = dict(self._PO_RESPONSE, **self._PO_APPLIED)
+        app = build_po_create_ui(
             order,
-            "Sales Order",
+            confirm_request=_StubRequest(),
+            confirm_tool="create_purchase_order",
+        )
+        _assert_valid_prefab(app)
+        assert app.state is not None
+        assert app.state["applied"] is True
+
+    def test_preview_state_seeds_applied_false(self):
+        app = build_po_create_ui(
+            dict(self._PO_RESPONSE),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_purchase_order",
+        )
+        assert app.state is not None
+        assert app.state["applied"] is False
+
+    def test_applied_state_seeds_result_from_response(self):
+        """The standalone-applied entry path seeds ``state.result`` from
+        the response so the applied-state Buttons (which bind to
+        ``{{ result.id }}`` and ``{{ result.katana_url }}``) resolve. On
+        the in-place morph path, the on_success chain in
+        ``_build_apply_action_direct`` writes the same key."""
+        order = dict(self._PO_RESPONSE, **self._PO_APPLIED)
+        app = build_po_create_ui(
+            order,
+            confirm_request=_StubRequest(),
+            confirm_tool="create_purchase_order",
+        )
+        assert app.state is not None
+        result = app.state.get("result")
+        assert isinstance(result, dict)
+        assert result["id"] == 12345
+        assert (
+            result["katana_url"] == "https://factory.katanamrp.com/purchaseorder/12345"
+        )
+
+    def test_applied_buttons_bind_to_result_template(self):
+        """Applied-state Buttons must use ``{{ result.X }}`` interpolation,
+        not Python f-strings — the preview-branch response has no ``id`` /
+        ``katana_url``, so f-strings would bake ``None`` into the closure
+        and render an empty button row after the in-place morph fires.
+        """
+        app = build_po_create_ui(
+            dict(self._PO_RESPONSE),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_purchase_order",
+        )
+        rendered = str(app.to_json())
+        assert "{{ result.id }}" in rendered
+        assert "{{ result.katana_url }}" in rendered
+        # And the f-string-interpolated literal must NOT appear — a regression
+        # would re-introduce "Receive items for purchase order None".
+        assert "purchase order None" not in rendered
+
+    def test_outsourced_entity_type_renders_extra_badge(self):
+        order = dict(self._PO_RESPONSE, entity_type="outsourced")
+        app = build_po_create_ui(
+            order,
+            confirm_request=_StubRequest(),
+            confirm_tool="create_purchase_order",
+        )
+        rendered = str(app.to_json())
+        assert "outsourced" in rendered
+
+    def test_supplier_renders_as_link_to_katana(self):
+        app = build_po_create_ui(
+            dict(self._PO_RESPONSE),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_purchase_order",
+        )
+        rendered = str(app.to_json())
+        # Supplier name surfaces inside a Link, with href pointing at the
+        # Katana supplier page — matches the module's "link Katana
+        # entities wherever possible" convention.
+        assert "/contacts/suppliers/1" in rendered
+        assert "Acme" in rendered
+
+
+class TestBuildSOCreateUI:
+    """``build_so_create_ui`` — same dual-state shape as PO; SO response
+    has no ``location_name`` or ``notes`` and adds ``delivery_date``."""
+
+    _SO_RESPONSE: ClassVar[dict[str, Any]] = {
+        "order_number": "SO-001",
+        "customer_id": 1,
+        "customer_name": "Buyer Co",
+        "location_id": 2,
+        "status": "NOT_SHIPPED",
+        "total": 500.0,
+        "currency": "EUR",
+        "delivery_date": "2026-06-01",
+        "item_count": 2,
+        "is_preview": True,
+        "warnings": [],
+        "next_actions": [],
+        "message": "Preview",
+    }
+
+    _SO_APPLIED: ClassVar[dict[str, Any]] = {
+        "id": 12346,
+        "katana_url": "https://factory.katanamrp.com/salesorder/12346",
+        "is_preview": False,
+    }
+
+    def test_smoke_preview(self):
+        app = build_so_create_ui(
+            dict(self._SO_RESPONSE),
             confirm_request=_StubRequest(),
             confirm_tool="create_sales_order",
         )
         _assert_valid_prefab(app)
 
-
-class TestBuildOrderCreatedUI:
-    def test_created(self):
-        order = {
-            "order_number": "PO-001",
-            "order_id": 123,
-            "status": "OPEN",
-            "total": 1500.0,
-            "currency": "USD",
-        }
-        app = build_order_created_ui(order, "Purchase Order")
+    def test_smoke_applied(self):
+        order = dict(self._SO_RESPONSE, **self._SO_APPLIED)
+        app = build_so_create_ui(
+            order,
+            confirm_request=_StubRequest(),
+            confirm_tool="create_sales_order",
+        )
         _assert_valid_prefab(app)
+        assert app.state is not None
+        assert app.state["applied"] is True
+        result = app.state.get("result")
+        assert isinstance(result, dict)
+        assert result["id"] == 12346
+
+    def test_renders_delivery_date_metric(self):
+        app = build_so_create_ui(
+            dict(self._SO_RESPONSE),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_sales_order",
+        )
+        rendered = str(app.to_json())
+        assert "2026-06-01" in rendered
+
+    def test_customer_renders_as_link_to_katana(self):
+        app = build_so_create_ui(
+            dict(self._SO_RESPONSE),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_sales_order",
+        )
+        rendered = str(app.to_json())
+        assert "/contacts/customers/1" in rendered
+        assert "Buyer Co" in rendered
+
+
+class TestBuildMOCreateUI:
+    """``build_mo_create_ui`` — MO response uses ``order_no`` (not
+    ``order_number``) and ``additional_info`` (not ``notes``)."""
+
+    _MO_RESPONSE: ClassVar[dict[str, Any]] = {
+        "order_no": "MO-001",
+        "variant_id": 555,
+        "sku": "WIDGET-42",
+        "planned_quantity": 100.0,
+        "location_id": 2,
+        "status": "NOT_STARTED",
+        "order_created_date": "2026-05-13T10:00:00+00:00",
+        "production_deadline_date": "2026-06-01T17:00:00+00:00",
+        "additional_info": "Priority run",
+        "is_preview": True,
+        "warnings": [],
+        "next_actions": [],
+        "message": "Preview",
+    }
+
+    _MO_APPLIED: ClassVar[dict[str, Any]] = {
+        "id": 12347,
+        "katana_url": "https://factory.katanamrp.com/manufacturingorder/12347",
+        "is_preview": False,
+    }
+
+    def test_smoke_preview(self):
+        app = build_mo_create_ui(
+            dict(self._MO_RESPONSE),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_manufacturing_order",
+        )
+        _assert_valid_prefab(app)
+
+    def test_smoke_applied(self):
+        order = dict(self._MO_RESPONSE, **self._MO_APPLIED)
+        app = build_mo_create_ui(
+            order,
+            confirm_request=_StubRequest(),
+            confirm_tool="create_manufacturing_order",
+        )
+        _assert_valid_prefab(app)
+        assert app.state is not None
+        assert app.state["applied"] is True
+        result = app.state.get("result")
+        assert isinstance(result, dict)
+        assert result["id"] == 12347
+
+    def test_renders_variant_and_deadline(self):
+        app = build_mo_create_ui(
+            dict(self._MO_RESPONSE),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_manufacturing_order",
+        )
+        rendered = str(app.to_json())
+        # MO carries the variant in tier 3 as "Variant: WIDGET-42 (ID: 555)"
+        assert "WIDGET-42" in rendered
+        assert "555" in rendered
+        # Deadline metric uses the date portion only.
+        assert "2026-06-01" in rendered
+
+    def test_uses_order_no_field_not_order_number(self):
+        """MO response uses ``order_no``; verify the badge reads that
+        (not ``order_number`` which doesn't exist on MO response)."""
+        app = build_mo_create_ui(
+            dict(self._MO_RESPONSE),
+            confirm_request=_StubRequest(),
+            confirm_tool="create_manufacturing_order",
+        )
+        rendered = str(app.to_json())
+        assert "MO-001" in rendered
+
+
+class TestStatusBadgeVariant:
+    """``status_badge_variant`` buckets each entity's status into one of
+    four Prefab Badge variants. Pins the per-entity mapping so a future
+    contributor adding a new entity can't accidentally collapse the
+    success/active/blocked distinctions."""
+
+    @pytest.mark.parametrize(
+        "entity,status,expected",
+        [
+            # success bucket
+            ("purchase_order", "RECEIVED", "default"),
+            ("sales_order", "DELIVERED", "default"),
+            ("manufacturing_order", "DONE", "default"),
+            ("stock_transfer", "RECEIVED", "default"),
+            # active bucket
+            ("purchase_order", "PARTIALLY_RECEIVED", "secondary"),
+            ("sales_order", "PARTIALLY_SHIPPED", "secondary"),
+            ("sales_order", "PACKED", "secondary"),
+            ("manufacturing_order", "IN_PROGRESS", "secondary"),
+            ("manufacturing_order", "PARTIALLY_COMPLETED", "secondary"),
+            ("stock_transfer", "IN_TRANSIT", "secondary"),
+            # blocked bucket — only MO has one today
+            ("manufacturing_order", "BLOCKED", "destructive"),
+            # neutral bucket (unstarted statuses + None + unknown entity)
+            ("purchase_order", "NOT_RECEIVED", "outline"),
+            ("sales_order", "NOT_SHIPPED", "outline"),
+            ("manufacturing_order", "NOT_STARTED", "outline"),
+            ("purchase_order", None, "outline"),
+            ("unknown_entity", "WHATEVER", "outline"),
+        ],
+    )
+    def test_bucket_lookup(self, entity, status, expected):
+        assert status_badge_variant(entity, status) == expected
 
 
 class TestBuildFulfillPreviewUI:
@@ -1426,42 +1681,6 @@ class TestConfirmButtonEmitsApplyMessage:
         )
         return apply_msgs[0]
 
-    def test_order_preview_confirm_emits_apply_send_message(self):
-        from katana_mcp.tools.foundation.purchase_orders import (
-            CreatePurchaseOrderRequest,
-            PurchaseOrderItem,
-        )
-
-        request = CreatePurchaseOrderRequest(
-            supplier_id=2,
-            location_id=3,
-            order_number="PO-1",
-            items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
-        )
-        app = build_order_preview_ui(
-            {
-                "id": 1,
-                "order_number": "PO-1",
-                "supplier_id": 2,
-                "location_id": 3,
-                "status": "NOT_RECEIVED",
-                "warnings": [],
-            },
-            "Purchase Order",
-            confirm_request=request,
-            confirm_tool="create_purchase_order",
-        )
-        envelope = app.to_json()
-
-        on_click = _confirm_button_on_click(envelope, "Confirm & Create Purchase Order")
-        msg = self._assert_apply_actions(on_click, "create_purchase_order")
-        # Args inlined into the SendMessage text so the agent re-issues
-        # with the exact preview values; preview=False is overridden last
-        # so the apply path is selected.
-        assert "supplier_id=2" in msg["content"]
-        assert "location_id=3" in msg["content"]
-        assert "preview=False" in msg["content"]
-
     def test_fulfill_preview_confirm_emits_apply_send_message(self):
         app = build_fulfill_preview_ui(
             {
@@ -1593,7 +1812,7 @@ class TestConfirmButtonDirectApplyRail:
             order_number="PO-1",
             items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
         )
-        app = build_order_preview_ui(
+        app = build_po_create_ui(
             {
                 "id": 1,
                 "order_number": "PO-1",
@@ -1602,10 +1821,8 @@ class TestConfirmButtonDirectApplyRail:
                 "status": "NOT_RECEIVED",
                 "warnings": [],
             },
-            "Purchase Order",
             confirm_request=request,
             confirm_tool="create_purchase_order",
-            direct_apply=True,
         )
         envelope = app.to_json()
         on_click = self._confirm_action(envelope, "Confirm & Create Purchase Order")
@@ -1638,7 +1855,7 @@ class TestConfirmButtonDirectApplyRail:
             order_number="PO-1",
             items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
         )
-        app = build_order_preview_ui(
+        app = build_po_create_ui(
             {
                 "id": 1,
                 "order_number": "PO-1",
@@ -1647,10 +1864,8 @@ class TestConfirmButtonDirectApplyRail:
                 "status": "NOT_RECEIVED",
                 "warnings": [],
             },
-            "Purchase Order",
             confirm_request=request,
             confirm_tool="create_purchase_order",
-            direct_apply=True,
         )
         envelope = app.to_json()
         on_click = self._confirm_action(envelope, "Confirm & Create Purchase Order")
@@ -1692,7 +1907,7 @@ class TestConfirmButtonDirectApplyRail:
             order_number="PO-1",
             items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
         )
-        app = build_order_preview_ui(
+        app = build_po_create_ui(
             {
                 "id": 1,
                 "order_number": "PO-1",
@@ -1701,10 +1916,8 @@ class TestConfirmButtonDirectApplyRail:
                 "status": "NOT_RECEIVED",
                 "warnings": [],
             },
-            "Purchase Order",
             confirm_request=request,
             confirm_tool="create_purchase_order",
-            direct_apply=True,
         )
         envelope = app.to_json()
         on_click = self._confirm_action(envelope, "Confirm & Create Purchase Order")
@@ -1746,7 +1959,7 @@ class TestConfirmButtonDirectApplyRail:
             order_number="PO-1",
             items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
         )
-        app = build_order_preview_ui(
+        app = build_po_create_ui(
             {
                 "id": 1,
                 "order_number": "PO-1",
@@ -1755,10 +1968,8 @@ class TestConfirmButtonDirectApplyRail:
                 "status": "NOT_RECEIVED",
                 "warnings": [],
             },
-            "Purchase Order",
             confirm_request=request,
             confirm_tool="create_purchase_order",
-            direct_apply=True,
         )
         envelope = app.to_json()
 
@@ -1842,9 +2053,8 @@ class TestCancelButtonEmitsCancelMessage:
             order_number="PO-CANCEL-1",
             items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
         )
-        app = build_order_preview_ui(
+        app = build_po_create_ui(
             {"order_number": "PO-CANCEL-1", "warnings": []},
-            "Purchase Order",
             confirm_request=request,
             confirm_tool="create_purchase_order",
         )
@@ -1894,13 +2104,12 @@ class TestPreviewCardSeedsPendingState:
             order_number="PO-STATE-1",
             items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
         )
-        app = build_order_preview_ui(
+        app = build_po_create_ui(
             {"order_number": "PO-STATE-1", "warnings": []},
-            "Purchase Order",
             confirm_request=request,
             confirm_tool="create_purchase_order",
         )
-        self._assert_seeds_state(app.to_json(), "build_order_preview_ui")
+        self._assert_seeds_state(app.to_json(), "build_po_create_ui")
 
     def test_fulfill_preview(self):
         app = build_fulfill_preview_ui(
@@ -2189,9 +2398,8 @@ class TestBlockWarningSuppressesConfirm:
                 "BLOCK: sales_order_row 99 already linked to MO 88",
             ],
         }
-        app = build_order_preview_ui(
+        app = build_mo_create_ui(
             order,
-            "Manufacturing Order",
             confirm_request=_StubRequest(),
             confirm_tool="create_manufacturing_order",
         )
@@ -2217,9 +2425,8 @@ class TestBlockWarningSuppressesConfirm:
             "planned_quantity": 5,
             "warnings": ["No production_deadline_date specified"],  # not BLOCK:
         }
-        app = build_order_preview_ui(
+        app = build_mo_create_ui(
             order,
-            "Manufacturing Order",
             confirm_request=_StubRequest(),
             confirm_tool="create_manufacturing_order",
         )
@@ -2294,9 +2501,8 @@ class TestBlockWarningSuppressesConfirm:
             "order_number": "MO-1",
             "warnings": ["BLOCK: this is the diagnostic message"],
         }
-        app = build_order_preview_ui(
+        app = build_mo_create_ui(
             order,
-            "Manufacturing Order",
             confirm_request=_StubRequest(),
             confirm_tool="create_manufacturing_order",
         )

--- a/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
+++ b/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
@@ -53,7 +53,7 @@ def registered_tools() -> dict[str, Any]:
 
 # Tools currently using the direct-apply rail (per ADR-0016 spike).
 DIRECT_APPLY_TOOLS = [
-    # Order creates that route through build_order_preview_ui.
+    # Order creates that route through per-entity build_<po|so|mo>_create_ui.
     "create_purchase_order",
     "create_sales_order",
     "create_manufacturing_order",

--- a/katana_mcp_server/tests/tools/test_customers.py
+++ b/katana_mcp_server/tests/tools/test_customers.py
@@ -212,10 +212,11 @@ async def test_get_customer_fetches_and_surfaces_addresses():
 
 
 @pytest.mark.asyncio
-async def test_get_customer_markdown_uses_canonical_field_names():
-    """Markdown labels use Pydantic field names (not prettified headers)
-    so LLM consumers can't misread a section label as a different field
-    (motivation: #346 follow-on, supplier_item_codes misread)."""
+async def test_get_customer_uses_canonical_field_names_in_content():
+    """Response content uses Pydantic field names (not prettified headers)
+    so LLM consumers can't misread a key as a different field — same
+    motivation as the #346 supplier_item_codes misread, now satisfied by
+    JSON content keying off the Pydantic field names directly."""
     context, lifespan_ctx = create_mock_context()
     lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(
         return_value=_make_cached_customer(
@@ -230,11 +231,11 @@ async def test_get_customer_markdown_uses_canonical_field_names():
         result = await get_customer(customer_id=42, context=context)
 
     text = result.content[0].text
-    assert "**reference_id**: WGT-2024-001" in text
-    assert "**discount_rate**: 5.0" in text
-    # Empty address list renders with explicit [] syntax, not a heading
-    # that a reader might mistake for a section:
-    assert "**addresses**: []" in text
+    # Field names appear as JSON keys; values appear next to them.
+    assert '"reference_id": "WGT-2024-001"' in text
+    assert '"discount_rate": 5.0' in text
+    # Empty address list serializes as the empty array, not a section header.
+    assert '"addresses": []' in text
 
 
 @pytest.mark.asyncio
@@ -249,7 +250,7 @@ async def test_get_customer_not_found():
 
 
 # ============================================================================
-# format=json / format=markdown
+# JSON content (#567 — markdown formatters dropped, JSON is the only mode)
 # ============================================================================
 
 
@@ -259,25 +260,10 @@ def _content_text(result) -> str:
 
 
 @pytest.mark.asyncio
-async def test_search_customers_format_json_returns_json():
-    """format='json' returns JSON-parseable content."""
-    context, lifespan_ctx = create_mock_context()
-    lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
-        return_value=[_make_cached_customer(id=1, name="Acme Corp", email="a@b.c")]
-    )
-
-    result = await search_customers(
-        query="acme", limit=20, format="json", context=context
-    )
-
-    data = json.loads(_content_text(result))
-    assert data["total_count"] == 1
-    assert data["customers"][0]["name"] == "Acme Corp"
-
-
-@pytest.mark.asyncio
-async def test_search_customers_format_markdown_default():
-    """Default markdown format produces markdown-ish content (not JSON)."""
+async def test_search_customers_content_is_indented_json():
+    """``content`` is the indented JSON form of the response model.
+    Programmatic consumers can ``json.loads`` it and get the same shape
+    as ``structured_content``."""
     context, lifespan_ctx = create_mock_context()
     lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
         return_value=[_make_cached_customer(id=1, name="Acme Corp", email="a@b.c")]
@@ -285,15 +271,16 @@ async def test_search_customers_format_markdown_default():
 
     result = await search_customers(query="acme", limit=20, context=context)
 
-    text = _content_text(result)
-    assert "Acme Corp" in text
-    # Not JSON — should have markdown characters
-    assert "##" in text or "**" in text
+    data = json.loads(_content_text(result))
+    assert data["total_count"] == 1
+    assert data["customers"][0]["name"] == "Acme Corp"
+    # Structured content carries the same payload (per the #567 contract).
+    assert result.structured_content["total_count"] == 1
 
 
 @pytest.mark.asyncio
-async def test_get_customer_format_json_returns_json():
-    """format='json' returns JSON-parseable content."""
+async def test_get_customer_content_is_indented_json():
+    """get_customer ``content`` parses as JSON matching the response shape."""
     context, lifespan_ctx = create_mock_context()
     lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(
         return_value=_make_cached_customer(
@@ -302,7 +289,7 @@ async def test_get_customer_format_json_returns_json():
     )
 
     with patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])):
-        result = await get_customer(customer_id=42, format="json", context=context)
+        result = await get_customer(customer_id=42, context=context)
 
     data = json.loads(_content_text(result))
     assert data["id"] == 42

--- a/katana_mcp_server/tests/tools/test_customers.py
+++ b/katana_mcp_server/tests/tools/test_customers.py
@@ -230,12 +230,12 @@ async def test_get_customer_uses_canonical_field_names_in_content():
     with patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])):
         result = await get_customer(customer_id=42, context=context)
 
-    text = result.content[0].text
-    # Field names appear as JSON keys; values appear next to them.
-    assert '"reference_id": "WGT-2024-001"' in text
-    assert '"discount_rate": 5.0' in text
+    data = json.loads(result.content[0].text)
+    # Field names appear as JSON keys (not prettified headers).
+    assert data["reference_id"] == "WGT-2024-001"
+    assert data["discount_rate"] == 5.0
     # Empty address list serializes as the empty array, not a section header.
-    assert '"addresses": []' in text
+    assert data["addresses"] == []
 
 
 @pytest.mark.asyncio

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -32,7 +32,6 @@ from katana_mcp.tools.foundation.items import (
     SearchItemsRequest,
     _get_variant_details_impl,
     _search_items_impl,
-    get_variant_details,
     search_items,
 )
 from katana_mcp_server.tests.conftest import create_mock_context, patch_typed_cache_sync
@@ -651,11 +650,11 @@ async def test_get_inventory_movements_full_field_coverage():
 
 
 @pytest.mark.asyncio
-async def test_get_inventory_movements_markdown_uses_canonical_names():
-    """Markdown render uses canonical Pydantic field names as column headers.
-
-    Pins the #346 follow-on convention so a future refactor can't silently
-    swap back to friendly-name labels like ``Date`` or ``Change``.
+async def test_get_inventory_movements_response_uses_canonical_field_names():
+    """Response model surfaces every movement field by its canonical Pydantic
+    name — pins the #346 follow-on convention. JSON keys (and the
+    iframe-rendered Prefab table) read directly off those names, so a
+    silent rename would surface as a key-not-found everywhere at once.
     """
     from katana_mcp.tools.foundation.inventory import (
         InventoryMovementsResponse,
@@ -695,15 +694,11 @@ async def test_get_inventory_movements_markdown_uses_canonical_names():
         context, _ = create_mock_context()
         result = await get_inventory_movements(sku="WIDGET-001", context=context)
 
-    md = _content_text(result)
-    # Parse the header row directly and assert the exact column names.
-    # Substring checks like `"id" in md` are too weak: they pass even if the
-    # `id` column is missing, because `variant_id` / `resource_id` also contain
-    # "id". Pinning on the exact column sequence catches silent reorderings
-    # and drops.
-    header_line = next(line for line in md.splitlines() if line.startswith("| id |"))
-    columns = [c.strip() for c in header_line.split("|")[1:-1]]
-    assert columns == [
+    payload = json.loads(_content_text(result))
+    movement = payload["movements"][0]
+    # Every canonical field name from the response model surfaces on
+    # the wire payload. A silent rename would drop one of these keys.
+    expected_keys = {
         "id",
         "movement_date",
         "variant_id",
@@ -720,17 +715,12 @@ async def test_get_inventory_movements_markdown_uses_canonical_names():
         "rank",
         "created_at",
         "updated_at",
-    ]
-    # And the header labels too
-    assert "**sku**: WIDGET-001" in md
-    assert "**product_name**: Test Widget" in md
-    assert "**total_count**: 1" in md
-    # Should NOT contain the old friendly labels
-    assert "| Date |" not in md
-    assert "| Change |" not in md
-    assert "| Balance |" not in md
-    assert "| Type |" not in md
-    assert "| Order |" not in md
+    }
+    assert expected_keys.issubset(movement.keys())
+    # Identity fields surface on the top level too.
+    assert payload["sku"] == "WIDGET-001"
+    assert payload["product_name"] == "Test Widget"
+    assert payload["total_count"] == 1
 
 
 # ============================================================================
@@ -2107,60 +2097,16 @@ async def test_search_items_format_json_returns_json():
         return_value=[{"id": 1, "sku": "WIDGET-1", "display_name": "Widget"}]
     )
 
-    result = await search_items(
-        query="widget", limit=10, format="json", context=context
-    )
+    result = await search_items(query="widget", limit=10, context=context)
 
     data = json.loads(_content_text(result))
     assert data["total_count"] == 1
     assert data["items"][0]["sku"] == "WIDGET-1"
 
 
-@pytest.mark.asyncio
-async def test_get_variant_details_format_json_returns_json():
-    """format='json' returns JSON-parseable content."""
-    context, lifespan_ctx = create_mock_context()
-    lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(
-        return_value={
-            "id": 42,
-            "sku": "VAR-42",
-            "product_id": 100,
-            "type": "product",
-        }
-    )
-    # Mock _get_variant_details_impl via patching the cache lookup chain
-    # is complex; patch the impl directly.
-    with patch(
-        "katana_mcp.tools.foundation.items._get_variant_details_impl",
-        new_callable=AsyncMock,
-    ) as mock_impl:
-        from katana_mcp.tools.foundation.items import (
-            GetVariantDetailsResult,
-            VariantDetailsResponse,
-        )
-
-        mock_impl.return_value = GetVariantDetailsResult(
-            found=[
-                VariantDetailsResponse(
-                    id=42,
-                    sku="VAR-42",
-                    name="Test Variant",
-                    product_id=100,
-                    type="product",
-                    sales_price=10.0,
-                    purchase_price=5.0,
-                )
-            ],
-            not_found=[],
-        )
-
-        result = await get_variant_details(
-            variant_id=42, format="json", context=context
-        )
-
-    data = json.loads(_content_text(result))
-    assert data["variants"][0]["id"] == 42
-    assert data["variants"][0]["sku"] == "VAR-42"
+# (get_variant_details JSON-content behavior is exhaustively covered by
+# the items.py test suite; this file no longer carries a cross-file
+# duplicate.)
 
 
 # ============================================================================
@@ -2198,9 +2144,7 @@ async def test_check_inventory_format_json_returns_json():
             ),
         ]
         context, _ = create_mock_context()
-        result = await check_inventory(
-            skus_or_variant_ids=["A", "B"], format="json", context=context
-        )
+        result = await check_inventory(skus_or_variant_ids=["A", "B"], context=context)
 
     data = json.loads(_content_text(result))
     assert len(data["items"]) == 2
@@ -2231,7 +2175,7 @@ async def test_list_low_stock_items_format_json_returns_json():
             total_count=1,
         )
         context, _ = create_mock_context()
-        result = await list_low_stock_items(format="json", context=context)
+        result = await list_low_stock_items(context=context)
 
     data = json.loads(_content_text(result))
     assert data["total_count"] == 1
@@ -2254,9 +2198,7 @@ async def test_get_inventory_movements_format_json_returns_json():
             total_count=0,
         )
         context, _ = create_mock_context()
-        result = await get_inventory_movements(
-            sku="MOVE-1", format="json", context=context
-        )
+        result = await get_inventory_movements(sku="MOVE-1", context=context)
 
     data = json.loads(_content_text(result))
     assert data["sku"] == "MOVE-1"
@@ -2278,7 +2220,7 @@ async def test_list_stock_adjustments_format_json_returns_json():
             pagination=None,
         )
         context, _ = create_mock_context()
-        result = await list_stock_adjustments(format="json", context=context)
+        result = await list_stock_adjustments(context=context)
 
     data = json.loads(_content_text(result))
     assert data["total_count"] == 0

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -155,19 +155,20 @@ async def test_get_variant_details_surfaces_every_variant_field():
 
 
 @pytest.mark.asyncio
-async def test_get_variant_details_format_json_includes_deleted_at():
-    """format='json' round-trips deleted_at (the pre-#346 drop)."""
+async def test_get_variant_details_content_includes_deleted_at():
+    """JSON content round-trips ``deleted_at`` (the pre-#346 drop). Every
+    request shape — single or batch — returns the ``{variants, not_found}``
+    envelope so callers see one stable contract (#567 PR #719 review)."""
     context, lifespan_ctx = create_mock_context()
     variant = dict(_FULL_VARIANT_DICT)
     variant["deleted_at"] = "2024-09-01T12:00:00+00:00"
     lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=variant)
 
-    result = await get_variant_details(
-        sku="KNF-PRO-8PC-STL", format="json", context=context
-    )
+    result = await get_variant_details(sku="KNF-PRO-8PC-STL", context=context)
 
     data = json.loads(_content_text(result))
     assert data["variants"][0]["deleted_at"] == "2024-09-01T12:00:00+00:00"
+    assert data["not_found"] == []
 
 
 @pytest.mark.asyncio
@@ -797,10 +798,11 @@ async def test_get_variant_details_mixed_skus_and_variant_ids_partial():
 
 
 @pytest.mark.asyncio
-async def test_get_variant_details_batch_markdown_lists_not_found_section():
-    """Public tool's markdown rendering surfaces a ``Not found`` section
-    when a batch had misses, so callers see the gaps without parsing the
-    structured payload."""
+async def test_get_variant_details_batch_content_surfaces_misses_in_json():
+    """Batch JSON content carries a ``not_found`` array next to
+    ``variants`` so callers see the gaps without a separate side-channel.
+    Replaces the prior markdown-`Not found`-section test (#567 dropped
+    the markdown layer)."""
     context, lifespan_ctx = create_mock_context()
     by_sku = {
         "WIDGET-B": {"id": 2, "sku": "WIDGET-B", "display_name": "Widget B"},
@@ -811,10 +813,9 @@ async def test_get_variant_details_batch_markdown_lists_not_found_section():
 
     result = await get_variant_details(skus=["MISSING-A", "WIDGET-B"], context=context)
 
-    text = _content_text(result)
-    assert "WIDGET-B" in text
-    assert "Not found" in text
-    assert "MISSING-A" in text
+    data = json.loads(_content_text(result))
+    assert {v["sku"] for v in data["variants"]} == {"WIDGET-B"}
+    assert {n["sku"] for n in data["not_found"]} == {"MISSING-A"}
 
 
 @pytest.mark.asyncio
@@ -829,9 +830,7 @@ async def test_get_variant_details_batch_json_includes_not_found():
         side_effect=lambda sku, **_kw: by_sku.get(sku)
     )
 
-    result = await get_variant_details(
-        skus=["MISSING-A", "WIDGET-B"], format="json", context=context
-    )
+    result = await get_variant_details(skus=["MISSING-A", "WIDGET-B"], context=context)
 
     payload = json.loads(_content_text(result))
     assert [v["sku"] for v in payload["variants"]] == ["WIDGET-B"]
@@ -1168,7 +1167,7 @@ async def test_get_item_format_json_round_trips_nested():
     attrs_product = _make_attrs(_FULL_PRODUCT_DICT)
 
     with patch(_FETCH_ITEM_PATH, AsyncMock(return_value=attrs_product)):
-        result = await get_item(id=101, type="product", format="json", context=context)
+        result = await get_item(id=101, type="product", context=context)
 
     data = json.loads(_content_text(result))
     assert data["id"] == 101

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -1176,7 +1176,7 @@ async def test_list_manufacturing_orders_format_json_returns_json():
         mock_impl.return_value = ListManufacturingOrdersResponse(
             orders=[], total_count=0, pagination=None
         )
-        result = await list_manufacturing_orders(format="json", context=context)
+        result = await list_manufacturing_orders(context=context)
 
     data = json.loads(_content_text(result))
     assert data["total_count"] == 0
@@ -1199,9 +1199,7 @@ async def test_get_manufacturing_order_format_json_returns_json():
             order_no="MO-2024-001",
             status="IN_PROGRESS",
         )
-        result = await get_manufacturing_order(
-            order_id=1, format="json", context=context
-        )
+        result = await get_manufacturing_order(order_id=1, context=context)
 
     data = json.loads(_content_text(result))
     assert data["id"] == 3001
@@ -1231,7 +1229,7 @@ async def test_get_manufacturing_order_recipe_format_json_returns_json():
             manufacturing_order_id=7, rows=[], total_count=0
         )
         result = await get_manufacturing_order_recipe(
-            manufacturing_order_id=7, format="json", context=context
+            manufacturing_order_id=7, context=context
         )
 
     data = json.loads(_content_text(result))
@@ -1471,10 +1469,12 @@ async def test_get_manufacturing_order_fetches_related_resources():
 
 
 @pytest.mark.asyncio
-async def test_get_manufacturing_order_markdown_uses_canonical_field_names():
-    """Markdown labels use Pydantic field names (not prettified headers) so
-    LLM consumers can't misread a section label as a different field
-    (motivation: #346 follow-on, supplier_item_codes misread)."""
+async def test_get_manufacturing_order_response_uses_canonical_field_names():
+    """JSON content keys off the Pydantic field names directly — same
+    motivation as the #346 canonical-name convention. Verbose-mode
+    response surfaces every empty list explicitly (as ``[]``) so a
+    consumer parsing the payload can tell presence-vs-absence.
+    """
     from katana_mcp.tools.foundation.manufacturing_orders import (
         GetManufacturingOrderResponse,
     )
@@ -1496,10 +1496,6 @@ async def test_get_manufacturing_order_markdown_uses_canonical_field_names():
             subassemblies_cost=2250.0,
             sales_order_row_id=2501,
         )
-        # Verbose-mode rendering pins the explicit-empty-list contract.
-        # Compact mode (the default) suppresses ``**field**: []`` placeholders
-        # to keep the response small — that surface is exercised by separate
-        # compact-mode tests below.
         result = await get_manufacturing_order(
             order_id=3001,
             include_rows="all",
@@ -1509,21 +1505,18 @@ async def test_get_manufacturing_order_markdown_uses_canonical_field_names():
             context=context,
         )
 
-    text = result.content[0].text
-    # Canonical scalar labels — the prettified versions the old impl used
-    # (e.g. "**Deadline**:", "**Total Cost**:") are gone. These pin the
-    # new convention:
-    assert "**production_deadline_date**: 2024-01-25T17:00:00+00:00" in text
-    assert "**total_cost**: 12500.0" in text
-    assert "**subassemblies_cost**: 2250.0" in text
-    assert "**sales_order_row_id**: 2501" in text
-    # Empty list fields render with explicit [] syntax, not bare headers
-    # that a reader might mistake for a section:
-    assert "**recipe_rows**: []" in text
-    assert "**operation_rows**: []" in text
-    assert "**productions**: []" in text
-    assert "**batch_transactions**: []" in text
-    assert "**serial_numbers**: []" in text
+    data = json.loads(result.content[0].text)
+    # Canonical scalar field names appear as JSON keys.
+    assert data["production_deadline_date"] == "2024-01-25T17:00:00+00:00"
+    assert data["total_cost"] == 12500.0
+    assert data["subassemblies_cost"] == 2250.0
+    assert data["sales_order_row_id"] == 2501
+    # Verbose mode surfaces every collection key with an empty array.
+    assert data["recipe_rows"] == []
+    assert data["operation_rows"] == []
+    assert data["productions"] == []
+    assert data["batch_transactions"] == []
+    assert data["serial_numbers"] == []
 
 
 @pytest.mark.asyncio
@@ -1767,9 +1760,7 @@ async def test_get_manufacturing_order_compact_json_strips_row_metadata():
                 _mk_recipe_row(id=1, availability="NOT_AVAILABLE"),
             ],
         )
-        result = await get_manufacturing_order(
-            order_id=3001, format="json", context=context
-        )
+        result = await get_manufacturing_order(order_id=3001, context=context)
 
     data = json.loads(_content_text(result))
     row = data["recipe_rows"][0]
@@ -1802,7 +1793,7 @@ async def test_get_manufacturing_order_verbose_json_keeps_row_metadata():
             ],
         )
         result = await get_manufacturing_order(
-            order_id=3001, format="json", verbose=True, context=context
+            order_id=3001, verbose=True, context=context
         )
 
     data = json.loads(_content_text(result))
@@ -1812,9 +1803,10 @@ async def test_get_manufacturing_order_verbose_json_keeps_row_metadata():
 
 
 @pytest.mark.asyncio
-async def test_get_manufacturing_order_compact_markdown_omits_empty_lists():
-    """Compact markdown does not emit ``**field**: []`` placeholders for
-    suppressed/empty collections."""
+async def test_get_manufacturing_order_compact_omits_unset_collections():
+    """Compact mode (verbose=False) drops suppressed/empty collections from
+    the JSON payload rather than emitting them as empty arrays. Keeps the
+    response small for inline tool-result limits."""
     from katana_mcp.tools.foundation.manufacturing_orders import (
         GetManufacturingOrderResponse,
     )
@@ -1832,21 +1824,14 @@ async def test_get_manufacturing_order_compact_markdown_omits_empty_lists():
         )
         result = await get_manufacturing_order(order_id=3001, context=context)
 
-    text = result.content[0].text
-    # No bracketed-empty placeholders in compact mode.
-    assert "**recipe_rows**: []" not in text
-    assert "**operation_rows**: []" not in text
-    assert "**productions**: []" not in text
-    assert "**batch_transactions**: []" not in text
-    assert "**serial_numbers**: []" not in text
-    # Suppressed collections do not appear at all (no canonical-name header,
-    # no decorated label, no annotation note).
-    assert "**recipe_rows**" not in text
-    assert "**operation_rows**" not in text
-    assert "**productions**" not in text
-    assert "filtered to blocking rows only" not in text
-    # Scalar header is still rendered.
-    assert "**status**: IN_PROGRESS" in text
+    data = json.loads(result.content[0].text)
+    # Suppressed collections are absent from the payload (default
+    # include_rows="blocking" + include_operation_rows=False +
+    # include_productions=False drops those keys).
+    assert "operation_rows" not in data
+    assert "productions" not in data
+    # Scalar fields still surface.
+    assert data["status"] == "IN_PROGRESS"
 
 
 # ============================================================================
@@ -2259,7 +2244,7 @@ async def test_list_blocking_ingredients_omits_recipe_rows_in_compact_json():
             id=3001, order_no="MO-X", status="IN_PROGRESS"
         )
         result = await get_manufacturing_order(
-            order_id=3001, format="json", include_rows="none", context=context
+            order_id=3001, include_rows="none", context=context
         )
 
     data = json.loads(_content_text(result))

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -2719,10 +2719,11 @@ async def test_get_purchase_order_fetches_additional_costs_and_accounting_metada
 
 
 @pytest.mark.asyncio
-async def test_get_purchase_order_markdown_uses_canonical_field_names():
-    """Markdown labels use Pydantic field names (not prettified headers)
-    so LLM consumers can't misread a section label as a different field
-    (motivation: #346 follow-on, supplier_item_codes misread)."""
+async def test_get_purchase_order_response_uses_canonical_field_names():
+    """JSON content keys off the Pydantic field names directly — same
+    motivation as the #346 canonical-name convention. Nested lists
+    serialize cleanly as JSON arrays keyed by their canonical names.
+    """
     from katana_mcp.tools.foundation.purchase_orders import (
         GetPurchaseOrderResponse,
         PurchaseOrderAccountingMetadataInfo,
@@ -2776,26 +2777,19 @@ async def test_get_purchase_order_markdown_uses_canonical_field_names():
     ):
         result = await get_purchase_order(order_id=12345, context=context)
 
-    text = _content_text(result)
-
-    # Scalar PO fields — canonical names appear as labels
-    assert "**order_no**: PO-1022" in text
-    assert "**status**: NOT_RECEIVED" in text
-    assert "**supplier_id**: 999" in text
-    assert "**default_group_id**: 8080" in text
-    assert "**billing_status**" not in text  # unset, should not appear
-
-    # List-shaped fields — count-labeled header, canonical key
-    assert "**purchase_order_rows** (1):" in text
-    assert "**variant_id**: 100" in text
-    assert "**additional_cost_rows** (1):" in text
-    assert "**name**: Shipping" in text
-    assert "**accounting_metadata** (1):" in text
-    assert "**bill_id**: BILL-2026-001" in text
-
-    # The canonical-name convention rules out these prettified labels:
-    assert "**Supplier ID**" not in text
-    assert "### Line Items" not in text
+    data = json.loads(_content_text(result))
+    # Scalar PO fields show up as JSON keys.
+    assert data["order_no"] == "PO-1022"
+    assert data["status"] == "NOT_RECEIVED"
+    assert data["supplier_id"] == 999
+    assert data["default_group_id"] == 8080
+    # Nested arrays use canonical keys.
+    assert len(data["purchase_order_rows"]) == 1
+    assert data["purchase_order_rows"][0]["variant_id"] == 100
+    assert len(data["additional_cost_rows"]) == 1
+    assert data["additional_cost_rows"][0]["name"] == "Shipping"
+    assert len(data["accounting_metadata"]) == 1
+    assert data["accounting_metadata"][0]["bill_id"] == "BILL-2026-001"
 
 
 @pytest.mark.asyncio
@@ -2830,10 +2824,9 @@ async def test_get_purchase_order_surfaces_embedded_supplier():
 
 
 @pytest.mark.asyncio
-async def test_get_purchase_order_markdown_renders_supplier_inline():
-    """Embedded supplier renders under a canonical ``**supplier**:`` block
-    with per-field labels, matching the convention used for rows and
-    accounting metadata."""
+async def test_get_purchase_order_content_renders_embedded_supplier():
+    """Embedded supplier serializes under the canonical ``supplier`` key
+    with all populated fields preserved on the JSON payload."""
     from katana_mcp.tools.foundation.purchase_orders import (
         GetPurchaseOrderResponse,
         SupplierInfo,
@@ -2857,19 +2850,18 @@ async def test_get_purchase_order_markdown_renders_supplier_inline():
         return_value=response,
     ):
         result = await get_purchase_order(order_id=12345, context=context)
-    text = _content_text(result)
+    data = json.loads(_content_text(result))
 
-    assert "**supplier**:" in text
-    assert "**name**: Acme Supplies" in text
-    assert "**email**: orders@acme.example" in text
-    assert "**default_address_id**: 7001" in text
+    assert data["supplier"]["name"] == "Acme Supplies"
+    assert data["supplier"]["email"] == "orders@acme.example"
+    assert data["supplier"]["default_address_id"] == 7001
 
 
 @pytest.mark.asyncio
-async def test_get_purchase_order_markdown_renders_null_supplier_explicitly():
-    """When the PO payload does not embed a supplier the canonical key
-    still appears as ``**supplier**: null`` so an LLM consumer sees a
-    concrete field value rather than a missing section."""
+async def test_get_purchase_order_content_renders_null_supplier_explicitly():
+    """When the PO payload doesn't embed a supplier the canonical key still
+    appears on the JSON payload as ``supplier: null`` — an LLM consumer
+    sees a concrete value rather than a missing key."""
     from katana_mcp.tools.foundation.purchase_orders import GetPurchaseOrderResponse
 
     context, _ = create_mock_context()
@@ -2882,7 +2874,8 @@ async def test_get_purchase_order_markdown_renders_null_supplier_explicitly():
     ):
         result = await get_purchase_order(order_id=12345, context=context)
 
-    assert "**supplier**: null" in _content_text(result)
+    data = json.loads(_content_text(result))
+    assert data["supplier"] is None
 
 
 @pytest.mark.asyncio
@@ -3312,7 +3305,7 @@ async def test_list_purchase_orders_format_json_returns_json():
         mock_impl.return_value = ListPurchaseOrdersResponse(
             orders=[], total_count=0, pagination=None
         )
-        result = await list_purchase_orders(format="json", context=context)
+        result = await list_purchase_orders(context=context)
 
     data = json.loads(_content_text(result))
     assert data["total_count"] == 0
@@ -3342,7 +3335,7 @@ async def test_get_purchase_order_format_json_returns_json():
             additional_cost_rows=[],
             accounting_metadata=[],
         )
-        result = await get_purchase_order(order_id=5, format="json", context=context)
+        result = await get_purchase_order(order_id=5, context=context)
 
     data = json.loads(_content_text(result))
     assert data["id"] == 5
@@ -3372,7 +3365,6 @@ async def test_verify_order_document_format_json_returns_json():
         result = await verify_order_document(
             order_id=5,
             document_items=[DocumentItem(sku="A", quantity=1, unit_price=1.0)],
-            format="json",
             context=context,
         )
 

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -580,29 +580,31 @@ def test_po_response_to_tool_result_apply_renders_enriched_fields():
 
     tool_result = _po_response_to_tool_result(response, request=request)
 
-    # Walk the Prefab envelope, collecting Text content strings, and assert
-    # the enriched fields show up. The preview card already renders these
-    # via the shared ``_render_order_fields`` helper; the regression #618
-    # was the apply card silently losing them.
+    # Walk the Prefab envelope, collecting every string property
+    # (``content`` for Text, ``label``/``value`` for Metric, etc.), and
+    # assert the enriched fields show up. The preview card already renders
+    # these via ``build_po_create_ui``; the regression #618 was the apply
+    # card silently losing them.
     envelope = tool_result.structured_content
     assert envelope is not None
-    text_nodes: list[str] = []
+    strings: list[str] = []
 
     def collect(o):
         if isinstance(o, dict):
-            if isinstance(o.get("content"), str):
-                text_nodes.append(o["content"])
             for v in o.values():
-                collect(v)
+                if isinstance(v, str):
+                    strings.append(v)
+                else:
+                    collect(v)
         elif isinstance(o, list):
             for v in o:
                 collect(v)
 
     collect(envelope)
-    joined = "\n".join(text_nodes)
+    joined = "\n".join(strings)
     assert "Acme Supply Co" in joined
     assert "Main Warehouse" in joined
-    assert "Items: 2" in joined
+    assert "Line Items" in joined
     assert "Net-30 terms" in joined
 
 

--- a/katana_mcp_server/tests/tools/test_reference.py
+++ b/katana_mcp_server/tests/tools/test_reference.py
@@ -148,9 +148,7 @@ class TestListSuppliers:
         ]
         context, lifespan_ctx = _make_context(get_all=cached)
 
-        result = await list_suppliers(
-            query=None, limit=50, format="json", context=context
-        )
+        result = await list_suppliers(query=None, limit=50, context=context)
 
         assert lifespan_ctx.typed_cache.catalog.get_all.await_count == 1
         # smart_search must NOT be called when query is None
@@ -172,7 +170,7 @@ class TestListSuppliers:
         context, lifespan_ctx = _make_context(smart_search=matches, get_all=[])
 
         result = await list_suppliers(
-            query="Acme Components", limit=10, format="json", context=context
+            query="Acme Components", limit=10, context=context
         )
 
         # Query path must use FTS, not full-list dump
@@ -194,9 +192,7 @@ class TestListSuppliers:
         cached = [_supplier(id=i, name=f"Supplier-{i}") for i in range(1, 21)]
         context, _ = _make_context(get_all=cached)
 
-        result = await list_suppliers(
-            query=None, limit=5, format="json", context=context
-        )
+        result = await list_suppliers(query=None, limit=5, context=context)
 
         payload = json.loads(_extract_text(result))
         assert len(payload["suppliers"]) == 5
@@ -204,28 +200,13 @@ class TestListSuppliers:
         assert payload["total_count"] == 20
 
     @pytest.mark.asyncio
-    async def test_markdown_format_renders_bounded_summary_not_giant_blob(self):
-        cached = [_supplier(id=1, name="Acme", email="a@acme.com", currency="USD")]
-        context, _ = _make_context(get_all=cached)
-
-        result = await list_suppliers(
-            query=None, limit=50, format="markdown", context=context
-        )
-
-        text = _extract_text(result)
-        assert "## Suppliers" in text
-        assert "Acme" in text
-        assert "ID: 1" in text
-        # Markdown output is bullet-list — must not be a JSON dump
-        assert not text.lstrip().startswith("{")
-
-    @pytest.mark.asyncio
     async def test_empty_result_no_query(self):
         context, _ = _make_context(get_all=[])
-        result = await list_suppliers(
-            query=None, limit=50, format="markdown", context=context
-        )
-        assert "No suppliers cached" in _extract_text(result)
+        result = await list_suppliers(query=None, limit=50, context=context)
+        payload = json.loads(_extract_text(result))
+        assert payload["suppliers"] == []
+        assert payload["total_count"] == 0
+        assert payload["query"] is None
 
     @pytest.mark.asyncio
     async def test_empty_result_with_query(self):
@@ -233,35 +214,32 @@ class TestListSuppliers:
         result = await list_suppliers(
             query="NoSuchSupplier",
             limit=10,
-            format="markdown",
             context=context,
         )
-        text = _extract_text(result)
-        assert "No suppliers found matching" in text
-        assert "NoSuchSupplier" in text
+        payload = json.loads(_extract_text(result))
+        assert payload["suppliers"] == []
+        assert payload["total_count"] == 0
+        assert payload["query"] == "NoSuchSupplier"
 
     @pytest.mark.asyncio
     async def test_whitespace_only_query_treated_as_no_query(self):
         """``query="   "`` falls through to ``get_all`` (not smart_search)
-        and ``response.query`` ends up ``None`` — so the markdown header
-        renders the no-query form, not "query `   `".
+        and ``response.query`` ends up ``None`` — pinning the
+        normalization that keeps the response shape consistent regardless
+        of input whitespace.
         """
         cached = [_supplier(id=1, name="Acme")]
         context, lifespan_ctx = _make_context(get_all=cached, smart_search=[])
 
-        result = await list_suppliers(
-            query="   ", limit=50, format="markdown", context=context
-        )
+        result = await list_suppliers(query="   ", limit=50, context=context)
 
         # Whitespace-only query must NOT trigger smart_search
         assert lifespan_ctx.typed_cache.catalog.smart_search.await_count == 0
         assert lifespan_ctx.typed_cache.catalog.get_all.await_count == 1
 
-        text = _extract_text(result)
-        # Header should be the no-query form ("## Suppliers (1 of 1)"),
-        # not "query `   `"
-        assert "query" not in text.lower()
-        assert "Acme" in text
+        payload = json.loads(_extract_text(result))
+        assert payload["query"] is None
+        assert any(s["name"] == "Acme" for s in payload["suppliers"])
 
 
 # ============================================================================
@@ -286,7 +264,7 @@ class TestGetSupplier:
         )
         context, lifespan_ctx = _make_context(get_by_id=record)
 
-        result = await get_supplier(supplier_id=1302095, format="json", context=context)
+        result = await get_supplier(supplier_id=1302095, context=context)
 
         # Adapter takes the Cached* class as the first positional arg.
         await_args = lifespan_ctx.typed_cache.catalog.get_by_id.await_args
@@ -308,17 +286,19 @@ class TestGetSupplier:
         context2, lifespan_ctx2 = create_mock_context()
         lifespan_ctx2.typed_cache.catalog.get_by_id = AsyncMock(return_value=None)
         with pytest.raises(ValueError, match="Supplier with ID 999 not found"):
-            await get_supplier(supplier_id=999, format="json", context=context2)
+            await get_supplier(supplier_id=999, context=context2)
 
     @pytest.mark.asyncio
-    async def test_markdown_format_renders_card(self):
+    async def test_content_is_indented_json_with_full_fields(self):
+        """get_supplier ``content`` is the JSON form of the full response —
+        callers parsing programmatically get every cached field by name."""
         record = _supplier(id=1, name="Acme", email="a@acme.com", currency="USD")
         context, _ = _make_context(get_by_id=record)
-        result = await get_supplier(supplier_id=1, format="markdown", context=context)
-        text = _extract_text(result)
-        assert "## Acme" in text
-        assert "**email**: a@acme.com" in text
-        assert "**currency**: USD" in text
+        result = await get_supplier(supplier_id=1, context=context)
+        payload = json.loads(_extract_text(result))
+        assert payload["name"] == "Acme"
+        assert payload["email"] == "a@acme.com"
+        assert payload["currency"] == "USD"
 
 
 # ============================================================================
@@ -348,9 +328,7 @@ class TestListLocations:
             is_primary=True,
         )
         context, lifespan_ctx = _make_context(smart_search=[loc])
-        result = await list_locations(
-            query="Main", limit=5, format="json", context=context
-        )
+        result = await list_locations(query="Main", limit=5, context=context)
         lifespan_ctx.typed_cache.catalog.smart_search.assert_awaited_once()
         payload = json.loads(_extract_text(result))
         loc_payload = payload["locations"][0]
@@ -365,28 +343,27 @@ class TestListLocations:
         }
 
     @pytest.mark.asyncio
-    async def test_markdown_renders_city_country_from_nested_address(self):
-        # Bypass pydantic validation on the JSON column — the helper's
-        # ``_address_from_obj`` accepts either ``LocationAddress`` or a
-        # raw dict, and it's the dict shape that exercises the partial-
-        # field path (a real wire ``LocationAddress`` would carry every
-        # required field).
+    async def test_partial_address_from_dict_shape(self):
+        """``_address_from_obj`` accepts either a ``LocationAddress`` or a
+        raw dict (legacy cache shape). Pin the partial-field dict path —
+        a real wire ``LocationAddress`` would carry every required field;
+        the dict shape exercises the partial case where only city /
+        country are set.
+        """
         loc = _location(id=24141, name="Goleta DC")
         object.__setattr__(loc, "address", {"city": "Goleta", "country": "US"})
         context, _ = _make_context(get_all=[loc])
-        result = await list_locations(
-            query=None, limit=50, format="markdown", context=context
-        )
-        text = _extract_text(result)
-        assert "Goleta DC" in text
-        assert "Goleta, US" in text
+        result = await list_locations(query=None, limit=50, context=context)
+        payload = json.loads(_extract_text(result))
+        loc_payload = payload["locations"][0]
+        assert loc_payload["name"] == "Goleta DC"
+        assert loc_payload["address"]["city"] == "Goleta"
+        assert loc_payload["address"]["country"] == "US"
 
     @pytest.mark.asyncio
     async def test_missing_address_yields_none(self):
         context, _ = _make_context(get_all=[_location(id=1, name="No-address site")])
-        result = await list_locations(
-            query=None, limit=50, format="json", context=context
-        )
+        result = await list_locations(query=None, limit=50, context=context)
         payload = json.loads(_extract_text(result))
         assert payload["locations"][0]["address"] is None
 
@@ -420,9 +397,7 @@ class TestListLocations:
             },
         )
         context, _ = _make_context(get_all=[loc])
-        result = await list_locations(
-            query=None, limit=50, format="json", context=context
-        )
+        result = await list_locations(query=None, limit=50, context=context)
         payload = json.loads(_extract_text(result))
         assert payload["locations"][0]["address"] == {
             "line_1": "1 Main St",
@@ -454,9 +429,7 @@ class TestSmallReferenceTools:
                 )
             ]
         )
-        result = await list_tax_rates(
-            query=None, limit=50, format="json", context=context
-        )
+        result = await list_tax_rates(query=None, limit=50, context=context)
         payload = json.loads(_extract_text(result))
         assert payload["tax_rates"][0]["rate"] == 8.5
         assert payload["tax_rates"][0]["is_default_sales"] is True
@@ -469,9 +442,7 @@ class TestSmallReferenceTools:
                 _operator(id=2, operator_name="Bob"),
             ]
         )
-        result = await list_operators(
-            query=None, limit=50, format="json", context=context
-        )
+        result = await list_operators(query=None, limit=50, context=context)
         payload = json.loads(_extract_text(result))
         assert {op["name"] for op in payload["operators"]} == {"Alice", "Bob"}
 
@@ -483,9 +454,7 @@ class TestSmallReferenceTools:
                 _additional_cost(id=2, name="Import Duty"),
             ]
         )
-        result = await list_additional_costs(
-            query=None, limit=50, format="json", context=context
-        )
+        result = await list_additional_costs(query=None, limit=50, context=context)
         payload = json.loads(_extract_text(result))
         assert {ac["name"] for ac in payload["additional_costs"]} == {
             "Shipping",
@@ -510,20 +479,21 @@ class TestRequestModels:
         with pytest.raises(ValueError):
             ListSuppliersRequest(limit=0)
 
-    def test_format_must_be_known(self):
+    def test_format_param_dropped(self):
+        """``format`` parameter was removed in #567 — passing it
+        should now be rejected by ``extra="forbid"``."""
         with pytest.raises(ValueError):
-            ListSuppliersRequest.model_validate({"format": "xml"})
+            ListSuppliersRequest.model_validate({"format": "json"})
 
     def test_extra_fields_forbidden(self):
         """``extra="forbid"`` keeps callers honest about parameter names."""
         with pytest.raises(ValueError):
             ListSuppliersRequest.model_validate({"querystr": "Acme Components"})
 
-    def test_default_query_is_none_default_format_markdown(self):
+    def test_default_query_is_none(self):
         req = ListSuppliersRequest()
         assert req.query is None
         assert req.limit == 50
-        assert req.format == "markdown"
 
     def test_get_supplier_requires_id(self):
         with pytest.raises(ValueError):
@@ -543,7 +513,6 @@ class TestRequestModels:
         req = model()
         assert req.query is None
         assert req.limit == 50
-        assert req.format == "markdown"
 
 
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_reporting.py
+++ b/katana_mcp_server/tests/tools/test_reporting.py
@@ -729,7 +729,7 @@ def test_inventory_velocity_rejects_batch_too_large():
 
 
 # ============================================================================
-# format=json (reporting tools)
+# JSON content envelope (reporting tools)
 # ============================================================================
 
 
@@ -738,7 +738,7 @@ def _content_text(result) -> str:
 
 
 @pytest.mark.asyncio
-async def test_top_selling_variants_format_json_returns_json():
+async def test_top_selling_variants_content_is_json():
     from katana_mcp.tools.foundation.reporting import TopSellingVariantsResponse
 
     context, _ = create_mock_context()
@@ -764,7 +764,7 @@ async def test_top_selling_variants_format_json_returns_json():
 
 
 @pytest.mark.asyncio
-async def test_sales_summary_format_json_returns_json():
+async def test_sales_summary_content_is_json():
     from katana_mcp.tools.foundation.reporting import SalesSummaryResponse
 
     context, _ = create_mock_context()
@@ -791,7 +791,7 @@ async def test_sales_summary_format_json_returns_json():
 
 
 @pytest.mark.asyncio
-async def test_inventory_velocity_format_json_returns_json():
+async def test_inventory_velocity_content_is_json():
 
     context, _ = create_mock_context()
 

--- a/katana_mcp_server/tests/tools/test_reporting.py
+++ b/katana_mcp_server/tests/tools/test_reporting.py
@@ -756,7 +756,6 @@ async def test_top_selling_variants_format_json_returns_json():
         result = await top_selling_variants(
             start_date=date(2026, 1, 1),
             end_date=date(2026, 1, 31),
-            format="json",
             context=context,
         )
 
@@ -784,7 +783,6 @@ async def test_sales_summary_format_json_returns_json():
             start_date=date(2026, 1, 1),
             end_date=date(2026, 1, 31),
             group_by="day",
-            format="json",
             context=context,
         )
 
@@ -821,7 +819,6 @@ async def test_inventory_velocity_format_json_returns_json():
         result = await inventory_velocity(
             sku_or_variant_id="V-1",
             period_days=10,
-            format="json",
             context=context,
         )
 

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -1602,14 +1602,11 @@ async def test_get_sales_order_fetches_and_surfaces_addresses():
 
 
 @pytest.mark.asyncio
-async def test_get_sales_order_markdown_uses_canonical_field_names():
-    """Markdown labels use Pydantic field names (not prettified headers)
-    so LLM consumers can't misread a section label as a different field.
-
-    Pins the #346 canonical-name convention: scalar lines render as
-    ``**field_name**: value``, empty lists render as ``**field_name**: []``,
-    and non-empty lists render as ``**field_name** (N):`` with indented
-    per-item blocks.
+async def test_get_sales_order_response_uses_canonical_field_names():
+    """JSON content keys off the Pydantic field names directly — same
+    motivation as the #346 canonical-name convention (LLM readers can't
+    misread a key as a different field). Empty collections serialize as
+    ``[]``, populated ones as JSON arrays of objects.
     """
     context, lifespan_ctx = create_mock_context()
     lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(return_value=None)
@@ -1618,7 +1615,6 @@ async def test_get_sales_order_markdown_uses_canonical_field_names():
         order_no="SO-2001",
         rows=[_make_mock_row(id=10, variant_id=500, quantity=1, price_per_unit=99.0)],
     )
-    # Stamp distinctive values on fields whose labels we want to pin:
     mock_so.customer_ref = "CUST-REF-001"
     mock_so.tracking_number = "UPS1234567890"
 
@@ -1629,16 +1625,14 @@ async def test_get_sales_order_markdown_uses_canonical_field_names():
     ):
         result = await get_sales_order(order_id=2001, context=context)
 
-    text = result.content[0].text
-    # Canonical-name scalar labels (not "Delivery", not "Tracking", etc.):
-    assert "**delivery_date**:" in text
-    assert "**customer_ref**: CUST-REF-001" in text
-    assert "**tracking_number**: UPS1234567890" in text
-    # Empty collections render with explicit [] so readers can't mistake
-    # the heading for a section:
-    assert "**addresses**: []" in text
-    # Non-empty rows render with a count header:
-    assert "**rows** (1):" in text
+    data = json.loads(result.content[0].text)
+    # Canonical field names show up as JSON keys:
+    assert "delivery_date" in data
+    assert data["customer_ref"] == "CUST-REF-001"
+    assert data["tracking_number"] == "UPS1234567890"
+    # Empty/populated collections serialize cleanly:
+    assert data["addresses"] == []
+    assert len(data["rows"]) == 1
 
 
 # ============================================================================
@@ -1659,26 +1653,16 @@ async def test_list_sales_orders_format_json_returns_json(
     context, _, typed_cache = context_with_typed_cache
     await seed_cache(typed_cache, [make_sales_order(id=1, order_no="SO-1")])
 
-    result = await list_sales_orders(format="json", context=context)
+    result = await list_sales_orders(context=context)
 
     data = json.loads(_content_text(result))
     assert data["total_count"] == 1
     assert data["orders"][0]["order_no"] == "SO-1"
 
 
-@pytest.mark.asyncio
-async def test_list_sales_orders_format_markdown_default(
-    context_with_typed_cache, no_sync
-):
-    """Default markdown format produces a table."""
-    context, _, typed_cache = context_with_typed_cache
-    await seed_cache(typed_cache, [make_sales_order(id=1, order_no="SO-1")])
-
-    result = await list_sales_orders(context=context)
-
-    text = _content_text(result)
-    assert "|" in text  # markdown table
-    assert "SO-1" in text
+# list_sales_orders default content is the same JSON shape as the prior
+# format="json" path (#567 dropped the markdown alternative); the
+# coverage above already pins that.
 
 
 @pytest.mark.asyncio
@@ -1693,7 +1677,7 @@ async def test_get_sales_order_format_json_returns_json():
         patch(_SO_UNWRAP_AS, return_value=mock_so),
         patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
     ):
-        result = await get_sales_order(order_id=9, format="json", context=context)
+        result = await get_sales_order(order_id=9, context=context)
 
     data = json.loads(_content_text(result))
     assert data["id"] == 9

--- a/katana_mcp_server/tests/tools/test_stock_transfers.py
+++ b/katana_mcp_server/tests/tools/test_stock_transfers.py
@@ -781,7 +781,7 @@ async def test_delete_stock_transfer_confirm_success():
 
 
 # ============================================================================
-# format=json (stock_transfers read tool)
+# JSON content envelope (stock_transfers read tool)
 # ============================================================================
 
 
@@ -790,7 +790,7 @@ def _content_text(result) -> str:
 
 
 @pytest.mark.asyncio
-async def test_list_stock_transfers_format_json_returns_json():
+async def test_list_stock_transfers_content_is_json():
     from katana_mcp.tools.foundation.stock_transfers import (
         ListStockTransfersResponse,
     )

--- a/katana_mcp_server/tests/tools/test_stock_transfers.py
+++ b/katana_mcp_server/tests/tools/test_stock_transfers.py
@@ -804,7 +804,7 @@ async def test_list_stock_transfers_format_json_returns_json():
         mock_impl.return_value = ListStockTransfersResponse(
             transfers=[], total_count=0, pagination=None
         )
-        result = await list_stock_transfers(format="json", context=context)
+        result = await list_stock_transfers(context=context)
 
     data = json.loads(_content_text(result))
     assert data["total_count"] == 0


### PR DESCRIPTION
## Summary
- Replace the discriminator-dispatching `build_order_preview_ui` / `build_order_created_ui` pair with three per-entity entrypoints: `build_po_create_ui`, `build_so_create_ui`, `build_mo_create_ui`. Each handles BOTH preview AND applied state via `_init_create_card_state(response)` which reads `response["is_preview"]`.
- Add shared tier-1/4 scaffolding: `_render_preview_header`, `_render_warnings_block`, `_render_preview_footer`, plus `status_badge_variant` + `_STATUS_BUCKETS` (pre-populated for PO/SO/MO/stock_transfer so the upcoming modify follow-ups inherit it).
- Migrate the three create-order callers (`foundation/{purchase_orders,sales_orders,manufacturing_orders}.py`) — each branch collapses to a single call to its per-entity builder.
- Reorganize `test_prefab_ui.py` into three per-entity classes (`TestBuildPOCreateUI`, `TestBuildSOCreateUI`, `TestBuildMOCreateUI`) with smoke tests for both states. Add `TestStatusBadgeVariant` covering the bucket lookups parametrized across entities. Cross-cutting direct-apply rail + state-seeding tests now parametrize over all three entrypoints.

## Why per-entity entrypoints
Each create tool already knows what it's building, so the inner discriminator branch hid information at the boundary and made every caller pay the dispatch cost. Per-entity entrypoints give each card room to render its entity-specific Tier 2 metrics (PO total + line items, SO delivery_date + customer, MO planned_quantity + production_deadline + variant) without the branching tax — and they line up the surface the upcoming modify/delete/correct/receive/fulfill/verify follow-ups will copy.

## Scope caveats
- The `EntityFieldSpec` abstraction + canonical `state["status"]` key described in the plan are **deferred to the modify follow-up**. Create cards inline their Tier 3 content directly using the existing boolean state surface (`applied`/`pending`/`cancelled`/`error`), which is sufficient for the create-only scope. The abstraction earns its keep when modify lands and needs diff-decoration on the same field-level renderer.
- Modify/delete/correct cards are NOT touched here. Those follow-ups will reuse `_render_preview_header`, `_render_warnings_block`, `_render_preview_footer`, and `status_badge_variant` unchanged, then layer per-entity field specs + diff-decoration on top.

## Test plan
- [x] `uv run poe check` clean (3191 passed, 2 skipped — browser tests skip locally without chromium)
- [x] `uv run poe lint` (ruff + ty) clean
- [ ] CI green
- [ ] Live sanity: hit `create_purchase_order` / `create_sales_order` / `create_manufacturing_order` with `preview=true` in Claude Desktop, verify direct-apply morph and View-in-Katana link

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)