### PR TITLE
feat(mcp): point-in-time inventory — inventory_at tool + filter pass-through on get_inventory_movements

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -43,6 +43,8 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **get_variant_details** - Get full details for a specific item
 - **get_product_bom** / **manage_product_bom** - Read and edit a producible variant's BOM (Bill of Materials) — the master recipe future manufacturing orders are copied from. `manage_product_bom` supports add / update / delete BOM rows in one call (preview/apply). Distinct from `modify_manufacturing_order`'s recipe-row sub-payloads, which edit a single MO's snapshot.
 - **check_inventory** - Check stock levels for one or more SKUs or variant IDs (pass a list for a summary table)
+- **inventory_at** - Reconstruct historical balance: walks `inventory_movements` and returns per-location stock, value, and average cost as of an ISO-8601 `as_of` instant. Use for audit / point-in-time reconstruction; use `check_inventory` for current state.
+- **get_inventory_movements** - Stream of every stock change with dates, causes, and valuation. Filterable by location, resource type, and `created_at`/`updated_at` windows.
 - **list_low_stock_items** - Find items needing reorder
 - **create_stock_adjustment / list_stock_adjustments / update_stock_adjustment / delete_stock_adjustment** - Full CRUD for manual inventory adjustments
 
@@ -660,12 +662,52 @@ timestamps, and rank) so no follow-up lookups are needed for standard fields.
 **Parameters:**
 - `sku` (required): SKU to get movements for
 - `limit` (optional): Maximum movements to return (default: 50)
+- `location_id` (optional): Filter to a single warehouse/facility
+- `resource_type` (optional): Filter by what caused the movement. One of
+  `SalesOrderRow`, `ManufacturingOrder`, `ManufacturingOrderRecipeRow`,
+  `ProductionIngredient`, `PurchaseOrderRow`, `PurchaseOrderRecipeRow`,
+  `StockAdjustmentRow`, `StockTransferRow`, `SystemGenerated`
+- `created_at_min` / `created_at_max` (optional, ISO-8601): Audit-trail window
+  on when the movement record was first written
+- `updated_at_min` / `updated_at_max` (optional, ISO-8601): When the record was
+  last modified — useful for incremental sync
 
 **Returns:** Movement history with `id`, `variant_id`, `location_id`, `resource_type`,
 `resource_id`, `caused_by_order_no`, `caused_by_resource_id`, `movement_date`,
 `quantity_change`, `balance_after`, `value_per_unit`, `value_in_stock_after`,
 `average_cost_after`, `rank`, `created_at`, `updated_at`. Markdown render uses
 canonical Pydantic field names as column headers.
+
+For point-in-time balance reconstruction (e.g., "what was on hand on 2026-03-15"),
+prefer `inventory_at` — it walks movements and returns the resolved snapshot.
+
+---
+
+### inventory_at
+Reconstruct inventory balance at a specific point in time by walking movement history.
+The Katana `/inventory` endpoint is snapshot-only; this tool walks the
+`/inventory_movements` ledger, filters to `movement_date <= as_of`, and per location
+picks the most recent matching row — reading its `balance_after`,
+`value_in_stock_after`, and `average_cost_after` as the as-of snapshot.
+
+**Parameters:**
+- `skus_or_variant_ids` (required, min 1, max 100): List of SKUs (strings) or variant
+  IDs (integers) — mix freely. Output order matches input order.
+- `as_of` (required, ISO-8601): The instant to reconstruct. Movements after this
+  point are ignored.
+- `location_id` (optional): Filter to a single warehouse/facility — only movements
+  at that location are considered.
+
+**Returns:** `{as_of, items, not_found}`. Each item carries `variant_id`, `sku`,
+`display_name`, per-location rows (`location_id`, `location_name`, `balance_at`,
+`value_in_stock_at`, `average_cost_at`, `last_movement_date`, `last_movement_id`),
+and the totals across locations. Variants with no movements before `as_of` return
+an empty `by_location` list — they had no stock at that moment.
+
+**When to use which:**
+- `check_inventory` → current state (single direct call, fastest).
+- `inventory_at` → historical state (walks movements; for audits & reconstruction).
+- `get_inventory_movements` → the raw delta stream (every change in order).
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import time
 from datetime import datetime
+from itertools import batched
 from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
@@ -28,6 +29,8 @@ from katana_mcp.tools.tool_result_utils import (
     iso_or_none,
     make_json_result,
     make_tool_result,
+    naive_utc,
+    parse_iso_datetime,
     parse_request_dates,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
@@ -35,6 +38,9 @@ from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.api.stock_adjustment import get_all_stock_adjustments
 from katana_public_api_client.client_types import UNSET, Unset
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
+from katana_public_api_client.models.get_all_inventory_movements_resource_type import (
+    GetAllInventoryMovementsResourceType,
+)
 from katana_public_api_client.models_pydantic._generated import (
     CachedLocation,
     CachedVariant,
@@ -42,6 +48,16 @@ from katana_public_api_client.models_pydantic._generated import (
 from katana_public_api_client.utils import unwrap_data
 
 logger = get_logger(__name__)
+
+
+def _iso_str(val: Any) -> str:
+    """Return ``val.isoformat()`` when possible, else ``str(val)``.
+
+    The Katana attrs models type ``movement_date`` / ``created_at`` /
+    ``updated_at`` as ``datetime``, but unit tests fixture them as strings
+    via ``MagicMock`` — accept both so call sites stay shape-agnostic.
+    """
+    return val.isoformat() if hasattr(val, "isoformat") else str(val)
 
 
 def _attr(obj: Any, name: str, default: Any = None) -> Any:
@@ -527,6 +543,45 @@ class GetInventoryMovementsRequest(BaseModel):
 
     sku: str = Field(..., description="SKU to get movements for")
     limit: int = Field(default=50, description="Maximum movements to return")
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "Filter movements to a single warehouse/facility. "
+            "Look up via `list_locations`."
+        ),
+    )
+    resource_type: GetAllInventoryMovementsResourceType | None = Field(
+        default=None,
+        description=(
+            "Filter movements by what caused them. Accepts one of: "
+            "`SalesOrderRow`, `ManufacturingOrder`, "
+            "`ManufacturingOrderRecipeRow`, `ProductionIngredient`, "
+            "`PurchaseOrderRow`, `PurchaseOrderRecipeRow`, "
+            "`StockAdjustmentRow`, `StockTransferRow`, `SystemGenerated`."
+        ),
+    )
+    created_at_min: str | None = Field(
+        default=None,
+        description=(
+            "ISO-8601 lower bound on `created_at` — when the movement "
+            "record was first written. Useful as an audit-trail filter."
+        ),
+    )
+    created_at_max: str | None = Field(
+        default=None,
+        description="ISO-8601 upper bound on `created_at`.",
+    )
+    updated_at_min: str | None = Field(
+        default=None,
+        description=(
+            "ISO-8601 lower bound on `updated_at` — when the movement "
+            "record was last modified. Useful for incremental sync."
+        ),
+    )
+    updated_at_max: str | None = Field(
+        default=None,
+        description="ISO-8601 upper bound on `updated_at`.",
+    )
 
 
 class MovementInfo(BaseModel):
@@ -570,6 +625,14 @@ class InventoryMovementsResponse(BaseModel):
     total_count: int
 
 
+_INVENTORY_MOVEMENTS_DATE_FIELDS = (
+    "created_at_min",
+    "created_at_max",
+    "updated_at_min",
+    "updated_at_max",
+)
+
+
 async def _get_inventory_movements_impl(
     request: GetInventoryMovementsRequest, context: Context
 ) -> InventoryMovementsResponse:
@@ -584,6 +647,8 @@ async def _get_inventory_movements_impl(
         raise ValueError("SKU cannot be empty")
     if request.limit <= 0:
         raise ValueError("Limit must be positive")
+
+    parsed_dates = parse_request_dates(request, _INVENTORY_MOVEMENTS_DATE_FIELDS)
 
     start_time = time.monotonic()
     logger.info("inventory_movements_started", sku=request.sku)
@@ -620,16 +685,14 @@ async def _get_inventory_movements_impl(
             client=services.client,
             variant_ids=[variant_id],
             limit=request.limit,
+            location_id=to_unset(request.location_id),
+            resource_type=to_unset(request.resource_type),
+            created_at_min=to_unset(parsed_dates["created_at_min"]),
+            created_at_max=to_unset(parsed_dates["created_at_max"]),
+            updated_at_min=to_unset(parsed_dates["updated_at_min"]),
+            updated_at_max=to_unset(parsed_dates["updated_at_max"]),
         )
         attrs_list = unwrap_data(response)
-
-        def _iso(val: Any) -> str:
-            return val.isoformat() if hasattr(val, "isoformat") else str(val)
-
-        def _iso_opt(val: Any) -> str | None:
-            if val is None:
-                return None
-            return val.isoformat() if hasattr(val, "isoformat") else str(val)
 
         movements = [
             MovementInfo(
@@ -642,15 +705,15 @@ async def _get_inventory_movements_impl(
                 resource_id=unwrap_unset(m.resource_id, None),
                 caused_by_order_no=unwrap_unset(m.caused_by_order_no, None),
                 caused_by_resource_id=unwrap_unset(m.caused_by_resource_id, None),
-                movement_date=_iso(m.movement_date),
+                movement_date=_iso_str(m.movement_date),
                 quantity_change=m.quantity_change,
                 balance_after=m.balance_after,
                 value_per_unit=m.value_per_unit,
                 value_in_stock_after=m.value_in_stock_after,
                 average_cost_after=m.average_cost_after,
                 rank=unwrap_unset(m.rank, None),
-                created_at=_iso(m.created_at),
-                updated_at=_iso(m.updated_at),
+                created_at=_iso_str(m.created_at),
+                updated_at=_iso_str(m.updated_at),
             )
             for m in attrs_list
         ]
@@ -699,13 +762,327 @@ async def get_inventory_movements(
     timestamps, rank) so callers don't need follow-up lookups for standard
     fields. Use to investigate stock discrepancies or trace how inventory levels
     changed over time. Default limit is 50 movements, ordered most recent first.
+
+    Filter via optional ``location_id`` (single warehouse), ``resource_type``
+    (one of ``SalesOrderRow``, ``ManufacturingOrder``,
+    ``ManufacturingOrderRecipeRow``, ``ProductionIngredient``,
+    ``PurchaseOrderRow``, ``PurchaseOrderRecipeRow``, ``StockAdjustmentRow``,
+    ``StockTransferRow``, ``SystemGenerated``), and
+    ``created_at_min``/``created_at_max``/``updated_at_min``/``updated_at_max``
+    (ISO-8601 datetimes — audit-trail windows). For point-in-time inventory
+    reconstruction, prefer ``inventory_at`` which walks movements and returns
+    the balance ``as_of`` a specific moment.
     """
     response = await _get_inventory_movements_impl(request, context)
     return make_json_result(response)
 
 
 # ============================================================================
-# Tool 4: create_stock_adjustment
+# Tool 4: inventory_at — point-in-time balance reconstruction
+# ============================================================================
+
+
+class InventoryAtRequest(BaseModel):
+    """Request model for point-in-time inventory reconstruction."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    skus_or_variant_ids: CoercedStrIntList = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description=(
+            "JSON array of SKUs (strings) or variant IDs (integers) — mix freely. "
+            'E.g., ["WS74001", 12345] or ["WS74001", "WS74002"]. '
+            "Output order matches input order. Max 100 items per call."
+        ),
+    )
+    as_of: str = Field(
+        ...,
+        description=(
+            "ISO-8601 datetime. Returns the balance as of this moment by "
+            "walking inventory movements and picking the most recent "
+            "movement at-or-before `as_of` per location."
+        ),
+    )
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "Filter to a single warehouse/facility. When set, only "
+            "movements at this location are considered."
+        ),
+    )
+
+
+class InventoryAtLocation(BaseModel):
+    """Per-location balance snapshot at `as_of`."""
+
+    location_id: int
+    location_name: str | None = None
+    balance_at: float
+    value_in_stock_at: float
+    average_cost_at: float
+    last_movement_date: str
+    last_movement_id: int
+
+
+class InventoryAtItem(BaseModel):
+    """Per-variant point-in-time balance with location breakdown.
+
+    `sku` may be ``None`` — Katana allows variants without SKUs
+    (legacy NetSuite imports are a common source). See the documented
+    invariant in CLAUDE.md.
+    """
+
+    variant_id: int
+    sku: str | None
+    display_name: str
+    by_location: list[InventoryAtLocation] = Field(default_factory=list)
+    total_balance: float = 0.0
+    total_value: float = 0.0
+
+
+class InventoryAtResponse(BaseModel):
+    """Response containing point-in-time balances per variant."""
+
+    as_of: str
+    items: list[InventoryAtItem]
+    not_found: list[str | int] = Field(default_factory=list)
+
+
+_INVENTORY_AT_CHUNK_SIZE = 20  # variant_ids per movements-fetch call
+
+
+async def _inventory_at_impl(
+    request: InventoryAtRequest, context: Context
+) -> InventoryAtResponse:
+    """Reconstruct inventory balance at a specific point in time.
+
+    The Katana ``/inventory`` endpoint is snapshot-only. To answer "what
+    was the balance on date X", walk ``/inventory_movements`` for each
+    variant, filter to ``movement_date <= as_of``, then per location pick
+    the most recent matching row and read its ``balance_after`` /
+    ``value_in_stock_after`` / ``average_cost_after`` fields (the running
+    totals Katana computes as each movement lands).
+
+    Movements are fetched in chunks of variant_ids — the auto-paginating
+    transport collects multiple pages, capped at 25k movements per call,
+    so a chunk size of 20 keeps headroom for variants with high movement
+    velocity.
+    """
+    from katana_mcp.tools.foundation.items import _fetch_variant_by_id
+    from katana_public_api_client.api.inventory_movements import (
+        get_all_inventory_movements,
+    )
+    from katana_public_api_client.utils import unwrap_data
+
+    parsed_as_of = parse_iso_datetime(request.as_of, "as_of")
+    as_of_dt = naive_utc(parsed_as_of)
+    assert as_of_dt is not None  # parse_iso_datetime always returns datetime
+
+    items: list[str | int] = []
+    for raw in request.skus_or_variant_ids:
+        if isinstance(raw, str):
+            normalized = raw.strip()
+            if not normalized:
+                raise ValueError("SKU cannot be empty")
+            items.append(normalized)
+        else:
+            items.append(raw)
+
+    start_time = time.monotonic()
+    sku_count = sum(1 for item in items if isinstance(item, str))
+    logger.info(
+        "inventory_at_started",
+        sku_count=sku_count,
+        variant_id_count=len(items) - sku_count,
+        as_of=request.as_of,
+    )
+
+    try:
+        services = get_services(context)
+
+        async def _resolve(item: str | int) -> tuple[str | int, Any | None]:
+            if isinstance(item, str):
+                v = await services.typed_cache.catalog.get_by_sku(
+                    item, include_archived=True, include_deleted=True
+                )
+            else:
+                v = await _fetch_variant_by_id(services, item)
+            return (item, v)
+
+        resolved_pairs = list(await asyncio.gather(*(_resolve(i) for i in items)))
+
+        not_found: list[str | int] = []
+        # dict preserves first-seen input order; duplicate inputs collapse
+        # to one entry naturally without a separate dedup set.
+        input_to_variant: dict[str | int, tuple[int, str | None, str]] = {}
+        for item, variant in resolved_pairs:
+            if item in input_to_variant:
+                continue
+            vid = _attr(variant, "id") if variant is not None else None
+            if vid is None:
+                not_found.append(item)
+                continue
+            sku = _attr(variant, "sku")
+            display_name = _attr(variant, "display_name") or sku or ""
+            input_to_variant[item] = (vid, sku, display_name)
+
+        # Chunk variant_ids so we don't blow through the 25k-movement
+        # auto-pagination cap. 20 ids x ~1k movements/variant keeps headroom.
+        # Chunks fetch concurrently — independent network I/O dominates.
+        unique_vids = {vid for vid, _, _ in input_to_variant.values()}
+        chunks = list(batched(sorted(unique_vids), _INVENTORY_AT_CHUNK_SIZE))
+
+        async def _fetch_chunk(chunk: tuple[int, ...]) -> list[Any]:
+            response = await get_all_inventory_movements.asyncio_detailed(
+                client=services.client,
+                variant_ids=list(chunk),
+                location_id=to_unset(request.location_id),
+            )
+            return list(unwrap_data(response))
+
+        chunk_results = await asyncio.gather(*(_fetch_chunk(c) for c in chunks))
+        all_movements: list[Any] = [m for batch in chunk_results for m in batch]
+
+        # Reduce: for each (variant_id, location_id), keep the movement
+        # with max (movement_date, id) among those <= as_of_dt. The id
+        # tie-break ensures deterministic output when multiple movements
+        # share a back-dated timestamp.
+        latest: dict[tuple[int, int], Any] = {}
+        for m in all_movements:
+            md = naive_utc(m.movement_date)
+            if md is None or md > as_of_dt:
+                continue
+            key = (m.variant_id, m.location_id)
+            existing = latest.get(key)
+            if existing is None:
+                latest[key] = m
+                continue
+            existing_md = naive_utc(existing.movement_date)
+            if existing_md is None or (md, m.id) > (existing_md, existing.id):
+                latest[key] = m
+
+        unique_loc_ids = {loc_id for _, loc_id in latest}
+        loc_names: dict[int, str | None] = {}
+        if unique_loc_ids:
+            loc_lookups = await services.typed_cache.catalog.get_many_by_ids(
+                CachedLocation, unique_loc_ids
+            )
+            loc_names = {
+                lid: _attr(loc_lookups.get(lid), "name") for lid in unique_loc_ids
+            }
+
+        result_items: list[InventoryAtItem] = []
+        for _input, (vid, sku, display_name) in input_to_variant.items():
+            by_loc_rows: list[InventoryAtLocation] = []
+            total_balance = 0.0
+            total_value = 0.0
+            for (m_vid, loc_id), m in latest.items():
+                if m_vid != vid:
+                    continue
+                balance = float(m.balance_after)
+                value = float(m.value_in_stock_after)
+                by_loc_rows.append(
+                    InventoryAtLocation(
+                        location_id=loc_id,
+                        location_name=loc_names.get(loc_id),
+                        balance_at=balance,
+                        value_in_stock_at=value,
+                        average_cost_at=float(m.average_cost_after),
+                        last_movement_date=_iso_str(m.movement_date),
+                        last_movement_id=m.id,
+                    )
+                )
+                total_balance += balance
+                total_value += value
+            by_loc_rows.sort(key=lambda r: r.balance_at, reverse=True)
+            result_items.append(
+                InventoryAtItem(
+                    variant_id=vid,
+                    sku=sku,
+                    display_name=display_name,
+                    by_location=by_loc_rows,
+                    total_balance=total_balance,
+                    total_value=total_value,
+                )
+            )
+
+        duration_ms = round((time.monotonic() - start_time) * 1000, 2)
+        logger.info(
+            "inventory_at_completed",
+            items=len(result_items),
+            not_found_count=len(not_found),
+            duration_ms=duration_ms,
+        )
+        return InventoryAtResponse(
+            as_of=request.as_of,
+            items=result_items,
+            not_found=not_found,
+        )
+
+    except Exception as e:
+        duration_ms = round((time.monotonic() - start_time) * 1000, 2)
+        logger.error(
+            "inventory_at_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            duration_ms=duration_ms,
+            exc_info=True,
+        )
+        raise
+
+
+@observe_tool
+@unpack_pydantic_params
+async def inventory_at(
+    request: Annotated[InventoryAtRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Reconstruct inventory balance at a specific point in time by walking
+    movement history.
+
+    Pass a list of SKUs and/or variant IDs (mix freely), plus an ISO-8601
+    ``as_of`` datetime, to get the on-hand quantity, total value, and rolling
+    average cost as they stood at that moment — per location. Optionally
+    filter to a single ``location_id``.
+
+    Walks the variant's ``inventory_movements`` ledger, picks the most recent
+    movement at-or-before ``as_of`` per location, and returns the snapshot
+    fields (``balance_after`` / ``value_in_stock_after`` / ``average_cost_after``)
+    that movement left behind. Variants with no movements before ``as_of``
+    return an empty ``by_location`` list (no stock at that moment).
+
+    Use for historical reconstruction and audit. For current state, use
+    ``check_inventory`` — that's a single direct call against ``/inventory``
+    and is faster when you only need "now". Use ``get_inventory_movements``
+    to see the underlying delta stream.
+
+    Returns a card UI plus the JSON envelope ``{as_of, items, not_found}``.
+    Unresolved SKUs/IDs land in ``not_found``.
+    """
+    from katana_mcp.tools.prefab_ui import build_inventory_at_ui
+
+    response = await _inventory_at_impl(request, context)
+
+    items_dump = [item.model_dump(mode="json") for item in response.items]
+    payload = {
+        "as_of": response.as_of,
+        "items": items_dump,
+        "not_found": response.not_found,
+    }
+    content = json.dumps(payload, indent=2, default=str)
+
+    ui = build_inventory_at_ui(
+        items=items_dump,
+        as_of=response.as_of,
+        location_id=request.location_id,
+        not_found=list(response.not_found),
+    )
+    return ToolResult(content=content, structured_content=ui)
+
+
+# ============================================================================
+# Tool 5: create_stock_adjustment
 # ============================================================================
 
 
@@ -1702,6 +2079,7 @@ def register_tools(mcp: FastMCP) -> None:
         list_low_stock_items
     )
     mcp.tool(tags={"inventory", "read"}, annotations=_read)(get_inventory_movements)
+    mcp.tool(tags={"inventory", "read"}, annotations=_read, meta=UI_META)(inventory_at)
     mcp.tool(tags={"inventory", "read"}, annotations=_read)(list_stock_adjustments)
     register_preview_tool(
         mcp,

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -1407,6 +1407,199 @@ def build_low_stock_ui(
     return app
 
 
+def _inventory_at_table_rows(
+    items: list[dict[str, Any]],
+    currency: str | None,
+) -> list[dict[str, Any]]:
+    """Flatten the response shape into one row per (variant, location).
+
+    Variants with empty ``by_location`` (no movements before ``as_of``)
+    render a single row with location ``"—"`` and zeroed values so the
+    user sees they were checked but had no history. The table groups
+    naturally by SKU when sorted on it.
+    """
+    rows: list[dict[str, Any]] = []
+    for item in items:
+        sku = item.get("sku") or ""
+        display_name = item.get("display_name", "")
+        variant_id = item.get("variant_id")
+        by_location = item.get("by_location") or []
+        if not by_location:
+            rows.append(
+                {
+                    "sku": sku,
+                    "display_name": display_name,
+                    "variant_id": variant_id,
+                    "location_name": "—",
+                    "balance_label": "—",
+                    "value_label": "—",
+                    "cost_label": "—",
+                    "last_movement_date": "—",
+                }
+            )
+            continue
+        for loc in by_location:
+            rows.append(
+                {
+                    "sku": sku,
+                    "display_name": display_name,
+                    "variant_id": variant_id,
+                    "location_name": loc.get("location_name")
+                    or f"Location {loc.get('location_id')}",
+                    "balance_label": f"{float(loc.get('balance_at', 0)):.2f}",
+                    "value_label": _format_money(
+                        loc.get("value_in_stock_at"), currency
+                    ),
+                    "cost_label": _format_money(loc.get("average_cost_at"), currency),
+                    "last_movement_date": _iso_date_only(
+                        loc.get("last_movement_date", "")
+                    ),
+                }
+            )
+    return rows
+
+
+def build_inventory_at_ui(
+    items: list[dict[str, Any]],
+    as_of: str,
+    location_id: int | None = None,
+    not_found: list[str | int] | None = None,
+    currency: str | None = None,
+) -> PrefabApp:
+    """Build the point-in-time inventory card.
+
+    Header surfaces the ``as_of`` instant + item count and (when scoped)
+    the location filter. The body is a flat DataTable with one row per
+    (variant, location); variants with no history before ``as_of`` get a
+    single row with ``"—"`` placeholders so the caller sees they were
+    checked. Totals strip aggregates across all items.
+
+    Mirrors the ``check_inventory`` card's structural conventions: header
+    badges, conditional Muted "not found" hint, action buttons that
+    surface the obvious next-step tools.
+    """
+    not_found_list = list(not_found or [])
+    rows = _inventory_at_table_rows(items, currency)
+    total_balance = sum(
+        float(loc.get("balance_at", 0))
+        for item in items
+        for loc in (item.get("by_location") or [])
+    )
+    total_value = sum(
+        float(loc.get("value_in_stock_at", 0))
+        for item in items
+        for loc in (item.get("by_location") or [])
+    )
+
+    is_single = len(items) == 1
+    as_of_date = _iso_date_only(as_of)
+
+    with (
+        PrefabApp(state={"rows": rows}, css_class="p-4") as app,
+        Card(),
+    ):
+        with CardHeader(), Row(gap=2):
+            CardTitle(content=f"Inventory as of {as_of_date}")
+            Badge(
+                label=f"{len(items)} item{'s' if len(items) != 1 else ''}",
+                variant="secondary",
+            )
+            if location_id is not None:
+                Badge(label=f"Location {location_id}", variant="outline")
+            if is_single and items:
+                only = items[0]
+                Badge(label=only.get("sku") or "(no SKU)", variant="outline")
+
+        with CardContent(), Column(gap=3):
+            with Row(gap=4):
+                Metric(label="Total Balance", value=f"{total_balance:.2f}")
+                Metric(
+                    label="Total Value",
+                    value=_format_money(total_value, currency),
+                )
+
+            if not rows:
+                Muted(
+                    content=("No items resolved — every input is in `not_found` below.")
+                )
+            else:
+                Separator()
+                # Single-variant: drop SKU/Item columns (already in header).
+                # Batch: include them so the table reads as a flat ledger.
+                columns: list[DataTableColumn] = []
+                if not is_single:
+                    columns.append(
+                        DataTableColumn(key="sku", header="SKU", sortable=True)
+                    )
+                    columns.append(
+                        DataTableColumn(
+                            key="display_name", header="Item", sortable=True
+                        )
+                    )
+                columns.extend(
+                    [
+                        DataTableColumn(
+                            key="location_name", header="Location", sortable=True
+                        ),
+                        DataTableColumn(
+                            key="balance_label",
+                            header="Balance",
+                            align="right",
+                            sortable=True,
+                        ),
+                        DataTableColumn(
+                            key="value_label", header="Value", align="right"
+                        ),
+                        DataTableColumn(
+                            key="cost_label", header="Avg Cost", align="right"
+                        ),
+                        DataTableColumn(
+                            key="last_movement_date",
+                            header="Last Movement",
+                            sortable=True,
+                        ),
+                    ]
+                )
+                DataTable(columns=columns, rows="{{ rows }}")
+
+            if not_found_list:
+                Separator()
+                Muted(
+                    content=(
+                        f"Could not resolve {len(not_found_list)} "
+                        f"input{'s' if len(not_found_list) != 1 else ''}: "
+                        f"{', '.join(str(x) for x in not_found_list)}"
+                    )
+                )
+
+        with CardFooter(), Row(gap=2):
+            # First resolved SKU drives both follow-up actions; falls back
+            # to variant_id when the variant has no SKU (per the documented
+            # null-SKU invariant).
+            first_handle: str | int = ""
+            if items:
+                first_handle = items[0].get("sku") or items[0].get("variant_id") or ""
+            Button(
+                label="Check Current Inventory",
+                variant="outline",
+                on_click=SendMessage(
+                    f"Check current inventory for {first_handle}"
+                    if first_handle
+                    else "Check current inventory"
+                ),
+            )
+            Button(
+                label="View Movements",
+                variant="outline",
+                on_click=SendMessage(
+                    f"Show inventory movements for SKU {first_handle}"
+                    if first_handle
+                    else "Show recent inventory movements"
+                ),
+            )
+    return app
+
+
 # ============================================================================
 # Stock Adjustment UIs (Create / Update / Delete)
 # ============================================================================

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -27,6 +27,7 @@ from katana_mcp.tools._modification import (
 )
 from katana_mcp.tools.prefab_ui import (
     build_batch_recipe_update_ui,
+    build_inventory_at_ui,
     build_inventory_check_ui,
     build_item_detail_ui,
     build_modification_preview_ui,
@@ -257,6 +258,113 @@ def _inventory_check_app() -> PrefabApp:
     return build_inventory_check_ui(stock)
 
 
+def _inventory_at_single_app() -> PrefabApp:
+    """build_inventory_at_ui with one variant across two locations —
+    exercises the single-item layout (SKU/Item columns hidden, variant
+    info in the header)."""
+    items = [
+        {
+            "variant_id": 3001,
+            "sku": "SKU-WIDGET",
+            "display_name": "Widget",
+            "by_location": [
+                {
+                    "location_id": 1,
+                    "location_name": "Main Warehouse",
+                    "balance_at": 100.0,
+                    "value_in_stock_at": 5000.0,
+                    "average_cost_at": 50.0,
+                    "last_movement_date": "2026-03-15T12:00:00+00:00",
+                    "last_movement_id": 9001,
+                },
+                {
+                    "location_id": 2,
+                    "location_name": "East Warehouse",
+                    "balance_at": 40.0,
+                    "value_in_stock_at": 2000.0,
+                    "average_cost_at": 50.0,
+                    "last_movement_date": "2026-03-10T08:30:00+00:00",
+                    "last_movement_id": 9002,
+                },
+            ],
+            "total_balance": 140.0,
+            "total_value": 7000.0,
+        },
+    ]
+    return build_inventory_at_ui(
+        items=items, as_of="2026-04-01T00:00:00Z", location_id=None
+    )
+
+
+def _inventory_at_batch_app() -> PrefabApp:
+    """build_inventory_at_ui with multiple variants — exercises batch
+    layout (SKU/Item columns visible) plus a not_found entry and a
+    variant with no movement history (empty by_location → placeholder row).
+    """
+    items = [
+        {
+            "variant_id": 3001,
+            "sku": "SKU-A",
+            "display_name": "Widget A",
+            "by_location": [
+                {
+                    "location_id": 1,
+                    "location_name": "Main",
+                    "balance_at": 50.0,
+                    "value_in_stock_at": 2500.0,
+                    "average_cost_at": 50.0,
+                    "last_movement_date": "2026-03-01T00:00:00+00:00",
+                    "last_movement_id": 1,
+                },
+            ],
+            "total_balance": 50.0,
+            "total_value": 2500.0,
+        },
+        {
+            "variant_id": 3002,
+            "sku": "SKU-B",
+            "display_name": "Widget B",
+            "by_location": [
+                {
+                    "location_id": 1,
+                    "location_name": "Main",
+                    "balance_at": 25.0,
+                    "value_in_stock_at": 1250.0,
+                    "average_cost_at": 50.0,
+                    "last_movement_date": "2026-02-15T00:00:00+00:00",
+                    "last_movement_id": 2,
+                },
+                {
+                    "location_id": 2,
+                    "location_name": "Annex",
+                    "balance_at": 10.0,
+                    "value_in_stock_at": 500.0,
+                    "average_cost_at": 50.0,
+                    "last_movement_date": "2026-02-20T00:00:00+00:00",
+                    "last_movement_id": 3,
+                },
+            ],
+            "total_balance": 35.0,
+            "total_value": 1750.0,
+        },
+        {
+            # Empty by_location — placeholder row in the table.
+            "variant_id": 3003,
+            "sku": "SKU-C",
+            "display_name": "Widget C",
+            "by_location": [],
+            "total_balance": 0.0,
+            "total_value": 0.0,
+        },
+    ]
+    return build_inventory_at_ui(
+        items=items,
+        as_of="2026-04-01T00:00:00Z",
+        location_id=None,
+        not_found=["GHOST-SKU"],
+    )
+
+
 def _verification_app() -> PrefabApp:
     """build_verification_ui with matches + discrepancies — exercises both
     rows='{{ matches }}' and rows='{{ discrepancies }}'."""
@@ -447,6 +555,8 @@ SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
     "search_results": _search_results_app,
     "item_detail": _item_detail_app,
     "inventory_check": _inventory_check_app,
+    "inventory_at_single": _inventory_at_single_app,
+    "inventory_at_batch": _inventory_at_batch_app,
     "verification": _verification_app,
     "batch_recipe_update": _batch_recipe_update_app,
     # Stock-adjustment family (preview + result for each of create/update/delete).

--- a/katana_mcp_server/tests/browser/test_other_cards_render.py
+++ b/katana_mcp_server/tests/browser/test_other_cards_render.py
@@ -70,6 +70,48 @@ class TestOtherCardsRender:
         assert frame.locator("text=Main Warehouse").count() >= 1
         assert frame.locator("text=East Warehouse").count() >= 1
 
+    def test_inventory_at_single_renders(self, render_scenario):
+        """``build_inventory_at_ui`` single-item layout — variant info in the
+        header, per-location DataTable below.
+
+        Pins the path-expression form (``rows='{{ rows }}'``) for the
+        flattened (variant, location) row list. Single-item layout drops
+        the SKU/Item columns from the table — header carries them via a
+        Badge.
+        """
+        frame = render_scenario("inventory_at_single")
+        # Header chrome: "Inventory as of YYYY-MM-DD" title + SKU badge.
+        assert frame.locator("text=Inventory as of 2026-04-01").count() >= 1
+        assert frame.locator("text=SKU-WIDGET").count() >= 1
+        # Table with header + 2 location rows.
+        assert frame.locator("table").count() == 1
+        assert frame.locator("table tr").count() >= 3
+        assert frame.locator("text=Main Warehouse").count() >= 1
+        assert frame.locator("text=East Warehouse").count() >= 1
+
+    def test_inventory_at_batch_renders(self, render_scenario):
+        """``build_inventory_at_ui`` batch layout — SKU/Item columns visible,
+        flat (variant, location) row list, empty-history placeholder, and
+        a "not found" Muted footer.
+
+        Pins three things at once: the columns conditionally added in
+        batch mode, the empty by_location placeholder row, and the
+        not_found surfacing.
+        """
+        frame = render_scenario("inventory_at_batch")
+        # 3 items x locations: SKU-A (1 loc) + SKU-B (2 locs) + SKU-C
+        # (1 empty placeholder row) = 4 data rows + header = 5+ rows.
+        assert frame.locator("table").count() == 1
+        assert frame.locator("table tr").count() >= 5
+        # Batch layout includes SKU column rows.
+        assert frame.locator("text=SKU-A").count() >= 1
+        assert frame.locator("text=SKU-B").count() >= 1
+        assert frame.locator("text=SKU-C").count() >= 1  # placeholder row
+        # Annex appears in only one row (SKU-B), Main in two rows (A + B).
+        assert frame.locator("text=Annex").count() >= 1
+        # not_found footer surfaces the ghost SKU.
+        assert frame.locator("text=GHOST-SKU").count() >= 1
+
     def test_verification_renders(self, render_scenario):
         """``build_verification_ui`` — two state-bound DataTables in one
         card (rows='{{ matches }}' and rows='{{ discrepancies }}').

--- a/katana_mcp_server/tests/test_strict_input_validation.py
+++ b/katana_mcp_server/tests/test_strict_input_validation.py
@@ -55,6 +55,7 @@ _OUTPUT_SUFFIXES = ("Response", "Info", "Summary", "Detail", "Stats")
 _EXEMPT_CLASSES: frozenset[str] = frozenset(
     {
         "LowStockItem",  # nested in LowStockResponse
+        "InventoryAtItem",  # nested in InventoryAtResponse
         "BlockingRow",  # nested in BlockingIngredientByMO/Variant
         "VariantSalesRow",  # nested in TopSellingVariantsResponse / InventoryVelocityResponse
         "SummaryRow",  # nested in SalesSummaryResponse

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -2725,3 +2725,652 @@ def test_inventory_check_card_omits_by_location_table_when_single_location():
     rendered = _json.dumps(build_inventory_check_ui(stock).to_json())
     assert "DataTable" not in rendered
     assert "locations" not in rendered  # No "N locations" badge either
+
+
+# ============================================================================
+# get_inventory_movements: filter pass-through (Phase 1 of #761)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_inventory_movements_forwards_location_id():
+    """location_id reaches the API call kwargs verbatim."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+
+    with (
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        request = GetInventoryMovementsRequest(sku="W-1", location_id=42)
+        await _get_inventory_movements_impl(request, context)
+
+    assert mock_api.call_args.kwargs["location_id"] == 42
+
+
+@pytest.mark.asyncio
+async def test_get_inventory_movements_omits_unset_filters():
+    """Unset optional filters land as UNSET so the URL doesn't carry empty params."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+
+    with (
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        request = GetInventoryMovementsRequest(sku="W-1")
+        await _get_inventory_movements_impl(request, context)
+
+    kw = mock_api.call_args.kwargs
+    assert kw["location_id"] is UNSET
+    assert kw["resource_type"] is UNSET
+    assert kw["created_at_min"] is UNSET
+    assert kw["created_at_max"] is UNSET
+    assert kw["updated_at_min"] is UNSET
+    assert kw["updated_at_max"] is UNSET
+
+
+@pytest.mark.asyncio
+async def test_get_inventory_movements_forwards_resource_type_enum():
+    """Valid resource_type string is coerced to the enum and forwarded."""
+    from katana_public_api_client.models.get_all_inventory_movements_resource_type import (
+        GetAllInventoryMovementsResourceType,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+
+    with (
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        # Pydantic v2 coerces JSON string values into StrEnum members at
+        # request construction; pass the enum directly so pyright is happy
+        # in the test code itself.
+        request = GetInventoryMovementsRequest(
+            sku="W-1",
+            resource_type=GetAllInventoryMovementsResourceType.STOCKADJUSTMENTROW,
+        )
+        await _get_inventory_movements_impl(request, context)
+
+    assert (
+        mock_api.call_args.kwargs["resource_type"]
+        == GetAllInventoryMovementsResourceType.STOCKADJUSTMENTROW
+    )
+
+
+def test_get_inventory_movements_rejects_invalid_resource_type():
+    """Invalid resource_type surfaces as a Pydantic ValidationError naming the field.
+
+    Uses ``model_validate`` to mirror the real MCP path — caller-supplied
+    JSON arrives as raw dict values, not pre-typed kwargs.
+    """
+    with pytest.raises(ValidationError, match="resource_type"):
+        GetInventoryMovementsRequest.model_validate(
+            {"sku": "W-1", "resource_type": "NotARealType"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_inventory_movements_forwards_date_filters():
+    """Date strings parse into naive UTC datetimes on the API kwargs."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+
+    with (
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        request = GetInventoryMovementsRequest(
+            sku="W-1",
+            created_at_min="2026-01-01T00:00:00Z",
+            created_at_max="2026-04-01T00:00:00Z",
+            updated_at_min="2026-02-01T00:00:00Z",
+            updated_at_max="2026-03-01T00:00:00Z",
+        )
+        await _get_inventory_movements_impl(request, context)
+
+    kw = mock_api.call_args.kwargs
+    assert kw["created_at_min"] == datetime(2026, 1, 1, 0, 0, 0)
+    assert kw["created_at_max"] == datetime(2026, 4, 1, 0, 0, 0)
+    assert kw["updated_at_min"] == datetime(2026, 2, 1, 0, 0, 0)
+    assert kw["updated_at_max"] == datetime(2026, 3, 1, 0, 0, 0)
+
+
+@pytest.mark.asyncio
+async def test_get_inventory_movements_rejects_bad_iso_string():
+    """Malformed ISO datetime surfaces with the field name in the error."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+
+    request = GetInventoryMovementsRequest(sku="W-1", created_at_min="not-a-datetime")
+    with pytest.raises(ValueError, match="created_at_min"):
+        await _get_inventory_movements_impl(request, context)
+
+
+# ============================================================================
+# inventory_at: point-in-time balance reconstruction (Phase 2 of #761)
+# ============================================================================
+
+
+def _make_movement(
+    *,
+    movement_id: int,
+    variant_id: int,
+    location_id: int,
+    movement_date: datetime,
+    balance_after: float = 0.0,
+    value_in_stock_after: float = 0.0,
+    average_cost_after: float = 0.0,
+) -> MagicMock:
+    """Build a movement mock carrying only the fields _inventory_at_impl reads."""
+    m = MagicMock()
+    m.id = movement_id
+    m.variant_id = variant_id
+    m.location_id = location_id
+    m.movement_date = movement_date
+    m.balance_after = balance_after
+    m.value_in_stock_after = value_in_stock_after
+    m.average_cost_after = average_cost_after
+    return m
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_single_sku_resolution():
+    """Resolves a single SKU and returns the latest pre-as_of balance per location."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        return_value={1: {"id": 1, "name": "Main"}}
+    )
+
+    movements = [
+        _make_movement(
+            movement_id=1,
+            variant_id=3001,
+            location_id=1,
+            movement_date=datetime(2026, 1, 5, 12, 0, 0, tzinfo=UTC),
+            balance_after=50.0,
+            value_in_stock_after=2500.0,
+            average_cost_after=50.0,
+        ),
+        _make_movement(
+            movement_id=2,
+            variant_id=3001,
+            location_id=1,
+            movement_date=datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC),
+            balance_after=80.0,
+            value_in_stock_after=4000.0,
+            average_cost_after=50.0,
+        ),
+    ]
+
+    with (
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=movements),
+    ):
+        request = InventoryAtRequest(
+            skus_or_variant_ids=["W-1"], as_of="2026-04-01T00:00:00Z"
+        )
+        response = await _inventory_at_impl(request, context)
+
+    assert response.as_of == "2026-04-01T00:00:00Z"
+    assert response.not_found == []
+    assert len(response.items) == 1
+    item = response.items[0]
+    assert item.sku == "W-1"
+    assert item.variant_id == 3001
+    assert len(item.by_location) == 1
+    loc = item.by_location[0]
+    assert loc.location_id == 1
+    assert loc.location_name == "Main"
+    assert loc.balance_at == 80.0  # latest pre-as_of
+    assert loc.last_movement_id == 2
+    assert item.total_balance == 80.0
+    assert item.total_value == 4000.0
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_resolves_variant_id_directly():
+    """Integer inputs go through _fetch_variant_by_id, not get_by_sku."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=None)
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.items._fetch_variant_by_id",
+            new_callable=AsyncMock,
+        ) as mock_by_id,
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        mock_by_id.return_value = {
+            "id": 12345,
+            "sku": "BY-ID",
+            "display_name": "By ID",
+        }
+        request = InventoryAtRequest(
+            skus_or_variant_ids=[12345], as_of="2026-04-01T00:00:00Z"
+        )
+        response = await _inventory_at_impl(request, context)
+
+    assert response.not_found == []
+    assert response.items[0].variant_id == 12345
+    assert response.items[0].sku == "BY-ID"
+    mock_by_id.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_unresolved_inputs_land_in_not_found():
+    """SKUs and IDs that can't be resolved are reported via not_found."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=None)
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.items._fetch_variant_by_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        request = InventoryAtRequest(
+            skus_or_variant_ids=["GHOST", 99999],
+            as_of="2026-04-01T00:00:00Z",
+        )
+        response = await _inventory_at_impl(request, context)
+
+    assert response.items == []
+    assert set(response.not_found) == {"GHOST", 99999}
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_multi_location_grouping():
+    """Each location gets its own row; totals roll up across locations."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        return_value={
+            1: {"id": 1, "name": "Main"},
+            2: {"id": 2, "name": "Annex"},
+        }
+    )
+
+    movements = [
+        _make_movement(
+            movement_id=1,
+            variant_id=3001,
+            location_id=1,
+            movement_date=datetime(2026, 2, 1, tzinfo=UTC),
+            balance_after=10.0,
+            value_in_stock_after=100.0,
+        ),
+        _make_movement(
+            movement_id=2,
+            variant_id=3001,
+            location_id=2,
+            movement_date=datetime(2026, 2, 5, tzinfo=UTC),
+            balance_after=25.0,
+            value_in_stock_after=250.0,
+        ),
+    ]
+
+    with (
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=movements),
+    ):
+        request = InventoryAtRequest(
+            skus_or_variant_ids=["W-1"], as_of="2026-04-01T00:00:00Z"
+        )
+        response = await _inventory_at_impl(request, context)
+
+    item = response.items[0]
+    assert {loc.location_id for loc in item.by_location} == {1, 2}
+    assert item.total_balance == 35.0
+    assert item.total_value == 350.0
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_picks_latest_movement_per_location():
+    """When multiple movements precede as_of, the most recent (by date, id) wins."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(return_value={})
+
+    # Three movements at the same location, same day, different times + ids.
+    # The id-7 row has the latest movement_date — it should win.
+    movements = [
+        _make_movement(
+            movement_id=5,
+            variant_id=3001,
+            location_id=1,
+            movement_date=datetime(2026, 3, 1, 8, 0, tzinfo=UTC),
+            balance_after=10.0,
+        ),
+        _make_movement(
+            movement_id=7,
+            variant_id=3001,
+            location_id=1,
+            movement_date=datetime(2026, 3, 1, 14, 0, tzinfo=UTC),
+            balance_after=20.0,
+        ),
+        _make_movement(
+            movement_id=6,
+            variant_id=3001,
+            location_id=1,
+            movement_date=datetime(2026, 3, 1, 11, 0, tzinfo=UTC),
+            balance_after=15.0,
+        ),
+    ]
+
+    with (
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=movements),
+    ):
+        request = InventoryAtRequest(
+            skus_or_variant_ids=["W-1"], as_of="2026-04-01T00:00:00Z"
+        )
+        response = await _inventory_at_impl(request, context)
+
+    loc = response.items[0].by_location[0]
+    assert loc.balance_at == 20.0
+    assert loc.last_movement_id == 7
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_id_breaks_ties_when_dates_identical():
+    """If movement_date ties, higher id wins (deterministic output)."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(return_value={})
+
+    same_dt = datetime(2026, 3, 1, 12, 0, tzinfo=UTC)
+    movements = [
+        _make_movement(
+            movement_id=5,
+            variant_id=3001,
+            location_id=1,
+            movement_date=same_dt,
+            balance_after=10.0,
+        ),
+        _make_movement(
+            movement_id=7,
+            variant_id=3001,
+            location_id=1,
+            movement_date=same_dt,
+            balance_after=20.0,
+        ),
+    ]
+
+    with (
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=movements),
+    ):
+        request = InventoryAtRequest(
+            skus_or_variant_ids=["W-1"], as_of="2026-04-01T00:00:00Z"
+        )
+        response = await _inventory_at_impl(request, context)
+
+    assert response.items[0].by_location[0].last_movement_id == 7
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_skips_movements_after_as_of():
+    """Movements with movement_date > as_of_dt are excluded from the reduction."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(return_value={})
+
+    movements = [
+        _make_movement(
+            movement_id=1,
+            variant_id=3001,
+            location_id=1,
+            movement_date=datetime(2026, 1, 1, tzinfo=UTC),
+            balance_after=10.0,
+        ),
+        _make_movement(
+            movement_id=2,
+            variant_id=3001,
+            location_id=1,
+            movement_date=datetime(2026, 5, 1, tzinfo=UTC),  # AFTER as_of
+            balance_after=999.0,
+        ),
+    ]
+
+    with (
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=movements),
+    ):
+        request = InventoryAtRequest(
+            skus_or_variant_ids=["W-1"], as_of="2026-03-01T00:00:00Z"
+        )
+        response = await _inventory_at_impl(request, context)
+
+    assert response.items[0].by_location[0].balance_at == 10.0
+    assert response.items[0].by_location[0].last_movement_id == 1
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_empty_by_location_when_no_movements_before():
+    """as_of earlier than every movement → by_location is empty (no history)."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(return_value={})
+
+    movements = [
+        _make_movement(
+            movement_id=1,
+            variant_id=3001,
+            location_id=1,
+            movement_date=datetime(2026, 6, 1, tzinfo=UTC),
+            balance_after=10.0,
+        )
+    ]
+
+    with (
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=movements),
+    ):
+        request = InventoryAtRequest(
+            skus_or_variant_ids=["W-1"], as_of="2026-01-01T00:00:00Z"
+        )
+        response = await _inventory_at_impl(request, context)
+
+    assert response.items[0].by_location == []
+    assert response.items[0].total_balance == 0.0
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_forwards_location_id_filter():
+    """Optional location_id flows to the inventory_movements API call."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget"}
+    )
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(return_value={})
+
+    with (
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        request = InventoryAtRequest(
+            skus_or_variant_ids=["W-1"],
+            as_of="2026-04-01T00:00:00Z",
+            location_id=42,
+        )
+        await _inventory_at_impl(request, context)
+
+    assert mock_api.call_args.kwargs["location_id"] == 42
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_tolerates_null_sku():
+    """variant_id input where the variant has sku=None resolves cleanly (sku in
+    response is null; lookup never hits the SKU index)."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=None)
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.items._fetch_variant_by_id",
+            new_callable=AsyncMock,
+        ) as mock_by_id,
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        # Variant exists in cache but has no SKU (legacy NetSuite import).
+        mock_by_id.return_value = {
+            "id": 555,
+            "sku": None,
+            "display_name": "Mystery Widget",
+        }
+        request = InventoryAtRequest(
+            skus_or_variant_ids=[555], as_of="2026-04-01T00:00:00Z"
+        )
+        response = await _inventory_at_impl(request, context)
+
+    assert response.items[0].sku is None
+    assert response.items[0].variant_id == 555
+    assert response.items[0].display_name == "Mystery Widget"
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_batch_mix_of_sku_and_id():
+    """A list with strings and ints resolves both, preserving input order."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "W-1", "display_name": "Widget One"}
+    )
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.items._fetch_variant_by_id",
+            new_callable=AsyncMock,
+        ) as mock_by_id,
+        patch(f"{_MOVEMENTS_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        mock_by_id.return_value = {
+            "id": 2002,
+            "sku": "W-2",
+            "display_name": "Widget Two",
+        }
+        request = InventoryAtRequest(
+            skus_or_variant_ids=["W-1", 2002], as_of="2026-04-01T00:00:00Z"
+        )
+        response = await _inventory_at_impl(request, context)
+
+    assert [item.variant_id for item in response.items] == [3001, 2002]
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_rejects_blank_sku():
+    """Whitespace-only SKU surfaces as ValueError."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, _ = create_mock_context()
+    request = InventoryAtRequest(
+        skus_or_variant_ids=["   "], as_of="2026-04-01T00:00:00Z"
+    )
+    with pytest.raises(ValueError, match="SKU cannot be empty"):
+        await _inventory_at_impl(request, context)
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_rejects_bad_as_of():
+    """Malformed as_of surfaces with the field name in the error."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, _ = create_mock_context()
+    request = InventoryAtRequest(skus_or_variant_ids=["W-1"], as_of="not-a-datetime")
+    with pytest.raises(ValueError, match="as_of"):
+        await _inventory_at_impl(request, context)

--- a/uv.lock
+++ b/uv.lock
@@ -1278,7 +1278,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.78.0"
+version = "0.79.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1309,7 +1309,7 @@ requires-dist = [
 
 [[package]]
 name = "katana-openapi-client"
-version = "0.66.0"
+version = "0.67.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

Closes #761.

The Katana `/inventory` endpoint is snapshot-only — there's been no way to answer "what was on hand on date X" through the MCP. This PR adds two changes, both informed by the existing `inventory_movements` ledger:

- **New `inventory_at` tool**: walks `/inventory_movements` for a batch of SKUs/variant IDs (max 100, strings + ints mix freely) and returns the latest pre-`as_of` `balance_after` / `value_in_stock_after` / `average_cost_after` per `(variant, location)`. Optional `location_id` scopes to one warehouse. Variants with no movements before `as_of` return an empty `by_location` list; unresolved inputs land in `not_found`. Movement-fetch chunks (20 variant_ids each) run concurrently via `asyncio.gather` to keep wall time proportional to the longest chunk, not the chunk count.
- **`get_inventory_movements` pass-through**: forwards the filters the API already supports — `location_id`, `resource_type` (StrEnum field, Pydantic coerces JSON strings), and `created_at_min/max` / `updated_at_min/max` audit-trail windows.

**Decision guide** (now documented in `katana://help/tools`):
- `check_inventory` → current state (one direct call against `/inventory`, fastest).
- `inventory_at` → historical reconstruction / audit.
- `get_inventory_movements` → the raw delta stream.

### Why not server-side `as_of`?

The Katana API doesn't expose a `movement_date_min/max` filter or a snapshot endpoint other than `/inventory`. The reconstruction path is `walk → filter → reduce` over the existing movement records. Each movement carries the running totals Katana stamps as it lands, so the response is a direct read — no recomputation.

### Prefab UI

`build_inventory_at_ui` handles both layouts:
- **Single-item**: variant info goes in the header (Title + SKU badge); table drops SKU/Item columns.
- **Batch**: flat `(variant, location)` ledger with SKU/Item columns, totals strip aggregating across items, and a `not_found` Muted footer.
- Variants with empty `by_location` render a single `—` placeholder row so the caller sees they were checked but had no history.

## Test plan

- [x] `uv run poe check` — 3307 unit + 21 browser tests pass on the rebased branch.
- [x] 19 new unit tests pin filter pass-through (location_id, resource_type, dates, UNSET-omission) and `inventory_at` impl (single SKU / variant_id resolution, batch mix, multi-location grouping, tie-breaking on `(movement_date, id)`, future-dated `as_of`, pre-history `as_of`, null-SKU variants, `not_found`, bad ISO datetime, blank SKU).
- [x] 2 new Playwright render tests for the single + batch card layouts.
- [ ] Manual smoke against a real tenant: `inventory_at(skus_or_variant_ids=["SKU-A"], as_of="2026-03-15T00:00:00Z")` agrees with `check_inventory("SKU-A")` when `as_of=now`.

## Notes

- Non-breaking on the wire: every new field on `GetInventoryMovementsRequest` is optional with a `None` default, and `inventory_at` is purely additive. MCP-server release will be a MINOR bump.
- `InventoryAtItem` is added to `_EXEMPT_CLASSES` in `test_strict_input_validation.py` — same precedent as `LowStockItem`, since `Item`-suffixed response-nested models share their suffix with true input shapes.
- `_iso_str` was lifted from a closure inside `_get_inventory_movements_impl` to module scope so both impls share it.
- Pre-existing dead `_iso_opt` closure removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)