### PR TITLE
fix(mcp): land MO header status transitions in lock-safe order (#773)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -2876,7 +2876,8 @@ async def _modify_manufacturing_order_impl(
     # edits return 422. Landing the header first would close the MO before
     # the row edits run, causing partial failure with potential data loss
     # (#773). Conversely, reopening (closed → IN_PROGRESS) must happen first
-    # so the subsequent row edits can take effect. See ``_status_lock_phase``.
+    # so the subsequent row edits can take effect. See ``_classify_status_transition``
+    # and ``_HeaderPhase``.
     header_action: ActionSpec | None = None
     header_phase: _HeaderPhase = _HeaderPhase.FIRST
     if request.update_header is not None:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -2758,6 +2758,87 @@ def _build_update_production_request(
 
 
 # ----------------------------------------------------------------------------
+# Status-transition classification (#773)
+# ----------------------------------------------------------------------------
+
+
+class _HeaderPhase(StrEnum):
+    """When to land the ``update_header`` ActionSpec relative to row edits.
+
+    Katana locks an MO once it reaches a "closed" status — further edits to
+    recipe rows / operation rows / productions fail with
+    ``"You can not modify manufacturing order with status done"`` (422).
+    The plan builder reorders the header action to match the lock state:
+
+    - ``FIRST`` — header lands before row edits. Used when the header makes
+      no status change, the change is between two open states (open→open),
+      or it unlocks the MO (closed→open) so subsequent row edits succeed.
+    - ``LAST`` — header lands after all row edits. Used when the header
+      transitions an open MO into a closed/locked state (open→closed) so
+      row edits land while the MO is still editable.
+
+    Closed/locking statuses come from ``_reopen.MO_CLOSED_STATUSES``
+    (``DONE`` + ``PARTIALLY_COMPLETED``) so the lock-state taxonomy stays
+    in one place across the modify and ``correct_manufacturing_order`` paths.
+    """
+
+    FIRST = "first"
+    LAST = "last"
+
+
+def _classify_status_transition(
+    existing_mo: ManufacturingOrder | None,
+    target_status_literal: ManufacturingOrderStatusLiteral | None,
+) -> _HeaderPhase:
+    """Decide whether the header action lands first or last in the plan.
+
+    Args:
+        existing_mo: The pre-fetched MO (``None`` if the fetch failed —
+            treated as "current state unknown", which falls through to FIRST).
+        target_status_literal: The target status from ``update_header.status``,
+            or ``None`` if the patch doesn't touch status.
+
+    Returns:
+        ``_HeaderPhase.LAST`` only when the transition is from an open
+        (editable) state to a closed (locking) state. All other shapes —
+        no status change, target unknown, current state unknown, unlocking
+        transition, open→open, closed→closed — return ``_HeaderPhase.FIRST``
+        (the historical behavior).
+    """
+    # Lazy import — ``MO_CLOSED_STATUSES`` lives in ``_reopen`` (which already
+    # imports from this module's ``ManufacturingOrderStatus``), so eagerly
+    # importing it at module top would create a circular pair if either side
+    # ever grows another shared import.
+    from katana_mcp.tools._reopen import MO_CLOSED_STATUSES
+
+    if target_status_literal is None:
+        # Header patch with no status field — locking state can't change.
+        return _HeaderPhase.FIRST
+
+    target_locks = target_status_literal in MO_CLOSED_STATUSES
+
+    if existing_mo is None:
+        # Pre-fetch failed; we can't tell if this is open→closed. Fall back
+        # to the historical "first" placement — the worst case is the
+        # caller sees the existing partial-failure shape (the bug #773
+        # describes), which is no regression from the pre-fix behavior.
+        return _HeaderPhase.FIRST
+
+    current_status_enum = unwrap_unset(existing_mo.status, None)
+    current_status = (
+        current_status_enum.value if current_status_enum is not None else None
+    )
+    current_locked = current_status in MO_CLOSED_STATUSES
+
+    # Only open→closed needs to land LAST. closed→open ("reopen") must land
+    # FIRST so row edits can take effect; open→open and closed→closed are
+    # both safe to land FIRST (no lock-state change).
+    if target_locks and not current_locked:
+        return _HeaderPhase.LAST
+    return _HeaderPhase.FIRST
+
+
+# ----------------------------------------------------------------------------
 # Implementation
 # ----------------------------------------------------------------------------
 
@@ -2765,7 +2846,15 @@ def _build_update_production_request(
 async def _modify_manufacturing_order_impl(
     request: ModifyManufacturingOrderRequest, context: Context
 ) -> ModificationResponse:
-    """Build the action plan from sub-payloads and either preview or execute."""
+    """Build the action plan from sub-payloads and either preview or execute.
+
+    Header actions are reordered relative to row/operation/production edits
+    based on the status transition (#773): an open→closed transition (e.g.
+    → ``DONE``) lands LAST so row edits run while the MO is still editable;
+    a closed→open transition (reopen) lands FIRST so subsequent edits aren't
+    blocked by the locked state. All other shapes land FIRST as before. See
+    :class:`_HeaderPhase` and :func:`_classify_status_transition`.
+    """
     services = get_services(context)
 
     if not has_any_subpayload(request):
@@ -2781,25 +2870,38 @@ async def _modify_manufacturing_order_impl(
 
     plan: list[ActionSpec] = []
 
+    # Build the header ActionSpec separately so we can choose where in the plan
+    # it lands based on the status transition. Katana locks an MO once it
+    # reaches a "closed" status (DONE / PARTIALLY_COMPLETED) — further row
+    # edits return 422. Landing the header first would close the MO before
+    # the row edits run, causing partial failure with potential data loss
+    # (#773). Conversely, reopening (closed → IN_PROGRESS) must happen first
+    # so the subsequent row edits can take effect. See ``_status_lock_phase``.
+    header_action: ActionSpec | None = None
+    header_phase: _HeaderPhase = _HeaderPhase.FIRST
     if request.update_header is not None:
         diff = compute_field_diff(
             existing_mo, request.update_header, unknown_prior=existing_mo is None
         )
-        plan.append(
-            ActionSpec(
-                operation=MOOperation.UPDATE_HEADER,
-                target_id=request.id,
-                diff=diff,
-                apply=make_patch_apply(
-                    api_update_manufacturing_order,
-                    services,
-                    request.id,
-                    _build_update_header_request(request.update_header, existing_mo),
-                    return_type=ManufacturingOrder,
-                ),
-                verify=make_response_verifier(diff),
-            )
+        header_action = ActionSpec(
+            operation=MOOperation.UPDATE_HEADER,
+            target_id=request.id,
+            diff=diff,
+            apply=make_patch_apply(
+                api_update_manufacturing_order,
+                services,
+                request.id,
+                _build_update_header_request(request.update_header, existing_mo),
+                return_type=ManufacturingOrder,
+            ),
+            verify=make_response_verifier(diff),
         )
+        header_phase = _classify_status_transition(
+            existing_mo, request.update_header.status
+        )
+
+    if header_action is not None and header_phase is _HeaderPhase.FIRST:
+        plan.append(header_action)
 
     # Recipe rows.
     plan.extend(
@@ -2911,6 +3013,12 @@ async def _modify_manufacturing_order_impl(
             lambda pid: make_delete_apply(api_delete_mo_production, services, pid),
         )
     )
+
+    # Locking-status transitions (e.g. → DONE) must land after all row edits,
+    # otherwise Katana rejects them with "You can not modify manufacturing
+    # order with status done" and the operator gets a partial apply (#773).
+    if header_action is not None and header_phase is _HeaderPhase.LAST:
+        plan.append(header_action)
 
     return await run_modify_plan(
         request=request,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -3015,9 +3015,12 @@ async def _modify_manufacturing_order_impl(
         )
     )
 
-    # Locking-status transitions (e.g. → DONE) must land after all row edits,
-    # otherwise Katana rejects them with "You can not modify manufacturing
-    # order with status done" and the operator gets a partial apply (#773).
+    # Locking-status transitions (e.g. → DONE) must land after all row edits.
+    # The header transition itself succeeds, but it closes/locks the MO — so
+    # any subsequent row/operation/production edits get rejected with "You
+    # can not modify manufacturing order with status done", leaving the
+    # operator with a partial apply (#773). Sequencing the locking transition
+    # last keeps the row edits landing while the MO is still editable.
     if header_action is not None and header_phase is _HeaderPhase.LAST:
         plan.append(header_action)
 

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -2870,6 +2870,435 @@ async def test_modify_mo_canonical_order_across_all_three_sub_resources():
 
 
 # ============================================================================
+# #773: action-order swap for lock-state-changing header transitions
+# ============================================================================
+#
+# Katana locks an MO once it reaches ``DONE`` / ``PARTIALLY_COMPLETED`` —
+# subsequent row edits fail with ``"You can not modify manufacturing order
+# with status done"``. The plan builder reorders the ``update_header``
+# ActionSpec so locking transitions (open→DONE) land LAST and unlocking
+# transitions (DONE→IN_PROGRESS) land FIRST. Non-status changes stay first.
+
+
+_MODIFY_MO_RECIPE_UPDATE = (
+    "katana_public_api_client.api.manufacturing_order_recipe."
+    "update_manufacturing_order_recipe_rows"
+)
+
+
+def _mock_mo_with_status(
+    mo_id: int = 42, order_no: str = "MO-1", *, status: ManufacturingOrderStatus
+):
+    """Build a mock MO with an explicit status (rest of fields UNSET)."""
+    return mock_entity_for_modify(
+        ManufacturingOrder, id=mo_id, order_no=order_no, status=status
+    )
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_locking_transition_lands_header_last():
+    """#773: ``update_header={status: DONE}`` + ``update_recipe_rows`` in one
+    call must apply recipe edits BEFORE the header. Otherwise Katana locks
+    the MO and the recipe row write fails with the row silently dropped."""
+    context, _ = create_mock_context()
+    # Existing MO is IN_PROGRESS — caller wants to close it.
+    existing = _mock_mo_with_status(
+        mo_id=42, status=ManufacturingOrderStatus.IN_PROGRESS
+    )
+    updated = _mock_mo_with_status(mo_id=42, status=ManufacturingOrderStatus.DONE)
+    updated_row = MagicMock()
+    updated_row.id = 555
+
+    call_log: list[str] = []
+
+    async def fake_update_mo(*, id, client, body):
+        call_log.append("update_header")
+        resp = MagicMock()
+        resp.parsed = updated
+        return resp
+
+    async def fake_update_recipe(*, id, client, body):
+        call_log.append("update_recipe_row")
+        resp = MagicMock()
+        resp.parsed = updated_row
+        return resp
+
+    existing_row = MagicMock()
+    existing_row.id = 555
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_mo_recipe_row",
+            new_callable=AsyncMock,
+            return_value=existing_row,
+        ),
+        patch(f"{_MODIFY_MO_UPDATE}.asyncio_detailed", side_effect=fake_update_mo),
+        patch(
+            f"{_MODIFY_MO_RECIPE_UPDATE}.asyncio_detailed",
+            side_effect=fake_update_recipe,
+        ),
+        patch(_MODIFY_MO_UNWRAP_AS, side_effect=[updated_row, updated]),
+    ):
+        from katana_mcp.tools.foundation.manufacturing_orders import MORecipeRowUpdate
+
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            update_recipe_rows=[
+                MORecipeRowUpdate(id=555, planned_quantity_per_unit=3.0)
+            ],
+            update_header=MOHeaderPatch(status="DONE"),
+            preview=False,
+        )
+        response = await _modify_manufacturing_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert all(a.succeeded is True for a in response.actions)
+    # CRITICAL: recipe row edit ran BEFORE header close — otherwise Katana
+    # would have rejected the row PATCH with the "status done" 422.
+    assert call_log == ["update_recipe_row", "update_header"]
+    # Plan order matches the call order: row first, header last.
+    assert [a.operation for a in response.actions] == [
+        "update_recipe_row",
+        "update_header",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_locking_transition_preview_orders_actions_correctly():
+    """#773: preview path also reorders so the operator sees the actual
+    execution order before confirming."""
+    context, _ = create_mock_context()
+    existing = _mock_mo_with_status(
+        mo_id=42, status=ManufacturingOrderStatus.IN_PROGRESS
+    )
+    existing_row = MagicMock()
+    existing_row.id = 555
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_mo_recipe_row",
+            new_callable=AsyncMock,
+            return_value=existing_row,
+        ),
+    ):
+        from katana_mcp.tools.foundation.manufacturing_orders import MORecipeRowUpdate
+
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            update_recipe_rows=[
+                MORecipeRowUpdate(id=555, planned_quantity_per_unit=3.0)
+            ],
+            update_header=MOHeaderPatch(status="DONE"),
+            preview=True,
+        )
+        response = await _modify_manufacturing_order_impl(request, context)
+
+    assert response.is_preview is True
+    assert [a.operation for a in response.actions] == [
+        "update_recipe_row",
+        "update_header",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_unlocking_transition_lands_header_first():
+    """#773: ``update_header={status: IN_PROGRESS}`` (reopen from DONE) +
+    ``update_recipe_rows`` — header must land FIRST so Katana unlocks the MO
+    before the row edit attempts to land. Current behavior preserved."""
+    context, _ = create_mock_context()
+    # Existing MO is DONE — caller wants to reopen and edit.
+    existing = _mock_mo_with_status(mo_id=42, status=ManufacturingOrderStatus.DONE)
+    updated = _mock_mo_with_status(
+        mo_id=42, status=ManufacturingOrderStatus.IN_PROGRESS
+    )
+    updated_row = MagicMock()
+    updated_row.id = 555
+    existing_row = MagicMock()
+    existing_row.id = 555
+
+    call_log: list[str] = []
+
+    async def fake_update_mo(*, id, client, body):
+        call_log.append("update_header")
+        resp = MagicMock()
+        resp.parsed = updated
+        return resp
+
+    async def fake_update_recipe(*, id, client, body):
+        call_log.append("update_recipe_row")
+        resp = MagicMock()
+        resp.parsed = updated_row
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_mo_recipe_row",
+            new_callable=AsyncMock,
+            return_value=existing_row,
+        ),
+        patch(f"{_MODIFY_MO_UPDATE}.asyncio_detailed", side_effect=fake_update_mo),
+        patch(
+            f"{_MODIFY_MO_RECIPE_UPDATE}.asyncio_detailed",
+            side_effect=fake_update_recipe,
+        ),
+        patch(_MODIFY_MO_UNWRAP_AS, side_effect=[updated, updated_row]),
+    ):
+        from katana_mcp.tools.foundation.manufacturing_orders import MORecipeRowUpdate
+
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            update_header=MOHeaderPatch(status="IN_PROGRESS"),
+            update_recipe_rows=[
+                MORecipeRowUpdate(id=555, planned_quantity_per_unit=3.0)
+            ],
+            preview=False,
+        )
+        response = await _modify_manufacturing_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert all(a.succeeded is True for a in response.actions)
+    # Header reopens MO first, then row edit lands while MO is editable.
+    assert call_log == ["update_header", "update_recipe_row"]
+    assert [a.operation for a in response.actions] == [
+        "update_header",
+        "update_recipe_row",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_locking_status_only_no_row_edits_still_works():
+    """#773: pure status→DONE with no row edits keeps working — the reorder
+    is a no-op since there are no row actions to land before the header."""
+    context, _ = create_mock_context()
+    existing = _mock_mo_with_status(
+        mo_id=42, status=ManufacturingOrderStatus.IN_PROGRESS
+    )
+    updated = _mock_mo_with_status(mo_id=42, status=ManufacturingOrderStatus.DONE)
+
+    async def fake_update_mo(*, id, client, body):
+        resp = MagicMock()
+        resp.parsed = updated
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(f"{_MODIFY_MO_UPDATE}.asyncio_detailed", side_effect=fake_update_mo),
+        patch(_MODIFY_MO_UNWRAP_AS, return_value=updated),
+    ):
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            update_header=MOHeaderPatch(status="DONE"),
+            preview=False,
+        )
+        response = await _modify_manufacturing_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "update_header"
+    assert response.actions[0].succeeded is True
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_row_edits_without_header_unchanged_behavior():
+    """#773: pure row edits with no header sub-payload stay where they are —
+    the reorder logic only fires when ``update_header`` is set."""
+    context, _ = create_mock_context()
+    existing = _mock_mo_with_status(
+        mo_id=42, status=ManufacturingOrderStatus.IN_PROGRESS
+    )
+    updated_row = MagicMock()
+    updated_row.id = 555
+    existing_row = MagicMock()
+    existing_row.id = 555
+
+    async def fake_update_recipe(*, id, client, body):
+        resp = MagicMock()
+        resp.parsed = updated_row
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_mo_recipe_row",
+            new_callable=AsyncMock,
+            return_value=existing_row,
+        ),
+        patch(
+            f"{_MODIFY_MO_RECIPE_UPDATE}.asyncio_detailed",
+            side_effect=fake_update_recipe,
+        ),
+        patch(_MODIFY_MO_UNWRAP_AS, return_value=updated_row),
+    ):
+        from katana_mcp.tools.foundation.manufacturing_orders import MORecipeRowUpdate
+
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            update_recipe_rows=[
+                MORecipeRowUpdate(id=555, planned_quantity_per_unit=3.0)
+            ],
+            preview=False,
+        )
+        response = await _modify_manufacturing_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert len(response.actions) == 1
+    assert response.actions[0].operation == "update_recipe_row"
+    assert response.actions[0].succeeded is True
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_non_status_header_change_lands_first():
+    """#773: header changes that don't touch ``status`` (e.g. order_no rename)
+    keep landing FIRST — they can't change the lock state."""
+    context, _ = create_mock_context()
+    existing = _mock_mo_with_status(
+        mo_id=42, status=ManufacturingOrderStatus.IN_PROGRESS
+    )
+    updated = _mock_mo_with_status(
+        mo_id=42, order_no="MO-RENAMED", status=ManufacturingOrderStatus.IN_PROGRESS
+    )
+    updated_row = MagicMock()
+    updated_row.id = 555
+    existing_row = MagicMock()
+    existing_row.id = 555
+
+    call_log: list[str] = []
+
+    async def fake_update_mo(*, id, client, body):
+        call_log.append("update_header")
+        resp = MagicMock()
+        resp.parsed = updated
+        return resp
+
+    async def fake_update_recipe(*, id, client, body):
+        call_log.append("update_recipe_row")
+        resp = MagicMock()
+        resp.parsed = updated_row
+        return resp
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_mo_recipe_row",
+            new_callable=AsyncMock,
+            return_value=existing_row,
+        ),
+        patch(f"{_MODIFY_MO_UPDATE}.asyncio_detailed", side_effect=fake_update_mo),
+        patch(
+            f"{_MODIFY_MO_RECIPE_UPDATE}.asyncio_detailed",
+            side_effect=fake_update_recipe,
+        ),
+        patch(_MODIFY_MO_UNWRAP_AS, side_effect=[updated, updated_row]),
+    ):
+        from katana_mcp.tools.foundation.manufacturing_orders import MORecipeRowUpdate
+
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            update_header=MOHeaderPatch(order_no="MO-RENAMED"),
+            update_recipe_rows=[
+                MORecipeRowUpdate(id=555, planned_quantity_per_unit=3.0)
+            ],
+            preview=False,
+        )
+        response = await _modify_manufacturing_order_impl(request, context)
+
+    assert all(a.succeeded is True for a in response.actions)
+    assert call_log == ["update_header", "update_recipe_row"]
+
+
+def test_classify_status_transition_open_to_locked_returns_last():
+    """Unit-level coverage of the lock-state classifier."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        _classify_status_transition,
+        _HeaderPhase,
+    )
+
+    existing = _mock_mo_with_status(status=ManufacturingOrderStatus.IN_PROGRESS)
+    assert _classify_status_transition(existing, "DONE") is _HeaderPhase.LAST
+    assert (
+        _classify_status_transition(existing, "PARTIALLY_COMPLETED")
+        is _HeaderPhase.LAST
+    )
+
+
+def test_classify_status_transition_locked_to_open_returns_first():
+    """Reopen / closed→open lands FIRST so subsequent edits aren't blocked."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        _classify_status_transition,
+        _HeaderPhase,
+    )
+
+    existing = _mock_mo_with_status(status=ManufacturingOrderStatus.DONE)
+    assert _classify_status_transition(existing, "IN_PROGRESS") is _HeaderPhase.FIRST
+    assert _classify_status_transition(existing, "NOT_STARTED") is _HeaderPhase.FIRST
+
+
+def test_classify_status_transition_no_status_change_returns_first():
+    """Header patches without a ``status`` field can't change the lock state."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        _classify_status_transition,
+        _HeaderPhase,
+    )
+
+    existing = _mock_mo_with_status(status=ManufacturingOrderStatus.IN_PROGRESS)
+    assert _classify_status_transition(existing, None) is _HeaderPhase.FIRST
+
+
+def test_classify_status_transition_unknown_existing_falls_back_to_first():
+    """Pre-fetch failure can't be told apart from closed→open — default to
+    the historical FIRST placement (no regression from pre-fix behavior)."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        _classify_status_transition,
+        _HeaderPhase,
+    )
+
+    assert _classify_status_transition(None, "DONE") is _HeaderPhase.FIRST
+
+
+def test_classify_status_transition_locked_to_locked_returns_first():
+    """DONE → PARTIALLY_COMPLETED (or vice versa) doesn't change the lock
+    state, so it's safe to land FIRST. Katana may still reject the transition
+    itself server-side, but the plan-builder shouldn't be the one to fail."""
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        _classify_status_transition,
+        _HeaderPhase,
+    )
+
+    existing = _mock_mo_with_status(status=ManufacturingOrderStatus.DONE)
+    assert (
+        _classify_status_transition(existing, "PARTIALLY_COMPLETED")
+        is _HeaderPhase.FIRST
+    )
+
+
+# ============================================================================
 # #505 follow-on: PATCH-wipe `additional_info` workaround on MOs
 # ============================================================================
 #


### PR DESCRIPTION
## Summary

When `modify_manufacturing_order` mixed `update_header={status: "DONE", ...}` with `update_recipe_rows` / `update_operation_rows` / `update_productions` in one call, the planner applied the header first. Katana locked the MO, and the subsequent row edits failed with `"You can not modify manufacturing order with status done"`. **The header succeeded; the row edits silently dropped** — leaving the MO closed with no record of the intended ingredient changes.

## Reproduction

```python
modify_manufacturing_order(
    id=16332895,
    update_recipe_rows=[{id: 96724613, variant_id: <new fork SKU>}],
    update_header={status: "DONE", done_date: "..."},
    preview=False,
)
# Before: header APPLIED, recipe row FAILED ("You can not modify ... done"),
#         MO ends up DONE with a dropped row.
# After:  recipe row APPLIED first while MO is still editable, then header
#         closes it. Both succeed atomically.
```

## Option chosen: 1 — topological reorder

Pick rationale (option 1 in the issue, in increasing strictness): the lock taxonomy is finite and already encoded in `_reopen.MO_CLOSED_STATUSES` (`DONE` + `PARTIALLY_COMPLETED`), and option 1 supports both `close-with-edits` and `reopen-and-edit` in a single call. Option 3 (preview-time reject) would force callers to split into two round-trips even when the order can be made safe automatically. Option 2 (transactional rollback) is more complex than this surface needs.

The classifier `_classify_status_transition(existing_mo, target_status)` returns:
- **`LAST`** — open→closed (locking). Row edits run first while editable; header closes the MO last.
- **`FIRST`** — every other shape: closed→open (reopen), open→open, closed→closed, no status change, or pre-fetch failure. Preserves the historical placement so `reopen → edit` keeps working.

`MO_CLOSED_STATUSES` is the single source of truth for which statuses lock — the modify path and `correct_manufacturing_order` agree on the taxonomy.

## Test plan

- [x] `update_recipe_rows + update_header={status: "DONE"}` lands recipe edits BEFORE header close (the #773 repro). New: `test_modify_mo_locking_transition_lands_header_last`.
- [x] Preview path reorders identically. New: `test_modify_mo_locking_transition_preview_orders_actions_correctly`.
- [x] `update_header={status: "IN_PROGRESS"}` (reopen) + `update_recipe_rows` lands header FIRST. New: `test_modify_mo_unlocking_transition_lands_header_first`.
- [x] `update_header={status: "DONE"}` alone (no row edits) still works. New: `test_modify_mo_locking_status_only_no_row_edits_still_works`.
- [x] Pure row edits (no header) unchanged. New: `test_modify_mo_row_edits_without_header_unchanged_behavior`.
- [x] Header with no status change (e.g. `order_no` rename) keeps landing FIRST. New: `test_modify_mo_non_status_header_change_lands_first`.
- [x] Unit-level coverage of the classifier across all 5 lock-state combinations.
- [x] `uv run poe check` — all 3316 tests pass.

## Adjacent

- **#518** — `MORecipeRowAdd` / `MORecipeRowUpdate` drop `batch_transactions`. Different data-loss class (field-set drift on the wire model, not action ordering). Already fixed.
- **#487** — `extra="forbid"` on MCP patch models. Defense-in-depth against a different drift class.

These don't address the action-ordering or partial-failure-recovery story; this PR completes the close-with-edits workflow in one round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)