### PR TITLE
feat(mcp): add Prefab UI for check_inventory batch path

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -96,7 +96,7 @@ class CheckInventoryRequest(BaseModel):
             "JSON array of SKUs (strings) or variant IDs (integers) — mix freely. "
             'E.g., ["WS74001", 12345] or ["WS74001", "WS74002"]. '
             "Response is always the JSON `{items: [...]}` envelope (single OR batch); "
-            "single-item calls additionally attach a Prefab stock card for UI hosts. "
+            "a Prefab stock card is attached for UI hosts on every shape. "
             "Batching N items in a single call beats N separate invocations. "
             "Output order matches input order."
         ),
@@ -524,9 +524,10 @@ async def check_inventory(
     Pass a list of SKUs (strings) or variant IDs (integers) — or mix both — to
     ``skus_or_variant_ids``. Returns the JSON ``{items: [...]}`` envelope for
     every request shape — single OR batch — so programmatic consumers see one
-    stable contract. Single-item requests additionally attach a rich Prefab
-    stock card via ``structured_content`` for MCP-Apps hosts. Batching N
-    checks in one call is faster than N separate invocations.
+    stable contract. ``structured_content`` carries a rich Prefab card on
+    every shape: the single-item card on a 1-item request, the batch summary
+    + per-variant by-location card on N-item requests. Batching N checks in
+    one call is faster than N separate invocations.
 
     By default returns totals summed across every location the variant has
     stock at, plus a per-location ``by_location`` breakdown so callers can
@@ -539,7 +540,10 @@ async def check_inventory(
     batch list to check multiple ingredients at once (e.g. all EXPECTED
     items in an MO recipe).
     """
-    from katana_mcp.tools.prefab_ui import build_inventory_check_ui
+    from katana_mcp.tools.prefab_ui import (
+        build_inventory_check_batch_ui,
+        build_inventory_check_ui,
+    )
 
     results = await _check_inventory_impl(request, context)
 
@@ -550,15 +554,13 @@ async def check_inventory(
     payload = {"items": [r.model_dump(mode="json") for r in results]}
     content = json.dumps(payload, indent=2, default=str)
 
-    # Single-variant request: attach the rich Prefab card on top of the
-    # envelope content. The batch Prefab UI (tracked in #562) will read
-    # the same ``items`` key when it ships.
+    # Batch path uses its own builder (#562).
     is_single = len(results) == 1 and len(request.skus_or_variant_ids) == 1
     if is_single:
         ui = build_inventory_check_ui(results[0].model_dump())
-        return ToolResult(content=content, structured_content=ui)
-
-    return ToolResult(content=content, structured_content=payload)
+    else:
+        ui = build_inventory_check_batch_ui([r.model_dump() for r in results])
+    return ToolResult(content=content, structured_content=ui)
 
 
 # ============================================================================

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -1290,6 +1290,14 @@ _STATUS_BELOW_REORDER = "Below reorder"
 _STATUS_AT_REORDER = "At reorder"
 _STATUS_HEALTHY = "Healthy"
 
+# Per-variant status used by the batch inventory card, written by
+# ``_annotate_batch_summary_row``. Kept separate from the per-location
+# reorder buckets above — the batch row reports presence + zero-stock,
+# not reorder thresholds.
+_STATUS_NOT_FOUND = "Not found"
+_STATUS_OUT_OF_STOCK = "Out of stock"
+_STATUS_IN_STOCK = "In stock"
+
 
 _LOW_STOCK_STATUSES = frozenset({_STATUS_BELOW_REORDER, _STATUS_AT_REORDER})
 
@@ -1486,6 +1494,204 @@ def build_inventory_check_ui(
 
         with CardFooter(), Row(gap=2):
             _inventory_footer_section(stock)
+    return app
+
+
+def _annotate_batch_summary_row(item: dict[str, Any]) -> None:
+    """Mutate a batch summary row in place with derived presentation fields.
+
+    ``location_count`` and ``status_label`` aren't on the ``StockInfo``
+    wire shape — they're presentation-only — so compute them here rather
+    than pushing them onto the response model. Status uses the
+    ``is_found`` flag (added in #549) to distinguish echoed not-found
+    stubs from real zero-stock variants; without the explicit
+    indicator the two collapse to "0 in stock" in the table.
+    """
+    item["location_count"] = len(item.get("by_location") or [])
+    if not item.get("is_found", True):
+        item["status_label"] = _STATUS_NOT_FOUND
+    elif (item.get("in_stock") or 0) <= 0:
+        # ``<= 0`` not ``== 0`` — Katana sums inventory points directly,
+        # and adjustments / backorders / accounting fixes can drive the
+        # total negative. A negative balance is "no stock available" for
+        # any decision the card supports, so collapse it into the same
+        # out-of-stock bucket rather than masquerading as "In stock".
+        item["status_label"] = _STATUS_OUT_OF_STOCK
+    else:
+        item["status_label"] = _STATUS_IN_STOCK
+
+
+_BATCH_METRIC_KEYS: tuple[str, ...] = (
+    "in_stock",
+    "available_stock",
+    "committed",
+    "expected",
+)
+
+
+def build_inventory_check_batch_ui(
+    items: list[dict[str, Any]],
+) -> PrefabApp:
+    """Build a batch inventory-check card with summary metrics + per-variant table.
+
+    Mirrors :func:`build_batch_recipe_update_ui`: flat top table with one
+    row per variant, plus an inline by-location sub-table for each
+    variant whose stock is split across more than one warehouse. Each
+    sub-table binds to its own state slot (``by_location_<i>``) rather
+    than a bracket-indexed mustache path (``items[i].by_location``) —
+    Prefab's mustache resolver rejects bracket subscripts, and the
+    state-validation harness fails the build if one slips in.
+
+    Single-location variants don't render a sub-table (the row in the
+    summary table already carries everything). Not-found stubs
+    (``is_found == False``) surface as a "Not found" status badge so the
+    table doesn't silently collapse them into zero-stock rows.
+
+    Empty input renders a "no items" hint. Mutates each ``item`` in
+    place via ``_annotate_batch_summary_row`` — callers must pass
+    throwaway dicts (e.g. ``model_dump()`` output). See #562.
+    """
+    # Single pass: annotate + aggregate + count not-found in one loop
+    # rather than four genexps over the same list. Sums only count
+    # found rows so a not-found stub (zeroed totals) doesn't dilute
+    # per-found averages if we ever surface them. ``_annotate_location_rows``
+    # is reused from the single-item card so per-warehouse status labels
+    # (Below reorder / At reorder / Healthy) stay consistent across both
+    # surfaces.
+    not_found_count = 0
+    totals: dict[str, float] = dict.fromkeys(_BATCH_METRIC_KEYS, 0.0)
+    for item in items:
+        _annotate_batch_summary_row(item)
+        _annotate_location_rows(item)
+        if not item.get("is_found", True):
+            not_found_count += 1
+            continue
+        for key in _BATCH_METRIC_KEYS:
+            totals[key] += float(item.get(key) or 0)
+    total_items = len(items)
+
+    # Per-variant by-location sub-tables need their own state keys so
+    # the validator (and the JS renderer) can resolve the mustache path
+    # without bracket-indexing into ``items[i]`` — the harness rejects
+    # bracket subscripts because Prefab's runtime can't traverse them.
+    # The render loop emits a Separator + label above each slot's
+    # DataTable so the sub-tables visually attach to the right variant.
+    #
+    # The summary table only reads top-level item fields, never
+    # ``by_location``. Slim each row down before putting it in state so
+    # the by-location data doesn't get serialized twice (once under
+    # ``items[i].by_location``, once under ``by_location_<i>``) — wire
+    # payload would otherwise scale with N*L for multi-location batches.
+    summary_items = [
+        {k: v for k, v in item.items() if k != "by_location"} for item in items
+    ]
+    state: dict[str, Any] = {"items": summary_items}
+    multi_location_slots: list[tuple[str, dict[str, Any]]] = []
+    for i, item in enumerate(items):
+        if len(item.get("by_location") or []) > 1:
+            slot = f"by_location_{i}"
+            state[slot] = item["by_location"]
+            multi_location_slots.append((slot, item))
+
+    with (
+        PrefabApp(state=state, css_class="p-4") as app,
+        Column(gap=4),
+    ):
+        with Row(gap=2):
+            H3(content="Inventory Check")
+            Badge(label=f"{total_items} items", variant="outline")
+            if not_found_count:
+                Badge(
+                    label=f"{not_found_count} not found",
+                    variant="destructive",
+                )
+
+        if total_items == 0:
+            Muted(content="No items in this batch.")
+            return app
+
+        with Row(gap=4):
+            Metric(label="In Stock", value=str(totals["in_stock"]))
+            Metric(label="Available", value=str(totals["available_stock"]))
+            Metric(label="Committed", value=str(totals["committed"]))
+            Metric(label="Expected", value=str(totals["expected"]))
+
+        DataTable(
+            columns=[
+                DataTableColumn(key="sku", header="SKU", sortable=True),
+                # Variant ID is the row's other primary identifier. A
+                # not-found stub from a variant-ID lookup has empty SKU
+                # and empty product_name — without this column the row
+                # has no visible identity at all and the user can't tell
+                # which input was missing. SKU-bearing rows also get to
+                # show their variant_id so downstream tools (which key
+                # on variant_id) can copy it directly off the table.
+                DataTableColumn(
+                    key="variant_id", header="Variant ID", sortable=True, align="right"
+                ),
+                DataTableColumn(key="product_name", header="Product", sortable=True),
+                DataTableColumn(key="uom", header="UoM"),
+                DataTableColumn(
+                    key="in_stock", header="In Stock", sortable=True, align="right"
+                ),
+                DataTableColumn(
+                    key="available_stock",
+                    header="Available",
+                    sortable=True,
+                    align="right",
+                ),
+                DataTableColumn(
+                    key="committed", header="Committed", sortable=True, align="right"
+                ),
+                DataTableColumn(
+                    key="expected", header="Expected", sortable=True, align="right"
+                ),
+                DataTableColumn(
+                    key="location_count",
+                    header="Locations",
+                    sortable=True,
+                    align="right",
+                ),
+                DataTableColumn(key="status_label", header="Status", sortable=True),
+            ],
+            rows="{{ items }}",
+            search=True,
+            paginated=True,
+            pageSize=25,
+        )
+
+        for slot, item in multi_location_slots:
+            Separator()
+            label = (
+                item.get("sku")
+                or item.get("product_name")
+                or (
+                    f"variant_id {item['variant_id']}"
+                    if item.get("variant_id")
+                    else "(unknown)"
+                )
+            )
+            Muted(content=f"{label} — by location ({len(item['by_location'])}):")
+            DataTable(
+                columns=[
+                    DataTableColumn(key="location_name", header="Location"),
+                    DataTableColumn(key="location_id", header="ID", align="right"),
+                    DataTableColumn(key="in_stock", header="In Stock", align="right"),
+                    DataTableColumn(key="available", header="Available", align="right"),
+                    DataTableColumn(key="committed", header="Committed", align="right"),
+                    DataTableColumn(key="expected", header="Expected", align="right"),
+                    # Column parity with ``_inventory_reference_section``
+                    # in the single-item card — batch users need the same
+                    # warehouse-level reorder signal when a variant spans
+                    # multiple locations. ``status_label`` is populated by
+                    # ``_annotate_location_rows`` above.
+                    DataTableColumn(
+                        key="reorder_point", header="Reorder Pt", align="right"
+                    ),
+                    DataTableColumn(key="status_label", header="Status"),
+                ],
+                rows=f"{{{{ {slot} }}}}",
+            )
     return app
 
 

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -19,6 +19,7 @@ from katana_mcp.tools.prefab_ui import (
     build_batch_recipe_update_ui,
     build_fulfill_preview_ui,
     build_fulfill_success_ui,
+    build_inventory_check_batch_ui,
     build_inventory_check_ui,
     build_item_detail_ui,
     build_item_mutation_ui,
@@ -2687,6 +2688,283 @@ class TestBuildReceiptUI:
         }
         app = build_receipt_ui(response)
         _assert_valid_prefab(app)
+
+
+class TestBuildInventoryCheckBatchUI:
+    """Pin the batch ``check_inventory`` card shape (#562). The single-item
+    path is covered by ``TestBuildInventoryCheckUI``; this class covers
+    the multi-row path that previously had no Prefab builder at all."""
+
+    def _multi_item_payload(self) -> list[dict[str, Any]]:
+        """Four rows covering every distinct render branch:
+        - split across two locations (multi-location sub-table)
+        - single-location (no sub-table)
+        - not-found by SKU (sku echoed, variant_id None)
+        - not-found by variant_id (sku empty, variant_id echoed)
+        The fourth row pins the regression Copilot flagged in #769 R2:
+        a variant-id miss must remain identifiable in the summary
+        table even though SKU and Product columns are blank."""
+        return [
+            {
+                "sku": "WIDGET-001",
+                "product_name": "Test Widget",
+                "variant_id": 100,
+                "in_stock": 15.0,
+                "available_stock": 13.0,
+                "committed": 2.0,
+                "expected": 5.0,
+                "uom": "pcs",
+                "is_found": True,
+                "by_location": [
+                    {
+                        "location_id": 1,
+                        "location_name": "Main",
+                        "in_stock": 10.0,
+                        "committed": 2.0,
+                        "expected": 5.0,
+                        "available": 8.0,
+                    },
+                    {
+                        "location_id": 2,
+                        "location_name": "East",
+                        "in_stock": 5.0,
+                        "committed": 0.0,
+                        "expected": 0.0,
+                        "available": 5.0,
+                    },
+                ],
+            },
+            {
+                "sku": "WIDGET-002",
+                "product_name": "Single-Location Widget",
+                "variant_id": 101,
+                "in_stock": 4.0,
+                "available_stock": 4.0,
+                "committed": 0.0,
+                "expected": 0.0,
+                "uom": "pcs",
+                "is_found": True,
+                "by_location": [
+                    {
+                        "location_id": 1,
+                        "location_name": "Main",
+                        "in_stock": 4.0,
+                        "committed": 0.0,
+                        "expected": 0.0,
+                        "available": 4.0,
+                    },
+                ],
+            },
+            {
+                "sku": "MISSING-SKU",
+                "product_name": "",
+                "variant_id": None,
+                "in_stock": 0.0,
+                "available_stock": 0.0,
+                "committed": 0.0,
+                "expected": 0.0,
+                "is_found": False,
+            },
+            {
+                "sku": "",
+                "product_name": "",
+                "variant_id": 99999,
+                "in_stock": 0.0,
+                "available_stock": 0.0,
+                "committed": 0.0,
+                "expected": 0.0,
+                "is_found": False,
+            },
+        ]
+
+    def test_renders_summary_table_with_all_rows(self):
+        items = self._multi_item_payload()
+        app = build_inventory_check_batch_ui(items)
+        _assert_valid_prefab(app)
+        rendered = json.dumps(app.to_json())
+        # Header carries the row count.
+        assert "4 items" in rendered
+        # Top-level DataTable is the summary surface.
+        assert "DataTable" in rendered
+        # All input identities land in state.
+        assert "WIDGET-001" in rendered
+        assert "WIDGET-002" in rendered
+        assert "MISSING-SKU" in rendered
+        # The variant-id not-found row has no SKU — its identity must
+        # still be discoverable in the table. The variant_id column
+        # carries the echoed ID.
+        assert "99999" in rendered
+
+    def test_negative_in_stock_renders_as_out_of_stock(self):
+        """Negative ``in_stock`` totals are real — adjustments,
+        backorders, and accounting fixes can drive the sum below zero.
+        A negative balance is "no stock available" for any decision the
+        card supports, so the status badge must surface "Out of stock"
+        rather than the default "In stock" for ``in_stock > 0``."""
+        items = [
+            {
+                "sku": "BACKORDER-1",
+                "product_name": "Oversold Item",
+                "variant_id": 200,
+                "in_stock": -5.0,
+                "available_stock": -7.0,
+                "committed": 2.0,
+                "expected": 0.0,
+                "is_found": True,
+                "by_location": [],
+            }
+        ]
+        app = build_inventory_check_batch_ui(items)
+        # The annotator wrote the status onto the row in place.
+        assert items[0]["status_label"] == "Out of stock"
+        # And the label flows through to the rendered envelope.
+        rendered = json.dumps(app.to_json())
+        assert "Out of stock" in rendered
+
+    def test_state_items_omits_by_location_to_avoid_duplication(self):
+        """The summary table never reads ``by_location`` — only the
+        sub-tables do. State carries each item's by-location list under
+        a dedicated ``by_location_<i>`` slot, so leaving it inside
+        ``state['items']`` too would double the wire payload for
+        multi-location variants. Pin the slim contract."""
+        items = self._multi_item_payload()
+        app = build_inventory_check_batch_ui(items)
+        state = app.to_json().get("state") or {}
+        state_items = state.get("items") or []
+        # Every entry under ``items`` must be stripped of ``by_location``.
+        for row in state_items:
+            assert "by_location" not in row, (
+                f"state['items'] row leaked by_location: {row.get('sku')!r}"
+            )
+        # The multi-location variant's by-location data still surfaces
+        # via its dedicated slot (the sub-table needs it).
+        assert "by_location_0" in state
+        assert len(state["by_location_0"]) == 2
+
+    def test_per_location_sub_table_carries_reorder_columns(self):
+        """Column parity with the single-item card: the per-location
+        sub-table must surface ``reorder_point`` and ``status_label``
+        so users get the same warehouse-level reorder signal in batch
+        responses they'd see for a single-item check. Status labels
+        come from ``_annotate_location_rows`` (shared with the
+        single-item card)."""
+        items = self._multi_item_payload()
+        # Wire reorder thresholds onto the multi-location variant so the
+        # annotator has something to evaluate.
+        items[0]["by_location"][0]["reorder_point"] = 5.0
+        items[0]["by_location"][1]["reorder_point"] = 10.0
+        app = build_inventory_check_batch_ui(items)
+        # Find the per-location DataTable — the summary table also
+        # carries an ``in_stock`` column, so disambiguate by checking
+        # for the ``location_name`` column that's unique to the
+        # sub-table.
+        sub_table = None
+        for node in _walk_view_tree(app.to_json().get("view")):
+            if node.get("type") != "DataTable":
+                continue
+            keys = [c.get("key") for c in node.get("columns") or []]
+            if "location_name" in keys:
+                sub_table = node
+                break
+        assert sub_table is not None, "per-location sub-table not found"
+        column_keys = [c["key"] for c in sub_table["columns"]]
+        assert "reorder_point" in column_keys
+        assert "status_label" in column_keys
+        # The annotator wrote labels back onto each location row in
+        # state — verify they made it through. WIDGET-001 has 8.0
+        # available at Main with reorder 5.0 (Healthy) and 5.0 at East
+        # with reorder 10.0 (Below reorder).
+        locations = items[0]["by_location"]
+        assert locations[0]["status_label"] == "Healthy"
+        assert locations[1]["status_label"] == "Below reorder"
+
+    def test_renders_per_location_sub_table_only_for_multi_location(self):
+        """Single-location and not-found variants must NOT get their own
+        by-location sub-table — the summary row already says everything,
+        and not-found rows have no locations at all."""
+        items = self._multi_item_payload()
+        app = build_inventory_check_batch_ui(items)
+        rendered = json.dumps(app.to_json())
+        # Exactly one per-variant sub-table marker: only WIDGET-001 is
+        # multi-location. Match the inline label, not the heading prefix,
+        # so we don't double-count if the rendering inserts the SKU in
+        # multiple places.
+        assert rendered.count("by location (") == 1
+        # The multi-location variant gets its own state slot — the
+        # builder allocates ``by_location_<i>`` keyed on the variant's
+        # index in the input list (WIDGET-001 is index 0).
+        assert "by_location_0" in rendered
+
+    def test_not_found_row_renders_status_badge(self):
+        items = self._multi_item_payload()
+        app = build_inventory_check_batch_ui(items)
+        rendered = json.dumps(app.to_json())
+        # Header badge: SKU-miss + variant-id-miss = 2 not-found rows.
+        assert "2 not found" in rendered
+        # Row-level status label is on the table row.
+        assert "Not found" in rendered
+
+    def test_variant_id_column_renders_for_not_found_variant_id_row(self):
+        """A not-found stub from a variant-id lookup has empty SKU and
+        empty product_name; without the variant_id column the row is
+        completely unidentifiable. The Variant ID column must render
+        and the column key must point at the right state field."""
+        items = self._multi_item_payload()
+        app = build_inventory_check_batch_ui(items)
+        # Walk the rendered tree and find the summary DataTable —
+        # match it by the SKU column key, then assert the Variant ID
+        # column is present.
+        summary_table = None
+        for node in _walk_view_tree(app.to_json().get("view")):
+            if node.get("type") != "DataTable":
+                continue
+            cols = node.get("columns") or []
+            keys = [c.get("key") for c in cols]
+            if "sku" in keys:
+                summary_table = node
+                break
+        assert summary_table is not None, "summary DataTable not found"
+        column_keys = [c["key"] for c in summary_table["columns"]]
+        assert "variant_id" in column_keys
+        # Echoed ID is in the rendered state — the column will resolve
+        # it at render time on the host.
+        assert "99999" in json.dumps(app.to_json())
+
+    def test_empty_batch_renders_friendly_message(self):
+        """Zero rows must not render a DataTable — the table would
+        display an empty grid with no rows, which reads as an error.
+        Drop straight to a hint instead."""
+        app = build_inventory_check_batch_ui([])
+        _assert_valid_prefab(app)
+        rendered = json.dumps(app.to_json())
+        assert "0 items" in rendered
+        assert "No items in this batch" in rendered
+        # No DataTable on the empty path.
+        assert "DataTable" not in rendered
+
+    def test_aggregate_metrics_exclude_not_found_rows(self):
+        """The summary metrics ('In Stock', 'Available', ...) must sum
+        only over found rows. A not-found stub carries zeroed totals
+        and would otherwise dilute the average if we ever surfaced one
+        — exclude them so the top-line totals match the table sums."""
+        items = self._multi_item_payload()
+        app = build_inventory_check_batch_ui(items)
+        # Pluck the Metric components from the rendered tree and assert
+        # their values directly — substring matches on "19" / "17" pass
+        # by accident via collision with location IDs / page numbers /
+        # any digit-rich field in the envelope.
+        metrics: dict[str, str] = {}
+        for node in _walk_view_tree(app.to_json().get("view")):
+            if node.get("type") == "Metric":
+                metrics[node["label"]] = node["value"]
+        # WIDGET-001 (15) + WIDGET-002 (4) = 19; not-found row contributes 0.
+        assert metrics["In Stock"] == "19.0"
+        # Available: 13 + 4 = 17.
+        assert metrics["Available"] == "17.0"
+        # Committed: only WIDGET-001 commits stock; WIDGET-002 / not-found are 0.
+        assert metrics["Committed"] == "2.0"
+        # Expected: only WIDGET-001 expects stock.
+        assert metrics["Expected"] == "5.0"
 
 
 class TestBuildBatchRecipeUpdateUI:


### PR DESCRIPTION
## Summary
- Adds `build_inventory_check_batch_ui` — mirrors `build_batch_recipe_update_ui`: summary metrics + flat top DataTable + inline per-variant by-location sub-tables for multi-location variants.
- Wires the batch path in `check_inventory` to use the new builder. Single-item path is unchanged; the JSON envelope shape is identical for both paths.
- Adds 5 UI-shape tests covering: summary table renders all rows, per-location sub-table only for multi-location variants, not-found status badge, empty-batch hint, aggregate-metric exclusion of not-found rows.

Closes #562.

## Design notes
- Each multi-location sub-table binds to its own state slot (`by_location_<index>`) instead of bracket-indexed `items[i].by_location`. The prefab-UI validator (and the JS renderer) reject bracket subscripts in mustache paths.
- Aggregate metrics sum only over `is_found=True` rows so not-found stubs don't dilute the totals.
- Status badges: "Not found" for `is_found=False`, "Out of stock" when found-but-zero, "In stock" otherwise.

## Test plan
- [x] `uv run poe check` — ruff/mdformat/ty/pyright/yamllint/3306 unit tests + 21 browser tests pass
- [x] New tests: 5 / 5 pass
- [x] Existing `test_inventory.py`: 108 pass, 6 well-known skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)