### PR TITLE
refactor(mcp): _format_money helper + Babel currency rendering + #749 boundary fixes

### DIFF
--- a/katana_mcp_server/pyproject.toml
+++ b/katana_mcp_server/pyproject.toml
@@ -47,6 +47,10 @@ dependencies = [
     # context for the DB driver. Declared explicitly for the #342 typed
     # cache; without it, async session operations raise at runtime.
     "greenlet>=3.0.0",
+    # ISO 4217 currency-aware money formatting (Prefab UI ``Total`` metrics).
+    # Picks per-currency symbol, decimal digits, and separators so non-USD
+    # orders render correctly (€1,500.00, ¥1500 with no decimals, etc.).
+    "babel>=2.17",
 ]
 
 # Note: Development dependencies like mcp-hmr require Python >=3.12

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -60,6 +60,7 @@ from katana_mcp.tools.tool_result_utils import (
     apply_date_window_filters,
     coerce_enum,
     enum_to_str,
+    float_or_none,
     iso_or_none,
     make_json_result,
     make_tool_result,
@@ -838,8 +839,12 @@ def _recipe_row_info_from_attrs(
         sku=sku,
         display_name=display_name,
         notes=unwrap_unset(row.notes, None),
-        planned_quantity_per_unit=unwrap_unset(row.planned_quantity_per_unit, None),
-        total_actual_quantity=unwrap_unset(row.total_actual_quantity, None),
+        planned_quantity_per_unit=float_or_none(
+            unwrap_unset(row.planned_quantity_per_unit, None)
+        ),
+        total_actual_quantity=float_or_none(
+            unwrap_unset(row.total_actual_quantity, None)
+        ),
         total_consumed_quantity=unwrap_unset(row.total_consumed_quantity, None),
         total_remaining_quantity=unwrap_unset(row.total_remaining_quantity, None),
         ingredient_availability=unwrap_unset(row.ingredient_availability, None),
@@ -847,7 +852,7 @@ def _recipe_row_info_from_attrs(
             unwrap_unset(row.ingredient_expected_date, None)
         ),
         batch_transactions=batch_infos,
-        cost=unwrap_unset(row.cost, None),
+        cost=float_or_none(unwrap_unset(row.cost, None)),
         created_at=iso_or_none(unwrap_unset(row.created_at, None)),
         updated_at=iso_or_none(unwrap_unset(row.updated_at, None)),
         deleted_at=iso_or_none(unwrap_unset(row.deleted_at, None)),
@@ -885,13 +890,19 @@ def _operation_row_info_from_attrs(row: Any) -> OperationRowInfo:
         assigned_operators=assigned,
         completed_by_operators=completed,
         active_operator_id=unwrap_unset(row.active_operator_id, None),
-        planned_time_per_unit=unwrap_unset(row.planned_time_per_unit, None),
-        planned_time_parameter=unwrap_unset(row.planned_time_parameter, None),
-        total_actual_time=unwrap_unset(row.total_actual_time, None),
+        planned_time_per_unit=float_or_none(
+            unwrap_unset(row.planned_time_per_unit, None)
+        ),
+        planned_time_parameter=float_or_none(
+            unwrap_unset(row.planned_time_parameter, None)
+        ),
+        total_actual_time=float_or_none(unwrap_unset(row.total_actual_time, None)),
         total_consumed_time=unwrap_unset(row.total_consumed_time, None),
         total_remaining_time=unwrap_unset(row.total_remaining_time, None),
-        planned_cost_per_unit=unwrap_unset(row.planned_cost_per_unit, None),
-        total_actual_cost=unwrap_unset(row.total_actual_cost, None),
+        planned_cost_per_unit=float_or_none(
+            unwrap_unset(row.planned_cost_per_unit, None)
+        ),
+        total_actual_cost=float_or_none(unwrap_unset(row.total_actual_cost, None)),
         cost_per_hour=unwrap_unset(row.cost_per_hour, None),
         cost_parameter=unwrap_unset(row.cost_parameter, None),
         group_boundary=unwrap_unset(row.group_boundary, None),

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -917,7 +917,7 @@ async def _list_sales_orders_impl(
                 location_id=so.location_id,
                 status=enum_to_str(so.status),
                 production_status=enum_to_str(so.production_status),
-                invoicing_status=so.invoicing_status,
+                invoicing_status=enum_to_str(so.invoicing_status),
                 created_at=iso_or_none(so.created_at),
                 delivery_date=iso_or_none(so.delivery_date),
                 total=so.total,
@@ -1335,7 +1335,7 @@ async def _get_sales_order_impl(
         order_created_date=iso_or_none(unwrap_unset(so.order_created_date, None)),
         status=enum_to_str(unwrap_unset(so.status, None)),
         production_status=enum_to_str(unwrap_unset(so.production_status, None)),
-        invoicing_status=unwrap_unset(so.invoicing_status, None),
+        invoicing_status=enum_to_str(unwrap_unset(so.invoicing_status, None)),
         product_availability=enum_to_str(unwrap_unset(so.product_availability, None)),
         product_expected_date=iso_or_none(unwrap_unset(so.product_expected_date, None)),
         ingredient_availability=enum_to_str(

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+from babel.numbers import format_currency
 from prefab_ui.actions import Action, SetState, ShowToast
 from prefab_ui.actions.mcp import CallTool, SendMessage, UpdateContext
 from prefab_ui.actions.navigation import OpenLink
@@ -830,7 +831,12 @@ def build_variant_details_ui(
         if p is None:
             return "N/A"
         suffix = f" / {uom}" if uom and uom not in ("pcs", "ea") else ""
-        return f"${p:,.2f}{suffix}"
+        # Variant prices are tenant-wide and don't carry a per-record
+        # currency on the wire; they're denominated in
+        # ``Factory.base_currency_code``. The factory record isn't
+        # plumbed into this builder yet, so the format falls back to
+        # USD via :func:`_format_money` — wiring tracked in #751.
+        return f"{_format_money(p, None)}{suffix}"
 
     with PrefabApp(state={"variant": variant}, css_class="p-4") as app, Card():
         with CardHeader(), Column(gap=1):
@@ -1337,6 +1343,36 @@ def _format_cost(cost: float | int | None) -> str:
     if cost is None:
         return "—"
     return f"{cost:.2f}"
+
+
+def _format_money(amount: float | int | None, currency: str | None) -> str:
+    """Format a Metric ``Total`` value using ISO 4217 currency-aware rules.
+
+    Delegates to :func:`babel.numbers.format_currency` so the rendered string
+    picks up the right symbol, decimal-digit count, and grouping for the
+    currency (``$1,500.00`` for USD, ``€1,500.00`` for EUR, ``¥1,500`` for
+    JPY with no decimals). Integer ``amount`` is passed through unchanged
+    — Babel handles ``int`` and ``float`` identically.
+
+    Katana has two currency concepts:
+
+    - **Transaction currency** — ``SalesOrder.currency`` / ``PurchaseOrder.currency``;
+      the currency the line totals (``total``, ``total_cost``, ``price_per_unit``)
+      are denominated in. Pass this when formatting per-order amounts.
+    - **Factory base currency** — ``Factory.base_currency_code``; the tenant's
+      home currency. Pass this when formatting ``*_in_base_currency`` amounts
+      (converted totals).
+
+    Falls back to ``USD`` when ``currency`` is missing so the widget reads
+    cleanly even on the path where the response hasn't populated the field.
+    Unlike :func:`_format_cost`, never returns ``—`` — every Total-style
+    metric has a value to show (``$0.00`` for unset).
+    """
+    return format_currency(
+        0 if amount is None else amount,
+        currency or "USD",
+        locale="en_US",
+    )
 
 
 def _iso_date_only(value: object) -> str:
@@ -1850,7 +1886,9 @@ def build_po_create_ui(
     Four-tier framework (#537):
     - Tier 1 — Identity: title, order_number badge, PREVIEW/CREATED state
       badge, status badge, entity_type badge (regular/outsourced).
-    - Tier 2 — Decision metrics: Total ($X.XX <currency>), Line Items.
+    - Tier 2 — Decision metrics: Total (formatted per
+      ``response["currency"]`` via :func:`_format_money` — symbol + decimal
+      precision picked by Babel from the ISO 4217 code), Line Items.
     - Tier 3 — Reference: supplier, location, notes, plus warnings.
     - Tier 4 — Actions: Confirm + Cancel via the direct-apply rail
       (Confirm fires ``tools/call`` directly and pushes the structured
@@ -1861,7 +1899,7 @@ def build_po_create_ui(
     status = response.get("status")
     entity_type = response.get("entity_type")
     total_cost = response.get("total_cost")
-    currency = response.get("currency") or "USD"
+    currency = response.get("currency")
     item_count = response.get("item_count")
 
     apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
@@ -1885,7 +1923,7 @@ def build_po_create_ui(
             if total_cost is not None or item_count is not None:
                 with Row(gap=4):
                     if total_cost is not None:
-                        Metric(label="Total", value=f"${total_cost:,.2f} {currency}")
+                        Metric(label="Total", value=_format_money(total_cost, currency))
                     if item_count is not None:
                         Metric(label="Line Items", value=str(item_count))
             _render_party_line(
@@ -1945,7 +1983,7 @@ def build_so_create_ui(
     order_number = response.get("order_number") or "N/A"
     status = response.get("status")
     total = response.get("total")
-    currency = response.get("currency") or "USD"
+    currency = response.get("currency")
     item_count = response.get("item_count")
     delivery_date = response.get("delivery_date")
 
@@ -1966,7 +2004,7 @@ def build_so_create_ui(
             if total is not None or item_count is not None or delivery_date:
                 with Row(gap=4):
                     if total is not None:
-                        Metric(label="Total", value=f"${total:,.2f} {currency}")
+                        Metric(label="Total", value=_format_money(total, currency))
                     if item_count is not None:
                         Metric(label="Line Items", value=str(item_count))
                     if delivery_date:
@@ -2736,7 +2774,9 @@ def build_receipt_ui(
             if response.get("total_cost") is not None:
                 Metric(
                     label="PO Total",
-                    value=f"${response['total_cost']:,.2f} {response.get('currency') or 'USD'}",
+                    value=_format_money(
+                        response["total_cost"], response.get("currency")
+                    ),
                 )
 
             block_warnings, regular_warnings = _split_warnings(response.get("warnings"))

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -15,6 +15,7 @@ import pytest
 from katana_mcp.tools.prefab_ui import (
     PREVIEW_APPLY_COACHING,
     PREVIEW_APPLY_DIRECT_COACHING,
+    _format_money,
     build_batch_recipe_update_ui,
     build_fulfill_preview_ui,
     build_fulfill_success_ui,
@@ -110,6 +111,32 @@ def _assert_valid_prefab(app: PrefabApp) -> None:
     # produced that pydantic_core wouldn't accept downstream.
     json.dumps(result)
     _assert_state_bindings_resolve(result)
+
+
+class TestFormatMoney:
+    """``_format_money`` delegates to Babel for currency-aware rendering."""
+
+    def test_usd_amount(self):
+        assert _format_money(1500.0, "USD") == "$1,500.00"
+
+    def test_eur_uses_euro_symbol(self):
+        assert _format_money(1500.0, "EUR") == "€1,500.00"
+
+    def test_jpy_has_no_decimals(self):
+        # JPY's ISO definition has zero decimal places — Babel drops them
+        # automatically; a hand-rolled formatter would render "¥1500.00".
+        assert _format_money(1500, "JPY") == "¥1,500"
+
+    def test_missing_currency_falls_back_to_usd(self):
+        assert _format_money(1500.0, None) == "$1,500.00"
+
+    def test_none_amount_renders_as_zero(self):
+        assert _format_money(None, "USD") == "$0.00"
+
+    def test_unknown_currency_keeps_code_prefix(self):
+        # Babel gracefully handles unknown ISO codes by prefixing the code
+        # instead of raising — keeps the helper total over partial.
+        assert _format_money(1500.0, "XYZ") == "XYZ1,500.00"
 
 
 class TestBuildSearchResultsUI:

--- a/uv.lock
+++ b/uv.lock
@@ -1282,6 +1282,7 @@ version = "0.76.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "babel" },
     { name = "fastmcp" },
     { name = "greenlet" },
     { name = "katana-openapi-client" },
@@ -1295,6 +1296,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "babel", specifier = ">=2.17" },
     { name = "fastmcp", specifier = ">=3.0" },
     { name = "greenlet", specifier = ">=3.0.0" },
     { name = "katana-openapi-client", editable = "." },


### PR DESCRIPTION
## Summary

Three threads:

### 1. Extract ``_format_money`` (closes #744)

Pulled the duplicated ``f\"\${amount:,.2f} {currency or 'USD'}\"`` block
out of three create-card builders (PO create, SO create, PO receipt)
plus the variant-detail price display into a single
``_format_money(amount, currency)`` helper.

### 2. Babel for currency-aware rendering

The old inline format hardcoded ``$`` and 2 decimals — **wrong for
non-USD currencies**:

| Currency | Old (broken) | New (Babel) |
| --- | --- | --- |
| USD | ``$1,500.00 USD`` | ``$1,500.00`` |
| EUR | ``$1,500.00 EUR`` ❌ | ``€1,500.00`` ✓ |
| JPY | ``$1,500.00 JPY`` ❌❌ | ``¥1,500`` ✓ (no decimals) |
| GBP | ``$1,500.00 GBP`` ❌ | ``£1,500.00`` ✓ |
| Unknown | ``$1,500.00 XYZ`` | ``XYZ1,500.00`` |

``_format_money`` delegates to ``babel.numbers.format_currency`` so
the rendered string picks up the right symbol, decimal-digit count,
and grouping per ISO 4217. Added ``babel>=2.17`` as a direct
dependency (it was already a transitive via mkdocs-material; promoting).

### 3. Two-currency model documented

Katana has two currency concepts. The helper docstring + the
related follow-up issue (#751) capture both:

- **Transaction currency** — ``SalesOrder.currency`` /
  ``PurchaseOrder.currency``; the currency line totals are
  denominated in.
- **Factory base currency** — ``Factory.base_currency_code``;
  the tenant's home currency. ``*_in_base_currency`` amounts
  + ``conversion_rate`` + ``conversion_date`` round it out.

This PR formats the three migrated Metric ``Total`` values
correctly using **transaction currency**. Threading factory base
currency into builders (for variant prices, future
``*_in_base_currency`` displays) is tracked in #751.

### 4. MCP boundary fixes for the #749 schema changes

PR #749 reclassified two MO recipe row fields from ``number`` to
``string`` (their wire format), and made ``SalesOrder.invoicing_status``
an enum. This PR closes the consumer-side gaps:

- ``_recipe_row_info_from_attrs`` — wrapped string-on-wire fields
  with ``float_or_none(unwrap_unset(...))`` matching the
  boundary pattern established in #741 for SalesOrderRow
  (``cost``, ``total_actual_quantity``, ``planned_quantity_per_unit``)
- ``_operation_row_info_from_attrs`` — same treatment for the five
  string-on-wire MO operation fields (``planned_time_per_unit``,
  ``planned_time_parameter``, ``total_actual_time``,
  ``planned_cost_per_unit``, ``total_actual_cost``)
- ``invoicing_status`` — wrapped with ``enum_to_str`` in both
  ``SalesOrderSummary`` and the get-SO response so it aligns
  with sibling status fields (``status``, ``production_status``)

## Test plan

- [x] New ``TestFormatMoney`` class — 6 test cases covering
  USD / EUR / JPY / missing-currency / None-amount / unknown-code
- [x] ``uv run poe agent-check`` (format / lint / typecheck) clean
- [x] ``uv run poe test`` — 3216 passed, 2 skipped
- [ ] CI on push

## Related

- Closes #744
- Filed follow-up #751 (factory base currency wiring + ``*_in_base_currency`` surfacing)
- Stacked on #749 (will rebase to ``main`` once that merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)