### PR TITLE
fix(client): surface undocumented-status response bodies + document 412 on DELETE endpoints

### DIFF
--- a/docs/KATANA_API_QUESTIONS.md
+++ b/docs/KATANA_API_QUESTIONS.md
@@ -159,6 +159,44 @@ ______________________________________________________________________
 endpoint, not CRUD resource); body requires `variant_id` + `location_id` + `periods` on
 POST and DELETE; our spec mirrors it, no follow-up needed.*
 
+### 5.2 `GET /sales_returns?sales_order_id=N` silently ignores the filter
+
+**Status: CONFIRMED via live API on 2026-05-14**
+
+The `sales_order_id` query parameter on `GET /sales_returns` is declared in the spec and
+accepted by the server with a 200 response, but the filter is not applied — the endpoint
+returns every sales return in the account regardless of the value passed.
+
+**Investigation (2026-05-14):** While investigating why `DELETE /sales_orders/{id}`
+returned 412 for SO 40190868, we listed sales returns with
+`GET /sales_returns?sales_order_id=40190868`. The endpoint returned 43 records, but
+inspection of the response payload showed only 2 actually had
+`sales_order_id == 40190868` — the other 41 were unrelated. A second call without the
+filter parameter returned an identical 43-record list (same IDs, same order), proving
+the server treats `sales_order_id=N` as a no-op.
+
+```
+# With filter
+GET /sales_returns?sales_order_id=40190868&limit=100 → 200, 43 records returned
+# Without filter
+GET /sales_returns?limit=100 → 200, 43 records returned (same set)
+# Client-side filter after the fact
+[sr for sr in records if sr["sales_order_id"] == 40190868] → 2 records
+```
+
+**Conclusion:** Either the upstream `GET /sales_returns` doesn't honor `sales_order_id`
+as a filter, or it honors a different parameter name. Until this is resolved upstream,
+callers must fetch the full list and filter client-side — which also defeats pagination
+if the account has more than `limit` sales returns. The same caution likely applies to
+any consumer of this filter, and other declared filter parameters on this endpoint
+should be re-verified.
+
+**Cross-reference:** Surfaced during investigation tracked in #740 (MCP returns-gap).
+Needs an upstream report to Katana — our spec correctly documents the filter parameter;
+the gap is in upstream behavior, not our client.
+
+**Last verified:** 2026-05-14 (live API, against production tenant).
+
 ______________________________________________________________________
 
 ## 6. PATCH Asymmetric Field-Wipe Behavior

--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -1108,6 +1108,36 @@ components:
             statusCode: 400
             name: BadRequest
             message: Bad Request
+    PreconditionFailedError:
+      description: |-
+        Precondition failed - the resource cannot be modified or deleted in its
+        current state. Typically returned when a delete is blocked by linked
+        child records (e.g. a sales order with attached return orders, or a
+        purchase order with received stock).
+
+        Note: 412 responses observed on these endpoints arrive wrapped in
+        Katana's nested ``{"error": {...}}`` envelope (see example). The
+        ``ErrorResponse`` schema describes the inner object; the wire payload
+        nests it under an ``error`` key. The client's ``unwrap()`` helper
+        handles both shapes transparently. Callers inspecting the raw
+        payload directly (via ``sync_detailed()`` / ``asyncio_detailed()``
+        and ``Response.content``) should expect the wrapped form.
+      headers:
+        X-Ratelimit-Limit:
+          $ref: "#/components/headers/X-Ratelimit-Limit"
+        X-Ratelimit-Remaining:
+          $ref: "#/components/headers/X-Ratelimit-Remaining"
+        X-Ratelimit-Reset:
+          $ref: "#/components/headers/X-Ratelimit-Reset"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error:
+              statusCode: 412
+              name: PreconditionFailedError
+              message: Cannot delete sales orders as sales orders have return orders.
   schemas:
     ErrorResponse:
       type: object
@@ -13571,6 +13601,8 @@ paths:
           $ref: "#/components/responses/UnauthorizedError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+        "412":
+          $ref: "#/components/responses/PreconditionFailedError"
         "422":
           $ref: "#/components/responses/UnprocessableEntityError"
         "429":
@@ -15728,6 +15760,8 @@ paths:
           $ref: "#/components/responses/UnauthorizedError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+        "412":
+          $ref: "#/components/responses/PreconditionFailedError"
         "429":
           $ref: "#/components/responses/TooManyRequests"
         "500":
@@ -18541,6 +18575,8 @@ paths:
           $ref: "#/components/responses/UnauthorizedError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+        "412":
+          $ref: "#/components/responses/PreconditionFailedError"
         "429":
           $ref: "#/components/responses/TooManyRequests"
         "500":

--- a/katana_public_api_client/api/manufacturing_order/delete_manufacturing_order.py
+++ b/katana_public_api_client/api/manufacturing_order/delete_manufacturing_order.py
@@ -42,6 +42,11 @@ def _parse_response(
 
         return response_404
 
+    if response.status_code == 412:
+        response_412 = ErrorResponse.from_dict(response.json())
+
+        return response_412
+
     if response.status_code == 422:
         response_422 = DetailedErrorResponse.from_dict(response.json())
 

--- a/katana_public_api_client/api/purchase_order/delete_purchase_order.py
+++ b/katana_public_api_client/api/purchase_order/delete_purchase_order.py
@@ -41,6 +41,11 @@ def _parse_response(
 
         return response_404
 
+    if response.status_code == 412:
+        response_412 = ErrorResponse.from_dict(response.json())
+
+        return response_412
+
     if response.status_code == 429:
         response_429 = ErrorResponse.from_dict(response.json())
 

--- a/katana_public_api_client/api/sales_order/delete_sales_order.py
+++ b/katana_public_api_client/api/sales_order/delete_sales_order.py
@@ -41,6 +41,11 @@ def _parse_response(
 
         return response_404
 
+    if response.status_code == 412:
+        response_412 = ErrorResponse.from_dict(response.json())
+
+        return response_412
+
     if response.status_code == 429:
         response_429 = ErrorResponse.from_dict(response.json())
 

--- a/katana_public_api_client/utils.py
+++ b/katana_public_api_client/utils.py
@@ -4,9 +4,10 @@ This module provides convenient helpers for unwrapping API responses,
 handling errors, extracting data, and formatting display values.
 """
 
+import json
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, overload
 
 from .client_types import Response, Unset
 from .domain.converters import unwrap_unset
@@ -266,65 +267,156 @@ def unwrap[T](
         ```
     """
     if response.parsed is None:
-        if raise_on_error:
-            raise APIError(
-                f"No parsed response data for status {response.status_code}",
-                response.status_code,
-            )
-        return None
+        if not raise_on_error:
+            return None
+        name, message, parsed_error = _try_parse_error_body(response.content)
+        _raise_for_status(response.status_code, name, message, parsed_error)
 
     # Check if it's an error response — assign to local for type narrowing
     parsed = response.parsed
     if isinstance(parsed, ErrorResponse | DetailedErrorResponse):
         if not raise_on_error:
             return None
-
-        parsed_error = parsed
-
-        error_name = (
-            parsed_error.name if not isinstance(parsed_error.name, Unset) else "Unknown"
-        )
-        error_message = (
-            parsed_error.message
-            if not isinstance(parsed_error.message, Unset)
-            else "No error message provided"
-        )
-
-        # Handle nested error format — Katana wraps errors in {"error": {...}}
-        nested = parsed_error.additional_properties
-        if isinstance(nested, dict) and "error" in nested:
-            nested_error = nested["error"]
-            if isinstance(nested_error, dict):
-                error_name = str(nested_error.get("name", error_name))
-                error_message = str(nested_error.get("message", error_message))
-                # Re-parse as DetailedErrorResponse to capture details
-                if "details" in nested_error:
-                    parsed_error = DetailedErrorResponse.from_dict(nested_error)
-
-        message = f"{error_name}: {error_message}"
-
-        if response.status_code == HTTPStatus.UNAUTHORIZED:
-            raise AuthenticationError(message, response.status_code, parsed_error)
-        elif response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-            # ValidationError expects DetailedErrorResponse, but parsed_error could be ErrorResponse
-            detailed_error = (
-                parsed_error
-                if isinstance(parsed_error, DetailedErrorResponse)
-                else None
-            )
-            raise ValidationError(
-                message,
-                response.status_code,
-                detailed_error,
-            )
-        elif response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-            raise RateLimitError(message, response.status_code, parsed_error)
-        elif 500 <= response.status_code < 600:
-            raise ServerError(message, response.status_code, parsed_error)
-        else:
-            raise APIError(message, response.status_code, parsed_error)
+        name, message, parsed_error = _extract_error_fields(parsed)
+        _raise_for_status(response.status_code, name, message, parsed_error)
 
     return response.parsed
+
+
+def _try_parse_error_body(
+    content: bytes,
+) -> tuple[str, str, ErrorResponse | DetailedErrorResponse | None]:
+    """Best-effort parse of an unrecognized response body.
+
+    Used when ``response.parsed`` is None because the OpenAPI spec didn't
+    document the status code — the body bytes are still available on the
+    Response object, and they're usually a Katana ``ErrorResponse``-shaped
+    payload. Returns ``(name, message, error_response)``: when parsing
+    succeeds the typed model is included for callers that inspect it; when
+    it doesn't, ``message`` falls back to a truncated body snippet so the
+    caller still sees something actionable.
+    """
+    if not content:
+        return ("UnexpectedResponse", "<empty response body>", None)
+
+    try:
+        body = json.loads(content)
+    except (json.JSONDecodeError, ValueError, TypeError, UnicodeDecodeError):
+        # TypeError covers callers (notably test mocks) that pass non-bytes
+        # content; UnicodeDecodeError covers bytes that aren't valid UTF-8/16/32
+        # (json.loads detects encoding from BOM but raises during decode for
+        # invalid sequences). Fall back to a stringified snippet so we still
+        # surface something rather than crashing the unwrap path.
+        try:
+            snippet = content.decode("utf-8", errors="replace").strip()
+        except (AttributeError, UnicodeDecodeError):
+            snippet = str(content)[:200]
+        return (
+            "UnexpectedResponse",
+            _truncate(snippet) or "<empty response body>",
+            None,
+        )
+
+    # Katana wraps errors in {"error": {...}} on some endpoints
+    if isinstance(body, dict) and "error" in body and isinstance(body["error"], dict):
+        body = body["error"]
+
+    if not isinstance(body, dict):
+        return ("UnexpectedResponse", _truncate(json.dumps(body)), None)
+
+    name_raw = body.get("name")
+    message_raw = body.get("message")
+
+    # Body parsed as a dict but didn't carry ErrorResponse fields — fall back
+    # to surfacing the JSON snippet so the caller can see what Katana sent
+    # instead of an opaque "<no error message>" placeholder.
+    if name_raw is None and message_raw is None:
+        if not body:
+            return ("UnexpectedResponse", "<empty response body>", None)
+        return ("UnexpectedResponse", _truncate(json.dumps(body)), None)
+
+    name = str(name_raw) if name_raw is not None else "UnexpectedResponse"
+    message = (
+        str(message_raw) if message_raw is not None else _truncate(json.dumps(body))
+    )
+
+    try:
+        if "details" in body:
+            parsed_error: ErrorResponse | DetailedErrorResponse | None = (
+                DetailedErrorResponse.from_dict(body)
+            )
+        else:
+            parsed_error = ErrorResponse.from_dict(body)
+    except Exception:
+        parsed_error = None
+
+    return (name, message, parsed_error)
+
+
+def _truncate(snippet: str, limit: int = 200) -> str:
+    """Truncate a snippet at ``limit`` chars with an ellipsis marker."""
+    if len(snippet) > limit:
+        return snippet[:limit] + "…"
+    return snippet
+
+
+def _extract_error_fields(
+    parsed: ErrorResponse | DetailedErrorResponse,
+) -> tuple[str, str, ErrorResponse | DetailedErrorResponse]:
+    """Pull (name, message, parsed_error) from a parsed Katana error.
+
+    Handles the nested-under-``"error"`` wrapping that some Katana endpoints
+    use — when present, name/message come from the inner object and the
+    returned parsed_error is also re-parsed from the inner object so callers
+    inspecting ``APIError.error_response`` see the actual structured fields
+    instead of an outer envelope where everything is UNSET.
+    """
+    name = parsed.name if not isinstance(parsed.name, Unset) else "Unknown"
+    message = (
+        parsed.message
+        if not isinstance(parsed.message, Unset)
+        else "No error message provided"
+    )
+
+    nested = parsed.additional_properties
+    if isinstance(nested, dict) and "error" in nested:
+        nested_error = nested["error"]
+        if isinstance(nested_error, dict):
+            name = str(nested_error.get("name", name))
+            message = str(nested_error.get("message", message))
+            # Re-parse the inner object so error_response carries the real
+            # name/message/statusCode rather than the UNSET-everything outer
+            # envelope. Use DetailedErrorResponse when "details" is present
+            # so validation details survive the unwrap.
+            if "details" in nested_error:
+                parsed = DetailedErrorResponse.from_dict(nested_error)
+            else:
+                parsed = ErrorResponse.from_dict(nested_error)
+
+    return (name, message, parsed)
+
+
+def _raise_for_status(
+    status_code: int,
+    name: str,
+    message: str,
+    parsed_error: ErrorResponse | DetailedErrorResponse | None,
+) -> NoReturn:
+    """Raise the right APIError subclass for this status code."""
+    full_message = f"{name}: {message}"
+
+    if status_code == HTTPStatus.UNAUTHORIZED:
+        raise AuthenticationError(full_message, status_code, parsed_error)
+    if status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+        detailed = (
+            parsed_error if isinstance(parsed_error, DetailedErrorResponse) else None
+        )
+        raise ValidationError(full_message, status_code, detailed)
+    if status_code == HTTPStatus.TOO_MANY_REQUESTS:
+        raise RateLimitError(full_message, status_code, parsed_error)
+    if 500 <= status_code < 600:
+        raise ServerError(full_message, status_code, parsed_error)
+    raise APIError(full_message, status_code, parsed_error)
 
 
 @overload

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,10 +36,13 @@ class TestUnwrap:
         assert isinstance(result, WebhookListResponse)
 
     def test_unwrap_with_none_parsed_raises_error(self):
-        """Test that unwrap raises APIError when parsed is None."""
+        """Test that unwrap raises APIError when parsed is None.
+
+        Empty body falls back to the "<empty response body>" placeholder.
+        """
         response: Response[Any] = Response(
             status_code=HTTPStatus.OK,
-            content=b"{}",
+            content=b"",
             headers={},
             parsed=None,
         )
@@ -49,7 +52,7 @@ class TestUnwrap:
 
         error = exc_info.value
         assert isinstance(error, utils.APIError)
-        assert "No parsed response data" in str(error)
+        assert "<empty response body>" in str(error)
         assert error.status_code == 200
 
     def test_unwrap_with_none_parsed_returns_none_when_not_raising(self):
@@ -64,6 +67,160 @@ class TestUnwrap:
         result = utils.unwrap(response, raise_on_error=False)
 
         assert result is None
+
+    def test_unwrap_undocumented_status_surfaces_body(self):
+        """Undocumented status codes (e.g. 412) parse the raw body and surface
+        Katana's actual error name/message in the raised exception.
+
+        412 has no dedicated APIError subclass (subclassing only kicks in for
+        401/422/429/5xx), so the base ``APIError`` is raised — but with the
+        body's name/message populated and ``error_response`` re-parsed from
+        the nested-under-``"error"`` envelope.
+        """
+        body = (
+            b'{"error":{"statusCode":412,"name":"PreconditionFailedError",'
+            b'"message":"Cannot delete sales orders as sales orders have return orders."}}'
+        )
+        response: Response[Any] = Response(
+            status_code=HTTPStatus(412),
+            content=body,
+            headers={},
+            parsed=None,
+        )
+
+        with pytest.raises(utils.APIError) as exc_info:
+            utils.unwrap(response)
+
+        error = exc_info.value
+        assert type(error) is utils.APIError  # base class, not a subclass
+        assert error.status_code == 412
+        assert "PreconditionFailedError" in str(error)
+        assert "Cannot delete sales orders" in str(error)
+        assert isinstance(error.error_response, ErrorResponse)
+
+    def test_unwrap_undocumented_status_routes_to_subclass(self):
+        """When status code matches a known bucket (e.g. 503), the routing
+        helper still picks the right APIError subclass even for undocumented
+        statuses."""
+        body = b'{"name":"ServiceUnavailable","message":"upstream down"}'
+        response: Response[Any] = Response(
+            status_code=HTTPStatus(503),
+            content=body,
+            headers={},
+            parsed=None,
+        )
+
+        with pytest.raises(utils.ServerError) as exc_info:
+            utils.unwrap(response)
+
+        assert "upstream down" in str(exc_info.value)
+
+    def test_unwrap_undocumented_status_with_non_json_body(self):
+        """When the body isn't JSON, fall back to a truncated snippet so the
+        caller still sees what Katana sent."""
+        response: Response[Any] = Response(
+            status_code=HTTPStatus(502),
+            content=b"<html><body>nginx 502 bad gateway</body></html>",
+            headers={},
+            parsed=None,
+        )
+
+        with pytest.raises(utils.ServerError) as exc_info:
+            utils.unwrap(response)
+
+        msg = str(exc_info.value)
+        assert "UnexpectedResponse" in msg
+        assert "nginx 502 bad gateway" in msg
+
+    def test_unwrap_undocumented_status_with_long_body_truncates(self):
+        """Long non-JSON bodies are truncated to keep the error readable."""
+        response: Response[Any] = Response(
+            status_code=HTTPStatus(418),
+            content=b"x" * 1000,
+            headers={},
+            parsed=None,
+        )
+
+        with pytest.raises(utils.APIError) as exc_info:
+            utils.unwrap(response)
+
+        msg = str(exc_info.value)
+        assert "…" in msg  # truncation marker
+        # 200-char limit on snippet + the "UnexpectedResponse: " prefix + "…"
+        assert len(msg) < 300
+
+    def test_unwrap_undocumented_status_with_invalid_utf8_body(self):
+        """Bytes that aren't valid UTF-8 raise ``UnicodeDecodeError`` from
+        ``json.loads`` (not ``JSONDecodeError``). The fallback must catch
+        that and still produce an ``APIError`` with a body snippet."""
+        # 0xc3 0x28 is a classic invalid UTF-8 continuation byte sequence
+        response: Response[Any] = Response(
+            status_code=HTTPStatus(502),
+            content=b"\xc3\x28 bad gateway garbage",
+            headers={},
+            parsed=None,
+        )
+
+        with pytest.raises(utils.ServerError) as exc_info:
+            utils.unwrap(response)
+
+        msg = str(exc_info.value)
+        assert "UnexpectedResponse" in msg
+        # decode(errors="replace") substitutes U+FFFD for invalid bytes
+        assert "bad gateway garbage" in msg
+
+    def test_unwrap_undocumented_status_with_empty_json_object(self):
+        """A JSON body of ``{}`` falls back to the empty-body placeholder
+        rather than the misleading ``<no error message>`` default."""
+        response: Response[Any] = Response(
+            status_code=HTTPStatus(412),
+            content=b"{}",
+            headers={},
+            parsed=None,
+        )
+
+        with pytest.raises(utils.APIError) as exc_info:
+            utils.unwrap(response)
+
+        msg = str(exc_info.value)
+        assert "<empty response body>" in msg
+        assert "<no error message>" not in msg
+
+    def test_unwrap_undocumented_status_with_unknown_dict_shape(self):
+        """A JSON body that parses as a dict but doesn't carry name/message
+        surfaces the JSON snippet instead of an opaque placeholder."""
+        response: Response[Any] = Response(
+            status_code=HTTPStatus(412),
+            content=b'{"foo":"bar","baz":42}',
+            headers={},
+            parsed=None,
+        )
+
+        with pytest.raises(utils.APIError) as exc_info:
+            utils.unwrap(response)
+
+        msg = str(exc_info.value)
+        assert '"foo"' in msg
+        assert '"bar"' in msg
+        assert "<no error message>" not in msg
+
+    def test_unwrap_undocumented_status_with_name_but_no_message(self):
+        """When only ``name`` is present, ``message`` falls back to the body
+        snippet so no detail is lost."""
+        response: Response[Any] = Response(
+            status_code=HTTPStatus(412),
+            content=b'{"name":"PreconditionFailedError","reason":"check upstream"}',
+            headers={},
+            parsed=None,
+        )
+
+        with pytest.raises(utils.APIError) as exc_info:
+            utils.unwrap(response)
+
+        msg = str(exc_info.value)
+        assert "PreconditionFailedError" in msg
+        assert "check upstream" in msg
+        assert "<no error message>" not in msg
 
     def test_unwrap_401_raises_authentication_error(self):
         """Test that 401 status raises AuthenticationError."""
@@ -273,6 +430,35 @@ class TestUnwrap:
             utils.unwrap(response)
 
         assert "BadRequestError: Invalid parameter" in str(exc_info.value)
+
+    def test_unwrap_nested_error_reparses_into_error_response(self):
+        """When the body uses the nested ``{"error": {...}}`` shape, the
+        ``error_response`` attached to the raised exception must be re-parsed
+        from the inner object so callers see the actual name/message/
+        statusCode instead of the UNSET-everything outer envelope."""
+        outer = ErrorResponse(name=UNSET, message=UNSET)
+        outer.additional_properties = {
+            "error": {
+                "statusCode": 412,
+                "name": "PreconditionFailedError",
+                "message": "Cannot delete sales orders as sales orders have return orders.",
+            }
+        }
+        response: Response[Any] = Response(
+            status_code=HTTPStatus(412),
+            content=b"{}",
+            headers={},
+            parsed=outer,
+        )
+
+        with pytest.raises(utils.APIError) as exc_info:
+            utils.unwrap(response)
+
+        err_resp = exc_info.value.error_response
+        assert isinstance(err_resp, ErrorResponse)
+        # Re-parsed from the inner dict, so these fields are now real
+        assert err_resp.name == "PreconditionFailedError"
+        assert "Cannot delete" in str(err_resp.message)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- **Universal fix:** `unwrap()` no longer discards `response.content` when `response.parsed is None`. New `_try_parse_error_body` helper does a best-effort JSON+ErrorResponse parse (including the nested-under-`"error"` shape Katana uses on some endpoints) and routes through the existing status→exception-class logic. Non-JSON bodies fall through to a truncated snippet. Every undocumented status anywhere in the API now produces an informative `APIError`.
- **Targeted spec fix:** new shared `PreconditionFailedError` response in `components/responses`, referenced from `deleteSalesOrder`, `deleteManufacturingOrder`, and `deletePurchaseOrder`. The generated parsers now have proper 412 arms.
- **Docs:** new `KATANA_API_QUESTIONS §5.2` entry for an upstream bug surfaced during investigation — `GET /sales_returns?sales_order_id=N` silently ignores its filter parameter.

## Why

`delete_sales_order` (and likely other ops) was failing with `APIError: No parsed response data for status 412` — completely opaque. Live capture showed Katana actually sends a clean `{"error":{"statusCode":412,"name":"PreconditionFailedError","message":"Cannot delete sales orders as sales orders have return orders."}}` body; the unwrap layer was throwing it away. With this PR, that exact string surfaces all the way up to MCP cards.

## Test plan

- [x] `uv run poe check` passes (3207 unit + 19 browser)
- [x] New unit tests in `tests/test_utils.py` cover the four fallback paths: 412 with nested `"error"` shape, status→subclass routing on 503, non-JSON body (HTML 502), long-body truncation
- [x] Pre-existing MCP tests still pass — the `_try_parse_error_body` helper is defensive against test mocks passing non-bytes `content`
- [x] Manual probe: live `DELETE /sales_orders/40190868` returned the expected 412 with the body shape the new code parses

## Notes

- Filed [#740](https://github.com/dougborg/katana-openapi-client/issues/740) separately: MCP has no tools for sales returns, which blocks SO-with-RO cleanup workflows.
- The `_try_parse_error_body` `except Exception` is intentional (best-effort parse — any failure falls through to a non-typed snippet); justified in its docstring.
- The conservative scope (412 declared on only three DELETE endpoints) is intentional. The universal unwrap-layer fallback handles other endpoints automatically; the spec gets tightened as we collect production evidence of where else 412 fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)