### PR TITLE
fix(client)!: relax non-nullable spec fields to match live Katana wire

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -2603,11 +2603,21 @@ components:
             type:
               $ref: "#/components/schemas/VariantType"
             internal_barcode:
-              type: string
-              description: Internal barcode for warehouse scanning and tracking
+              type:
+                - string
+                - "null"
+              description: |-
+                Internal barcode for warehouse scanning and tracking. The wire
+                delivers ``null`` for variants that don't have one assigned;
+                ours-vs-Katana spec gap — Katana's published spec marks this
+                non-nullable but the live API returns null on most rows. See #727.
             registered_barcode:
-              type: string
-              description: Official registered barcode (UPC, EAN, etc.) for retail use
+              type:
+                - string
+                - "null"
+              description: |-
+                Official registered barcode (UPC, EAN, etc.) for retail use.
+                Nullable per live-wire behavior — see ``internal_barcode``.
             supplier_item_codes:
               type: array
               description: Supplier-specific part numbers or SKUs for purchasing
@@ -2624,8 +2634,14 @@ components:
                 - "null"
               description: Minimum quantity that must be ordered from suppliers
             custom_fields:
-              type: array
-              description: Custom field values specific to this variant
+              type:
+                - array
+                - "null"
+              description: |-
+                Custom field values specific to this variant. The wire delivers
+                ``null`` (not an empty array) when no custom fields are set —
+                see #727. Consumers should treat ``null`` and ``[]`` as
+                equivalent ("no custom fields").
               items:
                 type: object
                 properties:
@@ -2636,8 +2652,15 @@ components:
                     type: string
                     description: Value stored in the custom field
             config_attributes:
-              type: array
-              description: Configuration attribute values that define this variant (color, size, etc.)
+              type:
+                - array
+                - "null"
+              description: |-
+                Configuration attribute values that define this variant (color,
+                size, etc.). Marked nullable defensively (mirrors
+                ``custom_fields`` shape) so a future wire change to ``null``
+                doesn't crash the generated parser — current wire always
+                delivers an array, even if empty.
               items:
                 type: object
                 properties:
@@ -2867,8 +2890,15 @@ components:
           type: string
           description: Difference between expected and actual stock (negative means missing, positive means excess)
         quantity_potential:
-          type: string
-          description: Total quantity that could be available (in stock + expected)
+          type:
+            - string
+            - "null"
+          description: |-
+            Total quantity that could be available (in stock + expected).
+            Wire delivers ``null`` on the typical row (observed 100% on a
+            50-row sample). The field is still ``required`` because Katana
+            ships the key on every row — it's the *value* that may be null,
+            not the key. See #727.
         variant:
           $ref: "#/components/schemas/Variant"
           description: Product variant details associated with this inventory record
@@ -2882,8 +2912,14 @@ components:
           format: date-time
           description: Timestamp when this inventory record was archived
         default_storage_bin:
-          description: Default storage bin for this variant at this location, when one has been linked via the variant default storage bin endpoints
-          $ref: "#/components/schemas/VariantDefaultStorageBinLinkResponse"
+          description: |-
+            Default storage bin for this variant at this location, when one has
+            been linked via the variant default storage bin endpoints. The wire
+            delivers ``null`` when no bin is linked (the typical case) — see
+            #727.
+          anyOf:
+            - $ref: "#/components/schemas/VariantDefaultStorageBinLinkResponse"
+            - type: "null"
       required:
         - variant_id
         - location_id
@@ -6636,11 +6672,21 @@ components:
             type:
               $ref: "#/components/schemas/VariantType"
             internal_barcode:
-              type: string
-              description: Internal barcode for warehouse scanning and tracking
+              type:
+                - string
+                - "null"
+              description: |-
+                Internal barcode for warehouse scanning and tracking. The wire
+                delivers ``null`` for variants without one assigned — ours-vs-
+                Katana spec gap; see ``Variant.internal_barcode`` for the
+                rationale.
             registered_barcode:
-              type: string
-              description: Official registered barcode (UPC, EAN, etc.) for retail use
+              type:
+                - string
+                - "null"
+              description: |-
+                Official registered barcode (UPC, EAN, etc.) for retail use.
+                Nullable per live-wire behavior — see ``internal_barcode``.
             supplier_item_codes:
               type: array
               description: Supplier-specific part numbers or SKUs for purchasing
@@ -6657,8 +6703,13 @@ components:
                 - "null"
               description: Minimum quantity that must be ordered from suppliers
             config_attributes:
-              type: array
-              description: Configuration attribute values that define this variant
+              type:
+                - array
+                - "null"
+              description: |-
+                Configuration attribute values that define this variant. Marked
+                nullable to mirror ``custom_fields`` and the inline ``Variant``
+                schema — see #727.
               items:
                 type: object
                 properties:
@@ -6669,8 +6720,12 @@ components:
                     type: string
                     description: Value for this configuration attribute (e.g., Blue, Large)
             custom_fields:
-              type: array
-              description: Custom field values specific to this variant
+              type:
+                - array
+                - "null"
+              description: |-
+                Custom field values specific to this variant. The wire delivers
+                ``null`` (not ``[]``) when no custom fields are set — see #727.
               items:
                 type: object
                 properties:
@@ -10171,13 +10226,25 @@ components:
           type: string
           description: Base currency code
         default_so_delivery_time:
-          type: string
-          format: date-time
-          description: Default sales order delivery time
+          type:
+            - string
+            - "null"
+          description: |-
+            Default sales order delivery time. Schema gap: Katana's upstream
+            example shows an ISO-8601 datetime, but the live wire delivers
+            either ``null`` or an opaque short string (e.g. ``"14"`` for
+            days-lead-time). We deliberately drop ``format: date-time`` here
+            because the wire doesn't honor it. See #727.
         default_po_lead_time:
-          type: string
-          format: date-time
-          description: Default purchase order lead time
+          type:
+            - string
+            - "null"
+          description: |-
+            Default purchase order lead time. Schema gap: same shape as
+            ``default_so_delivery_time`` — Katana's upstream example shows an
+            ISO-8601 datetime, but the live wire delivers ``null`` or an
+            opaque short string (e.g. ``"14"`` for days). ``format: date-time``
+            omitted intentionally. See #727.
         default_manufacturing_location_id:
           type: integer
           description: Default manufacturing location ID
@@ -10188,9 +10255,16 @@ components:
           type: integer
           description: Default sales location ID
         inventory_closing_date:
-          type: string
+          type:
+            - string
+            - "null"
           format: date-time
-          description: Inventory closing date
+          description: |-
+            Inventory closing date. Marked nullable defensively — current
+            wire returns a valid ISO-8601 datetime, but the Factory schema
+            is sparsely documented and other date-time fields here
+            (``default_so_delivery_time`` / ``default_po_lead_time``) have
+            been observed delivering ``null``. See #727.
       required:
         - display_name
         - base_currency_code

--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -10190,20 +10190,24 @@ components:
         base_currency_code:
           type: string
           description: Base currency code
-        # Schema gap: Katana's upstream example shows these as ISO-8601 datetimes,
-        # but the live wire delivers either ``null`` or an opaque short string
-        # (e.g. ``"14"`` for days-lead-time). ``format: date-time`` is omitted
-        # because the wire doesn't honor it.
         default_so_delivery_time:
           type:
             - string
             - "null"
-          description: Default sales order delivery time
+          description: |-
+            Default sales order delivery time. Note: Katana's upstream
+            example shows an ISO-8601 datetime, but the live wire delivers
+            either ``null`` or an opaque short string (e.g. ``"14"`` for
+            days). ``format: date-time`` is intentionally omitted.
         default_po_lead_time:
           type:
             - string
             - "null"
-          description: Default purchase order lead time
+          description: |-
+            Default purchase order lead time. Same shape as
+            ``default_so_delivery_time`` — wire delivers ``null`` or an
+            opaque short string, not a datetime. ``format: date-time``
+            intentionally omitted.
         default_manufacturing_location_id:
           type: integer
           description: Default manufacturing location ID

--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -2606,18 +2606,12 @@ components:
               type:
                 - string
                 - "null"
-              description: |-
-                Internal barcode for warehouse scanning and tracking. The wire
-                delivers ``null`` for variants that don't have one assigned;
-                ours-vs-Katana spec gap — Katana's published spec marks this
-                non-nullable but the live API returns null on most rows. See #727.
+              description: Internal barcode for warehouse scanning and tracking
             registered_barcode:
               type:
                 - string
                 - "null"
-              description: |-
-                Official registered barcode (UPC, EAN, etc.) for retail use.
-                Nullable per live-wire behavior — see ``internal_barcode``.
+              description: Official registered barcode (UPC, EAN, etc.) for retail use
             supplier_item_codes:
               type: array
               description: Supplier-specific part numbers or SKUs for purchasing
@@ -2637,11 +2631,7 @@ components:
               type:
                 - array
                 - "null"
-              description: |-
-                Custom field values specific to this variant. The wire delivers
-                ``null`` (not an empty array) when no custom fields are set —
-                see #727. Consumers should treat ``null`` and ``[]`` as
-                equivalent ("no custom fields").
+              description: Custom field values specific to this variant
               items:
                 type: object
                 properties:
@@ -2655,12 +2645,7 @@ components:
               type:
                 - array
                 - "null"
-              description: |-
-                Configuration attribute values that define this variant (color,
-                size, etc.). Marked nullable defensively (mirrors
-                ``custom_fields`` shape) so a future wire change to ``null``
-                doesn't crash the generated parser — current wire always
-                delivers an array, even if empty.
+              description: Configuration attribute values that define this variant (color, size, etc.)
               items:
                 type: object
                 properties:
@@ -2893,12 +2878,7 @@ components:
           type:
             - string
             - "null"
-          description: |-
-            Total quantity that could be available (in stock + expected).
-            Wire delivers ``null`` on the typical row (observed 100% on a
-            50-row sample). The field is still ``required`` because Katana
-            ships the key on every row — it's the *value* that may be null,
-            not the key. See #727.
+          description: Total quantity that could be available (in stock + expected)
         variant:
           $ref: "#/components/schemas/Variant"
           description: Product variant details associated with this inventory record
@@ -2912,11 +2892,7 @@ components:
           format: date-time
           description: Timestamp when this inventory record was archived
         default_storage_bin:
-          description: |-
-            Default storage bin for this variant at this location, when one has
-            been linked via the variant default storage bin endpoints. The wire
-            delivers ``null`` when no bin is linked (the typical case) — see
-            #727.
+          description: Default storage bin for this variant at this location, when one has been linked via the variant default storage bin endpoints
           anyOf:
             - $ref: "#/components/schemas/VariantDefaultStorageBinLinkResponse"
             - type: "null"
@@ -6675,18 +6651,12 @@ components:
               type:
                 - string
                 - "null"
-              description: |-
-                Internal barcode for warehouse scanning and tracking. The wire
-                delivers ``null`` for variants without one assigned — ours-vs-
-                Katana spec gap; see ``Variant.internal_barcode`` for the
-                rationale.
+              description: Internal barcode for warehouse scanning and tracking
             registered_barcode:
               type:
                 - string
                 - "null"
-              description: |-
-                Official registered barcode (UPC, EAN, etc.) for retail use.
-                Nullable per live-wire behavior — see ``internal_barcode``.
+              description: Official registered barcode (UPC, EAN, etc.) for retail use
             supplier_item_codes:
               type: array
               description: Supplier-specific part numbers or SKUs for purchasing
@@ -6706,10 +6676,7 @@ components:
               type:
                 - array
                 - "null"
-              description: |-
-                Configuration attribute values that define this variant. Marked
-                nullable to mirror ``custom_fields`` and the inline ``Variant``
-                schema — see #727.
+              description: Configuration attribute values that define this variant
               items:
                 type: object
                 properties:
@@ -6723,9 +6690,7 @@ components:
               type:
                 - array
                 - "null"
-              description: |-
-                Custom field values specific to this variant. The wire delivers
-                ``null`` (not ``[]``) when no custom fields are set — see #727.
+              description: Custom field values specific to this variant
               items:
                 type: object
                 properties:
@@ -10225,26 +10190,20 @@ components:
         base_currency_code:
           type: string
           description: Base currency code
+        # Schema gap: Katana's upstream example shows these as ISO-8601 datetimes,
+        # but the live wire delivers either ``null`` or an opaque short string
+        # (e.g. ``"14"`` for days-lead-time). ``format: date-time`` is omitted
+        # because the wire doesn't honor it.
         default_so_delivery_time:
           type:
             - string
             - "null"
-          description: |-
-            Default sales order delivery time. Schema gap: Katana's upstream
-            example shows an ISO-8601 datetime, but the live wire delivers
-            either ``null`` or an opaque short string (e.g. ``"14"`` for
-            days-lead-time). We deliberately drop ``format: date-time`` here
-            because the wire doesn't honor it. See #727.
+          description: Default sales order delivery time
         default_po_lead_time:
           type:
             - string
             - "null"
-          description: |-
-            Default purchase order lead time. Schema gap: same shape as
-            ``default_so_delivery_time`` — Katana's upstream example shows an
-            ISO-8601 datetime, but the live wire delivers ``null`` or an
-            opaque short string (e.g. ``"14"`` for days). ``format: date-time``
-            omitted intentionally. See #727.
+          description: Default purchase order lead time
         default_manufacturing_location_id:
           type: integer
           description: Default manufacturing location ID
@@ -10259,12 +10218,7 @@ components:
             - string
             - "null"
           format: date-time
-          description: |-
-            Inventory closing date. Marked nullable defensively — current
-            wire returns a valid ISO-8601 datetime, but the Factory schema
-            is sparsely documented and other date-time fields here
-            (``default_so_delivery_time`` / ``default_po_lead_time``) have
-            been observed delivering ``null``. See #727.
+          description: Inventory closing date
       required:
         - display_name
         - base_currency_code

--- a/katana_mcp_server/src/katana_mcp/server.py
+++ b/katana_mcp_server/src/katana_mcp/server.py
@@ -15,6 +15,7 @@ Features:
 import asyncio
 import os
 import time
+import traceback
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Literal, cast
@@ -124,12 +125,26 @@ async def _warm_caches_in_background(
         if isinstance(r, BaseException)
     ]
     if failures:
+        # Capture full tracebacks per-failure so the next regression is one-shot
+        # diagnosable. Without these the user-facing tool error surfaces only
+        # the bare ``str(exc)`` via ``observe_tool`` — agents waste a turn
+        # guessing at root cause when the stack frame would have been
+        # definitive. See #727 for the originating incident (4-day silent
+        # ``ensure_factory_synced`` crash + matching variants regression).
+        tracebacks = {
+            fn.__name__: "".join(
+                traceback.format_exception(type(r), r, r.__traceback__)
+            )
+            for fn, r in zip(helpers, results, strict=True)
+            if isinstance(r, BaseException)
+        }
         logger.warning(
             "cache_warmup_partial",
             elapsed_s=elapsed_s,
             success_count=len(helpers) - len(failures),
             failure_count=len(failures),
             failures=failures,
+            tracebacks=tracebacks,
         )
     else:
         logger.info(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -1825,11 +1825,13 @@ def _dict_to_variant_details(
     def _dump_list(items: Any) -> list[Any]:
         # Cache rows carry pydantic items (``ConfigAttribute`` /
         # ``CustomField``); API-fallback variants carry attrs items
-        # (``VariantConfigAttributesItem`` / ``VariantCustomFieldsItem``).
-        # Both need to land as plain dicts on the response so the
-        # pydantic ``VariantDetailsResponse`` validator accepts them
-        # — attrs models expose ``to_dict()``, pydantic models expose
-        # ``model_dump()``.
+        # (``VariantConfigAttributesType0Item`` /
+        # ``VariantCustomFieldsType0Item`` — the generator suffix
+        # ``Type0`` reflects the array-side of the nullable union
+        # type, see #727). Both need to land as plain dicts on the
+        # response so the pydantic ``VariantDetailsResponse`` validator
+        # accepts them — attrs models expose ``to_dict()``, pydantic
+        # models expose ``model_dump()``.
         if not items:
             return []
         return [

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -323,11 +323,11 @@ async def test_get_variant_details_api_fallback_derives_display_name_and_parent_
     """
     from katana_public_api_client.client_types import UNSET
     from katana_public_api_client.models.variant import Variant
-    from katana_public_api_client.models.variant_config_attributes_item import (
-        VariantConfigAttributesItem,
+    from katana_public_api_client.models.variant_config_attributes_type_0_item import (
+        VariantConfigAttributesType0Item,
     )
-    from katana_public_api_client.models.variant_custom_fields_item import (
-        VariantCustomFieldsItem,
+    from katana_public_api_client.models.variant_custom_fields_type_0_item import (
+        VariantCustomFieldsType0Item,
     )
     from katana_public_api_client.models.variant_type import VariantType
 
@@ -353,15 +353,15 @@ async def test_get_variant_details_api_fallback_derives_display_name_and_parent_
         purchase_price=150.0,
         type_=VariantType.PRODUCT,
         config_attributes=[
-            VariantConfigAttributesItem(
+            VariantConfigAttributesType0Item(
                 config_name="Piece Count", config_value="8-piece"
             ),
-            VariantConfigAttributesItem(
+            VariantConfigAttributesType0Item(
                 config_name="Handle Material", config_value="Steel"
             ),
         ],
         custom_fields=[
-            VariantCustomFieldsItem(
+            VariantCustomFieldsType0Item(
                 field_name="Warranty Period", field_value="5 years"
             ),
         ],
@@ -480,11 +480,11 @@ async def test_get_variant_details_cache_hit_and_api_fallback_paths_match():
     point at the divergence.
     """
     from katana_public_api_client.models.variant import Variant
-    from katana_public_api_client.models.variant_config_attributes_item import (
-        VariantConfigAttributesItem,
+    from katana_public_api_client.models.variant_config_attributes_type_0_item import (
+        VariantConfigAttributesType0Item,
     )
-    from katana_public_api_client.models.variant_custom_fields_item import (
-        VariantCustomFieldsItem,
+    from katana_public_api_client.models.variant_custom_fields_type_0_item import (
+        VariantCustomFieldsType0Item,
     )
     from katana_public_api_client.models.variant_type import VariantType
 
@@ -550,15 +550,15 @@ async def test_get_variant_details_cache_hit_and_api_fallback_paths_match():
         lead_time=7,
         minimum_order_quantity=1,
         config_attributes=[
-            VariantConfigAttributesItem(
+            VariantConfigAttributesType0Item(
                 config_name="Piece Count", config_value="8-piece"
             ),
-            VariantConfigAttributesItem(
+            VariantConfigAttributesType0Item(
                 config_name="Handle Material", config_value="Steel"
             ),
         ],
         custom_fields=[
-            VariantCustomFieldsItem(
+            VariantCustomFieldsType0Item(
                 field_name="Warranty Period", field_value="5 years"
             ),
         ],

--- a/katana_public_api_client/api/price_list_customer/create_price_list_customer.py
+++ b/katana_public_api_client/api/price_list_customer/create_price_list_customer.py
@@ -1,5 +1,6 @@
+from collections.abc import Mapping
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -38,7 +39,9 @@ def _parse_response(
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
-            response_200_item = PriceListCustomer.from_dict(response_200_item_data)
+            response_200_item = PriceListCustomer.from_dict(
+                cast(Mapping[str, Any], response_200_item_data)
+            )
 
             response_200.append(response_200_item)
 

--- a/katana_public_api_client/api/price_list_row/create_price_list_row.py
+++ b/katana_public_api_client/api/price_list_row/create_price_list_row.py
@@ -1,5 +1,6 @@
+from collections.abc import Mapping
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -38,7 +39,9 @@ def _parse_response(
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
-            response_200_item = PriceListRow.from_dict(response_200_item_data)
+            response_200_item = PriceListRow.from_dict(
+                cast(Mapping[str, Any], response_200_item_data)
+            )
 
             response_200.append(response_200_item)
 

--- a/katana_public_api_client/api/sales_order/get_sales_order_returnable_items.py
+++ b/katana_public_api_client/api/sales_order/get_sales_order_returnable_items.py
@@ -1,5 +1,6 @@
+from collections.abc import Mapping
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
@@ -32,7 +33,9 @@ def _parse_response(
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
-            response_200_item = ReturnableItem.from_dict(response_200_item_data)
+            response_200_item = ReturnableItem.from_dict(
+                cast(Mapping[str, Any], response_200_item_data)
+            )
 
             response_200.append(response_200_item)
 

--- a/katana_public_api_client/api/sales_return/get_sales_return_reasons.py
+++ b/katana_public_api_client/api/sales_return/get_sales_return_reasons.py
@@ -1,5 +1,6 @@
+from collections.abc import Mapping
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -27,7 +28,9 @@ def _parse_response(
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
-            response_200_item = SalesReturnReason.from_dict(response_200_item_data)
+            response_200_item = SalesReturnReason.from_dict(
+                cast(Mapping[str, Any], response_200_item_data)
+            )
 
             response_200.append(response_200_item)
 

--- a/katana_public_api_client/api/stocktake_row/create_stocktake_row.py
+++ b/katana_public_api_client/api/stocktake_row/create_stocktake_row.py
@@ -1,5 +1,6 @@
+from collections.abc import Mapping
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -38,7 +39,9 @@ def _parse_response(
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
-            response_200_item = StocktakeRow.from_dict(response_200_item_data)
+            response_200_item = StocktakeRow.from_dict(
+                cast(Mapping[str, Any], response_200_item_data)
+            )
 
             response_200.append(response_200_item)
 

--- a/katana_public_api_client/api/variant_default_storage_bin/link_variant_default_storage_bins.py
+++ b/katana_public_api_client/api/variant_default_storage_bin/link_variant_default_storage_bins.py
@@ -1,5 +1,6 @@
+from collections.abc import Mapping
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -46,7 +47,7 @@ def _parse_response(
         _response_200 = response.json()
         for response_200_item_data in _response_200:
             response_200_item = VariantDefaultStorageBinLinkResponse.from_dict(
-                response_200_item_data
+                cast(Mapping[str, Any], response_200_item_data)
             )
 
             response_200.append(response_200_item)

--- a/katana_public_api_client/models/__init__.py
+++ b/katana_public_api_client/models/__init__.py
@@ -531,16 +531,20 @@ from .user import User
 from .user_info import UserInfo
 from .user_list_response import UserListResponse
 from .variant import Variant
-from .variant_config_attributes_item import VariantConfigAttributesItem
-from .variant_custom_fields_item import VariantCustomFieldsItem
+from .variant_config_attributes_type_0_item import VariantConfigAttributesType0Item
+from .variant_custom_fields_type_0_item import VariantCustomFieldsType0Item
 from .variant_default_storage_bin_link import VariantDefaultStorageBinLink
 from .variant_default_storage_bin_link_response import (
     VariantDefaultStorageBinLinkResponse,
 )
 from .variant_list_response import VariantListResponse
 from .variant_response import VariantResponse
-from .variant_response_config_attributes_item import VariantResponseConfigAttributesItem
-from .variant_response_custom_fields_item import VariantResponseCustomFieldsItem
+from .variant_response_config_attributes_type_0_item import (
+    VariantResponseConfigAttributesType0Item,
+)
+from .variant_response_custom_fields_type_0_item import (
+    VariantResponseCustomFieldsType0Item,
+)
 from .variant_type import VariantType
 from .webhook import Webhook
 from .webhook_event import WebhookEvent
@@ -951,14 +955,14 @@ __all__ = (
     "UserInfo",
     "UserListResponse",
     "Variant",
-    "VariantConfigAttributesItem",
-    "VariantCustomFieldsItem",
+    "VariantConfigAttributesType0Item",
+    "VariantCustomFieldsType0Item",
     "VariantDefaultStorageBinLink",
     "VariantDefaultStorageBinLinkResponse",
     "VariantListResponse",
     "VariantResponse",
-    "VariantResponseConfigAttributesItem",
-    "VariantResponseCustomFieldsItem",
+    "VariantResponseConfigAttributesType0Item",
+    "VariantResponseCustomFieldsType0Item",
     "VariantType",
     "Webhook",
     "WebhookEvent",

--- a/katana_public_api_client/models/additional_cost_list_response.py
+++ b/katana_public_api_client/models/additional_cost_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -56,7 +56,9 @@ class AdditionalCostListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = AdditionalCost.from_dict(data_item_data)
+                data_item = AdditionalCost.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/batch_create_bom_rows_request.py
+++ b/katana_public_api_client/models/batch_create_bom_rows_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -52,7 +52,9 @@ class BatchCreateBomRowsRequest:
         data = []
         _data = d.pop("data")
         for data_item_data in _data:
-            data_item = CreateBomRowRequest.from_dict(data_item_data)
+            data_item = CreateBomRowRequest.from_dict(
+                cast(Mapping[str, Any], data_item_data)
+            )
 
             data.append(data_item)
 

--- a/katana_public_api_client/models/batch_stock_list_response.py
+++ b/katana_public_api_client/models/batch_stock_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -58,7 +58,9 @@ class BatchStockListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = BatchStock.from_dict(data_item_data)
+                data_item = BatchStock.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/bom_row_list_response.py
+++ b/katana_public_api_client/models/bom_row_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -58,7 +58,7 @@ class BomRowListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = BomRow.from_dict(data_item_data)
+                data_item = BomRow.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/clear_demand_forecast_request.py
+++ b/katana_public_api_client/models/clear_demand_forecast_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -64,7 +64,7 @@ class ClearDemandForecastRequest:
         _periods = d.pop("periods")
         for periods_item_data in _periods:
             periods_item = ClearDemandForecastRequestPeriodsItem.from_dict(
-                periods_item_data
+                cast(Mapping[str, Any], periods_item_data)
             )
 
             periods.append(periods_item)

--- a/katana_public_api_client/models/create_customer_request.py
+++ b/katana_public_api_client/models/create_customer_request.py
@@ -251,7 +251,7 @@ class CreateCustomerRequest:
             addresses = []
             for addresses_item_data in _addresses:
                 addresses_item = CreateCustomerRequestAddressesItem.from_dict(
-                    addresses_item_data
+                    cast(Mapping[str, Any], addresses_item_data)
                 )
 
                 addresses.append(addresses_item)

--- a/katana_public_api_client/models/create_demand_forecast_request.py
+++ b/katana_public_api_client/models/create_demand_forecast_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -64,7 +64,7 @@ class CreateDemandForecastRequest:
         _periods = d.pop("periods")
         for periods_item_data in _periods:
             periods_item = CreateDemandForecastRequestPeriodsItem.from_dict(
-                periods_item_data
+                cast(Mapping[str, Any], periods_item_data)
             )
 
             periods.append(periods_item)

--- a/katana_public_api_client/models/create_manufacturing_order_operation_row_request.py
+++ b/katana_public_api_client/models/create_manufacturing_order_operation_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -147,7 +147,7 @@ class CreateManufacturingOrderOperationRowRequest:
             assigned_operators = []
             for assigned_operators_item_data in _assigned_operators:
                 assigned_operators_item = Operator.from_dict(
-                    assigned_operators_item_data
+                    cast(Mapping[str, Any], assigned_operators_item_data)
                 )
 
                 assigned_operators.append(assigned_operators_item)

--- a/katana_public_api_client/models/create_manufacturing_order_production_request.py
+++ b/katana_public_api_client/models/create_manufacturing_order_production_request.py
@@ -141,7 +141,7 @@ class CreateManufacturingOrderProductionRequest:
             ingredients = []
             for ingredients_item_data in _ingredients:
                 ingredients_item = ManufacturingOrderProductionIngredient.from_dict(
-                    ingredients_item_data
+                    cast(Mapping[str, Any], ingredients_item_data)
                 )
 
                 ingredients.append(ingredients_item)
@@ -152,7 +152,7 @@ class CreateManufacturingOrderProductionRequest:
             operations = []
             for operations_item_data in _operations:
                 operations_item = ManufacturingOrderOperationRow.from_dict(
-                    operations_item_data
+                    cast(Mapping[str, Any], operations_item_data)
                 )
 
                 operations.append(operations_item)

--- a/katana_public_api_client/models/create_manufacturing_order_recipe_row_request.py
+++ b/katana_public_api_client/models/create_manufacturing_order_recipe_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -100,7 +100,7 @@ class CreateManufacturingOrderRecipeRowRequest:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = CreateManufacturingOrderRecipeRowRequestBatchTransactionsItem.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/create_manufacturing_order_request.py
+++ b/katana_public_api_client/models/create_manufacturing_order_request.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -145,7 +145,7 @@ class CreateManufacturingOrderRequest:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = BatchTransaction.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/create_material_request.py
+++ b/katana_public_api_client/models/create_material_request.py
@@ -121,7 +121,9 @@ class CreateMaterialRequest:
         variants = []
         _variants = d.pop("variants")
         for variants_item_data in _variants:
-            variants_item = CreateVariantRequest.from_dict(variants_item_data)
+            variants_item = CreateVariantRequest.from_dict(
+                cast(Mapping[str, Any], variants_item_data)
+            )
 
             variants.append(variants_item)
 
@@ -146,7 +148,9 @@ class CreateMaterialRequest:
         if _configs is not UNSET:
             configs = []
             for configs_item_data in _configs:
-                configs_item = MaterialConfig.from_dict(configs_item_data)
+                configs_item = MaterialConfig.from_dict(
+                    cast(Mapping[str, Any], configs_item_data)
+                )
 
                 configs.append(configs_item)
 

--- a/katana_public_api_client/models/create_outsourced_purchase_order_recipe_row_request.py
+++ b/katana_public_api_client/models/create_outsourced_purchase_order_recipe_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -75,7 +75,7 @@ class CreateOutsourcedPurchaseOrderRecipeRowRequest:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = BatchTransactionRequest.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/create_price_list_customer_request.py
+++ b/katana_public_api_client/models/create_price_list_customer_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -58,7 +58,7 @@ class CreatePriceListCustomerRequest:
         for price_list_customers_item_data in _price_list_customers:
             price_list_customers_item = (
                 CreatePriceListCustomerRequestPriceListCustomersItem.from_dict(
-                    price_list_customers_item_data
+                    cast(Mapping[str, Any], price_list_customers_item_data)
                 )
             )
 

--- a/katana_public_api_client/models/create_price_list_row_request.py
+++ b/katana_public_api_client/models/create_price_list_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -58,7 +58,7 @@ class CreatePriceListRowRequest:
         _price_list_rows = d.pop("price_list_rows")
         for price_list_rows_item_data in _price_list_rows:
             price_list_rows_item = CreatePriceListRowRequestPriceListRowsItem.from_dict(
-                price_list_rows_item_data
+                cast(Mapping[str, Any], price_list_rows_item_data)
             )
 
             price_list_rows.append(price_list_rows_item)

--- a/katana_public_api_client/models/create_product_operation_rows_request.py
+++ b/katana_public_api_client/models/create_product_operation_rows_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -51,7 +51,9 @@ class CreateProductOperationRowsRequest:
         rows = []
         _rows = d.pop("rows")
         for rows_item_data in _rows:
-            rows_item = CreateProductOperationRowItem.from_dict(rows_item_data)
+            rows_item = CreateProductOperationRowItem.from_dict(
+                cast(Mapping[str, Any], rows_item_data)
+            )
 
             rows.append(rows_item)
 

--- a/katana_public_api_client/models/create_product_request.py
+++ b/katana_public_api_client/models/create_product_request.py
@@ -152,7 +152,9 @@ class CreateProductRequest:
         variants = []
         _variants = d.pop("variants")
         for variants_item_data in _variants:
-            variants_item = CreateVariantRequest.from_dict(variants_item_data)
+            variants_item = CreateVariantRequest.from_dict(
+                cast(Mapping[str, Any], variants_item_data)
+            )
 
             variants.append(variants_item)
 
@@ -188,7 +190,7 @@ class CreateProductRequest:
             configs = []
             for configs_item_data in _configs:
                 configs_item = CreateProductRequestConfigsItem.from_dict(
-                    configs_item_data
+                    cast(Mapping[str, Any], configs_item_data)
                 )
 
                 configs.append(configs_item)

--- a/katana_public_api_client/models/create_purchase_order_request.py
+++ b/katana_public_api_client/models/create_purchase_order_request.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from dateutil.parser import isoparse
@@ -136,7 +136,7 @@ class CreatePurchaseOrderRequest:
         _purchase_order_rows = d.pop("purchase_order_rows")
         for purchase_order_rows_item_data in _purchase_order_rows:
             purchase_order_rows_item = PurchaseOrderRowRequest.from_dict(
-                purchase_order_rows_item_data
+                cast(Mapping[str, Any], purchase_order_rows_item_data)
             )
 
             purchase_order_rows.append(purchase_order_rows_item)

--- a/katana_public_api_client/models/create_recipes_request.py
+++ b/katana_public_api_client/models/create_recipes_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -56,7 +56,9 @@ class CreateRecipesRequest:
         rows = []
         _rows = d.pop("rows")
         for rows_item_data in _rows:
-            rows_item = CreateRecipesRequestRowsItem.from_dict(rows_item_data)
+            rows_item = CreateRecipesRequestRowsItem.from_dict(
+                cast(Mapping[str, Any], rows_item_data)
+            )
 
             rows.append(rows_item)
 

--- a/katana_public_api_client/models/create_sales_order_fulfillment_request.py
+++ b/katana_public_api_client/models/create_sales_order_fulfillment_request.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from dateutil.parser import isoparse
@@ -106,7 +106,7 @@ class CreateSalesOrderFulfillmentRequest:
         for sales_order_fulfillment_rows_item_data in _sales_order_fulfillment_rows:
             sales_order_fulfillment_rows_item = (
                 SalesOrderFulfillmentRowRequest.from_dict(
-                    sales_order_fulfillment_rows_item_data
+                    cast(Mapping[str, Any], sales_order_fulfillment_rows_item_data)
                 )
             )
 

--- a/katana_public_api_client/models/create_sales_order_request.py
+++ b/katana_public_api_client/models/create_sales_order_request.py
@@ -236,7 +236,7 @@ class CreateSalesOrderRequest:
         _sales_order_rows = d.pop("sales_order_rows")
         for sales_order_rows_item_data in _sales_order_rows:
             sales_order_rows_item = CreateSalesOrderRequestSalesOrderRowsItem.from_dict(
-                sales_order_rows_item_data
+                cast(Mapping[str, Any], sales_order_rows_item_data)
             )
 
             sales_order_rows.append(sales_order_rows_item)
@@ -266,7 +266,9 @@ class CreateSalesOrderRequest:
         if _addresses is not UNSET:
             addresses = []
             for addresses_item_data in _addresses:
-                addresses_item = SalesOrderAddress.from_dict(addresses_item_data)
+                addresses_item = SalesOrderAddress.from_dict(
+                    cast(Mapping[str, Any], addresses_item_data)
+                )
 
                 addresses.append(addresses_item)
 
@@ -380,7 +382,9 @@ class CreateSalesOrderRequest:
         if _custom_fields is not UNSET:
             custom_fields = []
             for custom_fields_item_data in _custom_fields:
-                custom_fields_item = CustomFieldValue.from_dict(custom_fields_item_data)
+                custom_fields_item = CustomFieldValue.from_dict(
+                    cast(Mapping[str, Any], custom_fields_item_data)
+                )
 
                 custom_fields.append(custom_fields_item)
 

--- a/katana_public_api_client/models/create_sales_order_request_sales_order_rows_item.py
+++ b/katana_public_api_client/models/create_sales_order_request_sales_order_rows_item.py
@@ -145,7 +145,7 @@ class CreateSalesOrderRequestSalesOrderRowsItem:
             for attributes_item_data in _attributes:
                 attributes_item = (
                     CreateSalesOrderRequestSalesOrderRowsItemAttributesItem.from_dict(
-                        attributes_item_data
+                        cast(Mapping[str, Any], attributes_item_data)
                     )
                 )
 

--- a/katana_public_api_client/models/create_sales_order_row_request.py
+++ b/katana_public_api_client/models/create_sales_order_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -103,7 +103,7 @@ class CreateSalesOrderRowRequest:
             attributes = []
             for attributes_item_data in _attributes:
                 attributes_item = CreateSalesOrderRowRequestAttributesItem.from_dict(
-                    attributes_item_data
+                    cast(Mapping[str, Any], attributes_item_data)
                 )
 
                 attributes.append(attributes_item)

--- a/katana_public_api_client/models/create_service_request.py
+++ b/katana_public_api_client/models/create_service_request.py
@@ -86,7 +86,9 @@ class CreateServiceRequest:
         variants = []
         _variants = d.pop("variants")
         for variants_item_data in _variants:
-            variants_item = CreateServiceVariantRequest.from_dict(variants_item_data)
+            variants_item = CreateServiceVariantRequest.from_dict(
+                cast(Mapping[str, Any], variants_item_data)
+            )
 
             variants.append(variants_item)
 

--- a/katana_public_api_client/models/create_service_variant_request.py
+++ b/katana_public_api_client/models/create_service_variant_request.py
@@ -102,7 +102,7 @@ class CreateServiceVariantRequest:
             for custom_fields_item_data in _custom_fields:
                 custom_fields_item = (
                     CreateServiceVariantRequestCustomFieldsItem.from_dict(
-                        custom_fields_item_data
+                        cast(Mapping[str, Any], custom_fields_item_data)
                     )
                 )
 

--- a/katana_public_api_client/models/create_stock_adjustment_request.py
+++ b/katana_public_api_client/models/create_stock_adjustment_request.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from dateutil.parser import isoparse
@@ -87,7 +87,7 @@ class CreateStockAdjustmentRequest:
         for stock_adjustment_rows_item_data in _stock_adjustment_rows:
             stock_adjustment_rows_item = (
                 CreateStockAdjustmentRequestStockAdjustmentRowsItem.from_dict(
-                    stock_adjustment_rows_item_data
+                    cast(Mapping[str, Any], stock_adjustment_rows_item_data)
                 )
             )
 

--- a/katana_public_api_client/models/create_stock_adjustment_request_stock_adjustment_rows_item.py
+++ b/katana_public_api_client/models/create_stock_adjustment_request_stock_adjustment_rows_item.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -71,7 +71,7 @@ class CreateStockAdjustmentRequestStockAdjustmentRowsItem:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = StockAdjustmentBatchTransaction.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/create_stock_transfer_request.py
+++ b/katana_public_api_client/models/create_stock_transfer_request.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from dateutil.parser import isoparse
@@ -91,7 +91,7 @@ class CreateStockTransferRequest:
         _stock_transfer_rows = d.pop("stock_transfer_rows")
         for stock_transfer_rows_item_data in _stock_transfer_rows:
             stock_transfer_rows_item = StockTransferRowRequest.from_dict(
-                stock_transfer_rows_item_data
+                cast(Mapping[str, Any], stock_transfer_rows_item_data)
             )
 
             stock_transfer_rows.append(stock_transfer_rows_item)

--- a/katana_public_api_client/models/create_stocktake_request.py
+++ b/katana_public_api_client/models/create_stocktake_request.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from dateutil.parser import isoparse
@@ -110,7 +110,7 @@ class CreateStocktakeRequest:
             stocktake_rows = []
             for stocktake_rows_item_data in _stocktake_rows:
                 stocktake_rows_item = CreateStocktakeRequestStocktakeRowsItem.from_dict(
-                    stocktake_rows_item_data
+                    cast(Mapping[str, Any], stocktake_rows_item_data)
                 )
 
                 stocktake_rows.append(stocktake_rows_item)

--- a/katana_public_api_client/models/create_stocktake_row_request.py
+++ b/katana_public_api_client/models/create_stocktake_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -66,7 +66,7 @@ class CreateStocktakeRowRequest:
             for stocktake_rows_item_data in _stocktake_rows:
                 stocktake_rows_item = (
                     CreateStocktakeRowRequestStocktakeRowsItem.from_dict(
-                        stocktake_rows_item_data
+                        cast(Mapping[str, Any], stocktake_rows_item_data)
                     )
                 )
 

--- a/katana_public_api_client/models/create_supplier_request.py
+++ b/katana_public_api_client/models/create_supplier_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -89,7 +89,9 @@ class CreateSupplierRequest:
         if _addresses is not UNSET:
             addresses = []
             for addresses_item_data in _addresses:
-                addresses_item = SupplierAddressRequest.from_dict(addresses_item_data)
+                addresses_item = SupplierAddressRequest.from_dict(
+                    cast(Mapping[str, Any], addresses_item_data)
+                )
 
                 addresses.append(addresses_item)
 

--- a/katana_public_api_client/models/create_variant_request.py
+++ b/katana_public_api_client/models/create_variant_request.py
@@ -184,7 +184,7 @@ class CreateVariantRequest:
             for config_attributes_item_data in _config_attributes:
                 config_attributes_item = (
                     CreateVariantRequestConfigAttributesItem.from_dict(
-                        config_attributes_item_data
+                        cast(Mapping[str, Any], config_attributes_item_data)
                     )
                 )
 
@@ -196,7 +196,7 @@ class CreateVariantRequest:
             custom_fields = []
             for custom_fields_item_data in _custom_fields:
                 custom_fields_item = CreateVariantRequestCustomFieldsItem.from_dict(
-                    custom_fields_item_data
+                    cast(Mapping[str, Any], custom_fields_item_data)
                 )
 
                 custom_fields.append(custom_fields_item)

--- a/katana_public_api_client/models/custom_field_definition_list_response.py
+++ b/katana_public_api_client/models/custom_field_definition_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -56,7 +56,9 @@ class CustomFieldDefinitionListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = CustomFieldDefinition.from_dict(data_item_data)
+                data_item = CustomFieldDefinition.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/custom_fields_collection.py
+++ b/katana_public_api_client/models/custom_fields_collection.py
@@ -147,7 +147,9 @@ class CustomFieldsCollection:
         if _custom_fields is not UNSET:
             custom_fields = []
             for custom_fields_item_data in _custom_fields:
-                custom_fields_item = CustomField.from_dict(custom_fields_item_data)
+                custom_fields_item = CustomField.from_dict(
+                    cast(Mapping[str, Any], custom_fields_item_data)
+                )
 
                 custom_fields.append(custom_fields_item)
 

--- a/katana_public_api_client/models/custom_fields_collection_list_response.py
+++ b/katana_public_api_client/models/custom_fields_collection_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -62,7 +62,9 @@ class CustomFieldsCollectionListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = CustomFieldsCollection.from_dict(data_item_data)
+                data_item = CustomFieldsCollection.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/customer.py
+++ b/katana_public_api_client/models/customer.py
@@ -340,7 +340,9 @@ class Customer:
         if _addresses is not UNSET:
             addresses = []
             for addresses_item_data in _addresses:
-                addresses_item = CustomerAddress.from_dict(addresses_item_data)
+                addresses_item = CustomerAddress.from_dict(
+                    cast(Mapping[str, Any], addresses_item_data)
+                )
 
                 addresses.append(addresses_item)
 

--- a/katana_public_api_client/models/customer_address_list_response.py
+++ b/katana_public_api_client/models/customer_address_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -61,7 +61,9 @@ class CustomerAddressListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = CustomerAddress.from_dict(data_item_data)
+                data_item = CustomerAddress.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/customer_list_response.py
+++ b/katana_public_api_client/models/customer_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -66,7 +66,7 @@ class CustomerListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = Customer.from_dict(data_item_data)
+                data_item = Customer.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/demand_forecast_response.py
+++ b/katana_public_api_client/models/demand_forecast_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -77,7 +77,9 @@ class DemandForecastResponse:
         if _periods is not UNSET:
             periods = []
             for periods_item_data in _periods:
-                periods_item = DemandForecastPeriod.from_dict(periods_item_data)
+                periods_item = DemandForecastPeriod.from_dict(
+                    cast(Mapping[str, Any], periods_item_data)
+                )
 
                 periods.append(periods_item)
 

--- a/katana_public_api_client/models/factory.py
+++ b/katana_public_api_client/models/factory.py
@@ -39,12 +39,12 @@ class Factory:
     timezone: str | Unset = UNSET
     legal_address: FactoryLegalAddress | Unset = UNSET
     legal_name: str | Unset = UNSET
-    default_so_delivery_time: datetime.datetime | Unset = UNSET
-    default_po_lead_time: datetime.datetime | Unset = UNSET
+    default_so_delivery_time: None | str | Unset = UNSET
+    default_po_lead_time: None | str | Unset = UNSET
     default_manufacturing_location_id: int | Unset = UNSET
     default_purchases_location_id: int | Unset = UNSET
     default_sales_location_id: int | Unset = UNSET
-    inventory_closing_date: datetime.datetime | Unset = UNSET
+    inventory_closing_date: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -70,13 +70,17 @@ class Factory:
 
         legal_name = self.legal_name
 
-        default_so_delivery_time: str | Unset = UNSET
-        if not isinstance(self.default_so_delivery_time, Unset):
-            default_so_delivery_time = self.default_so_delivery_time.isoformat()
+        default_so_delivery_time: None | str | Unset
+        if isinstance(self.default_so_delivery_time, Unset):
+            default_so_delivery_time = UNSET
+        else:
+            default_so_delivery_time = self.default_so_delivery_time
 
-        default_po_lead_time: str | Unset = UNSET
-        if not isinstance(self.default_po_lead_time, Unset):
-            default_po_lead_time = self.default_po_lead_time.isoformat()
+        default_po_lead_time: None | str | Unset
+        if isinstance(self.default_po_lead_time, Unset):
+            default_po_lead_time = UNSET
+        else:
+            default_po_lead_time = self.default_po_lead_time
 
         default_manufacturing_location_id = self.default_manufacturing_location_id
 
@@ -84,9 +88,13 @@ class Factory:
 
         default_sales_location_id = self.default_sales_location_id
 
-        inventory_closing_date: str | Unset = UNSET
-        if not isinstance(self.inventory_closing_date, Unset):
+        inventory_closing_date: None | str | Unset
+        if isinstance(self.inventory_closing_date, Unset):
+            inventory_closing_date = UNSET
+        elif isinstance(self.inventory_closing_date, datetime.datetime):
             inventory_closing_date = self.inventory_closing_date.isoformat()
+        else:
+            inventory_closing_date = self.inventory_closing_date
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -158,19 +166,27 @@ class Factory:
 
         legal_name = d.pop("legal_name", UNSET)
 
-        _default_so_delivery_time = d.pop("default_so_delivery_time", UNSET)
-        default_so_delivery_time: datetime.datetime | Unset
-        if isinstance(_default_so_delivery_time, Unset):
-            default_so_delivery_time = UNSET
-        else:
-            default_so_delivery_time = isoparse(_default_so_delivery_time)
+        def _parse_default_so_delivery_time(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
 
-        _default_po_lead_time = d.pop("default_po_lead_time", UNSET)
-        default_po_lead_time: datetime.datetime | Unset
-        if isinstance(_default_po_lead_time, Unset):
-            default_po_lead_time = UNSET
-        else:
-            default_po_lead_time = isoparse(_default_po_lead_time)
+        default_so_delivery_time = _parse_default_so_delivery_time(
+            d.pop("default_so_delivery_time", UNSET)
+        )
+
+        def _parse_default_po_lead_time(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        default_po_lead_time = _parse_default_po_lead_time(
+            d.pop("default_po_lead_time", UNSET)
+        )
 
         default_manufacturing_location_id = d.pop(
             "default_manufacturing_location_id", UNSET
@@ -180,12 +196,26 @@ class Factory:
 
         default_sales_location_id = d.pop("default_sales_location_id", UNSET)
 
-        _inventory_closing_date = d.pop("inventory_closing_date", UNSET)
-        inventory_closing_date: datetime.datetime | Unset
-        if isinstance(_inventory_closing_date, Unset):
-            inventory_closing_date = UNSET
-        else:
-            inventory_closing_date = isoparse(_inventory_closing_date)
+        def _parse_inventory_closing_date(
+            data: object,
+        ) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                inventory_closing_date_type_0 = isoparse(data)
+
+                return inventory_closing_date_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        inventory_closing_date = _parse_inventory_closing_date(
+            d.pop("inventory_closing_date", UNSET)
+        )
 
         factory = cls(
             display_name=display_name,

--- a/katana_public_api_client/models/inventory.py
+++ b/katana_public_api_client/models/inventory.py
@@ -43,15 +43,19 @@ class Inventory:
     quantity_committed: str
     quantity_expected: str
     quantity_missing_or_excess: str
-    quantity_potential: str
+    quantity_potential: None | str
     safety_stock_level: str | Unset = UNSET
     variant: Variant | Unset = UNSET
     location: Location | Unset = UNSET
     archived_at: datetime.datetime | None | Unset = UNSET
-    default_storage_bin: VariantDefaultStorageBinLinkResponse | Unset = UNSET
+    default_storage_bin: None | Unset | VariantDefaultStorageBinLinkResponse = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.variant_default_storage_bin_link_response import (
+            VariantDefaultStorageBinLinkResponse,
+        )
+
         variant_id = self.variant_id
 
         location_id = self.location_id
@@ -70,6 +74,7 @@ class Inventory:
 
         quantity_missing_or_excess = self.quantity_missing_or_excess
 
+        quantity_potential: None | str
         quantity_potential = self.quantity_potential
 
         safety_stock_level = self.safety_stock_level
@@ -90,9 +95,13 @@ class Inventory:
         else:
             archived_at = self.archived_at
 
-        default_storage_bin: dict[str, Any] | Unset = UNSET
-        if not isinstance(self.default_storage_bin, Unset):
+        default_storage_bin: dict[str, Any] | None | Unset
+        if isinstance(self.default_storage_bin, Unset):
+            default_storage_bin = UNSET
+        elif isinstance(self.default_storage_bin, VariantDefaultStorageBinLinkResponse):
             default_storage_bin = self.default_storage_bin.to_dict()
+        else:
+            default_storage_bin = self.default_storage_bin
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -150,7 +159,12 @@ class Inventory:
 
         quantity_missing_or_excess = d.pop("quantity_missing_or_excess")
 
-        quantity_potential = d.pop("quantity_potential")
+        def _parse_quantity_potential(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        quantity_potential = _parse_quantity_potential(d.pop("quantity_potential"))
 
         safety_stock_level = d.pop("safety_stock_level", UNSET)
 
@@ -185,14 +199,33 @@ class Inventory:
 
         archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
 
-        _default_storage_bin = d.pop("default_storage_bin", UNSET)
-        default_storage_bin: VariantDefaultStorageBinLinkResponse | Unset
-        if isinstance(_default_storage_bin, Unset):
-            default_storage_bin = UNSET
-        else:
-            default_storage_bin = VariantDefaultStorageBinLinkResponse.from_dict(
-                _default_storage_bin
-            )
+        def _parse_default_storage_bin(
+            data: object,
+        ) -> None | Unset | VariantDefaultStorageBinLinkResponse:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                default_storage_bin_type_0 = (
+                    VariantDefaultStorageBinLinkResponse.from_dict(
+                        cast(Mapping[str, Any], data)
+                    )
+                )
+
+                return default_storage_bin_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | VariantDefaultStorageBinLinkResponse, data)
+
+        default_storage_bin = _parse_default_storage_bin(
+            d.pop("default_storage_bin", UNSET)
+        )
 
         inventory = cls(
             variant_id=variant_id,

--- a/katana_public_api_client/models/inventory_item.py
+++ b/katana_public_api_client/models/inventory_item.py
@@ -272,7 +272,9 @@ class InventoryItem:
         if _variants is not UNSET:
             variants = []
             for variants_item_data in _variants:
-                variants_item = Variant.from_dict(variants_item_data)
+                variants_item = Variant.from_dict(
+                    cast(Mapping[str, Any], variants_item_data)
+                )
 
                 variants.append(variants_item)
 
@@ -281,7 +283,9 @@ class InventoryItem:
         if _configs is not UNSET:
             configs = []
             for configs_item_data in _configs:
-                configs_item = ItemConfig.from_dict(configs_item_data)
+                configs_item = ItemConfig.from_dict(
+                    cast(Mapping[str, Any], configs_item_data)
+                )
 
                 configs.append(configs_item)
 

--- a/katana_public_api_client/models/inventory_list_response.py
+++ b/katana_public_api_client/models/inventory_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -59,7 +59,7 @@ class InventoryListResponse:
         data = []
         _data = d.pop("data")
         for data_item_data in _data:
-            data_item = Inventory.from_dict(data_item_data)
+            data_item = Inventory.from_dict(cast(Mapping[str, Any], data_item_data))
 
             data.append(data_item)
 

--- a/katana_public_api_client/models/inventory_movement_list_response.py
+++ b/katana_public_api_client/models/inventory_movement_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -55,7 +55,9 @@ class InventoryMovementListResponse:
         data = []
         _data = d.pop("data")
         for data_item_data in _data:
-            data_item = InventoryMovement.from_dict(data_item_data)
+            data_item = InventoryMovement.from_dict(
+                cast(Mapping[str, Any], data_item_data)
+            )
 
             data.append(data_item)
 

--- a/katana_public_api_client/models/location_list_response.py
+++ b/katana_public_api_client/models/location_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -50,7 +50,7 @@ class LocationListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = Location.from_dict(data_item_data)
+                data_item = Location.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/manufacturing_order.py
+++ b/katana_public_api_client/models/manufacturing_order.py
@@ -354,7 +354,7 @@ class ManufacturingOrder:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = BatchTransaction.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)
@@ -459,7 +459,9 @@ class ManufacturingOrder:
         if _serial_numbers is not UNSET:
             serial_numbers = []
             for serial_numbers_item_data in _serial_numbers:
-                serial_numbers_item = SerialNumber.from_dict(serial_numbers_item_data)
+                serial_numbers_item = SerialNumber.from_dict(
+                    cast(Mapping[str, Any], serial_numbers_item_data)
+                )
 
                 serial_numbers.append(serial_numbers_item)
 

--- a/katana_public_api_client/models/manufacturing_order_list_response.py
+++ b/katana_public_api_client/models/manufacturing_order_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -67,7 +67,9 @@ class ManufacturingOrderListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = ManufacturingOrder.from_dict(data_item_data)
+                data_item = ManufacturingOrder.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/manufacturing_order_operation_row.py
+++ b/katana_public_api_client/models/manufacturing_order_operation_row.py
@@ -283,7 +283,7 @@ class ManufacturingOrderOperationRow:
             assigned_operators = []
             for assigned_operators_item_data in _assigned_operators:
                 assigned_operators_item = AssignedOperator.from_dict(
-                    assigned_operators_item_data
+                    cast(Mapping[str, Any], assigned_operators_item_data)
                 )
 
                 assigned_operators.append(assigned_operators_item)
@@ -294,7 +294,7 @@ class ManufacturingOrderOperationRow:
             completed_by_operators = []
             for completed_by_operators_item_data in _completed_by_operators:
                 completed_by_operators_item = AssignedOperator.from_dict(
-                    completed_by_operators_item_data
+                    cast(Mapping[str, Any], completed_by_operators_item_data)
                 )
 
                 completed_by_operators.append(completed_by_operators_item)

--- a/katana_public_api_client/models/manufacturing_order_operation_row_list_response.py
+++ b/katana_public_api_client/models/manufacturing_order_operation_row_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -60,7 +60,9 @@ class ManufacturingOrderOperationRowListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = ManufacturingOrderOperationRow.from_dict(data_item_data)
+                data_item = ManufacturingOrderOperationRow.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/manufacturing_order_production.py
+++ b/katana_public_api_client/models/manufacturing_order_production.py
@@ -201,7 +201,7 @@ class ManufacturingOrderProduction:
             ingredients = []
             for ingredients_item_data in _ingredients:
                 ingredients_item = ManufacturingOrderProductionIngredient.from_dict(
-                    ingredients_item_data
+                    cast(Mapping[str, Any], ingredients_item_data)
                 )
 
                 ingredients.append(ingredients_item)
@@ -212,7 +212,7 @@ class ManufacturingOrderProduction:
             operations = []
             for operations_item_data in _operations:
                 operations_item = ManufacturingOrderOperationProduction.from_dict(
-                    operations_item_data
+                    cast(Mapping[str, Any], operations_item_data)
                 )
 
                 operations.append(operations_item)
@@ -222,7 +222,9 @@ class ManufacturingOrderProduction:
         if _serial_numbers is not UNSET:
             serial_numbers = []
             for serial_numbers_item_data in _serial_numbers:
-                serial_numbers_item = SerialNumber.from_dict(serial_numbers_item_data)
+                serial_numbers_item = SerialNumber.from_dict(
+                    cast(Mapping[str, Any], serial_numbers_item_data)
+                )
 
                 serial_numbers.append(serial_numbers_item)
 

--- a/katana_public_api_client/models/manufacturing_order_production_list_response.py
+++ b/katana_public_api_client/models/manufacturing_order_production_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -67,7 +67,9 @@ class ManufacturingOrderProductionListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = ManufacturingOrderProduction.from_dict(data_item_data)
+                data_item = ManufacturingOrderProduction.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/manufacturing_order_recipe_row.py
+++ b/katana_public_api_client/models/manufacturing_order_recipe_row.py
@@ -232,7 +232,7 @@ class ManufacturingOrderRecipeRow:
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = (
                     ManufacturingOrderRecipeRowBatchTransactionsItem.from_dict(
-                        batch_transactions_item_data
+                        cast(Mapping[str, Any], batch_transactions_item_data)
                     )
                 )
 

--- a/katana_public_api_client/models/manufacturing_order_recipe_row_list_response.py
+++ b/katana_public_api_client/models/manufacturing_order_recipe_row_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -57,7 +57,9 @@ class ManufacturingOrderRecipeRowListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = ManufacturingOrderRecipeRow.from_dict(data_item_data)
+                data_item = ManufacturingOrderRecipeRow.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/material.py
+++ b/katana_public_api_client/models/material.py
@@ -305,7 +305,9 @@ class Material:
         if _variants is not UNSET:
             variants = []
             for variants_item_data in _variants:
-                variants_item = Variant.from_dict(variants_item_data)
+                variants_item = Variant.from_dict(
+                    cast(Mapping[str, Any], variants_item_data)
+                )
 
                 variants.append(variants_item)
 
@@ -314,7 +316,9 @@ class Material:
         if _configs is not UNSET:
             configs = []
             for configs_item_data in _configs:
-                configs_item = ItemConfig.from_dict(configs_item_data)
+                configs_item = ItemConfig.from_dict(
+                    cast(Mapping[str, Any], configs_item_data)
+                )
 
                 configs.append(configs_item)
 

--- a/katana_public_api_client/models/material_list_response.py
+++ b/katana_public_api_client/models/material_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -66,7 +66,7 @@ class MaterialListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = Material.from_dict(data_item_data)
+                data_item = Material.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/negative_stock_list_response.py
+++ b/katana_public_api_client/models/negative_stock_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -57,7 +57,9 @@ class NegativeStockListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = NegativeStock.from_dict(data_item_data)
+                data_item = NegativeStock.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/operator_list_response.py
+++ b/katana_public_api_client/models/operator_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -50,7 +50,7 @@ class OperatorListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = Operator.from_dict(data_item_data)
+                data_item = Operator.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/outsourced_purchase_order.py
+++ b/katana_public_api_client/models/outsourced_purchase_order.py
@@ -302,7 +302,7 @@ class OutsourcedPurchaseOrder:
             purchase_order_rows = []
             for purchase_order_rows_item_data in _purchase_order_rows:
                 purchase_order_rows_item = PurchaseOrderRow.from_dict(
-                    purchase_order_rows_item_data
+                    cast(Mapping[str, Any], purchase_order_rows_item_data)
                 )
 
                 purchase_order_rows.append(purchase_order_rows_item)

--- a/katana_public_api_client/models/outsourced_purchase_order_recipe_row.py
+++ b/katana_public_api_client/models/outsourced_purchase_order_recipe_row.py
@@ -230,7 +230,7 @@ class OutsourcedPurchaseOrderRecipeRow:
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = (
                     OutsourcedPurchaseOrderRecipeRowBatchTransactionsItem.from_dict(
-                        batch_transactions_item_data
+                        cast(Mapping[str, Any], batch_transactions_item_data)
                     )
                 )
 

--- a/katana_public_api_client/models/outsourced_purchase_order_recipe_row_list_response.py
+++ b/katana_public_api_client/models/outsourced_purchase_order_recipe_row_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -60,7 +60,9 @@ class OutsourcedPurchaseOrderRecipeRowListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = OutsourcedPurchaseOrderRecipeRow.from_dict(data_item_data)
+                data_item = OutsourcedPurchaseOrderRecipeRow.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/price_list_customer_list_response.py
+++ b/katana_public_api_client/models/price_list_customer_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -56,7 +56,9 @@ class PriceListCustomerListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = PriceListCustomer.from_dict(data_item_data)
+                data_item = PriceListCustomer.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/price_list_list_response.py
+++ b/katana_public_api_client/models/price_list_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -60,7 +60,7 @@ class PriceListListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = PriceList.from_dict(data_item_data)
+                data_item = PriceList.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/price_list_row_list_response.py
+++ b/katana_public_api_client/models/price_list_row_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -57,7 +57,9 @@ class PriceListRowListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = PriceListRow.from_dict(data_item_data)
+                data_item = PriceListRow.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/product.py
+++ b/katana_public_api_client/models/product.py
@@ -340,7 +340,9 @@ class Product:
         if _variants is not UNSET:
             variants = []
             for variants_item_data in _variants:
-                variants_item = Variant.from_dict(variants_item_data)
+                variants_item = Variant.from_dict(
+                    cast(Mapping[str, Any], variants_item_data)
+                )
 
                 variants.append(variants_item)
 
@@ -349,7 +351,9 @@ class Product:
         if _configs is not UNSET:
             configs = []
             for configs_item_data in _configs:
-                configs_item = ItemConfig.from_dict(configs_item_data)
+                configs_item = ItemConfig.from_dict(
+                    cast(Mapping[str, Any], configs_item_data)
+                )
 
                 configs.append(configs_item)
 

--- a/katana_public_api_client/models/product_list_response.py
+++ b/katana_public_api_client/models/product_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -59,7 +59,7 @@ class ProductListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = Product.from_dict(data_item_data)
+                data_item = Product.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/product_operation_row_list_response.py
+++ b/katana_public_api_client/models/product_operation_row_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -50,7 +50,9 @@ class ProductOperationRowListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = ProductOperationRow.from_dict(data_item_data)
+                data_item = ProductOperationRow.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/purchase_order_accounting_metadata_list_response.py
+++ b/katana_public_api_client/models/purchase_order_accounting_metadata_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -62,7 +62,9 @@ class PurchaseOrderAccountingMetadataListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = PurchaseOrderAccountingMetadata.from_dict(data_item_data)
+                data_item = PurchaseOrderAccountingMetadata.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/purchase_order_additional_cost_row_list_response.py
+++ b/katana_public_api_client/models/purchase_order_additional_cost_row_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -63,7 +63,9 @@ class PurchaseOrderAdditionalCostRowListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = PurchaseOrderAdditionalCostRow.from_dict(data_item_data)
+                data_item = PurchaseOrderAdditionalCostRow.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/purchase_order_base.py
+++ b/katana_public_api_client/models/purchase_order_base.py
@@ -271,7 +271,7 @@ class PurchaseOrderBase:
             purchase_order_rows = []
             for purchase_order_rows_item_data in _purchase_order_rows:
                 purchase_order_rows_item = PurchaseOrderRow.from_dict(
-                    purchase_order_rows_item_data
+                    cast(Mapping[str, Any], purchase_order_rows_item_data)
                 )
 
                 purchase_order_rows.append(purchase_order_rows_item)

--- a/katana_public_api_client/models/purchase_order_receive_row.py
+++ b/katana_public_api_client/models/purchase_order_receive_row.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from dateutil.parser import isoparse
@@ -87,7 +87,7 @@ class PurchaseOrderReceiveRow:
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = (
                     PurchaseOrderReceiveRowBatchTransactionsItem.from_dict(
-                        batch_transactions_item_data
+                        cast(Mapping[str, Any], batch_transactions_item_data)
                     )
                 )
 

--- a/katana_public_api_client/models/purchase_order_row.py
+++ b/katana_public_api_client/models/purchase_order_row.py
@@ -329,7 +329,7 @@ class PurchaseOrderRow:
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = (
                     PurchaseOrderRowBatchTransactionsItem.from_dict(
-                        batch_transactions_item_data
+                        cast(Mapping[str, Any], batch_transactions_item_data)
                     )
                 )
 

--- a/katana_public_api_client/models/purchase_order_row_list_response.py
+++ b/katana_public_api_client/models/purchase_order_row_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -60,7 +60,9 @@ class PurchaseOrderRowListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = PurchaseOrderRow.from_dict(data_item_data)
+                data_item = PurchaseOrderRow.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/recipe_list_response.py
+++ b/katana_public_api_client/models/recipe_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -57,7 +57,7 @@ class RecipeListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = Recipe.from_dict(data_item_data)
+                data_item = Recipe.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/regular_purchase_order.py
+++ b/katana_public_api_client/models/regular_purchase_order.py
@@ -276,7 +276,7 @@ class RegularPurchaseOrder:
             purchase_order_rows = []
             for purchase_order_rows_item_data in _purchase_order_rows:
                 purchase_order_rows_item = PurchaseOrderRow.from_dict(
-                    purchase_order_rows_item_data
+                    cast(Mapping[str, Any], purchase_order_rows_item_data)
                 )
 
                 purchase_order_rows.append(purchase_order_rows_item)

--- a/katana_public_api_client/models/sales_order.py
+++ b/katana_public_api_client/models/sales_order.py
@@ -578,7 +578,7 @@ class SalesOrder:
             sales_order_rows = []
             for sales_order_rows_item_data in _sales_order_rows:
                 sales_order_rows_item = SalesOrderRow.from_dict(
-                    sales_order_rows_item_data
+                    cast(Mapping[str, Any], sales_order_rows_item_data)
                 )
 
                 sales_order_rows.append(sales_order_rows_item)
@@ -799,7 +799,9 @@ class SalesOrder:
         if _addresses is not UNSET:
             addresses = []
             for addresses_item_data in _addresses:
-                addresses_item = SalesOrderAddress.from_dict(addresses_item_data)
+                addresses_item = SalesOrderAddress.from_dict(
+                    cast(Mapping[str, Any], addresses_item_data)
+                )
 
                 addresses.append(addresses_item)
 

--- a/katana_public_api_client/models/sales_order_accounting_metadata_list_response.py
+++ b/katana_public_api_client/models/sales_order_accounting_metadata_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -57,7 +57,9 @@ class SalesOrderAccountingMetadataListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = SalesOrderAccountingMetadata.from_dict(data_item_data)
+                data_item = SalesOrderAccountingMetadata.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/sales_order_address_list_response.py
+++ b/katana_public_api_client/models/sales_order_address_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -61,7 +61,9 @@ class SalesOrderAddressListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = SalesOrderAddress.from_dict(data_item_data)
+                data_item = SalesOrderAddress.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/sales_order_fulfillment.py
+++ b/katana_public_api_client/models/sales_order_fulfillment.py
@@ -331,7 +331,7 @@ class SalesOrderFulfillment:
             for sales_order_fulfillment_rows_item_data in _sales_order_fulfillment_rows:
                 sales_order_fulfillment_rows_item = (
                     SalesOrderFulfillmentSalesOrderFulfillmentRowsItem.from_dict(
-                        sales_order_fulfillment_rows_item_data
+                        cast(Mapping[str, Any], sales_order_fulfillment_rows_item_data)
                     )
                 )
 

--- a/katana_public_api_client/models/sales_order_fulfillment_list_response.py
+++ b/katana_public_api_client/models/sales_order_fulfillment_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -59,7 +59,9 @@ class SalesOrderFulfillmentListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = SalesOrderFulfillment.from_dict(data_item_data)
+                data_item = SalesOrderFulfillment.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/sales_order_fulfillment_sales_order_fulfillment_rows_item.py
+++ b/katana_public_api_client/models/sales_order_fulfillment_sales_order_fulfillment_rows_item.py
@@ -82,7 +82,7 @@ class SalesOrderFulfillmentSalesOrderFulfillmentRowsItem:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = SalesOrderFulfillmentSalesOrderFulfillmentRowsItemBatchTransactionsItem.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/sales_order_list_response.py
+++ b/katana_public_api_client/models/sales_order_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -62,7 +62,9 @@ class SalesOrderListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = SalesOrder.from_dict(data_item_data)
+                data_item = SalesOrder.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/sales_order_row.py
+++ b/katana_public_api_client/models/sales_order_row.py
@@ -417,7 +417,7 @@ class SalesOrderRow:
             attributes = []
             for attributes_item_data in _attributes:
                 attributes_item = SalesOrderRowAttributesItem.from_dict(
-                    attributes_item_data
+                    cast(Mapping[str, Any], attributes_item_data)
                 )
 
                 attributes.append(attributes_item)
@@ -428,7 +428,7 @@ class SalesOrderRow:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = SalesOrderRowBatchTransactionsItem.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/sales_order_row_list_response.py
+++ b/katana_public_api_client/models/sales_order_row_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -63,7 +63,9 @@ class SalesOrderRowListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = SalesOrderRow.from_dict(data_item_data)
+                data_item = SalesOrderRow.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/sales_order_shipping_fee_list_response.py
+++ b/katana_public_api_client/models/sales_order_shipping_fee_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -55,7 +55,9 @@ class SalesOrderShippingFeeListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = SalesOrderShippingFee.from_dict(data_item_data)
+                data_item = SalesOrderShippingFee.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/sales_return.py
+++ b/katana_public_api_client/models/sales_return.py
@@ -343,7 +343,7 @@ class SalesReturn:
             sales_return_rows = []
             for sales_return_rows_item_data in _sales_return_rows:
                 sales_return_rows_item = SalesReturnRow.from_dict(
-                    sales_return_rows_item_data
+                    cast(Mapping[str, Any], sales_return_rows_item_data)
                 )
 
                 sales_return_rows.append(sales_return_rows_item)

--- a/katana_public_api_client/models/sales_return_list_response.py
+++ b/katana_public_api_client/models/sales_return_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -57,7 +57,9 @@ class SalesReturnListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = SalesReturn.from_dict(data_item_data)
+                data_item = SalesReturn.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/sales_return_row.py
+++ b/katana_public_api_client/models/sales_return_row.py
@@ -184,7 +184,7 @@ class SalesReturnRow:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = SalesReturnRowBatchTransactionsItem.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/sales_return_row_list_response.py
+++ b/katana_public_api_client/models/sales_return_row_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -55,7 +55,9 @@ class SalesReturnRowListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = SalesReturnRow.from_dict(data_item_data)
+                data_item = SalesReturnRow.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/serial_number_list_response.py
+++ b/katana_public_api_client/models/serial_number_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -57,7 +57,9 @@ class SerialNumberListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = SerialNumber.from_dict(data_item_data)
+                data_item = SerialNumber.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/serial_number_stock.py
+++ b/katana_public_api_client/models/serial_number_stock.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -69,7 +69,7 @@ class SerialNumberStock:
         _transactions = d.pop("transactions")
         for transactions_item_data in _transactions:
             transactions_item = SerialNumberStockTransactionsItem.from_dict(
-                transactions_item_data
+                cast(Mapping[str, Any], transactions_item_data)
             )
 
             transactions.append(transactions_item)

--- a/katana_public_api_client/models/serial_number_stock_list_response.py
+++ b/katana_public_api_client/models/serial_number_stock_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -50,7 +50,9 @@ class SerialNumberStockListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = SerialNumberStock.from_dict(data_item_data)
+                data_item = SerialNumberStock.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/service.py
+++ b/katana_public_api_client/models/service.py
@@ -225,7 +225,9 @@ class Service:
         if _variants is not UNSET:
             variants = []
             for variants_item_data in _variants:
-                variants_item = ServiceVariant.from_dict(variants_item_data)
+                variants_item = ServiceVariant.from_dict(
+                    cast(Mapping[str, Any], variants_item_data)
+                )
 
                 variants.append(variants_item)
 

--- a/katana_public_api_client/models/service_list_response.py
+++ b/katana_public_api_client/models/service_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -60,7 +60,7 @@ class ServiceListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = Service.from_dict(data_item_data)
+                data_item = Service.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/service_variant.py
+++ b/katana_public_api_client/models/service_variant.py
@@ -192,7 +192,7 @@ class ServiceVariant:
             custom_fields = []
             for custom_fields_item_data in _custom_fields:
                 custom_fields_item = ServiceVariantCustomFieldsItem.from_dict(
-                    custom_fields_item_data
+                    cast(Mapping[str, Any], custom_fields_item_data)
                 )
 
                 custom_fields.append(custom_fields_item)

--- a/katana_public_api_client/models/stock_adjustment.py
+++ b/katana_public_api_client/models/stock_adjustment.py
@@ -189,7 +189,7 @@ class StockAdjustment:
             stock_adjustment_rows = []
             for stock_adjustment_rows_item_data in _stock_adjustment_rows:
                 stock_adjustment_rows_item = StockAdjustmentRow.from_dict(
-                    stock_adjustment_rows_item_data
+                    cast(Mapping[str, Any], stock_adjustment_rows_item_data)
                 )
 
                 stock_adjustment_rows.append(stock_adjustment_rows_item)

--- a/katana_public_api_client/models/stock_adjustment_list_response.py
+++ b/katana_public_api_client/models/stock_adjustment_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -60,7 +60,9 @@ class StockAdjustmentListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = StockAdjustment.from_dict(data_item_data)
+                data_item = StockAdjustment.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/stock_adjustment_row.py
+++ b/katana_public_api_client/models/stock_adjustment_row.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -85,7 +85,7 @@ class StockAdjustmentRow:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = StockAdjustmentBatchTransaction.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/stock_transfer.py
+++ b/katana_public_api_client/models/stock_transfer.py
@@ -247,7 +247,7 @@ class StockTransfer:
             stock_transfer_rows = []
             for stock_transfer_rows_item_data in _stock_transfer_rows:
                 stock_transfer_rows_item = StockTransferRow.from_dict(
-                    stock_transfer_rows_item_data
+                    cast(Mapping[str, Any], stock_transfer_rows_item_data)
                 )
 
                 stock_transfer_rows.append(stock_transfer_rows_item)

--- a/katana_public_api_client/models/stock_transfer_list_response.py
+++ b/katana_public_api_client/models/stock_transfer_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -57,7 +57,9 @@ class StockTransferListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = StockTransfer.from_dict(data_item_data)
+                data_item = StockTransfer.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/stock_transfer_row.py
+++ b/katana_public_api_client/models/stock_transfer_row.py
@@ -98,7 +98,7 @@ class StockTransferRow:
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = (
                     StockTransferRowBatchTransactionsItem.from_dict(
-                        batch_transactions_item_data
+                        cast(Mapping[str, Any], batch_transactions_item_data)
                     )
                 )
 

--- a/katana_public_api_client/models/stocktake_list_response.py
+++ b/katana_public_api_client/models/stocktake_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -59,7 +59,7 @@ class StocktakeListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = Stocktake.from_dict(data_item_data)
+                data_item = Stocktake.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/stocktake_row_list_response.py
+++ b/katana_public_api_client/models/stocktake_row_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -58,7 +58,9 @@ class StocktakeRowListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = StocktakeRow.from_dict(data_item_data)
+                data_item = StocktakeRow.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/storage_bin_list_response.py
+++ b/katana_public_api_client/models/storage_bin_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -55,7 +55,9 @@ class StorageBinListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = StorageBinResponse.from_dict(data_item_data)
+                data_item = StorageBinResponse.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/supplier.py
+++ b/katana_public_api_client/models/supplier.py
@@ -169,7 +169,9 @@ class Supplier:
         if _addresses is not UNSET:
             addresses = []
             for addresses_item_data in _addresses:
-                addresses_item = SupplierAddress.from_dict(addresses_item_data)
+                addresses_item = SupplierAddress.from_dict(
+                    cast(Mapping[str, Any], addresses_item_data)
+                )
 
                 addresses.append(addresses_item)
 

--- a/katana_public_api_client/models/supplier_address_list_response.py
+++ b/katana_public_api_client/models/supplier_address_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -58,7 +58,9 @@ class SupplierAddressListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = SupplierAddress.from_dict(data_item_data)
+                data_item = SupplierAddress.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/supplier_list_response.py
+++ b/katana_public_api_client/models/supplier_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -60,7 +60,7 @@ class SupplierListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = Supplier.from_dict(data_item_data)
+                data_item = Supplier.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/tax_rate_list_response.py
+++ b/katana_public_api_client/models/tax_rate_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -58,7 +58,7 @@ class TaxRateListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = TaxRate.from_dict(data_item_data)
+                data_item = TaxRate.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/unassigned_batch_transaction_list_response.py
+++ b/katana_public_api_client/models/unassigned_batch_transaction_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -50,7 +50,9 @@ class UnassignedBatchTransactionListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = UnassignedBatchTransaction.from_dict(data_item_data)
+                data_item = UnassignedBatchTransaction.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/update_manufacturing_order_operation_row_request.py
+++ b/katana_public_api_client/models/update_manufacturing_order_operation_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -160,7 +160,7 @@ class UpdateManufacturingOrderOperationRowRequest:
             assigned_operators = []
             for assigned_operators_item_data in _assigned_operators:
                 assigned_operators_item = Operator.from_dict(
-                    assigned_operators_item_data
+                    cast(Mapping[str, Any], assigned_operators_item_data)
                 )
 
                 assigned_operators.append(assigned_operators_item)
@@ -171,7 +171,7 @@ class UpdateManufacturingOrderOperationRowRequest:
             completed_by_operators = []
             for completed_by_operators_item_data in _completed_by_operators:
                 completed_by_operators_item = Operator.from_dict(
-                    completed_by_operators_item_data
+                    cast(Mapping[str, Any], completed_by_operators_item_data)
                 )
 
                 completed_by_operators.append(completed_by_operators_item)

--- a/katana_public_api_client/models/update_manufacturing_order_production_ingredient_request.py
+++ b/katana_public_api_client/models/update_manufacturing_order_production_ingredient_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -55,7 +55,7 @@ class UpdateManufacturingOrderProductionIngredientRequest:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = BatchTransaction.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/update_manufacturing_order_recipe_row_request.py
+++ b/katana_public_api_client/models/update_manufacturing_order_recipe_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -93,7 +93,7 @@ class UpdateManufacturingOrderRecipeRowRequest:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = UpdateManufacturingOrderRecipeRowRequestBatchTransactionsItem.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/update_manufacturing_order_request.py
+++ b/katana_public_api_client/models/update_manufacturing_order_request.py
@@ -164,7 +164,7 @@ class UpdateManufacturingOrderRequest:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = BatchTransaction.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/update_material_request.py
+++ b/katana_public_api_client/models/update_material_request.py
@@ -138,7 +138,7 @@ class UpdateMaterialRequest:
             configs = []
             for configs_item_data in _configs:
                 configs_item = UpdateMaterialRequestConfigsItem.from_dict(
-                    configs_item_data
+                    cast(Mapping[str, Any], configs_item_data)
                 )
 
                 configs.append(configs_item)

--- a/katana_public_api_client/models/update_outsourced_purchase_order_recipe_row_request.py
+++ b/katana_public_api_client/models/update_outsourced_purchase_order_recipe_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -68,7 +68,7 @@ class UpdateOutsourcedPurchaseOrderRecipeRowRequest:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = BatchTransactionRequest.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/update_product_request.py
+++ b/katana_public_api_client/models/update_product_request.py
@@ -176,7 +176,7 @@ class UpdateProductRequest:
             configs = []
             for configs_item_data in _configs:
                 configs_item = UpdateProductRequestConfigsItem.from_dict(
-                    configs_item_data
+                    cast(Mapping[str, Any], configs_item_data)
                 )
 
                 configs.append(configs_item)

--- a/katana_public_api_client/models/update_sales_order_request.py
+++ b/katana_public_api_client/models/update_sales_order_request.py
@@ -221,7 +221,9 @@ class UpdateSalesOrderRequest:
         if _custom_fields is not UNSET:
             custom_fields = []
             for custom_fields_item_data in _custom_fields:
-                custom_fields_item = CustomFieldValue.from_dict(custom_fields_item_data)
+                custom_fields_item = CustomFieldValue.from_dict(
+                    cast(Mapping[str, Any], custom_fields_item_data)
+                )
 
                 custom_fields.append(custom_fields_item)
 

--- a/katana_public_api_client/models/update_sales_order_row_request.py
+++ b/katana_public_api_client/models/update_sales_order_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -129,7 +129,7 @@ class UpdateSalesOrderRowRequest:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = BatchTransaction.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)
@@ -143,7 +143,7 @@ class UpdateSalesOrderRowRequest:
             for serial_number_transactions_item_data in _serial_number_transactions:
                 serial_number_transactions_item = (
                     UpdateSalesOrderRowRequestSerialNumberTransactionsItem.from_dict(
-                        serial_number_transactions_item_data
+                        cast(Mapping[str, Any], serial_number_transactions_item_data)
                     )
                 )
 
@@ -155,7 +155,7 @@ class UpdateSalesOrderRowRequest:
             attributes = []
             for attributes_item_data in _attributes:
                 attributes_item = UpdateSalesOrderRowRequestAttributesItem.from_dict(
-                    attributes_item_data
+                    cast(Mapping[str, Any], attributes_item_data)
                 )
 
                 attributes.append(attributes_item)

--- a/katana_public_api_client/models/update_sales_return_row_request.py
+++ b/katana_public_api_client/models/update_sales_return_row_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -68,7 +68,7 @@ class UpdateSalesReturnRowRequest:
             batch_transactions = []
             for batch_transactions_item_data in _batch_transactions:
                 batch_transactions_item = BatchTransactionRequest.from_dict(
-                    batch_transactions_item_data
+                    cast(Mapping[str, Any], batch_transactions_item_data)
                 )
 
                 batch_transactions.append(batch_transactions_item)

--- a/katana_public_api_client/models/update_service_request.py
+++ b/katana_public_api_client/models/update_service_request.py
@@ -157,7 +157,9 @@ class UpdateServiceRequest:
         if _custom_fields is not UNSET:
             custom_fields = []
             for custom_fields_item_data in _custom_fields:
-                custom_fields_item = CustomFieldValue.from_dict(custom_fields_item_data)
+                custom_fields_item = CustomFieldValue.from_dict(
+                    cast(Mapping[str, Any], custom_fields_item_data)
+                )
 
                 custom_fields.append(custom_fields_item)
 

--- a/katana_public_api_client/models/update_variant_request.py
+++ b/katana_public_api_client/models/update_variant_request.py
@@ -149,7 +149,7 @@ class UpdateVariantRequest:
             for config_attributes_item_data in _config_attributes:
                 config_attributes_item = (
                     UpdateVariantRequestConfigAttributesItem.from_dict(
-                        config_attributes_item_data
+                        cast(Mapping[str, Any], config_attributes_item_data)
                     )
                 )
 
@@ -161,7 +161,7 @@ class UpdateVariantRequest:
             custom_fields = []
             for custom_fields_item_data in _custom_fields:
                 custom_fields_item = UpdateVariantRequestCustomFieldsItem.from_dict(
-                    custom_fields_item_data
+                    cast(Mapping[str, Any], custom_fields_item_data)
                 )
 
                 custom_fields.append(custom_fields_item)

--- a/katana_public_api_client/models/user_list_response.py
+++ b/katana_public_api_client/models/user_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -58,7 +58,7 @@ class UserListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = User.from_dict(data_item_data)
+                data_item = User.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/variant.py
+++ b/katana_public_api_client/models/variant.py
@@ -14,8 +14,10 @@ from ..client_types import UNSET, Unset
 from ..models.variant_type import VariantType
 
 if TYPE_CHECKING:
-    from ..models.variant_config_attributes_item import VariantConfigAttributesItem
-    from ..models.variant_custom_fields_item import VariantCustomFieldsItem
+    from ..models.variant_config_attributes_type_0_item import (
+        VariantConfigAttributesType0Item,
+    )
+    from ..models.variant_custom_fields_type_0_item import VariantCustomFieldsType0Item
 
 
 T = TypeVar("T", bound="Variant")
@@ -45,13 +47,13 @@ class Variant:
     material_id: int | None | Unset = UNSET
     purchase_price: float | Unset = UNSET
     type_: VariantType | Unset = UNSET
-    internal_barcode: str | Unset = UNSET
-    registered_barcode: str | Unset = UNSET
+    internal_barcode: None | str | Unset = UNSET
+    registered_barcode: None | str | Unset = UNSET
     supplier_item_codes: list[str] | Unset = UNSET
     lead_time: int | None | Unset = UNSET
     minimum_order_quantity: float | None | Unset = UNSET
-    custom_fields: list[VariantCustomFieldsItem] | Unset = UNSET
-    config_attributes: list[VariantConfigAttributesItem] | Unset = UNSET
+    custom_fields: list[VariantCustomFieldsType0Item] | None | Unset = UNSET
+    config_attributes: list[VariantConfigAttributesType0Item] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -100,9 +102,17 @@ class Variant:
         if not isinstance(self.type_, Unset):
             type_ = self.type_.value
 
-        internal_barcode = self.internal_barcode
+        internal_barcode: None | str | Unset
+        if isinstance(self.internal_barcode, Unset):
+            internal_barcode = UNSET
+        else:
+            internal_barcode = self.internal_barcode
 
-        registered_barcode = self.registered_barcode
+        registered_barcode: None | str | Unset
+        if isinstance(self.registered_barcode, Unset):
+            registered_barcode = UNSET
+        else:
+            registered_barcode = self.registered_barcode
 
         supplier_item_codes: list[str] | Unset = UNSET
         if not isinstance(self.supplier_item_codes, Unset):
@@ -120,19 +130,31 @@ class Variant:
         else:
             minimum_order_quantity = self.minimum_order_quantity
 
-        custom_fields: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.custom_fields, Unset):
+        custom_fields: list[dict[str, Any]] | None | Unset
+        if isinstance(self.custom_fields, Unset):
+            custom_fields = UNSET
+        elif isinstance(self.custom_fields, list):
             custom_fields = []
-            for custom_fields_item_data in self.custom_fields:
-                custom_fields_item = custom_fields_item_data.to_dict()
-                custom_fields.append(custom_fields_item)
+            for custom_fields_type_0_item_data in self.custom_fields:
+                custom_fields_type_0_item = custom_fields_type_0_item_data.to_dict()
+                custom_fields.append(custom_fields_type_0_item)
 
-        config_attributes: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.config_attributes, Unset):
+        else:
+            custom_fields = self.custom_fields
+
+        config_attributes: list[dict[str, Any]] | None | Unset
+        if isinstance(self.config_attributes, Unset):
+            config_attributes = UNSET
+        elif isinstance(self.config_attributes, list):
             config_attributes = []
-            for config_attributes_item_data in self.config_attributes:
-                config_attributes_item = config_attributes_item_data.to_dict()
-                config_attributes.append(config_attributes_item)
+            for config_attributes_type_0_item_data in self.config_attributes:
+                config_attributes_type_0_item = (
+                    config_attributes_type_0_item_data.to_dict()
+                )
+                config_attributes.append(config_attributes_type_0_item)
+
+        else:
+            config_attributes = self.config_attributes
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -177,8 +199,12 @@ class Variant:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.variant_config_attributes_item import VariantConfigAttributesItem
-        from ..models.variant_custom_fields_item import VariantCustomFieldsItem
+        from ..models.variant_config_attributes_type_0_item import (
+            VariantConfigAttributesType0Item,
+        )
+        from ..models.variant_custom_fields_type_0_item import (
+            VariantCustomFieldsType0Item,
+        )
 
         d = dict(src_dict)
         id = d.pop("id")
@@ -257,9 +283,25 @@ class Variant:
         else:
             type_ = VariantType(_type_)
 
-        internal_barcode = d.pop("internal_barcode", UNSET)
+        def _parse_internal_barcode(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
 
-        registered_barcode = d.pop("registered_barcode", UNSET)
+        internal_barcode = _parse_internal_barcode(d.pop("internal_barcode", UNSET))
+
+        def _parse_registered_barcode(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        registered_barcode = _parse_registered_barcode(
+            d.pop("registered_barcode", UNSET)
+        )
 
         supplier_item_codes = cast(list[str], d.pop("supplier_item_codes", UNSET))
 
@@ -283,27 +325,65 @@ class Variant:
             d.pop("minimum_order_quantity", UNSET)
         )
 
-        _custom_fields = d.pop("custom_fields", UNSET)
-        custom_fields: list[VariantCustomFieldsItem] | Unset = UNSET
-        if _custom_fields is not UNSET:
-            custom_fields = []
-            for custom_fields_item_data in _custom_fields:
-                custom_fields_item = VariantCustomFieldsItem.from_dict(
-                    custom_fields_item_data
-                )
+        def _parse_custom_fields(
+            data: object,
+        ) -> list[VariantCustomFieldsType0Item] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                custom_fields_type_0 = []
+                _custom_fields_type_0 = data
+                for custom_fields_type_0_item_data in _custom_fields_type_0:
+                    custom_fields_type_0_item = VariantCustomFieldsType0Item.from_dict(
+                        cast(Mapping[str, Any], custom_fields_type_0_item_data)
+                    )
 
-                custom_fields.append(custom_fields_item)
+                    custom_fields_type_0.append(custom_fields_type_0_item)
 
-        _config_attributes = d.pop("config_attributes", UNSET)
-        config_attributes: list[VariantConfigAttributesItem] | Unset = UNSET
-        if _config_attributes is not UNSET:
-            config_attributes = []
-            for config_attributes_item_data in _config_attributes:
-                config_attributes_item = VariantConfigAttributesItem.from_dict(
-                    config_attributes_item_data
-                )
+                return custom_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[VariantCustomFieldsType0Item] | None | Unset, data)
 
-                config_attributes.append(config_attributes_item)
+        custom_fields = _parse_custom_fields(d.pop("custom_fields", UNSET))
+
+        def _parse_config_attributes(
+            data: object,
+        ) -> list[VariantConfigAttributesType0Item] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                config_attributes_type_0 = []
+                _config_attributes_type_0 = data
+                for config_attributes_type_0_item_data in _config_attributes_type_0:
+                    config_attributes_type_0_item = (
+                        VariantConfigAttributesType0Item.from_dict(
+                            cast(Mapping[str, Any], config_attributes_type_0_item_data)
+                        )
+                    )
+
+                    config_attributes_type_0.append(config_attributes_type_0_item)
+
+                return config_attributes_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[VariantConfigAttributesType0Item] | None | Unset, data)
+
+        config_attributes = _parse_config_attributes(d.pop("config_attributes", UNSET))
 
         variant = cls(
             id=id,

--- a/katana_public_api_client/models/variant_config_attributes_type_0_item.py
+++ b/katana_public_api_client/models/variant_config_attributes_type_0_item.py
@@ -10,44 +10,44 @@ from attrs import (
 
 from ..client_types import UNSET, Unset
 
-T = TypeVar("T", bound="VariantCustomFieldsItem")
+T = TypeVar("T", bound="VariantConfigAttributesType0Item")
 
 
 @_attrs_define
-class VariantCustomFieldsItem:
-    field_name: str | Unset = UNSET
-    field_value: str | Unset = UNSET
+class VariantConfigAttributesType0Item:
+    config_name: str | Unset = UNSET
+    config_value: str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        field_name = self.field_name
+        config_name = self.config_name
 
-        field_value = self.field_value
+        config_value = self.config_value
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if field_name is not UNSET:
-            field_dict["field_name"] = field_name
-        if field_value is not UNSET:
-            field_dict["field_value"] = field_value
+        if config_name is not UNSET:
+            field_dict["config_name"] = config_name
+        if config_value is not UNSET:
+            field_dict["config_value"] = config_value
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        field_name = d.pop("field_name", UNSET)
+        config_name = d.pop("config_name", UNSET)
 
-        field_value = d.pop("field_value", UNSET)
+        config_value = d.pop("config_value", UNSET)
 
-        variant_custom_fields_item = cls(
-            field_name=field_name,
-            field_value=field_value,
+        variant_config_attributes_type_0_item = cls(
+            config_name=config_name,
+            config_value=config_value,
         )
 
-        variant_custom_fields_item.additional_properties = d
-        return variant_custom_fields_item
+        variant_config_attributes_type_0_item.additional_properties = d
+        return variant_config_attributes_type_0_item
 
     @property
     def additional_keys(self) -> list[str]:

--- a/katana_public_api_client/models/variant_custom_fields_type_0_item.py
+++ b/katana_public_api_client/models/variant_custom_fields_type_0_item.py
@@ -10,44 +10,44 @@ from attrs import (
 
 from ..client_types import UNSET, Unset
 
-T = TypeVar("T", bound="VariantResponseConfigAttributesItem")
+T = TypeVar("T", bound="VariantCustomFieldsType0Item")
 
 
 @_attrs_define
-class VariantResponseConfigAttributesItem:
-    config_name: str | Unset = UNSET
-    config_value: str | Unset = UNSET
+class VariantCustomFieldsType0Item:
+    field_name: str | Unset = UNSET
+    field_value: str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        config_name = self.config_name
+        field_name = self.field_name
 
-        config_value = self.config_value
+        field_value = self.field_value
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if config_name is not UNSET:
-            field_dict["config_name"] = config_name
-        if config_value is not UNSET:
-            field_dict["config_value"] = config_value
+        if field_name is not UNSET:
+            field_dict["field_name"] = field_name
+        if field_value is not UNSET:
+            field_dict["field_value"] = field_value
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        config_name = d.pop("config_name", UNSET)
+        field_name = d.pop("field_name", UNSET)
 
-        config_value = d.pop("config_value", UNSET)
+        field_value = d.pop("field_value", UNSET)
 
-        variant_response_config_attributes_item = cls(
-            config_name=config_name,
-            config_value=config_value,
+        variant_custom_fields_type_0_item = cls(
+            field_name=field_name,
+            field_value=field_value,
         )
 
-        variant_response_config_attributes_item.additional_properties = d
-        return variant_response_config_attributes_item
+        variant_custom_fields_type_0_item.additional_properties = d
+        return variant_custom_fields_type_0_item
 
     @property
     def additional_keys(self) -> list[str]:

--- a/katana_public_api_client/models/variant_list_response.py
+++ b/katana_public_api_client/models/variant_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -63,7 +63,9 @@ class VariantListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = VariantResponse.from_dict(data_item_data)
+                data_item = VariantResponse.from_dict(
+                    cast(Mapping[str, Any], data_item_data)
+                )
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models/variant_response.py
+++ b/katana_public_api_client/models/variant_response.py
@@ -16,11 +16,11 @@ from ..models.variant_type import VariantType
 if TYPE_CHECKING:
     from ..models.material import Material
     from ..models.product import Product
-    from ..models.variant_response_config_attributes_item import (
-        VariantResponseConfigAttributesItem,
+    from ..models.variant_response_config_attributes_type_0_item import (
+        VariantResponseConfigAttributesType0Item,
     )
-    from ..models.variant_response_custom_fields_item import (
-        VariantResponseCustomFieldsItem,
+    from ..models.variant_response_custom_fields_type_0_item import (
+        VariantResponseCustomFieldsType0Item,
     )
 
 
@@ -53,13 +53,15 @@ class VariantResponse:
     product_id: int | None | Unset = UNSET
     material_id: int | None | Unset = UNSET
     type_: VariantType | Unset = UNSET
-    internal_barcode: str | Unset = UNSET
-    registered_barcode: str | Unset = UNSET
+    internal_barcode: None | str | Unset = UNSET
+    registered_barcode: None | str | Unset = UNSET
     supplier_item_codes: list[str] | Unset = UNSET
     lead_time: int | None | Unset = UNSET
     minimum_order_quantity: float | None | Unset = UNSET
-    config_attributes: list[VariantResponseConfigAttributesItem] | Unset = UNSET
-    custom_fields: list[VariantResponseCustomFieldsItem] | Unset = UNSET
+    config_attributes: list[VariantResponseConfigAttributesType0Item] | None | Unset = (
+        UNSET
+    )
+    custom_fields: list[VariantResponseCustomFieldsType0Item] | None | Unset = UNSET
     product_or_material: Material | Product | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -110,9 +112,17 @@ class VariantResponse:
         if not isinstance(self.type_, Unset):
             type_ = self.type_.value
 
-        internal_barcode = self.internal_barcode
+        internal_barcode: None | str | Unset
+        if isinstance(self.internal_barcode, Unset):
+            internal_barcode = UNSET
+        else:
+            internal_barcode = self.internal_barcode
 
-        registered_barcode = self.registered_barcode
+        registered_barcode: None | str | Unset
+        if isinstance(self.registered_barcode, Unset):
+            registered_barcode = UNSET
+        else:
+            registered_barcode = self.registered_barcode
 
         supplier_item_codes: list[str] | Unset = UNSET
         if not isinstance(self.supplier_item_codes, Unset):
@@ -130,19 +140,31 @@ class VariantResponse:
         else:
             minimum_order_quantity = self.minimum_order_quantity
 
-        config_attributes: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.config_attributes, Unset):
+        config_attributes: list[dict[str, Any]] | None | Unset
+        if isinstance(self.config_attributes, Unset):
+            config_attributes = UNSET
+        elif isinstance(self.config_attributes, list):
             config_attributes = []
-            for config_attributes_item_data in self.config_attributes:
-                config_attributes_item = config_attributes_item_data.to_dict()
-                config_attributes.append(config_attributes_item)
+            for config_attributes_type_0_item_data in self.config_attributes:
+                config_attributes_type_0_item = (
+                    config_attributes_type_0_item_data.to_dict()
+                )
+                config_attributes.append(config_attributes_type_0_item)
 
-        custom_fields: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.custom_fields, Unset):
+        else:
+            config_attributes = self.config_attributes
+
+        custom_fields: list[dict[str, Any]] | None | Unset
+        if isinstance(self.custom_fields, Unset):
+            custom_fields = UNSET
+        elif isinstance(self.custom_fields, list):
             custom_fields = []
-            for custom_fields_item_data in self.custom_fields:
-                custom_fields_item = custom_fields_item_data.to_dict()
-                custom_fields.append(custom_fields_item)
+            for custom_fields_type_0_item_data in self.custom_fields:
+                custom_fields_type_0_item = custom_fields_type_0_item_data.to_dict()
+                custom_fields.append(custom_fields_type_0_item)
+
+        else:
+            custom_fields = self.custom_fields
 
         product_or_material: dict[str, Any] | Unset
         if isinstance(self.product_or_material, Unset):
@@ -200,11 +222,11 @@ class VariantResponse:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.material import Material
         from ..models.product import Product
-        from ..models.variant_response_config_attributes_item import (
-            VariantResponseConfigAttributesItem,
+        from ..models.variant_response_config_attributes_type_0_item import (
+            VariantResponseConfigAttributesType0Item,
         )
-        from ..models.variant_response_custom_fields_item import (
-            VariantResponseCustomFieldsItem,
+        from ..models.variant_response_custom_fields_type_0_item import (
+            VariantResponseCustomFieldsType0Item,
         )
 
         d = dict(src_dict)
@@ -279,9 +301,25 @@ class VariantResponse:
         else:
             type_ = VariantType(_type_)
 
-        internal_barcode = d.pop("internal_barcode", UNSET)
+        def _parse_internal_barcode(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
 
-        registered_barcode = d.pop("registered_barcode", UNSET)
+        internal_barcode = _parse_internal_barcode(d.pop("internal_barcode", UNSET))
+
+        def _parse_registered_barcode(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        registered_barcode = _parse_registered_barcode(
+            d.pop("registered_barcode", UNSET)
+        )
 
         supplier_item_codes = cast(list[str], d.pop("supplier_item_codes", UNSET))
 
@@ -305,27 +343,69 @@ class VariantResponse:
             d.pop("minimum_order_quantity", UNSET)
         )
 
-        _config_attributes = d.pop("config_attributes", UNSET)
-        config_attributes: list[VariantResponseConfigAttributesItem] | Unset = UNSET
-        if _config_attributes is not UNSET:
-            config_attributes = []
-            for config_attributes_item_data in _config_attributes:
-                config_attributes_item = VariantResponseConfigAttributesItem.from_dict(
-                    config_attributes_item_data
-                )
+        def _parse_config_attributes(
+            data: object,
+        ) -> list[VariantResponseConfigAttributesType0Item] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                config_attributes_type_0 = []
+                _config_attributes_type_0 = data
+                for config_attributes_type_0_item_data in _config_attributes_type_0:
+                    config_attributes_type_0_item = (
+                        VariantResponseConfigAttributesType0Item.from_dict(
+                            cast(Mapping[str, Any], config_attributes_type_0_item_data)
+                        )
+                    )
 
-                config_attributes.append(config_attributes_item)
+                    config_attributes_type_0.append(config_attributes_type_0_item)
 
-        _custom_fields = d.pop("custom_fields", UNSET)
-        custom_fields: list[VariantResponseCustomFieldsItem] | Unset = UNSET
-        if _custom_fields is not UNSET:
-            custom_fields = []
-            for custom_fields_item_data in _custom_fields:
-                custom_fields_item = VariantResponseCustomFieldsItem.from_dict(
-                    custom_fields_item_data
-                )
+                return config_attributes_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                list[VariantResponseConfigAttributesType0Item] | None | Unset, data
+            )
 
-                custom_fields.append(custom_fields_item)
+        config_attributes = _parse_config_attributes(d.pop("config_attributes", UNSET))
+
+        def _parse_custom_fields(
+            data: object,
+        ) -> list[VariantResponseCustomFieldsType0Item] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                custom_fields_type_0 = []
+                _custom_fields_type_0 = data
+                for custom_fields_type_0_item_data in _custom_fields_type_0:
+                    custom_fields_type_0_item = (
+                        VariantResponseCustomFieldsType0Item.from_dict(
+                            cast(Mapping[str, Any], custom_fields_type_0_item_data)
+                        )
+                    )
+
+                    custom_fields_type_0.append(custom_fields_type_0_item)
+
+                return custom_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[VariantResponseCustomFieldsType0Item] | None | Unset, data)
+
+        custom_fields = _parse_custom_fields(d.pop("custom_fields", UNSET))
 
         def _parse_product_or_material(data: object) -> Material | Product | Unset:
             if isinstance(data, Unset):

--- a/katana_public_api_client/models/variant_response_config_attributes_type_0_item.py
+++ b/katana_public_api_client/models/variant_response_config_attributes_type_0_item.py
@@ -10,44 +10,44 @@ from attrs import (
 
 from ..client_types import UNSET, Unset
 
-T = TypeVar("T", bound="VariantResponseCustomFieldsItem")
+T = TypeVar("T", bound="VariantResponseConfigAttributesType0Item")
 
 
 @_attrs_define
-class VariantResponseCustomFieldsItem:
-    field_name: str | Unset = UNSET
-    field_value: str | Unset = UNSET
+class VariantResponseConfigAttributesType0Item:
+    config_name: str | Unset = UNSET
+    config_value: str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        field_name = self.field_name
+        config_name = self.config_name
 
-        field_value = self.field_value
+        config_value = self.config_value
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if field_name is not UNSET:
-            field_dict["field_name"] = field_name
-        if field_value is not UNSET:
-            field_dict["field_value"] = field_value
+        if config_name is not UNSET:
+            field_dict["config_name"] = config_name
+        if config_value is not UNSET:
+            field_dict["config_value"] = config_value
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        field_name = d.pop("field_name", UNSET)
+        config_name = d.pop("config_name", UNSET)
 
-        field_value = d.pop("field_value", UNSET)
+        config_value = d.pop("config_value", UNSET)
 
-        variant_response_custom_fields_item = cls(
-            field_name=field_name,
-            field_value=field_value,
+        variant_response_config_attributes_type_0_item = cls(
+            config_name=config_name,
+            config_value=config_value,
         )
 
-        variant_response_custom_fields_item.additional_properties = d
-        return variant_response_custom_fields_item
+        variant_response_config_attributes_type_0_item.additional_properties = d
+        return variant_response_config_attributes_type_0_item
 
     @property
     def additional_keys(self) -> list[str]:

--- a/katana_public_api_client/models/variant_response_custom_fields_type_0_item.py
+++ b/katana_public_api_client/models/variant_response_custom_fields_type_0_item.py
@@ -10,44 +10,44 @@ from attrs import (
 
 from ..client_types import UNSET, Unset
 
-T = TypeVar("T", bound="VariantConfigAttributesItem")
+T = TypeVar("T", bound="VariantResponseCustomFieldsType0Item")
 
 
 @_attrs_define
-class VariantConfigAttributesItem:
-    config_name: str | Unset = UNSET
-    config_value: str | Unset = UNSET
+class VariantResponseCustomFieldsType0Item:
+    field_name: str | Unset = UNSET
+    field_value: str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        config_name = self.config_name
+        field_name = self.field_name
 
-        config_value = self.config_value
+        field_value = self.field_value
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if config_name is not UNSET:
-            field_dict["config_name"] = config_name
-        if config_value is not UNSET:
-            field_dict["config_value"] = config_value
+        if field_name is not UNSET:
+            field_dict["field_name"] = field_name
+        if field_value is not UNSET:
+            field_dict["field_value"] = field_value
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        config_name = d.pop("config_name", UNSET)
+        field_name = d.pop("field_name", UNSET)
 
-        config_value = d.pop("config_value", UNSET)
+        field_value = d.pop("field_value", UNSET)
 
-        variant_config_attributes_item = cls(
-            config_name=config_name,
-            config_value=config_value,
+        variant_response_custom_fields_type_0_item = cls(
+            field_name=field_name,
+            field_value=field_value,
         )
 
-        variant_config_attributes_item.additional_properties = d
-        return variant_config_attributes_item
+        variant_response_custom_fields_type_0_item.additional_properties = d
+        return variant_response_custom_fields_type_0_item
 
     @property
     def additional_keys(self) -> list[str]:

--- a/katana_public_api_client/models/webhook_list_response.py
+++ b/katana_public_api_client/models/webhook_list_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import (
     define as _attrs_define,
@@ -60,7 +60,7 @@ class WebhookListResponse:
         if _data is not UNSET:
             data = []
             for data_item_data in _data:
-                data_item = Webhook.from_dict(data_item_data)
+                data_item = Webhook.from_dict(cast(Mapping[str, Any], data_item_data))
 
                 data.append(data_item)
 

--- a/katana_public_api_client/models_pydantic/_base.py
+++ b/katana_public_api_client/models_pydantic/_base.py
@@ -292,9 +292,13 @@ def _convert_nested_value(value: Any, registry: Any) -> Any:
         # inline properties), so the pydantic generator emits
         # ``dict[str, Any]`` while the attrs generator still synthesizes
         # a concrete class. The pydantic model expects a dict, so fall
-        # back to ``to_dict()`` when the attrs side exposes it.
-        if hasattr(value, "to_dict"):
-            return value.to_dict()
+        # back to ``to_dict()`` when the attrs side exposes it as a
+        # callable (``callable`` rather than ``hasattr`` guards against
+        # an exotic non-callable ``to_dict`` attribute, which would
+        # otherwise raise ``TypeError`` at call time).
+        to_dict_fn = getattr(value, "to_dict", None)
+        if callable(to_dict_fn):
+            return to_dict_fn()
         # Last resort: warn and pass through. Pydantic validation will
         # surface the type mismatch loudly enough.
         logger = logging.getLogger(__name__)

--- a/katana_public_api_client/models_pydantic/_base.py
+++ b/katana_public_api_client/models_pydantic/_base.py
@@ -253,9 +253,14 @@ def _convert_nested_value(value: Any, registry: Any) -> Any:
         The converted value suitable for a Pydantic model.
 
     Note:
-        If an attrs object is not registered in the registry, a warning is logged
-        and the original attrs object is returned as-is. This may cause issues
-        with Pydantic validation.
+        For attrs objects without a registered pydantic class, falls back
+        to ``value.to_dict()`` when the attrs side exposes that method —
+        covers the OpenAPI ``type: object`` (no $ref / no inline properties)
+        case where the pydantic generator emits ``dict[str, Any]`` while
+        the attrs generator still synthesizes a concrete class. When the
+        attrs object also has no ``to_dict``, the value is returned as-is
+        with a warning; pydantic validation will surface the mismatch
+        downstream.
     """
     import logging
 

--- a/katana_public_api_client/models_pydantic/_base.py
+++ b/katana_public_api_client/models_pydantic/_base.py
@@ -282,11 +282,28 @@ def _convert_nested_value(value: Any, registry: Any) -> Any:
         pydantic_class = registry.get_pydantic_class(type(value))
         if pydantic_class:
             return pydantic_class.from_attrs(value)
-        # Warn about unregistered attrs classes
+        # No registered pydantic class — happens when the OpenAPI spec
+        # declares the field as a bare ``type: object`` (no $ref, no
+        # inline properties), so the pydantic generator emits
+        # ``dict[str, Any]`` while the attrs generator still synthesizes
+        # a concrete class (e.g. ``FactoryLegalAddress``). The pydantic
+        # model expects a dict, so fall back to ``to_dict()`` when the
+        # attrs side exposes it. This also recovers the previous-
+        # behavior path for ``Variant.config_attributes`` /
+        # ``custom_fields`` item classes whose names changed under the
+        # type-union regen (e.g. ``VariantConfigAttributesItem`` →
+        # ``VariantConfigAttributesType0Item``) — the registry doesn't
+        # know about the new names yet, but the attrs ``to_dict`` shape
+        # matches what pydantic accepts.
+        if hasattr(value, "to_dict"):
+            return value.to_dict()
+        # Last resort: warn and pass through. Pydantic validation will
+        # surface the type mismatch loudly enough.
         logger = logging.getLogger(__name__)
         logger.warning(
-            "Nested attrs class %s is not registered in the pydantic registry. "
-            "Conversion may fail or produce unexpected results.",
+            "Nested attrs class %s is not registered in the pydantic registry "
+            "and has no ``to_dict`` fallback. Conversion may fail or produce "
+            "unexpected results.",
             type(value).__name__,
         )
 

--- a/katana_public_api_client/models_pydantic/_base.py
+++ b/katana_public_api_client/models_pydantic/_base.py
@@ -286,15 +286,8 @@ def _convert_nested_value(value: Any, registry: Any) -> Any:
         # declares the field as a bare ``type: object`` (no $ref, no
         # inline properties), so the pydantic generator emits
         # ``dict[str, Any]`` while the attrs generator still synthesizes
-        # a concrete class (e.g. ``FactoryLegalAddress``). The pydantic
-        # model expects a dict, so fall back to ``to_dict()`` when the
-        # attrs side exposes it. This also recovers the previous-
-        # behavior path for ``Variant.config_attributes`` /
-        # ``custom_fields`` item classes whose names changed under the
-        # type-union regen (e.g. ``VariantConfigAttributesItem`` →
-        # ``VariantConfigAttributesType0Item``) — the registry doesn't
-        # know about the new names yet, but the attrs ``to_dict`` shape
-        # matches what pydantic accepts.
+        # a concrete class. The pydantic model expects a dict, so fall
+        # back to ``to_dict()`` when the attrs side exposes it.
         if hasattr(value, "to_dict"):
             return value.to_dict()
         # Last resort: warn and pass through. Pydantic validation will

--- a/katana_public_api_client/models_pydantic/_generated/common.py
+++ b/katana_public_api_client/models_pydantic/_generated/common.py
@@ -852,10 +852,16 @@ class Factory(KatanaPydanticBase):
     display_name: Annotated[str, Field(description="Display name of the company")]
     base_currency_code: Annotated[str, Field(description="Base currency code")]
     default_so_delivery_time: Annotated[
-        AwareDatetime | None, Field(description="Default sales order delivery time")
+        str | None,
+        Field(
+            description="Default sales order delivery time. Schema gap: Katana's upstream\nexample shows an ISO-8601 datetime, but the live wire delivers\neither ``null`` or an opaque short string (e.g. ``\"14\"`` for\ndays-lead-time). We deliberately drop ``format: date-time`` here\nbecause the wire doesn't honor it. See #727."
+        ),
     ] = None
     default_po_lead_time: Annotated[
-        AwareDatetime | None, Field(description="Default purchase order lead time")
+        str | None,
+        Field(
+            description='Default purchase order lead time. Schema gap: same shape as\n``default_so_delivery_time`` — Katana\'s upstream example shows an\nISO-8601 datetime, but the live wire delivers ``null`` or an\nopaque short string (e.g. ``"14"`` for days). ``format: date-time``\nomitted intentionally. See #727.'
+        ),
     ] = None
     default_manufacturing_location_id: Annotated[
         int | None, Field(description="Default manufacturing location ID")
@@ -867,7 +873,10 @@ class Factory(KatanaPydanticBase):
         int | None, Field(description="Default sales location ID")
     ] = None
     inventory_closing_date: Annotated[
-        AwareDatetime | None, Field(description="Inventory closing date")
+        AwareDatetime | None,
+        Field(
+            description="Inventory closing date. Marked nullable defensively — current\nwire returns a valid ISO-8601 datetime, but the Factory schema\nis sparsely documented and other date-time fields here\n(``default_so_delivery_time`` / ``default_po_lead_time``) have\nbeen observed delivering ``null``. See #727."
+        ),
     ] = None
 
 
@@ -1308,10 +1317,16 @@ class CachedFactory(KatanaPydanticBase, table=True):
     ]
     base_currency_code: Annotated[Mapped[str], Field(description="Base currency code")]
     default_so_delivery_time: Annotated[
-        Mapped[datetime | None], Field(description="Default sales order delivery time")
+        Mapped[str | None],
+        Field(
+            description="Default sales order delivery time. Schema gap: Katana's upstream\nexample shows an ISO-8601 datetime, but the live wire delivers\neither ``null`` or an opaque short string (e.g. ``\"14\"`` for\ndays-lead-time). We deliberately drop ``format: date-time`` here\nbecause the wire doesn't honor it. See #727."
+        ),
     ] = None
     default_po_lead_time: Annotated[
-        Mapped[datetime | None], Field(description="Default purchase order lead time")
+        Mapped[str | None],
+        Field(
+            description='Default purchase order lead time. Schema gap: same shape as\n``default_so_delivery_time`` — Katana\'s upstream example shows an\nISO-8601 datetime, but the live wire delivers ``null`` or an\nopaque short string (e.g. ``"14"`` for days). ``format: date-time``\nomitted intentionally. See #727.'
+        ),
     ] = None
     default_manufacturing_location_id: Annotated[
         Mapped[int | None], Field(description="Default manufacturing location ID")
@@ -1323,7 +1338,10 @@ class CachedFactory(KatanaPydanticBase, table=True):
         Mapped[int | None], Field(description="Default sales location ID")
     ] = None
     inventory_closing_date: Annotated[
-        Mapped[datetime | None], Field(description="Inventory closing date")
+        Mapped[datetime | None],
+        Field(
+            description="Inventory closing date. Marked nullable defensively — current\nwire returns a valid ISO-8601 datetime, but the Factory schema\nis sparsely documented and other date-time fields here\n(``default_so_delivery_time`` / ``default_po_lead_time``) have\nbeen observed delivering ``null``. See #727."
+        ),
     ] = None
 
 

--- a/katana_public_api_client/models_pydantic/_generated/common.py
+++ b/katana_public_api_client/models_pydantic/_generated/common.py
@@ -852,16 +852,10 @@ class Factory(KatanaPydanticBase):
     display_name: Annotated[str, Field(description="Display name of the company")]
     base_currency_code: Annotated[str, Field(description="Base currency code")]
     default_so_delivery_time: Annotated[
-        str | None,
-        Field(
-            description="Default sales order delivery time. Schema gap: Katana's upstream\nexample shows an ISO-8601 datetime, but the live wire delivers\neither ``null`` or an opaque short string (e.g. ``\"14\"`` for\ndays-lead-time). We deliberately drop ``format: date-time`` here\nbecause the wire doesn't honor it. See #727."
-        ),
+        str | None, Field(description="Default sales order delivery time")
     ] = None
     default_po_lead_time: Annotated[
-        str | None,
-        Field(
-            description='Default purchase order lead time. Schema gap: same shape as\n``default_so_delivery_time`` — Katana\'s upstream example shows an\nISO-8601 datetime, but the live wire delivers ``null`` or an\nopaque short string (e.g. ``"14"`` for days). ``format: date-time``\nomitted intentionally. See #727.'
-        ),
+        str | None, Field(description="Default purchase order lead time")
     ] = None
     default_manufacturing_location_id: Annotated[
         int | None, Field(description="Default manufacturing location ID")
@@ -873,10 +867,7 @@ class Factory(KatanaPydanticBase):
         int | None, Field(description="Default sales location ID")
     ] = None
     inventory_closing_date: Annotated[
-        AwareDatetime | None,
-        Field(
-            description="Inventory closing date. Marked nullable defensively — current\nwire returns a valid ISO-8601 datetime, but the Factory schema\nis sparsely documented and other date-time fields here\n(``default_so_delivery_time`` / ``default_po_lead_time``) have\nbeen observed delivering ``null``. See #727."
-        ),
+        AwareDatetime | None, Field(description="Inventory closing date")
     ] = None
 
 
@@ -1317,16 +1308,10 @@ class CachedFactory(KatanaPydanticBase, table=True):
     ]
     base_currency_code: Annotated[Mapped[str], Field(description="Base currency code")]
     default_so_delivery_time: Annotated[
-        Mapped[str | None],
-        Field(
-            description="Default sales order delivery time. Schema gap: Katana's upstream\nexample shows an ISO-8601 datetime, but the live wire delivers\neither ``null`` or an opaque short string (e.g. ``\"14\"`` for\ndays-lead-time). We deliberately drop ``format: date-time`` here\nbecause the wire doesn't honor it. See #727."
-        ),
+        Mapped[str | None], Field(description="Default sales order delivery time")
     ] = None
     default_po_lead_time: Annotated[
-        Mapped[str | None],
-        Field(
-            description='Default purchase order lead time. Schema gap: same shape as\n``default_so_delivery_time`` — Katana\'s upstream example shows an\nISO-8601 datetime, but the live wire delivers ``null`` or an\nopaque short string (e.g. ``"14"`` for days). ``format: date-time``\nomitted intentionally. See #727.'
-        ),
+        Mapped[str | None], Field(description="Default purchase order lead time")
     ] = None
     default_manufacturing_location_id: Annotated[
         Mapped[int | None], Field(description="Default manufacturing location ID")
@@ -1338,10 +1323,7 @@ class CachedFactory(KatanaPydanticBase, table=True):
         Mapped[int | None], Field(description="Default sales location ID")
     ] = None
     inventory_closing_date: Annotated[
-        Mapped[datetime | None],
-        Field(
-            description="Inventory closing date. Marked nullable defensively — current\nwire returns a valid ISO-8601 datetime, but the Factory schema\nis sparsely documented and other date-time fields here\n(``default_so_delivery_time`` / ``default_po_lead_time``) have\nbeen observed delivering ``null``. See #727."
-        ),
+        Mapped[datetime | None], Field(description="Inventory closing date")
     ] = None
 
 

--- a/katana_public_api_client/models_pydantic/_generated/common.py
+++ b/katana_public_api_client/models_pydantic/_generated/common.py
@@ -852,10 +852,16 @@ class Factory(KatanaPydanticBase):
     display_name: Annotated[str, Field(description="Display name of the company")]
     base_currency_code: Annotated[str, Field(description="Base currency code")]
     default_so_delivery_time: Annotated[
-        str | None, Field(description="Default sales order delivery time")
+        str | None,
+        Field(
+            description='Default sales order delivery time. Note: Katana\'s upstream\nexample shows an ISO-8601 datetime, but the live wire delivers\neither ``null`` or an opaque short string (e.g. ``"14"`` for\ndays). ``format: date-time`` is intentionally omitted.'
+        ),
     ] = None
     default_po_lead_time: Annotated[
-        str | None, Field(description="Default purchase order lead time")
+        str | None,
+        Field(
+            description="Default purchase order lead time. Same shape as\n``default_so_delivery_time`` — wire delivers ``null`` or an\nopaque short string, not a datetime. ``format: date-time``\nintentionally omitted."
+        ),
     ] = None
     default_manufacturing_location_id: Annotated[
         int | None, Field(description="Default manufacturing location ID")
@@ -1308,10 +1314,16 @@ class CachedFactory(KatanaPydanticBase, table=True):
     ]
     base_currency_code: Annotated[Mapped[str], Field(description="Base currency code")]
     default_so_delivery_time: Annotated[
-        Mapped[str | None], Field(description="Default sales order delivery time")
+        Mapped[str | None],
+        Field(
+            description='Default sales order delivery time. Note: Katana\'s upstream\nexample shows an ISO-8601 datetime, but the live wire delivers\neither ``null`` or an opaque short string (e.g. ``"14"`` for\ndays). ``format: date-time`` is intentionally omitted.'
+        ),
     ] = None
     default_po_lead_time: Annotated[
-        Mapped[str | None], Field(description="Default purchase order lead time")
+        Mapped[str | None],
+        Field(
+            description="Default purchase order lead time. Same shape as\n``default_so_delivery_time`` — wire delivers ``null`` or an\nopaque short string, not a datetime. ``format: date-time``\nintentionally omitted."
+        ),
     ] = None
     default_manufacturing_location_id: Annotated[
         Mapped[int | None], Field(description="Default manufacturing location ID")

--- a/katana_public_api_client/models_pydantic/_generated/inventory.py
+++ b/katana_public_api_client/models_pydantic/_generated/inventory.py
@@ -187,14 +187,12 @@ class Variant(UpdatableEntity, DeletableEntity):
     type: VariantType | None = None
     internal_barcode: Annotated[
         str | None,
-        Field(
-            description="Internal barcode for warehouse scanning and tracking. The wire\ndelivers ``null`` for variants that don't have one assigned;\nours-vs-Katana spec gap — Katana's published spec marks this\nnon-nullable but the live API returns null on most rows. See #727."
-        ),
+        Field(description="Internal barcode for warehouse scanning and tracking"),
     ] = None
     registered_barcode: Annotated[
         str | None,
         Field(
-            description="Official registered barcode (UPC, EAN, etc.) for retail use.\nNullable per live-wire behavior — see ``internal_barcode``."
+            description="Official registered barcode (UPC, EAN, etc.) for retail use"
         ),
     ] = None
     supplier_item_codes: Annotated[
@@ -211,14 +209,12 @@ class Variant(UpdatableEntity, DeletableEntity):
     ] = None
     custom_fields: Annotated[
         list[CustomField] | None,
-        Field(
-            description='Custom field values specific to this variant. The wire delivers\n``null`` (not an empty array) when no custom fields are set —\nsee #727. Consumers should treat ``null`` and ``[]`` as\nequivalent ("no custom fields").'
-        ),
+        Field(description="Custom field values specific to this variant"),
     ] = None
     config_attributes: Annotated[
         list[ConfigAttribute] | None,
         Field(
-            description="Configuration attribute values that define this variant (color,\nsize, etc.). Marked nullable defensively (mirrors\n``custom_fields`` shape) so a future wire change to ``null``\ndoesn't crash the generated parser — current wire always\ndelivers an array, even if empty."
+            description="Configuration attribute values that define this variant (color, size, etc.)"
         ),
     ] = None
 
@@ -900,7 +896,7 @@ class Inventory(KatanaPydanticBase):
     quantity_potential: Annotated[
         str | None,
         Field(
-            description="Total quantity that could be available (in stock + expected).\nWire delivers ``null`` on the typical row (observed 100% on a\n50-row sample). The field is still ``required`` because Katana\nships the key on every row — it's the *value* that may be null,\nnot the key. See #727."
+            description="Total quantity that could be available (in stock + expected)"
         ),
     ]
     variant: Annotated[
@@ -920,7 +916,7 @@ class Inventory(KatanaPydanticBase):
     default_storage_bin: Annotated[
         VariantDefaultStorageBinLinkResponse | None,
         Field(
-            description="Default storage bin for this variant at this location, when one has\nbeen linked via the variant default storage bin endpoints. The wire\ndelivers ``null`` when no bin is linked (the typical case) — see\n#727.",
+            description="Default storage bin for this variant at this location, when one has been linked via the variant default storage bin endpoints",
         ),
     ] = None
 
@@ -1424,14 +1420,12 @@ class VariantResponse(DeletableEntity):
     type: VariantType | None = None
     internal_barcode: Annotated[
         str | None,
-        Field(
-            description="Internal barcode for warehouse scanning and tracking. The wire\ndelivers ``null`` for variants without one assigned — ours-vs-\nKatana spec gap; see ``Variant.internal_barcode`` for the\nrationale."
-        ),
+        Field(description="Internal barcode for warehouse scanning and tracking"),
     ] = None
     registered_barcode: Annotated[
         str | None,
         Field(
-            description="Official registered barcode (UPC, EAN, etc.) for retail use.\nNullable per live-wire behavior — see ``internal_barcode``."
+            description="Official registered barcode (UPC, EAN, etc.) for retail use"
         ),
     ] = None
     supplier_item_codes: Annotated[
@@ -1448,15 +1442,11 @@ class VariantResponse(DeletableEntity):
     ] = None
     config_attributes: Annotated[
         list[ConfigAttribute2] | None,
-        Field(
-            description="Configuration attribute values that define this variant. Marked\nnullable to mirror ``custom_fields`` and the inline ``Variant``\nschema — see #727."
-        ),
+        Field(description="Configuration attribute values that define this variant"),
     ] = None
     custom_fields: Annotated[
         list[CustomField3] | None,
-        Field(
-            description="Custom field values specific to this variant. The wire delivers\n``null`` (not ``[]``) when no custom fields are set — see #727."
-        ),
+        Field(description="Custom field values specific to this variant"),
     ] = None
     product_or_material: Annotated[
         Product | Material | None,
@@ -1520,14 +1510,12 @@ class CachedVariant(UpdatableEntity, DeletableEntity, table=True):
     type: Mapped[VariantType | None] = None
     internal_barcode: Annotated[
         Mapped[str | None],
-        Field(
-            description="Internal barcode for warehouse scanning and tracking. The wire\ndelivers ``null`` for variants that don't have one assigned;\nours-vs-Katana spec gap — Katana's published spec marks this\nnon-nullable but the live API returns null on most rows. See #727."
-        ),
+        Field(description="Internal barcode for warehouse scanning and tracking"),
     ] = None
     registered_barcode: Annotated[
         Mapped[str | None],
         Field(
-            description="Official registered barcode (UPC, EAN, etc.) for retail use.\nNullable per live-wire behavior — see ``internal_barcode``."
+            description="Official registered barcode (UPC, EAN, etc.) for retail use"
         ),
     ] = None
     supplier_item_codes: Annotated[
@@ -1549,14 +1537,14 @@ class CachedVariant(UpdatableEntity, DeletableEntity, table=True):
         Mapped[list[CustomField] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
-            description='Custom field values specific to this variant. The wire delivers\n``null`` (not an empty array) when no custom fields are set —\nsee #727. Consumers should treat ``null`` and ``[]`` as\nequivalent ("no custom fields").',
+            description="Custom field values specific to this variant",
         ),
     ] = None
     config_attributes: Annotated[
         Mapped[list[ConfigAttribute] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
-            description="Configuration attribute values that define this variant (color,\nsize, etc.). Marked nullable defensively (mirrors\n``custom_fields`` shape) so a future wire change to ``null``\ndoesn't crash the generated parser — current wire always\ndelivers an array, even if empty.",
+            description="Configuration attribute values that define this variant (color, size, etc.)",
         ),
     ] = None
     parent_archived_at: Annotated[

--- a/katana_public_api_client/models_pydantic/_generated/inventory.py
+++ b/katana_public_api_client/models_pydantic/_generated/inventory.py
@@ -187,12 +187,14 @@ class Variant(UpdatableEntity, DeletableEntity):
     type: VariantType | None = None
     internal_barcode: Annotated[
         str | None,
-        Field(description="Internal barcode for warehouse scanning and tracking"),
+        Field(
+            description="Internal barcode for warehouse scanning and tracking. The wire\ndelivers ``null`` for variants that don't have one assigned;\nours-vs-Katana spec gap — Katana's published spec marks this\nnon-nullable but the live API returns null on most rows. See #727."
+        ),
     ] = None
     registered_barcode: Annotated[
         str | None,
         Field(
-            description="Official registered barcode (UPC, EAN, etc.) for retail use"
+            description="Official registered barcode (UPC, EAN, etc.) for retail use.\nNullable per live-wire behavior — see ``internal_barcode``."
         ),
     ] = None
     supplier_item_codes: Annotated[
@@ -209,12 +211,14 @@ class Variant(UpdatableEntity, DeletableEntity):
     ] = None
     custom_fields: Annotated[
         list[CustomField] | None,
-        Field(description="Custom field values specific to this variant"),
+        Field(
+            description='Custom field values specific to this variant. The wire delivers\n``null`` (not an empty array) when no custom fields are set —\nsee #727. Consumers should treat ``null`` and ``[]`` as\nequivalent ("no custom fields").'
+        ),
     ] = None
     config_attributes: Annotated[
         list[ConfigAttribute] | None,
         Field(
-            description="Configuration attribute values that define this variant (color, size, etc.)"
+            description="Configuration attribute values that define this variant (color,\nsize, etc.). Marked nullable defensively (mirrors\n``custom_fields`` shape) so a future wire change to ``null``\ndoesn't crash the generated parser — current wire always\ndelivers an array, even if empty."
         ),
     ] = None
 
@@ -894,9 +898,9 @@ class Inventory(KatanaPydanticBase):
         ),
     ]
     quantity_potential: Annotated[
-        str,
+        str | None,
         Field(
-            description="Total quantity that could be available (in stock + expected)"
+            description="Total quantity that could be available (in stock + expected).\nWire delivers ``null`` on the typical row (observed 100% on a\n50-row sample). The field is still ``required`` because Katana\nships the key on every row — it's the *value* that may be null,\nnot the key. See #727."
         ),
     ]
     variant: Annotated[
@@ -916,7 +920,7 @@ class Inventory(KatanaPydanticBase):
     default_storage_bin: Annotated[
         VariantDefaultStorageBinLinkResponse | None,
         Field(
-            description="Default storage bin for this variant at this location, when one has been linked via the variant default storage bin endpoints"
+            description="Default storage bin for this variant at this location, when one has\nbeen linked via the variant default storage bin endpoints. The wire\ndelivers ``null`` when no bin is linked (the typical case) — see\n#727.",
         ),
     ] = None
 
@@ -1420,12 +1424,14 @@ class VariantResponse(DeletableEntity):
     type: VariantType | None = None
     internal_barcode: Annotated[
         str | None,
-        Field(description="Internal barcode for warehouse scanning and tracking"),
+        Field(
+            description="Internal barcode for warehouse scanning and tracking. The wire\ndelivers ``null`` for variants without one assigned — ours-vs-\nKatana spec gap; see ``Variant.internal_barcode`` for the\nrationale."
+        ),
     ] = None
     registered_barcode: Annotated[
         str | None,
         Field(
-            description="Official registered barcode (UPC, EAN, etc.) for retail use"
+            description="Official registered barcode (UPC, EAN, etc.) for retail use.\nNullable per live-wire behavior — see ``internal_barcode``."
         ),
     ] = None
     supplier_item_codes: Annotated[
@@ -1442,11 +1448,15 @@ class VariantResponse(DeletableEntity):
     ] = None
     config_attributes: Annotated[
         list[ConfigAttribute2] | None,
-        Field(description="Configuration attribute values that define this variant"),
+        Field(
+            description="Configuration attribute values that define this variant. Marked\nnullable to mirror ``custom_fields`` and the inline ``Variant``\nschema — see #727."
+        ),
     ] = None
     custom_fields: Annotated[
         list[CustomField3] | None,
-        Field(description="Custom field values specific to this variant"),
+        Field(
+            description="Custom field values specific to this variant. The wire delivers\n``null`` (not ``[]``) when no custom fields are set — see #727."
+        ),
     ] = None
     product_or_material: Annotated[
         Product | Material | None,
@@ -1510,12 +1520,14 @@ class CachedVariant(UpdatableEntity, DeletableEntity, table=True):
     type: Mapped[VariantType | None] = None
     internal_barcode: Annotated[
         Mapped[str | None],
-        Field(description="Internal barcode for warehouse scanning and tracking"),
+        Field(
+            description="Internal barcode for warehouse scanning and tracking. The wire\ndelivers ``null`` for variants that don't have one assigned;\nours-vs-Katana spec gap — Katana's published spec marks this\nnon-nullable but the live API returns null on most rows. See #727."
+        ),
     ] = None
     registered_barcode: Annotated[
         Mapped[str | None],
         Field(
-            description="Official registered barcode (UPC, EAN, etc.) for retail use"
+            description="Official registered barcode (UPC, EAN, etc.) for retail use.\nNullable per live-wire behavior — see ``internal_barcode``."
         ),
     ] = None
     supplier_item_codes: Annotated[
@@ -1537,14 +1549,14 @@ class CachedVariant(UpdatableEntity, DeletableEntity, table=True):
         Mapped[list[CustomField] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
-            description="Custom field values specific to this variant",
+            description='Custom field values specific to this variant. The wire delivers\n``null`` (not an empty array) when no custom fields are set —\nsee #727. Consumers should treat ``null`` and ``[]`` as\nequivalent ("no custom fields").',
         ),
     ] = None
     config_attributes: Annotated[
         Mapped[list[ConfigAttribute] | None],
         SQLField(
             sa_column=Column(PydanticJSON),
-            description="Configuration attribute values that define this variant (color, size, etc.)",
+            description="Configuration attribute values that define this variant (color,\nsize, etc.). Marked nullable defensively (mirrors\n``custom_fields`` shape) so a future wire change to ``null``\ndoesn't crash the generated parser — current wire always\ndelivers an array, even if empty.",
         ),
     ] = None
     parent_archived_at: Annotated[

--- a/scripts/regenerate_client.py
+++ b/scripts/regenerate_client.py
@@ -817,8 +817,32 @@ def fix_ty_type_errors(workspace_path: Path) -> None:
                 content,
             )
 
-            # Ensure cast and Mapping are imported
-            if "cast(Mapping[str, Any], data)" in content:
+            # Pattern 3: union-aware loop-item calls (post-#727).
+            # When a property is typed as ``[array, "null"]``, the generator emits
+            # ``for X_item_data in <data>: Y.from_dict(X_item_data)`` inside a
+            # ``try / except`` block. ``X_item_data`` is inferred as ``object``
+            # by ty (the outer ``data`` is ``object``; ``isinstance(data, list)``
+            # narrows to ``list`` but items stay ``object``), so ``from_dict``
+            # rejects the argument. Cast at the call site — pre-existing
+            # ``data``-named pattern (#1, #2) had the same root cause but used a
+            # short fixed name. Match any ``..._data`` variable; the variable
+            # naming is the generator's convention for loop items in this
+            # union-aware path.
+            content = re.sub(
+                r"(\w+)\.from_dict\((\w+_data)\)",
+                r"\1.from_dict(cast(Mapping[str, Any], \2))",
+                content,
+            )
+            # Same for the multi-line variant (the inner expression often wraps).
+            content = re.sub(
+                r"(\w+)\.from_dict\(\s*\n(\s+)(\w+_data)\s*\n(\s*)\)",
+                r"\1.from_dict(\n\2cast(Mapping[str, Any], \3)\n\4)",
+                content,
+            )
+
+            # Ensure cast and Mapping are imported (covers all four patterns
+            # above since they all emit ``cast(Mapping[str, Any], ...)``).
+            if "cast(Mapping[str, Any]," in content:
                 # Check if cast is already imported from typing
                 if not re.search(r"from typing import.*\bcast\b", content):
                     # Find the from typing import line and add cast at the end

--- a/tests/test_models_pydantic.py
+++ b/tests/test_models_pydantic.py
@@ -396,6 +396,167 @@ class TestVariantNullSku:
         assert pydantic_product.variants[1].sku is None
 
 
+class TestWireNullTolerance:
+    """Generated ``from_dict`` parsers must tolerate ``null`` for spec-nullable fields.
+
+    Pins the wire-vs-spec gaps fixed for #727, one case per affected field:
+    ``Variant`` / ``VariantResponse`` ``custom_fields`` and
+    ``config_attributes``, ``Variant.internal_barcode``,
+    ``Inventory.default_storage_bin`` and ``quantity_potential``, and
+    ``Factory.default_so_delivery_time`` / ``default_po_lead_time`` (the
+    latter also covering the non-datetime ``"14"`` opaque-string shape).
+    Each one was a live-API payload shape that crashed our generated
+    client because the OpenAPI spec declared the field as non-nullable
+    but Katana's actual API returns ``null`` (often unconditionally).
+    The test inputs mirror real responses captured against the live API
+    on 2026-05-14; if a future spec regen re-tightens these to
+    non-nullable, the relevant ``from_dict`` will raise
+    ``TypeError: 'NoneType' object is not iterable`` (or
+    ``has no len()``) and the test will fail.
+    """
+
+    def test_variant_from_dict_with_null_custom_fields(self) -> None:
+        """``Variant.custom_fields = null`` (observed on 100% of variants).
+
+        Crash site: ``for custom_fields_item_data in _custom_fields`` in the
+        generated parser, when the wire delivers ``null`` instead of ``[]``
+        or omission.
+        """
+        from katana_public_api_client.models import Variant as AttrsVariant
+
+        attrs_variant = AttrsVariant.from_dict(
+            {"id": 1, "sku": "TEST-SKU", "custom_fields": None}
+        )
+        # ``UNSET`` and ``None`` both mean "no custom fields"; the parser
+        # must accept the wire's literal null without raising.
+        assert attrs_variant.id == 1
+
+    def test_variant_from_dict_with_null_config_attributes(self) -> None:
+        """``Variant.config_attributes = null`` — defensive sibling case."""
+        from katana_public_api_client.models import Variant as AttrsVariant
+
+        attrs_variant = AttrsVariant.from_dict(
+            {"id": 1, "sku": "TEST-SKU", "config_attributes": None}
+        )
+        assert attrs_variant.id == 1
+
+    def test_variant_response_from_dict_with_null_custom_fields(self) -> None:
+        """``VariantResponse.custom_fields = null`` (single-variant endpoint)."""
+        from katana_public_api_client.models import VariantResponse as AttrsVR
+
+        attrs_variant = AttrsVR.from_dict(
+            {"id": 1, "sku": "TEST-SKU", "custom_fields": None}
+        )
+        assert attrs_variant.id == 1
+
+    def test_variant_from_dict_with_null_internal_barcode(self) -> None:
+        """``Variant.internal_barcode = null`` (observed on 41/50 variants)."""
+        from katana_public_api_client.models import Variant as AttrsVariant
+
+        attrs_variant = AttrsVariant.from_dict(
+            {"id": 1, "sku": "TEST-SKU", "internal_barcode": None}
+        )
+        assert attrs_variant.id == 1
+
+    def test_inventory_from_dict_with_null_default_storage_bin(self) -> None:
+        """``Inventory.default_storage_bin = null`` (observed on 100% of rows).
+
+        Crash site: ``VariantDefaultStorageBinLinkResponse.from_dict(None)``
+        → ``dict(None)`` in the generated parser. The wire delivers ``null``
+        whenever no bin has been linked (the typical case).
+        """
+        from katana_public_api_client.models import Inventory as AttrsInventory
+
+        attrs_inv = AttrsInventory.from_dict(
+            {
+                "variant_id": 1,
+                "location_id": 1,
+                "reorder_point": 0,
+                "average_cost": 0,
+                "value_in_stock": 0,
+                "quantity_in_stock": "0",
+                "quantity_committed": "0",
+                "quantity_expected": "0",
+                "quantity_missing_or_excess": "0",
+                # ``quantity_potential`` is required on the wire (Katana always
+                # ships the key) and may be ``null`` — see the sibling
+                # ``test_inventory_quantity_potential_nullable`` case.
+                "quantity_potential": None,
+                "default_storage_bin": None,
+            }
+        )
+        assert attrs_inv.variant_id == 1
+
+    def test_inventory_quantity_potential_nullable(self) -> None:
+        """``Inventory.quantity_potential = null`` (observed on 100% of rows).
+
+        Spec quirk: the field stays in ``required`` because Katana always
+        ships the key, but the value is ``null`` on the typical row. The
+        generated parser must accept ``null`` without raising.
+        """
+        from katana_public_api_client.models import Inventory as AttrsInventory
+
+        attrs_inv = AttrsInventory.from_dict(
+            {
+                "variant_id": 1,
+                "location_id": 1,
+                "reorder_point": 0,
+                "average_cost": 0,
+                "value_in_stock": 0,
+                "quantity_in_stock": "0",
+                "quantity_committed": "0",
+                "quantity_expected": "0",
+                "quantity_missing_or_excess": "0",
+                "quantity_potential": None,
+            }
+        )
+        assert attrs_inv.variant_id == 1
+        assert attrs_inv.quantity_potential is None
+
+    def test_factory_from_dict_with_null_default_so_delivery_time(self) -> None:
+        """``Factory.default_so_delivery_time = null`` (live wire ships null).
+
+        Crash site: ``isoparse(_default_so_delivery_time)`` →
+        ``len(None)`` inside dateutil. Schema gap with Katana's upstream
+        spec, which documents the field as ``date-time`` (their example
+        shows a valid datetime) but the live wire delivers ``null`` or an
+        opaque short string. See #727.
+        """
+        from katana_public_api_client.models import Factory as AttrsFactory
+
+        attrs_factory = AttrsFactory.from_dict(
+            {
+                "display_name": "Test Factory",
+                "base_currency_code": "USD",
+                "default_so_delivery_time": None,
+                "default_po_lead_time": None,
+            }
+        )
+        assert attrs_factory.display_name == "Test Factory"
+
+    def test_factory_from_dict_with_opaque_po_lead_time(self) -> None:
+        """``Factory.default_po_lead_time = "14"`` (live wire ships opaque short string).
+
+        Sibling of the null case — the field is declared as a plain string
+        (no ``format: date-time``) because the wire actually delivers
+        days-as-string ("14") rather than a datetime, contrary to Katana's
+        upstream example.
+        """
+        from katana_public_api_client.models import Factory as AttrsFactory
+
+        attrs_factory = AttrsFactory.from_dict(
+            {
+                "display_name": "Test Factory",
+                "base_currency_code": "USD",
+                "default_po_lead_time": "14",
+            }
+        )
+        assert attrs_factory.display_name == "Test Factory"
+        # The parser keeps the opaque string verbatim — it's the caller's
+        # job to interpret the format.
+        assert attrs_factory.default_po_lead_time == "14"
+
+
 class TestRequestModels:
     """Tests for request model instantiation."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1278,7 +1278,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.75.1"
+version = "0.75.2"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Marks 6 OpenAPI spec fields nullable to match the live Katana wire (the spec was strictly tighter than reality) — fixes the `'NoneType' object is not iterable` / `has no len()` crashes that took down `get_variant_details`, `check_inventory`, and the cache warmup since at least 2026-05-11.
- Extends `regenerate_client.py`'s ty-cast patcher to handle the union-aware loop pattern that the OpenAPI generator emits when an array property is `[array, "null"]`.
- Adds `cache_warmup_partial` traceback capture so the next regression is one-shot diagnosable instead of silently swallowed.
- Pins the wire contract with `TestWireNullTolerance` in `tests/test_models_pydantic.py` — 8 cases covering each crash site.

Closes #727.

## Spec changes (with rationale)

| Field | Old | New | Why |
| --- | --- | --- | --- |
| `Variant.custom_fields` / `VariantResponse.custom_fields` | `type: array` | `[array, null]` | Wire delivers `null` on 100% of variants sampled |
| `Variant.config_attributes` / `VariantResponse.config_attributes` | `type: array` | `[array, null]` | Defensive — mirrors `custom_fields` shape |
| `Variant.internal_barcode` / `registered_barcode` (×2 models) | `type: string` | `[string, null]` | Wire delivers `null` on most rows |
| `Inventory.default_storage_bin` | bare `$ref` | `anyOf: [$ref, null]` | Wire delivers `null` on 100% of rows |
| `Inventory.quantity_potential` | `type: string` (required) | `[string, null]` (required) | Key always shipped, value typically `null` |
| `Factory.default_so_delivery_time` / `default_po_lead_time` | `type: string, format: date-time` | `[string, null]` (no format) | Wire delivers `null` or `\"14\"` (days-as-string); Katana's upstream example is wrong |
| `Factory.inventory_closing_date` | `type: string` | `[string, null]` (kept format) | Defensive — sibling fields drift to null |

Where the wire shape is non-obvious (Factory `default_so_delivery_time` / `default_po_lead_time` actually deliver opaque short strings like `"14"` for days, not the documented datetime), the property `description` carries the rationale so it surfaces in the regenerated client docstrings. For the simpler null-tolerance cases (Variant `custom_fields`, `Inventory.default_storage_bin`, etc.) the regression test name does the documenting job — the spec just marks them nullable to match the wire.

Why the wire wins here: Katana's `live-gateway.yaml` ships **zero** response schemas (every 200 is `description: "Return value of ..."` with no `content`). Their README portal ships response examples but no schemas, and the examples are happy-path values that never trigger the null cases. The live API is the only source of truth, and nothing in our existing audit pipeline consults it.

## Why our existing tests missed this

- `validate-response-examples` checks Katana's curated examples against the spec, but their examples don't use `null` for these fields.
- `audit-spec` only compares request DTOs (the live gateway has no response schemas to diff).
- Unit tests construct pydantic objects with `custom_fields=None` (exercising the pydantic side), not `Variant.from_dict({\"custom_fields\": null, ...})` — which is the attrs `from_dict` parser that actually crashed.

New `TestWireNullTolerance` closes this gap by feeding each crash-site shape through the attrs `from_dict` directly. A future regen that re-tightens these to non-nullable will fail those tests.

## Generator + base-class changes

- `scripts/regenerate_client.py` — new regex pattern in `add_ty_type_ignores`: cast `<varname>_data` loop items to `Mapping[str, Any]` before passing to `<Class>.from_dict()`. The openapi-python-client generator now emits union-aware loops where the loop item is inferred as `object` by ty; the existing patcher only handled the literal `data` variable name.
- `katana_public_api_client/models_pydantic/_base.py` — when `_convert_nested_value` encounters an attrs object whose pydantic counterpart isn't in the registry (the case where the spec declares `type: object` inline without a `$ref`, e.g. `FactoryLegalAddress`), fall back to `value.to_dict()`. Previously the attrs object was passed through unchanged and failed pydantic validation downstream.
- `katana_mcp_server/src/katana_mcp/server.py` — persist full per-failure tracebacks in the `cache_warmup_partial` log event. The originating session had `ensure_factory_synced` failing silently for 3 days because the warning carried only `str(exc)`.

## Breaking change — generator class renames

The openapi-python-client generator renames inline `items` classes when the parent property's type union includes `null`:

| Old | New |
| --- | --- |
| `VariantConfigAttributesItem` | `VariantConfigAttributesType0Item` |
| `VariantCustomFieldsItem` | `VariantCustomFieldsType0Item` |
| `VariantResponseConfigAttributesItem` | `VariantResponseConfigAttributesType0Item` |
| `VariantResponseCustomFieldsItem` | `VariantResponseCustomFieldsType0Item` |

These are public symbols (`models/__init__.py` exports them). External importers will fail until they update. Marked as `fix(client)!:` per `COMMIT_STANDARDS.md`.

The only in-tree consumer is `katana_mcp_server/tests/tools/test_items.py`, updated in this PR.

## Test plan

- [x] `uv run poe regenerate-client` — generated code reflects new nullable shape
- [x] `uv run poe generate-pydantic` — pydantic mirrors updated
- [x] `uv run poe check` — 3180 unit tests + 19 browser tests pass; ruff/yamllint/ty clean
- [x] Live API verification: `ensure_factory_synced`, `ensure_products_synced`, `ensure_variants_synced` all succeed; `/inventory` parse returns 7 rows for variant FK74003
- [x] Regression: `TestWireNullTolerance` (8 cases) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
