### PR TITLE
feat(client)!: align SalesOrder custom_fields with live API dict shape

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -8461,6 +8461,24 @@ components:
               description: Complete address information for billing and shipping
               items:
                 $ref: "#/components/schemas/SalesOrderAddress"
+            custom_fields:
+              type:
+                - object
+                - "null"
+              additionalProperties: true
+              description: |
+                Custom field values for the sales order, keyed by
+                configured field name. ``null`` when the order's
+                ``custom_field_collection`` is unset; ``{}`` when a
+                collection is bound but no values are set. Keys
+                correspond to fields defined for the ``SalesOrder``
+                entity type (``GET /custom_fields_collections``); each
+                value matches the corresponding field's
+                ``CustomFieldType`` (``shortText`` / ``number`` /
+                ``singleSelect`` / ``date`` / ``boolean`` / ``url``).
+                The valid key set is tenant-specific runtime config, so
+                the schema declares ``additionalProperties: true``
+                rather than enumerating keys.
           required:
             - customer_id
             - order_no
@@ -8659,6 +8677,23 @@ components:
                 - "null"
               format: date-time
               description: Date when the currency conversion rate was applied
+            custom_fields:
+              type:
+                - object
+                - "null"
+              additionalProperties: true
+              description: |
+                Row-level custom field values, keyed by configured field
+                name. ``null`` when no values are set on the row; ``{}``
+                when a collection is bound but no values are set. Keys
+                correspond to fields defined for the ``SalesOrderRow``
+                entity type (``GET /custom_fields_collections``); each
+                value matches the corresponding field's
+                ``CustomFieldType`` (``shortText`` / ``number`` /
+                ``singleSelect`` / ``date`` / ``boolean`` / ``url``).
+                The valid key set is tenant-specific runtime config, so
+                the schema declares ``additionalProperties: true``
+                rather than enumerating keys.
           required:
             - id
             - quantity
@@ -8816,6 +8851,22 @@ components:
         total_discount:
           type: number
           description: Total discount amount applied to this line item
+        custom_fields:
+          type:
+            - object
+            - "null"
+          additionalProperties: true
+          description: |
+            Row-level custom field values, keyed by configured field
+            name. Keys correspond to fields defined for the
+            ``SalesOrderRow`` entity type on the tenant's
+            ``custom_field_collection`` (see
+            ``GET /custom_fields_collections``). Each value matches the
+            corresponding field's ``CustomFieldType`` (``shortText`` /
+            ``number`` / ``singleSelect`` / ``date`` / ``boolean`` /
+            ``url``). The valid key set is tenant-specific runtime
+            config, so the schema declares ``additionalProperties: true``
+            rather than enumerating keys.
       example:
         sales_order_id: 2001
         variant_id: 2101
@@ -8873,6 +8924,22 @@ components:
               value:
                 type: string
                 description: Attribute value
+        custom_fields:
+          type:
+            - object
+            - "null"
+          additionalProperties: true
+          description: |
+            Row-level custom field values, keyed by configured field
+            name. Keys correspond to fields defined for the
+            ``SalesOrderRow`` entity type on the tenant's
+            ``custom_field_collection`` (see
+            ``GET /custom_fields_collections``). Each value matches the
+            corresponding field's ``CustomFieldType`` (``shortText`` /
+            ``number`` / ``singleSelect`` / ``date`` / ``boolean`` /
+            ``url``). The valid key set is tenant-specific runtime
+            config, so the schema declares ``additionalProperties: true``
+            rather than enumerating keys.
       example:
         quantity: 3
         price_per_unit: 549.99
@@ -9121,6 +9188,23 @@ components:
                     value:
                       type: string
                       description: Attribute value
+              custom_fields:
+                type:
+                  - object
+                  - "null"
+                additionalProperties: true
+                description: |
+                  Row-level custom field values, keyed by configured field
+                  name. Keys correspond to fields defined for the
+                  ``SalesOrderRow`` entity type on the tenant's
+                  ``custom_field_collection`` (see
+                  ``GET /custom_fields_collections``). Each value matches
+                  the corresponding field's ``CustomFieldType``
+                  (``shortText`` / ``number`` / ``singleSelect`` /
+                  ``date`` / ``boolean`` / ``url``). The valid key set is
+                  tenant-specific runtime config, so the schema declares
+                  ``additionalProperties: true`` rather than enumerating
+                  keys.
             required:
               - quantity
               - variant_id
@@ -9191,14 +9275,21 @@ components:
             - "null"
           description: Original order ID from the ecommerce platform
         custom_fields:
-          type: array
-          maxItems: 3
+          type:
+            - object
+            - "null"
+          additionalProperties: true
           description: |
-            Custom field values to attach to the sales order. Field names
-            must match those configured for the ``sales_order`` resource
-            type (see ``GET /custom_fields_collections``).
-          items:
-            $ref: "#/components/schemas/CustomFieldValue"
+            Custom field values for the sales order, keyed by configured
+            field name. Keys correspond to fields defined for the
+            ``SalesOrder`` entity type on the tenant's
+            ``custom_field_collection`` (see
+            ``GET /custom_fields_collections``). Each value matches the
+            corresponding field's ``CustomFieldType`` (``shortText`` /
+            ``number`` / ``singleSelect`` / ``date`` / ``boolean`` /
+            ``url``). The valid key set is tenant-specific runtime
+            config, so the schema declares ``additionalProperties: true``
+            rather than enumerating keys.
       required:
         - customer_id
         - sales_order_rows
@@ -12692,14 +12783,21 @@ components:
           description: URL link to track the shipment on carrier website
           maxLength: 2048
         custom_fields:
-          type: array
-          maxItems: 3
+          type:
+            - object
+            - "null"
+          additionalProperties: true
           description: |
-            Custom field values to attach to the sales order. Field names
-            must match those configured for the ``sales_order`` resource
-            type (see ``GET /custom_fields_collections``).
-          items:
-            $ref: "#/components/schemas/CustomFieldValue"
+            Custom field values for the sales order, keyed by configured
+            field name. Keys correspond to fields defined for the
+            ``SalesOrder`` entity type on the tenant's
+            ``custom_field_collection`` (see
+            ``GET /custom_fields_collections``). Each value matches the
+            corresponding field's ``CustomFieldType`` (``shortText`` /
+            ``number`` / ``singleSelect`` / ``date`` / ``boolean`` /
+            ``url``). The valid key set is tenant-specific runtime
+            config, so the schema declares ``additionalProperties: true``
+            rather than enumerating keys.
     UpdateSalesReturnRowRequest:
       description: Request payload for updating a sales return row
       type: object

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -103,12 +103,12 @@ from katana_public_api_client.models import (
     CreateSalesOrderAddressRequest as APICreateSOAddressRequest,
     CreateSalesOrderFulfillmentRequest as APICreateSOFulfillmentRequest,
     CreateSalesOrderRequest as APICreateSalesOrderRequest,
+    CreateSalesOrderRequestCustomFieldsType0 as APISOCustomFieldsMap,
     CreateSalesOrderRequestSalesOrderRowsItem,
     CreateSalesOrderRequestSalesOrderRowsItemAttributesItem as APISORowAttributeItem,
     CreateSalesOrderRowRequest as APICreateSORowRequest,
     CreateSalesOrderShippingFeeRequest as APICreateSOShippingFeeRequest,
     CreateSalesOrderStatus,
-    CustomFieldValue as APICustomFieldValue,
     SalesOrder,
     SalesOrderAddress as APISalesOrderAddress,
     SalesOrderFulfillment,
@@ -150,19 +150,6 @@ class SalesOrderRowAttribute(BaseModel):
 
     key: str = Field(..., description="Attribute key")
     value: str = Field(..., description="Attribute value")
-
-
-class SalesOrderCustomField(BaseModel):
-    """A custom-field value attached to the sales order header.
-
-    Names must already exist on the SO custom-field collection (configured
-    via Katana's UI). Sending an unknown name yields a 422 from Katana.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    field_name: str = Field(..., description="Custom field name")
-    field_value: str = Field(..., description="Custom field value")
 
 
 class SalesOrderItem(BaseModel):
@@ -294,13 +281,14 @@ class CreateSalesOrderRequest(BaseModel):
             "cross-reference the Katana SO back to the storefront record."
         ),
     )
-    custom_fields: list[SalesOrderCustomField] | None = Field(
+    custom_fields: dict[str, Any] | None = Field(
         default=None,
         description=(
-            "Custom-field values attached to the sales order header. Names "
-            "must already exist on the SO custom-field collection (configured "
-            "via Katana's UI). Use a list-of-objects shape: "
-            "`[{field_name: 'PO Reference', field_value: 'PO-12345'}]`."
+            "Custom-field values attached to the sales order header, keyed by "
+            "configured field name (e.g. `{'PO Reference': 'PO-12345'}`). "
+            "Names must already exist on the SO custom-field collection "
+            "(configured via Katana's UI) and value types must match each "
+            "field's configured type."
         ),
     )
     preview: bool = Field(
@@ -455,14 +443,9 @@ async def _create_sales_order_impl(
         # datetime.now(UTC) hardcode silently overwrote any caller intent and
         # blocked back-fills, mirroring the create_purchase_order regression
         # that #605 / #627 fixed.
-        custom_fields_list: list[APICustomFieldValue] | Unset = UNSET
+        custom_fields_map: APISOCustomFieldsMap | Unset = UNSET
         if request.custom_fields is not None:
-            custom_fields_list = [
-                APICustomFieldValue(
-                    field_name=cf.field_name, field_value=cf.field_value
-                )
-                for cf in request.custom_fields
-            ]
+            custom_fields_map = APISOCustomFieldsMap.from_dict(request.custom_fields)
 
         api_request = APICreateSalesOrderRequest(
             order_no=request.order_number,
@@ -480,7 +463,7 @@ async def _create_sales_order_impl(
             ecommerce_order_type=to_unset(request.ecommerce_order_type),
             ecommerce_store_name=to_unset(request.ecommerce_store_name),
             ecommerce_order_id=to_unset(request.ecommerce_order_id),
-            custom_fields=custom_fields_list,
+            custom_fields=custom_fields_map,
             status=CreateSalesOrderStatus.PENDING,
         )
 

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -220,7 +220,6 @@ async def test_create_sales_order_forwards_new_header_and_row_fields():
     (#627 — write-side parity sweep).
     """
     from katana_mcp.tools.foundation.sales_orders import (
-        SalesOrderCustomField,
         SalesOrderRowAttribute,
     )
 
@@ -264,11 +263,7 @@ async def test_create_sales_order_forwards_new_header_and_row_fields():
             ecommerce_order_type="shopify_order",
             ecommerce_store_name="Acme Online Store",
             ecommerce_order_id="store-order-12345",
-            custom_fields=[
-                SalesOrderCustomField(
-                    field_name="PO Reference", field_value="PO-12345"
-                ),
-            ],
+            custom_fields={"PO Reference": "PO-12345"},
             preview=False,
         )
         await _create_sales_order_impl(request, context)
@@ -287,9 +282,7 @@ async def test_create_sales_order_forwards_new_header_and_row_fields():
     assert api_body.ecommerce_order_type == "shopify_order"
     assert api_body.ecommerce_store_name == "Acme Online Store"
     assert api_body.ecommerce_order_id == "store-order-12345"
-    assert len(api_body.custom_fields) == 1
-    assert api_body.custom_fields[0].field_name == "PO Reference"
-    assert api_body.custom_fields[0].field_value == "PO-12345"
+    assert api_body.custom_fields.to_dict() == {"PO Reference": "PO-12345"}
 
     # Row-level attributes
     row = api_body.sales_order_rows[0]

--- a/katana_public_api_client/models/__init__.py
+++ b/katana_public_api_client/models/__init__.py
@@ -96,15 +96,24 @@ from .create_recipes_request_rows_item import CreateRecipesRequestRowsItem
 from .create_sales_order_address_request import CreateSalesOrderAddressRequest
 from .create_sales_order_fulfillment_request import CreateSalesOrderFulfillmentRequest
 from .create_sales_order_request import CreateSalesOrderRequest
+from .create_sales_order_request_custom_fields_type_0 import (
+    CreateSalesOrderRequestCustomFieldsType0,
+)
 from .create_sales_order_request_sales_order_rows_item import (
     CreateSalesOrderRequestSalesOrderRowsItem,
 )
 from .create_sales_order_request_sales_order_rows_item_attributes_item import (
     CreateSalesOrderRequestSalesOrderRowsItemAttributesItem,
 )
+from .create_sales_order_request_sales_order_rows_item_custom_fields_type_0 import (
+    CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0,
+)
 from .create_sales_order_row_request import CreateSalesOrderRowRequest
 from .create_sales_order_row_request_attributes_item import (
     CreateSalesOrderRowRequestAttributesItem,
+)
+from .create_sales_order_row_request_custom_fields_type_0 import (
+    CreateSalesOrderRowRequestCustomFieldsType0,
 )
 from .create_sales_order_shipping_fee_request import CreateSalesOrderShippingFeeRequest
 from .create_sales_order_status import CreateSalesOrderStatus
@@ -376,6 +385,7 @@ from .sales_order_accounting_metadata_list_response import (
 )
 from .sales_order_address import SalesOrderAddress
 from .sales_order_address_list_response import SalesOrderAddressListResponse
+from .sales_order_custom_fields_type_0 import SalesOrderCustomFieldsType0
 from .sales_order_fulfillment import SalesOrderFulfillment
 from .sales_order_fulfillment_invoice_status import SalesOrderFulfillmentInvoiceStatus
 from .sales_order_fulfillment_list_response import SalesOrderFulfillmentListResponse
@@ -393,6 +403,7 @@ from .sales_order_production_status import SalesOrderProductionStatus
 from .sales_order_row import SalesOrderRow
 from .sales_order_row_attributes_item import SalesOrderRowAttributesItem
 from .sales_order_row_batch_transactions_item import SalesOrderRowBatchTransactionsItem
+from .sales_order_row_custom_fields_type_0 import SalesOrderRowCustomFieldsType0
 from .sales_order_row_list_response import SalesOrderRowListResponse
 from .sales_order_row_serial_number_transactions_item import (
     SalesOrderRowSerialNumberTransactionsItem,
@@ -511,9 +522,15 @@ from .update_recipe_row_request import UpdateRecipeRowRequest
 from .update_sales_order_address_request import UpdateSalesOrderAddressRequest
 from .update_sales_order_fulfillment_request import UpdateSalesOrderFulfillmentRequest
 from .update_sales_order_request import UpdateSalesOrderRequest
+from .update_sales_order_request_custom_fields_type_0 import (
+    UpdateSalesOrderRequestCustomFieldsType0,
+)
 from .update_sales_order_row_request import UpdateSalesOrderRowRequest
 from .update_sales_order_row_request_attributes_item import (
     UpdateSalesOrderRowRequestAttributesItem,
+)
+from .update_sales_order_row_request_custom_fields_type_0 import (
+    UpdateSalesOrderRowRequestCustomFieldsType0,
 )
 from .update_sales_order_row_request_serial_number_transactions_item import (
     UpdateSalesOrderRowRequestSerialNumberTransactionsItem,
@@ -633,10 +650,13 @@ __all__ = (
     "CreateSalesOrderAddressRequest",
     "CreateSalesOrderFulfillmentRequest",
     "CreateSalesOrderRequest",
+    "CreateSalesOrderRequestCustomFieldsType0",
     "CreateSalesOrderRequestSalesOrderRowsItem",
     "CreateSalesOrderRequestSalesOrderRowsItemAttributesItem",
+    "CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0",
     "CreateSalesOrderRowRequest",
     "CreateSalesOrderRowRequestAttributesItem",
+    "CreateSalesOrderRowRequestCustomFieldsType0",
     "CreateSalesOrderShippingFeeRequest",
     "CreateSalesOrderStatus",
     "CreateSalesReturnRequest",
@@ -845,6 +865,7 @@ __all__ = (
     "SalesOrderAccountingMetadataListResponse",
     "SalesOrderAddress",
     "SalesOrderAddressListResponse",
+    "SalesOrderCustomFieldsType0",
     "SalesOrderFulfillment",
     "SalesOrderFulfillmentInvoiceStatus",
     "SalesOrderFulfillmentListResponse",
@@ -858,6 +879,7 @@ __all__ = (
     "SalesOrderRow",
     "SalesOrderRowAttributesItem",
     "SalesOrderRowBatchTransactionsItem",
+    "SalesOrderRowCustomFieldsType0",
     "SalesOrderRowListResponse",
     "SalesOrderRowSerialNumberTransactionsItem",
     "SalesOrderRowSerialNumberTransactionsItemQuantity",
@@ -950,8 +972,10 @@ __all__ = (
     "UpdateSalesOrderAddressRequest",
     "UpdateSalesOrderFulfillmentRequest",
     "UpdateSalesOrderRequest",
+    "UpdateSalesOrderRequestCustomFieldsType0",
     "UpdateSalesOrderRowRequest",
     "UpdateSalesOrderRowRequestAttributesItem",
+    "UpdateSalesOrderRowRequestCustomFieldsType0",
     "UpdateSalesOrderRowRequestSerialNumberTransactionsItem",
     "UpdateSalesOrderShippingFeeRequest",
     "UpdateSalesOrderStatus",

--- a/katana_public_api_client/models/create_sales_order_request.py
+++ b/katana_public_api_client/models/create_sales_order_request.py
@@ -14,10 +14,12 @@ from ..client_types import UNSET, Unset
 from ..models.create_sales_order_status import CreateSalesOrderStatus
 
 if TYPE_CHECKING:
+    from ..models.create_sales_order_request_custom_fields_type_0 import (
+        CreateSalesOrderRequestCustomFieldsType0,
+    )
     from ..models.create_sales_order_request_sales_order_rows_item import (
         CreateSalesOrderRequestSalesOrderRowsItem,
     )
-    from ..models.custom_field_value import CustomFieldValue
     from ..models.sales_order_address import SalesOrderAddress
 
 
@@ -62,9 +64,17 @@ class CreateSalesOrderRequest:
         ecommerce_order_type (None | str | Unset): Type of ecommerce order if applicable
         ecommerce_store_name (None | str | Unset): Name of the ecommerce store if order originated from online
         ecommerce_order_id (None | str | Unset): Original order ID from the ecommerce platform
-        custom_fields (list[CustomFieldValue] | Unset): Custom field values to attach to the sales order. Field names
-            must match those configured for the ``sales_order`` resource
-            type (see ``GET /custom_fields_collections``).
+        custom_fields (CreateSalesOrderRequestCustomFieldsType0 | None | Unset): Custom field values for the sales
+            order, keyed by configured
+            field name. Keys correspond to fields defined for the
+            ``SalesOrder`` entity type on the tenant's
+            ``custom_field_collection`` (see
+            ``GET /custom_fields_collections``). Each value matches the
+            corresponding field's ``CustomFieldType`` (``shortText`` /
+            ``number`` / ``singleSelect`` / ``date`` / ``boolean`` /
+            ``url``). The valid key set is tenant-specific runtime
+            config, so the schema declares ``additionalProperties: true``
+            rather than enumerating keys.
     """
 
     customer_id: int
@@ -83,10 +93,14 @@ class CreateSalesOrderRequest:
     ecommerce_order_type: None | str | Unset = UNSET
     ecommerce_store_name: None | str | Unset = UNSET
     ecommerce_order_id: None | str | Unset = UNSET
-    custom_fields: list[CustomFieldValue] | Unset = UNSET
+    custom_fields: CreateSalesOrderRequestCustomFieldsType0 | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.create_sales_order_request_custom_fields_type_0 import (
+            CreateSalesOrderRequestCustomFieldsType0,
+        )
+
         customer_id = self.customer_id
 
         sales_order_rows = []
@@ -173,12 +187,13 @@ class CreateSalesOrderRequest:
         else:
             ecommerce_order_id = self.ecommerce_order_id
 
-        custom_fields: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.custom_fields, Unset):
-            custom_fields = []
-            for custom_fields_item_data in self.custom_fields:
-                custom_fields_item = custom_fields_item_data.to_dict()
-                custom_fields.append(custom_fields_item)
+        custom_fields: dict[str, Any] | None | Unset
+        if isinstance(self.custom_fields, Unset):
+            custom_fields = UNSET
+        elif isinstance(self.custom_fields, CreateSalesOrderRequestCustomFieldsType0):
+            custom_fields = self.custom_fields.to_dict()
+        else:
+            custom_fields = self.custom_fields
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -223,10 +238,12 @@ class CreateSalesOrderRequest:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.create_sales_order_request_custom_fields_type_0 import (
+            CreateSalesOrderRequestCustomFieldsType0,
+        )
         from ..models.create_sales_order_request_sales_order_rows_item import (
             CreateSalesOrderRequestSalesOrderRowsItem,
         )
-        from ..models.custom_field_value import CustomFieldValue
         from ..models.sales_order_address import SalesOrderAddress
 
         d = dict(src_dict)
@@ -379,16 +396,31 @@ class CreateSalesOrderRequest:
             d.pop("ecommerce_order_id", UNSET)
         )
 
-        _custom_fields = d.pop("custom_fields", UNSET)
-        custom_fields: list[CustomFieldValue] | Unset = UNSET
-        if _custom_fields is not UNSET:
-            custom_fields = []
-            for custom_fields_item_data in _custom_fields:
-                custom_fields_item = CustomFieldValue.from_dict(
-                    cast(Mapping[str, Any], custom_fields_item_data)
+        def _parse_custom_fields(
+            data: object,
+        ) -> CreateSalesOrderRequestCustomFieldsType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                custom_fields_type_0 = (
+                    CreateSalesOrderRequestCustomFieldsType0.from_dict(
+                        cast(Mapping[str, Any], data)
+                    )
                 )
 
-                custom_fields.append(custom_fields_item)
+                return custom_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(CreateSalesOrderRequestCustomFieldsType0 | None | Unset, data)
+
+        custom_fields = _parse_custom_fields(d.pop("custom_fields", UNSET))
 
         create_sales_order_request = cls(
             customer_id=customer_id,

--- a/katana_public_api_client/models/create_sales_order_request_custom_fields_type_0.py
+++ b/katana_public_api_client/models/create_sales_order_request_custom_fields_type_0.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import (
+    define as _attrs_define,
+    field as _attrs_field,
+)
+
+T = TypeVar("T", bound="CreateSalesOrderRequestCustomFieldsType0")
+
+
+@_attrs_define
+class CreateSalesOrderRequestCustomFieldsType0:
+    """Custom field values for the sales order, keyed by configured
+    field name. Keys correspond to fields defined for the
+    ``SalesOrder`` entity type on the tenant's
+    ``custom_field_collection`` (see
+    ``GET /custom_fields_collections``). Each value matches the
+    corresponding field's ``CustomFieldType`` (``shortText`` /
+    ``number`` / ``singleSelect`` / ``date`` / ``boolean`` /
+    ``url``). The valid key set is tenant-specific runtime
+    config, so the schema declares ``additionalProperties: true``
+    rather than enumerating keys.
+
+    """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        create_sales_order_request_custom_fields_type_0 = cls()
+
+        create_sales_order_request_custom_fields_type_0.additional_properties = d
+        return create_sales_order_request_custom_fields_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/katana_public_api_client/models/create_sales_order_request_sales_order_rows_item.py
+++ b/katana_public_api_client/models/create_sales_order_request_sales_order_rows_item.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from ..models.create_sales_order_request_sales_order_rows_item_attributes_item import (
         CreateSalesOrderRequestSalesOrderRowsItemAttributesItem,
     )
+    from ..models.create_sales_order_request_sales_order_rows_item_custom_fields_type_0 import (
+        CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0,
+    )
 
 
 T = TypeVar("T", bound="CreateSalesOrderRequestSalesOrderRowsItem")
@@ -30,9 +33,16 @@ class CreateSalesOrderRequestSalesOrderRowsItem:
     attributes: (
         list[CreateSalesOrderRequestSalesOrderRowsItemAttributesItem] | Unset
     ) = UNSET
+    custom_fields: (
+        CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0 | None | Unset
+    ) = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.create_sales_order_request_sales_order_rows_item_custom_fields_type_0 import (
+            CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0,
+        )
+
         quantity = self.quantity
 
         variant_id = self.variant_id
@@ -68,6 +78,17 @@ class CreateSalesOrderRequestSalesOrderRowsItem:
                 attributes_item = attributes_item_data.to_dict()
                 attributes.append(attributes_item)
 
+        custom_fields: dict[str, Any] | None | Unset
+        if isinstance(self.custom_fields, Unset):
+            custom_fields = UNSET
+        elif isinstance(
+            self.custom_fields,
+            CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0,
+        ):
+            custom_fields = self.custom_fields.to_dict()
+        else:
+            custom_fields = self.custom_fields
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -86,6 +107,8 @@ class CreateSalesOrderRequestSalesOrderRowsItem:
             field_dict["total_discount"] = total_discount
         if attributes is not UNSET:
             field_dict["attributes"] = attributes
+        if custom_fields is not UNSET:
+            field_dict["custom_fields"] = custom_fields
 
         return field_dict
 
@@ -93,6 +116,9 @@ class CreateSalesOrderRequestSalesOrderRowsItem:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.create_sales_order_request_sales_order_rows_item_attributes_item import (
             CreateSalesOrderRequestSalesOrderRowsItemAttributesItem,
+        )
+        from ..models.create_sales_order_request_sales_order_rows_item_custom_fields_type_0 import (
+            CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0,
         )
 
         d = dict(src_dict)
@@ -151,6 +177,32 @@ class CreateSalesOrderRequestSalesOrderRowsItem:
 
                 attributes.append(attributes_item)
 
+        def _parse_custom_fields(
+            data: object,
+        ) -> CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                custom_fields_type_0 = CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0.from_dict(
+                    cast(Mapping[str, Any], data)
+                )
+
+                return custom_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0
+                | None
+                | Unset,
+                data,
+            )
+
+        custom_fields = _parse_custom_fields(d.pop("custom_fields", UNSET))
+
         create_sales_order_request_sales_order_rows_item = cls(
             quantity=quantity,
             variant_id=variant_id,
@@ -159,6 +211,7 @@ class CreateSalesOrderRequestSalesOrderRowsItem:
             price_per_unit=price_per_unit,
             total_discount=total_discount,
             attributes=attributes,
+            custom_fields=custom_fields,
         )
 
         create_sales_order_request_sales_order_rows_item.additional_properties = d

--- a/katana_public_api_client/models/create_sales_order_request_sales_order_rows_item_custom_fields_type_0.py
+++ b/katana_public_api_client/models/create_sales_order_request_sales_order_rows_item_custom_fields_type_0.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import (
+    define as _attrs_define,
+    field as _attrs_field,
+)
+
+T = TypeVar("T", bound="CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0")
+
+
+@_attrs_define
+class CreateSalesOrderRequestSalesOrderRowsItemCustomFieldsType0:
+    """Row-level custom field values, keyed by configured field
+    name. Keys correspond to fields defined for the
+    ``SalesOrderRow`` entity type on the tenant's
+    ``custom_field_collection`` (see
+    ``GET /custom_fields_collections``). Each value matches
+    the corresponding field's ``CustomFieldType``
+    (``shortText`` / ``number`` / ``singleSelect`` /
+    ``date`` / ``boolean`` / ``url``). The valid key set is
+    tenant-specific runtime config, so the schema declares
+    ``additionalProperties: true`` rather than enumerating
+    keys.
+
+    """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        create_sales_order_request_sales_order_rows_item_custom_fields_type_0 = cls()
+
+        create_sales_order_request_sales_order_rows_item_custom_fields_type_0.additional_properties = d
+        return create_sales_order_request_sales_order_rows_item_custom_fields_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/katana_public_api_client/models/create_sales_order_row_request.py
+++ b/katana_public_api_client/models/create_sales_order_row_request.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from ..models.create_sales_order_row_request_attributes_item import (
         CreateSalesOrderRowRequestAttributesItem,
     )
+    from ..models.create_sales_order_row_request_custom_fields_type_0 import (
+        CreateSalesOrderRowRequestCustomFieldsType0,
+    )
 
 
 T = TypeVar("T", bound="CreateSalesOrderRowRequest")
@@ -33,8 +36,13 @@ class CreateSalesOrderRowRequest:
     location_id: int | Unset = UNSET
     attributes: list[CreateSalesOrderRowRequestAttributesItem] | Unset = UNSET
     total_discount: float | Unset = UNSET
+    custom_fields: CreateSalesOrderRowRequestCustomFieldsType0 | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.create_sales_order_row_request_custom_fields_type_0 import (
+            CreateSalesOrderRowRequestCustomFieldsType0,
+        )
+
         sales_order_id = self.sales_order_id
 
         variant_id = self.variant_id
@@ -56,6 +64,16 @@ class CreateSalesOrderRowRequest:
 
         total_discount = self.total_discount
 
+        custom_fields: dict[str, Any] | None | Unset
+        if isinstance(self.custom_fields, Unset):
+            custom_fields = UNSET
+        elif isinstance(
+            self.custom_fields, CreateSalesOrderRowRequestCustomFieldsType0
+        ):
+            custom_fields = self.custom_fields.to_dict()
+        else:
+            custom_fields = self.custom_fields
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -75,6 +93,8 @@ class CreateSalesOrderRowRequest:
             field_dict["attributes"] = attributes
         if total_discount is not UNSET:
             field_dict["total_discount"] = total_discount
+        if custom_fields is not UNSET:
+            field_dict["custom_fields"] = custom_fields
 
         return field_dict
 
@@ -82,6 +102,9 @@ class CreateSalesOrderRowRequest:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.create_sales_order_row_request_attributes_item import (
             CreateSalesOrderRowRequestAttributesItem,
+        )
+        from ..models.create_sales_order_row_request_custom_fields_type_0 import (
+            CreateSalesOrderRowRequestCustomFieldsType0,
         )
 
         d = dict(src_dict)
@@ -110,6 +133,34 @@ class CreateSalesOrderRowRequest:
 
         total_discount = d.pop("total_discount", UNSET)
 
+        def _parse_custom_fields(
+            data: object,
+        ) -> CreateSalesOrderRowRequestCustomFieldsType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                custom_fields_type_0 = (
+                    CreateSalesOrderRowRequestCustomFieldsType0.from_dict(
+                        cast(Mapping[str, Any], data)
+                    )
+                )
+
+                return custom_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                CreateSalesOrderRowRequestCustomFieldsType0 | None | Unset, data
+            )
+
+        custom_fields = _parse_custom_fields(d.pop("custom_fields", UNSET))
+
         create_sales_order_row_request = cls(
             sales_order_id=sales_order_id,
             variant_id=variant_id,
@@ -119,6 +170,7 @@ class CreateSalesOrderRowRequest:
             location_id=location_id,
             attributes=attributes,
             total_discount=total_discount,
+            custom_fields=custom_fields,
         )
 
         return create_sales_order_row_request

--- a/katana_public_api_client/models/create_sales_order_row_request_custom_fields_type_0.py
+++ b/katana_public_api_client/models/create_sales_order_row_request_custom_fields_type_0.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import (
+    define as _attrs_define,
+    field as _attrs_field,
+)
+
+T = TypeVar("T", bound="CreateSalesOrderRowRequestCustomFieldsType0")
+
+
+@_attrs_define
+class CreateSalesOrderRowRequestCustomFieldsType0:
+    """Row-level custom field values, keyed by configured field
+    name. Keys correspond to fields defined for the
+    ``SalesOrderRow`` entity type on the tenant's
+    ``custom_field_collection`` (see
+    ``GET /custom_fields_collections``). Each value matches the
+    corresponding field's ``CustomFieldType`` (``shortText`` /
+    ``number`` / ``singleSelect`` / ``date`` / ``boolean`` /
+    ``url``). The valid key set is tenant-specific runtime
+    config, so the schema declares ``additionalProperties: true``
+    rather than enumerating keys.
+
+    """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        create_sales_order_row_request_custom_fields_type_0 = cls()
+
+        create_sales_order_row_request_custom_fields_type_0.additional_properties = d
+        return create_sales_order_row_request_custom_fields_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/katana_public_api_client/models/sales_order.py
+++ b/katana_public_api_client/models/sales_order.py
@@ -19,6 +19,7 @@ from ..models.sales_order_status import SalesOrderStatus
 
 if TYPE_CHECKING:
     from ..models.sales_order_address import SalesOrderAddress
+    from ..models.sales_order_custom_fields_type_0 import SalesOrderCustomFieldsType0
     from ..models.sales_order_row import SalesOrderRow
     from ..models.sales_order_shipping_fee import SalesOrderShippingFee
 
@@ -101,6 +102,18 @@ class SalesOrder:
             associated production
         shipping_fee (None | SalesOrderShippingFee | Unset): Shipping fee details for this sales order
         addresses (list[SalesOrderAddress] | Unset): Complete address information for billing and shipping
+        custom_fields (None | SalesOrderCustomFieldsType0 | Unset): Custom field values for the sales order, keyed by
+            configured field name. ``null`` when the order's
+            ``custom_field_collection`` is unset; ``{}`` when a
+            collection is bound but no values are set. Keys
+            correspond to fields defined for the ``SalesOrder``
+            entity type (``GET /custom_fields_collections``); each
+            value matches the corresponding field's
+            ``CustomFieldType`` (``shortText`` / ``number`` /
+            ``singleSelect`` / ``date`` / ``boolean`` / ``url``).
+            The valid key set is tenant-specific runtime config, so
+            the schema declares ``additionalProperties: true``
+            rather than enumerating keys.
     """
 
     id: int
@@ -139,9 +152,13 @@ class SalesOrder:
     linked_manufacturing_order_id: int | None | Unset = UNSET
     shipping_fee: None | SalesOrderShippingFee | Unset = UNSET
     addresses: list[SalesOrderAddress] | Unset = UNSET
+    custom_fields: None | SalesOrderCustomFieldsType0 | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.sales_order_custom_fields_type_0 import (
+            SalesOrderCustomFieldsType0,
+        )
         from ..models.sales_order_shipping_fee import SalesOrderShippingFee
 
         id = self.id
@@ -346,6 +363,14 @@ class SalesOrder:
                 addresses_item = addresses_item_data.to_dict()
                 addresses.append(addresses_item)
 
+        custom_fields: dict[str, Any] | None | Unset
+        if isinstance(self.custom_fields, Unset):
+            custom_fields = UNSET
+        elif isinstance(self.custom_fields, SalesOrderCustomFieldsType0):
+            custom_fields = self.custom_fields.to_dict()
+        else:
+            custom_fields = self.custom_fields
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -419,12 +444,17 @@ class SalesOrder:
             field_dict["shipping_fee"] = shipping_fee
         if addresses is not UNSET:
             field_dict["addresses"] = addresses
+        if custom_fields is not UNSET:
+            field_dict["custom_fields"] = custom_fields
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.sales_order_address import SalesOrderAddress
+        from ..models.sales_order_custom_fields_type_0 import (
+            SalesOrderCustomFieldsType0,
+        )
         from ..models.sales_order_row import SalesOrderRow
         from ..models.sales_order_shipping_fee import SalesOrderShippingFee
 
@@ -822,6 +852,30 @@ class SalesOrder:
 
                 addresses.append(addresses_item)
 
+        def _parse_custom_fields(
+            data: object,
+        ) -> None | SalesOrderCustomFieldsType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                custom_fields_type_0 = SalesOrderCustomFieldsType0.from_dict(
+                    cast(Mapping[str, Any], data)
+                )
+
+                return custom_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | SalesOrderCustomFieldsType0 | Unset, data)
+
+        custom_fields = _parse_custom_fields(d.pop("custom_fields", UNSET))
+
         sales_order = cls(
             id=id,
             customer_id=customer_id,
@@ -859,6 +913,7 @@ class SalesOrder:
             linked_manufacturing_order_id=linked_manufacturing_order_id,
             shipping_fee=shipping_fee,
             addresses=addresses,
+            custom_fields=custom_fields,
         )
 
         sales_order.additional_properties = d

--- a/katana_public_api_client/models/sales_order_custom_fields_type_0.py
+++ b/katana_public_api_client/models/sales_order_custom_fields_type_0.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import (
+    define as _attrs_define,
+    field as _attrs_field,
+)
+
+T = TypeVar("T", bound="SalesOrderCustomFieldsType0")
+
+
+@_attrs_define
+class SalesOrderCustomFieldsType0:
+    """Custom field values for the sales order, keyed by
+    configured field name. ``null`` when the order's
+    ``custom_field_collection`` is unset; ``{}`` when a
+    collection is bound but no values are set. Keys
+    correspond to fields defined for the ``SalesOrder``
+    entity type (``GET /custom_fields_collections``); each
+    value matches the corresponding field's
+    ``CustomFieldType`` (``shortText`` / ``number`` /
+    ``singleSelect`` / ``date`` / ``boolean`` / ``url``).
+    The valid key set is tenant-specific runtime config, so
+    the schema declares ``additionalProperties: true``
+    rather than enumerating keys.
+
+    """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        sales_order_custom_fields_type_0 = cls()
+
+        sales_order_custom_fields_type_0.additional_properties = d
+        return sales_order_custom_fields_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/katana_public_api_client/models/sales_order_row.py
+++ b/katana_public_api_client/models/sales_order_row.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
     from ..models.sales_order_row_batch_transactions_item import (
         SalesOrderRowBatchTransactionsItem,
     )
+    from ..models.sales_order_row_custom_fields_type_0 import (
+        SalesOrderRowCustomFieldsType0,
+    )
     from ..models.sales_order_row_serial_number_transactions_item import (
         SalesOrderRowSerialNumberTransactionsItem,
     )
@@ -74,6 +77,18 @@ class SalesOrderRow:
                 for make-to-order items
             conversion_rate (float | None | Unset): Currency conversion rate used for this row
             conversion_date (datetime.datetime | None | Unset): Date when the currency conversion rate was applied
+            custom_fields (None | SalesOrderRowCustomFieldsType0 | Unset): Row-level custom field values, keyed by
+                configured field
+                name. ``null`` when no values are set on the row; ``{}``
+                when a collection is bound but no values are set. Keys
+                correspond to fields defined for the ``SalesOrderRow``
+                entity type (``GET /custom_fields_collections``); each
+                value matches the corresponding field's
+                ``CustomFieldType`` (``shortText`` / ``number`` /
+                ``singleSelect`` / ``date`` / ``boolean`` / ``url``).
+                The valid key set is tenant-specific runtime config, so
+                the schema declares ``additionalProperties: true``
+                rather than enumerating keys.
     """
 
     id: int
@@ -103,9 +118,14 @@ class SalesOrderRow:
     linked_manufacturing_order_id: int | None | Unset = UNSET
     conversion_rate: float | None | Unset = UNSET
     conversion_date: datetime.datetime | None | Unset = UNSET
+    custom_fields: None | SalesOrderRowCustomFieldsType0 | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.sales_order_row_custom_fields_type_0 import (
+            SalesOrderRowCustomFieldsType0,
+        )
+
         id = self.id
 
         quantity = self.quantity
@@ -231,6 +251,14 @@ class SalesOrderRow:
         else:
             conversion_date = self.conversion_date
 
+        custom_fields: dict[str, Any] | None | Unset
+        if isinstance(self.custom_fields, Unset):
+            custom_fields = UNSET
+        elif isinstance(self.custom_fields, SalesOrderRowCustomFieldsType0):
+            custom_fields = self.custom_fields.to_dict()
+        else:
+            custom_fields = self.custom_fields
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -286,6 +314,8 @@ class SalesOrderRow:
             field_dict["conversion_rate"] = conversion_rate
         if conversion_date is not UNSET:
             field_dict["conversion_date"] = conversion_date
+        if custom_fields is not UNSET:
+            field_dict["custom_fields"] = custom_fields
 
         return field_dict
 
@@ -294,6 +324,9 @@ class SalesOrderRow:
         from ..models.sales_order_row_attributes_item import SalesOrderRowAttributesItem
         from ..models.sales_order_row_batch_transactions_item import (
             SalesOrderRowBatchTransactionsItem,
+        )
+        from ..models.sales_order_row_custom_fields_type_0 import (
+            SalesOrderRowCustomFieldsType0,
         )
         from ..models.sales_order_row_serial_number_transactions_item import (
             SalesOrderRowSerialNumberTransactionsItem,
@@ -512,6 +545,30 @@ class SalesOrderRow:
 
         conversion_date = _parse_conversion_date(d.pop("conversion_date", UNSET))
 
+        def _parse_custom_fields(
+            data: object,
+        ) -> None | SalesOrderRowCustomFieldsType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                custom_fields_type_0 = SalesOrderRowCustomFieldsType0.from_dict(
+                    cast(Mapping[str, Any], data)
+                )
+
+                return custom_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | SalesOrderRowCustomFieldsType0 | Unset, data)
+
+        custom_fields = _parse_custom_fields(d.pop("custom_fields", UNSET))
+
         sales_order_row = cls(
             id=id,
             quantity=quantity,
@@ -538,6 +595,7 @@ class SalesOrderRow:
             linked_manufacturing_order_id=linked_manufacturing_order_id,
             conversion_rate=conversion_rate,
             conversion_date=conversion_date,
+            custom_fields=custom_fields,
         )
 
         sales_order_row.additional_properties = d

--- a/katana_public_api_client/models/sales_order_row_custom_fields_type_0.py
+++ b/katana_public_api_client/models/sales_order_row_custom_fields_type_0.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import (
+    define as _attrs_define,
+    field as _attrs_field,
+)
+
+T = TypeVar("T", bound="SalesOrderRowCustomFieldsType0")
+
+
+@_attrs_define
+class SalesOrderRowCustomFieldsType0:
+    """Row-level custom field values, keyed by configured field
+    name. ``null`` when no values are set on the row; ``{}``
+    when a collection is bound but no values are set. Keys
+    correspond to fields defined for the ``SalesOrderRow``
+    entity type (``GET /custom_fields_collections``); each
+    value matches the corresponding field's
+    ``CustomFieldType`` (``shortText`` / ``number`` /
+    ``singleSelect`` / ``date`` / ``boolean`` / ``url``).
+    The valid key set is tenant-specific runtime config, so
+    the schema declares ``additionalProperties: true``
+    rather than enumerating keys.
+
+    """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        sales_order_row_custom_fields_type_0 = cls()
+
+        sales_order_row_custom_fields_type_0.additional_properties = d
+        return sales_order_row_custom_fields_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/katana_public_api_client/models/update_sales_order_request.py
+++ b/katana_public_api_client/models/update_sales_order_request.py
@@ -11,7 +11,9 @@ from ..client_types import UNSET, Unset
 from ..models.update_sales_order_status import UpdateSalesOrderStatus
 
 if TYPE_CHECKING:
-    from ..models.custom_field_value import CustomFieldValue
+    from ..models.update_sales_order_request_custom_fields_type_0 import (
+        UpdateSalesOrderRequestCustomFieldsType0,
+    )
 
 
 T = TypeVar("T", bound="UpdateSalesOrderRequest")
@@ -35,9 +37,13 @@ class UpdateSalesOrderRequest:
     customer_ref: None | str | Unset = UNSET
     tracking_number: None | str | Unset = UNSET
     tracking_number_url: None | str | Unset = UNSET
-    custom_fields: list[CustomFieldValue] | Unset = UNSET
+    custom_fields: None | Unset | UpdateSalesOrderRequestCustomFieldsType0 = UNSET
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.update_sales_order_request_custom_fields_type_0 import (
+            UpdateSalesOrderRequestCustomFieldsType0,
+        )
+
         order_no = self.order_no
 
         customer_id = self.customer_id
@@ -90,12 +96,13 @@ class UpdateSalesOrderRequest:
         else:
             tracking_number_url = self.tracking_number_url
 
-        custom_fields: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.custom_fields, Unset):
-            custom_fields = []
-            for custom_fields_item_data in self.custom_fields:
-                custom_fields_item = custom_fields_item_data.to_dict()
-                custom_fields.append(custom_fields_item)
+        custom_fields: dict[str, Any] | None | Unset
+        if isinstance(self.custom_fields, Unset):
+            custom_fields = UNSET
+        elif isinstance(self.custom_fields, UpdateSalesOrderRequestCustomFieldsType0):
+            custom_fields = self.custom_fields.to_dict()
+        else:
+            custom_fields = self.custom_fields
 
         field_dict: dict[str, Any] = {}
 
@@ -135,7 +142,9 @@ class UpdateSalesOrderRequest:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.custom_field_value import CustomFieldValue
+        from ..models.update_sales_order_request_custom_fields_type_0 import (
+            UpdateSalesOrderRequestCustomFieldsType0,
+        )
 
         d = dict(src_dict)
         order_no = d.pop("order_no", UNSET)
@@ -216,16 +225,31 @@ class UpdateSalesOrderRequest:
             d.pop("tracking_number_url", UNSET)
         )
 
-        _custom_fields = d.pop("custom_fields", UNSET)
-        custom_fields: list[CustomFieldValue] | Unset = UNSET
-        if _custom_fields is not UNSET:
-            custom_fields = []
-            for custom_fields_item_data in _custom_fields:
-                custom_fields_item = CustomFieldValue.from_dict(
-                    cast(Mapping[str, Any], custom_fields_item_data)
+        def _parse_custom_fields(
+            data: object,
+        ) -> None | Unset | UpdateSalesOrderRequestCustomFieldsType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                custom_fields_type_0 = (
+                    UpdateSalesOrderRequestCustomFieldsType0.from_dict(
+                        cast(Mapping[str, Any], data)
+                    )
                 )
 
-                custom_fields.append(custom_fields_item)
+                return custom_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UpdateSalesOrderRequestCustomFieldsType0, data)
+
+        custom_fields = _parse_custom_fields(d.pop("custom_fields", UNSET))
 
         update_sales_order_request = cls(
             order_no=order_no,

--- a/katana_public_api_client/models/update_sales_order_request_custom_fields_type_0.py
+++ b/katana_public_api_client/models/update_sales_order_request_custom_fields_type_0.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import (
+    define as _attrs_define,
+    field as _attrs_field,
+)
+
+T = TypeVar("T", bound="UpdateSalesOrderRequestCustomFieldsType0")
+
+
+@_attrs_define
+class UpdateSalesOrderRequestCustomFieldsType0:
+    """Custom field values for the sales order, keyed by configured
+    field name. Keys correspond to fields defined for the
+    ``SalesOrder`` entity type on the tenant's
+    ``custom_field_collection`` (see
+    ``GET /custom_fields_collections``). Each value matches the
+    corresponding field's ``CustomFieldType`` (``shortText`` /
+    ``number`` / ``singleSelect`` / ``date`` / ``boolean`` /
+    ``url``). The valid key set is tenant-specific runtime
+    config, so the schema declares ``additionalProperties: true``
+    rather than enumerating keys.
+
+    """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        update_sales_order_request_custom_fields_type_0 = cls()
+
+        update_sales_order_request_custom_fields_type_0.additional_properties = d
+        return update_sales_order_request_custom_fields_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/katana_public_api_client/models/update_sales_order_row_request.py
+++ b/katana_public_api_client/models/update_sales_order_row_request.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
     from ..models.update_sales_order_row_request_attributes_item import (
         UpdateSalesOrderRowRequestAttributesItem,
     )
+    from ..models.update_sales_order_row_request_custom_fields_type_0 import (
+        UpdateSalesOrderRowRequestCustomFieldsType0,
+    )
     from ..models.update_sales_order_row_request_serial_number_transactions_item import (
         UpdateSalesOrderRowRequestSerialNumberTransactionsItem,
     )
@@ -39,8 +42,13 @@ class UpdateSalesOrderRowRequest:
         list[UpdateSalesOrderRowRequestSerialNumberTransactionsItem] | Unset
     ) = UNSET
     attributes: list[UpdateSalesOrderRowRequestAttributesItem] | Unset = UNSET
+    custom_fields: None | Unset | UpdateSalesOrderRowRequestCustomFieldsType0 = UNSET
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.update_sales_order_row_request_custom_fields_type_0 import (
+            UpdateSalesOrderRowRequestCustomFieldsType0,
+        )
+
         variant_id = self.variant_id
 
         quantity = self.quantity
@@ -76,6 +84,16 @@ class UpdateSalesOrderRowRequest:
                 attributes_item = attributes_item_data.to_dict()
                 attributes.append(attributes_item)
 
+        custom_fields: dict[str, Any] | None | Unset
+        if isinstance(self.custom_fields, Unset):
+            custom_fields = UNSET
+        elif isinstance(
+            self.custom_fields, UpdateSalesOrderRowRequestCustomFieldsType0
+        ):
+            custom_fields = self.custom_fields.to_dict()
+        else:
+            custom_fields = self.custom_fields
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
@@ -97,6 +115,8 @@ class UpdateSalesOrderRowRequest:
             field_dict["serial_number_transactions"] = serial_number_transactions
         if attributes is not UNSET:
             field_dict["attributes"] = attributes
+        if custom_fields is not UNSET:
+            field_dict["custom_fields"] = custom_fields
 
         return field_dict
 
@@ -105,6 +125,9 @@ class UpdateSalesOrderRowRequest:
         from ..models.batch_transaction import BatchTransaction
         from ..models.update_sales_order_row_request_attributes_item import (
             UpdateSalesOrderRowRequestAttributesItem,
+        )
+        from ..models.update_sales_order_row_request_custom_fields_type_0 import (
+            UpdateSalesOrderRowRequestCustomFieldsType0,
         )
         from ..models.update_sales_order_row_request_serial_number_transactions_item import (
             UpdateSalesOrderRowRequestSerialNumberTransactionsItem,
@@ -160,6 +183,34 @@ class UpdateSalesOrderRowRequest:
 
                 attributes.append(attributes_item)
 
+        def _parse_custom_fields(
+            data: object,
+        ) -> None | Unset | UpdateSalesOrderRowRequestCustomFieldsType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                custom_fields_type_0 = (
+                    UpdateSalesOrderRowRequestCustomFieldsType0.from_dict(
+                        cast(Mapping[str, Any], data)
+                    )
+                )
+
+                return custom_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                None | Unset | UpdateSalesOrderRowRequestCustomFieldsType0, data
+            )
+
+        custom_fields = _parse_custom_fields(d.pop("custom_fields", UNSET))
+
         update_sales_order_row_request = cls(
             variant_id=variant_id,
             quantity=quantity,
@@ -170,6 +221,7 @@ class UpdateSalesOrderRowRequest:
             batch_transactions=batch_transactions,
             serial_number_transactions=serial_number_transactions,
             attributes=attributes,
+            custom_fields=custom_fields,
         )
 
         return update_sales_order_row_request

--- a/katana_public_api_client/models/update_sales_order_row_request_custom_fields_type_0.py
+++ b/katana_public_api_client/models/update_sales_order_row_request_custom_fields_type_0.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import (
+    define as _attrs_define,
+    field as _attrs_field,
+)
+
+T = TypeVar("T", bound="UpdateSalesOrderRowRequestCustomFieldsType0")
+
+
+@_attrs_define
+class UpdateSalesOrderRowRequestCustomFieldsType0:
+    """Row-level custom field values, keyed by configured field
+    name. Keys correspond to fields defined for the
+    ``SalesOrderRow`` entity type on the tenant's
+    ``custom_field_collection`` (see
+    ``GET /custom_fields_collections``). Each value matches the
+    corresponding field's ``CustomFieldType`` (``shortText`` /
+    ``number`` / ``singleSelect`` / ``date`` / ``boolean`` /
+    ``url``). The valid key set is tenant-specific runtime
+    config, so the schema declares ``additionalProperties: true``
+    rather than enumerating keys.
+
+    """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        update_sales_order_row_request_custom_fields_type_0 = cls()
+
+        update_sales_order_row_request_custom_fields_type_0.additional_properties = d
+        return update_sales_order_row_request_custom_fields_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/katana_public_api_client/models_pydantic/_generated/sales_orders.py
+++ b/katana_public_api_client/models_pydantic/_generated/sales_orders.py
@@ -8,7 +8,7 @@ To regenerate, run:
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field
 from sqlalchemy import Column
@@ -27,7 +27,6 @@ from .common import (
     AddressEntityType,
     Attribute,
     Attribute3,
-    CustomFieldValue,
     ProductAvailability,
 )
 from .purchase_orders import OutsourcedPurchaseOrderIngredientAvailability
@@ -197,6 +196,12 @@ class SalesOrderRow(DeletableEntity):
         AwareDatetime | None,
         Field(description="Date when the currency conversion rate was applied"),
     ] = None
+    custom_fields: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description="Row-level custom field values, keyed by configured field\nname. ``null`` when no values are set on the row; ``{}``\nwhen a collection is bound but no values are set. Keys\ncorrespond to fields defined for the ``SalesOrderRow``\nentity type (``GET /custom_fields_collections``); each\nvalue matches the corresponding field's\n``CustomFieldType`` (``shortText`` / ``number`` /\n``singleSelect`` / ``date`` / ``boolean`` / ``url``).\nThe valid key set is tenant-specific runtime config, so\nthe schema declares ``additionalProperties: true``\nrather than enumerating keys.\n"
+        ),
+    ] = None
 
 
 class SalesOrderAddress(DeletableEntity):
@@ -261,6 +266,12 @@ class CreateSalesOrderRowRequest(KatanaPydanticBase):
         float | None,
         Field(description="Total discount amount applied to this line item"),
     ] = None
+    custom_fields: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description="Row-level custom field values, keyed by configured field\nname. Keys correspond to fields defined for the\n``SalesOrderRow`` entity type on the tenant's\n``custom_field_collection`` (see\n``GET /custom_fields_collections``). Each value matches the\ncorresponding field's ``CustomFieldType`` (``shortText`` /\n``number`` / ``singleSelect`` / ``date`` / ``boolean`` /\n``url``). The valid key set is tenant-specific runtime\nconfig, so the schema declares ``additionalProperties: true``\nrather than enumerating keys.\n"
+        ),
+    ] = None
 
 
 class UpdateSalesOrderRowRequest(KatanaPydanticBase):
@@ -298,6 +309,12 @@ class UpdateSalesOrderRowRequest(KatanaPydanticBase):
     attributes: Annotated[
         list[Attribute] | None,
         Field(description="Custom attributes for this line item"),
+    ] = None
+    custom_fields: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description="Row-level custom field values, keyed by configured field\nname. Keys correspond to fields defined for the\n``SalesOrderRow`` entity type on the tenant's\n``custom_field_collection`` (see\n``GET /custom_fields_collections``). Each value matches the\ncorresponding field's ``CustomFieldType`` (``shortText`` /\n``number`` / ``singleSelect`` / ``date`` / ``boolean`` /\n``url``). The valid key set is tenant-specific runtime\nconfig, so the schema declares ``additionalProperties: true``\nrather than enumerating keys.\n"
+        ),
     ] = None
 
 
@@ -378,10 +395,89 @@ class SalesOrderRow1(KatanaPydanticBase):
         list[Attribute3] | None,
         Field(description="Custom attributes for the order line"),
     ] = None
+    custom_fields: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description="Row-level custom field values, keyed by configured field\nname. Keys correspond to fields defined for the\n``SalesOrderRow`` entity type on the tenant's\n``custom_field_collection`` (see\n``GET /custom_fields_collections``). Each value matches\nthe corresponding field's ``CustomFieldType``\n(``shortText`` / ``number`` / ``singleSelect`` /\n``date`` / ``boolean`` / ``url``). The valid key set is\ntenant-specific runtime config, so the schema declares\n``additionalProperties: true`` rather than enumerating\nkeys.\n"
+        ),
+    ] = None
 
 
 class Address1(SalesOrderAddress):
     pass
+
+
+class CreateSalesOrderRequest(KatanaPydanticBase):
+    order_no: Annotated[
+        str | None,
+        Field(
+            description="Unique order number for tracking and reference. Optional — Katana\nauto-generates a sequential ``SO-N`` value when omitted.\n"
+        ),
+    ] = None
+    customer_id: Annotated[
+        int, Field(description="ID of the customer placing the order")
+    ]
+    sales_order_rows: Annotated[
+        list[SalesOrderRow1],
+        Field(
+            description="List of products and quantities being ordered", min_length=1
+        ),
+    ]
+    tracking_number: Annotated[
+        str | None, Field(description="Shipping tracking number if already known")
+    ] = None
+    tracking_number_url: Annotated[
+        AnyUrl | None, Field(description="URL for tracking shipment status")
+    ] = None
+    addresses: Annotated[
+        list[Address1] | None,
+        Field(description="Billing and shipping addresses for the order"),
+    ] = None
+    order_created_date: Annotated[
+        AwareDatetime | None,
+        Field(
+            description="Date when the order was originally created (defaults to current time)"
+        ),
+    ] = None
+    delivery_date: Annotated[
+        AwareDatetime | None, Field(description="Requested delivery date")
+    ] = None
+    currency: Annotated[
+        str | None,
+        Field(
+            description="Currency code for the order (defaults to company base currency)"
+        ),
+    ] = None
+    location_id: Annotated[
+        int | None, Field(description="Primary fulfillment location for the order")
+    ] = None
+    status: Annotated[
+        CreateSalesOrderStatus | None, Field(description="Initial status of the order")
+    ] = None
+    additional_info: Annotated[
+        str | None, Field(description="Additional notes or instructions for the order")
+    ] = None
+    customer_ref: Annotated[
+        str | None, Field(description="Customer's internal reference number")
+    ] = None
+    ecommerce_order_type: Annotated[
+        str | None, Field(description="Type of ecommerce order if applicable")
+    ] = None
+    ecommerce_store_name: Annotated[
+        str | None,
+        Field(
+            description="Name of the ecommerce store if order originated from online"
+        ),
+    ] = None
+    ecommerce_order_id: Annotated[
+        str | None, Field(description="Original order ID from the ecommerce platform")
+    ] = None
+    custom_fields: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description="Custom field values for the sales order, keyed by configured\nfield name. Keys correspond to fields defined for the\n``SalesOrder`` entity type on the tenant's\n``custom_field_collection`` (see\n``GET /custom_fields_collections``). Each value matches the\ncorresponding field's ``CustomFieldType`` (``shortText`` /\n``number`` / ``singleSelect`` / ``date`` / ``boolean`` /\n``url``). The valid key set is tenant-specific runtime\nconfig, so the schema declares ``additionalProperties: true``\nrather than enumerating keys.\n"
+        ),
+    ] = None
 
 
 class SalesOrderFulfillmentRow(KatanaPydanticBase):
@@ -891,10 +987,9 @@ class UpdateSalesOrderRequest(KatanaPydanticBase):
         ),
     ] = None
     custom_fields: Annotated[
-        list[CustomFieldValue] | None,
+        dict[str, Any] | None,
         Field(
-            description="Custom field values to attach to the sales order. Field names\nmust match those configured for the ``sales_order`` resource\ntype (see ``GET /custom_fields_collections``).\n",
-            max_length=3,
+            description="Custom field values for the sales order, keyed by configured\nfield name. Keys correspond to fields defined for the\n``SalesOrder`` entity type on the tenant's\n``custom_field_collection`` (see\n``GET /custom_fields_collections``). Each value matches the\ncorresponding field's ``CustomFieldType`` (``shortText`` /\n``number`` / ``singleSelect`` / ``date`` / ``boolean`` /\n``url``). The valid key set is tenant-specific runtime\nconfig, so the schema declares ``additionalProperties: true``\nrather than enumerating keys.\n"
         ),
     ] = None
 
@@ -1117,6 +1212,12 @@ class SalesOrder(DeletableEntity):
         list[SalesOrderAddress] | None,
         Field(description="Complete address information for billing and shipping"),
     ] = None
+    custom_fields: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description="Custom field values for the sales order, keyed by\nconfigured field name. ``null`` when the order's\n``custom_field_collection`` is unset; ``{}`` when a\ncollection is bound but no values are set. Keys\ncorrespond to fields defined for the ``SalesOrder``\nentity type (``GET /custom_fields_collections``); each\nvalue matches the corresponding field's\n``CustomFieldType`` (``shortText`` / ``number`` /\n``singleSelect`` / ``date`` / ``boolean`` / ``url``).\nThe valid key set is tenant-specific runtime config, so\nthe schema declares ``additionalProperties: true``\nrather than enumerating keys.\n"
+        ),
+    ] = None
 
 
 class SalesOrderListResponse(KatanaPydanticBase):
@@ -1124,80 +1225,6 @@ class SalesOrderListResponse(KatanaPydanticBase):
         list[SalesOrder] | None,
         Field(
             description="Array of sales orders with complete order details and status information"
-        ),
-    ] = None
-
-
-class CreateSalesOrderRequest(KatanaPydanticBase):
-    order_no: Annotated[
-        str | None,
-        Field(
-            description="Unique order number for tracking and reference. Optional — Katana\nauto-generates a sequential ``SO-N`` value when omitted.\n"
-        ),
-    ] = None
-    customer_id: Annotated[
-        int, Field(description="ID of the customer placing the order")
-    ]
-    sales_order_rows: Annotated[
-        list[SalesOrderRow1],
-        Field(
-            description="List of products and quantities being ordered", min_length=1
-        ),
-    ]
-    tracking_number: Annotated[
-        str | None, Field(description="Shipping tracking number if already known")
-    ] = None
-    tracking_number_url: Annotated[
-        AnyUrl | None, Field(description="URL for tracking shipment status")
-    ] = None
-    addresses: Annotated[
-        list[Address1] | None,
-        Field(description="Billing and shipping addresses for the order"),
-    ] = None
-    order_created_date: Annotated[
-        AwareDatetime | None,
-        Field(
-            description="Date when the order was originally created (defaults to current time)"
-        ),
-    ] = None
-    delivery_date: Annotated[
-        AwareDatetime | None, Field(description="Requested delivery date")
-    ] = None
-    currency: Annotated[
-        str | None,
-        Field(
-            description="Currency code for the order (defaults to company base currency)"
-        ),
-    ] = None
-    location_id: Annotated[
-        int | None, Field(description="Primary fulfillment location for the order")
-    ] = None
-    status: Annotated[
-        CreateSalesOrderStatus | None, Field(description="Initial status of the order")
-    ] = None
-    additional_info: Annotated[
-        str | None, Field(description="Additional notes or instructions for the order")
-    ] = None
-    customer_ref: Annotated[
-        str | None, Field(description="Customer's internal reference number")
-    ] = None
-    ecommerce_order_type: Annotated[
-        str | None, Field(description="Type of ecommerce order if applicable")
-    ] = None
-    ecommerce_store_name: Annotated[
-        str | None,
-        Field(
-            description="Name of the ecommerce store if order originated from online"
-        ),
-    ] = None
-    ecommerce_order_id: Annotated[
-        str | None, Field(description="Original order ID from the ecommerce platform")
-    ] = None
-    custom_fields: Annotated[
-        list[CustomFieldValue] | None,
-        Field(
-            description="Custom field values to attach to the sales order. Field names\nmust match those configured for the ``sales_order`` resource\ntype (see ``GET /custom_fields_collections``).\n",
-            max_length=3,
         ),
     ] = None
 
@@ -1411,6 +1438,13 @@ class CachedSalesOrderRow(DeletableEntity, table=True):
         Mapped[datetime | None],
         Field(description="Date when the currency conversion rate was applied"),
     ] = None
+    custom_fields: Annotated[
+        Mapped[dict[str, Any] | None],
+        SQLField(
+            sa_column=Column(PydanticJSON),
+            description="Row-level custom field values, keyed by configured field\nname. ``null`` when no values are set on the row; ``{}``\nwhen a collection is bound but no values are set. Keys\ncorrespond to fields defined for the ``SalesOrderRow``\nentity type (``GET /custom_fields_collections``); each\nvalue matches the corresponding field's\n``CustomFieldType`` (``shortText`` / ``number`` /\n``singleSelect`` / ``date`` / ``boolean`` / ``url``).\nThe valid key set is tenant-specific runtime config, so\nthe schema declares ``additionalProperties: true``\nrather than enumerating keys.\n",
+        ),
+    ] = None
     sales_order: Mapped[Optional["CachedSalesOrder"]] = Relationship(
         back_populates="sales_order_rows"
     )
@@ -1579,5 +1613,12 @@ class CachedSalesOrder(DeletableEntity, table=True):
         SQLField(
             sa_column=Column(PydanticJSON),
             description="Complete address information for billing and shipping",
+        ),
+    ] = None
+    custom_fields: Annotated[
+        Mapped[dict[str, Any] | None],
+        SQLField(
+            sa_column=Column(PydanticJSON),
+            description="Custom field values for the sales order, keyed by\nconfigured field name. ``null`` when the order's\n``custom_field_collection`` is unset; ``{}`` when a\ncollection is bound but no values are set. Keys\ncorrespond to fields defined for the ``SalesOrder``\nentity type (``GET /custom_fields_collections``); each\nvalue matches the corresponding field's\n``CustomFieldType`` (``shortText`` / ``number`` /\n``singleSelect`` / ``date`` / ``boolean`` / ``url``).\nThe valid key set is tenant-specific runtime config, so\nthe schema declares ``additionalProperties: true``\nrather than enumerating keys.\n",
         ),
     ] = None

--- a/scripts/generate_pydantic_models.py
+++ b/scripts/generate_pydantic_models.py
@@ -262,9 +262,10 @@ class CacheTableSpec:
 CACHE_TABLES: dict[str, CacheTableSpec] = {
     "SalesOrder": CacheTableSpec(
         # ``shipping_fee`` is a single nested object; ``addresses`` is a
-        # list of nested ``SalesOrderAddress``. Both stay JSON because
+        # list of nested ``SalesOrderAddress``. ``custom_fields`` is a
+        # tenant-keyed dict (see #734). All three stay JSON because
         # they're low-signal for the cache's filter workload.
-        json_columns=("shipping_fee", "addresses"),
+        json_columns=("shipping_fee", "addresses", "custom_fields"),
     ),
     "SalesOrderRow": CacheTableSpec(
         json_columns=(
@@ -272,6 +273,7 @@ CACHE_TABLES: dict[str, CacheTableSpec] = {
             "batch_transactions",
             "serial_numbers",
             "serial_number_transactions",
+            "custom_fields",
         ),
     ),
     "StockAdjustment": CacheTableSpec(),

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.80.0"
+version = "0.81.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Closes #734. Reconciles the `custom_fields` shape on `SalesOrder` / `SalesOrderRow` surfaces to match what the live Katana gateway actually accepts and returns: a tenant-keyed object, not the structured `[{field_name, field_value}]` array the local spec previously declared.

**Live-API verification** (production tenant 82932 — full investigation in the issue):

- `POST /sales_orders` row.custom_fields = `{…}` reaches the semantic validator (`Unknown custom field identifier`); array shape is rejected at the schema layer with `must be object`.
- `PATCH /variants/{id}` is the inverse — array required, dict rejected. **Variant family stays array-shape** (existing spec is correct).
- 50/50 production SOs return `custom_fields` as `null` or `{}`, never `[]` — corroborates dict on the read side.

## Spec changes (SO surface only)

- `CreateSalesOrderRequest.custom_fields`: structured array → `type: [object, null], additionalProperties: true`
- `UpdateSalesOrderRequest.custom_fields`: same change
- Added `custom_fields` (dict shape) to `CreateSalesOrderRequest.sales_order_rows[]` inline, `CreateSalesOrderRowRequest`, `UpdateSalesOrderRowRequest`, `SalesOrder` (read), `SalesOrderRow` (read)
- Descriptions document the field-type discipline — keys are validated against the tenant's `custom_field_collection`, values are typed per `CustomFieldType` (`shortText` / `number` / `singleSelect` / `date` / `boolean` / `url`). `additionalProperties: true` is the right OpenAPI choice because the valid key set is tenant-specific runtime config.

## Downstream updates

- Regenerated client + pydantic models (7 new `*_custom_fields_type_0` types)
- `katana_mcp.tools.foundation.sales_orders`: `CreateSalesOrderRequest.custom_fields` is now `dict[str, Any] | None`; payload built via `CreateSalesOrderRequestCustomFieldsType0.from_dict`. Obsolete `SalesOrderCustomField` Pydantic model removed (test updated to match).
- `scripts/generate_pydantic_models.py`: `SalesOrder` / `SalesOrderRow` cache specs declare `custom_fields` as a `json_column` so SQLModel reflection handles the dict.

## Error handling

No new exception types — existing `ValidationError` (422) covers both variants:
- Schema-layer `must be object` → routed through `TypeValidationError` detail subtype → rendered as `Field '.../custom_fields' must be of type: object`
- Semantic `Unknown custom field identifier` → `ValidationError` with empty `validation_errors`, message preserved in `str(exc)`

## Note on the comment crash

The `for x in _custom_fields: NoneType not iterable` traceback on the issue was already fixed in cfe6fef8 / client-v0.64.0 — the parser short-circuits on `data is None` at the top of `_parse_custom_fields`. The reporter is on a pre-v0.64.0 install. Verified clean against `{"custom_fields": null}` locally.

## Breaking change

`CreateSalesOrderRequest.custom_fields` / `UpdateSalesOrderRequest.custom_fields` change from `list[CustomFieldValue]` to a free-key dict type. Any caller previously sending the array shape was already being rejected by the live API with `422 must be object`, so the practical blast radius is the type signature. MCP callers must pass `dict[str, Any]` instead of `list[SalesOrderCustomField]`; `SalesOrderCustomField` has been removed from `katana_mcp.tools.foundation.sales_orders`.

## Test plan

- [x] `uv run poe check` — 3307 passed + 21 browser tests
- [x] `uv run pyright katana_mcp_server/.../sales_orders.py` — 0 errors
- [x] Round-trip test on the MCP boundary: `dict[str, str]` → `CreateSalesOrderRequestCustomFieldsType0.from_dict(...).to_dict()` returns the same dict
- [x] Live-API write probes (SDT-tagged, cleaned up via `spec_drift_verify cleanup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)