### PR TITLE
fix(client)!: create_sales_order addresses payload (three-layer fix)

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -9221,11 +9221,51 @@ components:
           description: URL for tracking shipment status
         addresses:
           type: array
-          description: Billing and shipping addresses for the order
+          description: |
+            Billing and shipping addresses for the order. Inline-create shape —
+            ``sales_order_id`` is implicit (set by the parent sales-order create)
+            and server-assigned fields (``id`` / ``sales_order_id``) are rejected
+            by the live API on this endpoint. For the standalone create endpoint
+            (``POST /sales_order_addresses``) see ``CreateSalesOrderAddressRequest``.
           items:
-            $ref: "#/components/schemas/SalesOrderAddress"
+            type: object
+            additionalProperties: false
             required:
               - entity_type
+            properties:
+              entity_type:
+                description: Whether this address is the shipping or billing address for the sales order
+                $ref: "#/components/schemas/AddressEntityType"
+              first_name:
+                type: string
+                description: First name for the address contact
+              last_name:
+                type: string
+                description: Last name for the address contact
+              company:
+                type: string
+                description: Company name for the address
+              line_1:
+                type: string
+                description: Primary address line
+              line_2:
+                type: string
+                description: Secondary address line
+              city:
+                type: string
+                description: City name
+              state:
+                type: string
+                description: State or province
+              zip:
+                type: string
+                description: Postal code
+              country:
+                type: string
+                description: Country code
+              phone:
+                type: string
+                description: Contact phone number
         order_created_date:
           type:
             - string
@@ -9311,9 +9351,7 @@ components:
         tracking_number: null
         tracking_number_url: null
         addresses:
-          - id: 1
-            sales_order_id: 2001
-            entity_type: billing
+          - entity_type: billing
             first_name: David
             last_name: Wilson
             company: Wilson's Catering
@@ -9322,9 +9360,7 @@ components:
             state: WA
             zip: "98101"
             country: US
-          - id: 2
-            sales_order_id: 2001
-            entity_type: shipping
+          - entity_type: shipping
             first_name: David
             last_name: Wilson
             company: Wilson's Catering

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -190,7 +190,7 @@ class SalesOrderAddress(BaseModel):
 
     Field names mirror the wire format — ``zip`` (not ``zip_code``) matches
     what ``get_sales_order`` returns and what the Katana API accepts on
-    inline create. The attrs-side wire field is ``zip_`` (Python-keyword
+    inline create. The attrs-side wire field is ``zip_`` (builtin-name
     avoidance, JSON name ``zip``); the field name here intentionally shadows
     the ``zip()`` builtin within this model scope to keep the JSON contract
     transparent for callers.

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -103,6 +103,7 @@ from katana_public_api_client.models import (
     CreateSalesOrderAddressRequest as APICreateSOAddressRequest,
     CreateSalesOrderFulfillmentRequest as APICreateSOFulfillmentRequest,
     CreateSalesOrderRequest as APICreateSalesOrderRequest,
+    CreateSalesOrderRequestAddressesItem as APICreateSORequestAddressesItem,
     CreateSalesOrderRequestCustomFieldsType0 as APISOCustomFieldsMap,
     CreateSalesOrderRequestSalesOrderRowsItem,
     CreateSalesOrderRequestSalesOrderRowsItemAttributesItem as APISORowAttributeItem,
@@ -185,7 +186,15 @@ class SalesOrderItem(BaseModel):
 
 
 class SalesOrderAddress(BaseModel):
-    """Billing or shipping address for a sales order."""
+    """Billing or shipping address for a sales order.
+
+    Field names mirror the wire format — ``zip`` (not ``zip_code``) matches
+    what ``get_sales_order`` returns and what the Katana API accepts on
+    inline create. The attrs-side wire field is ``zip_`` (Python-keyword
+    avoidance, JSON name ``zip``); the field name here intentionally shadows
+    the ``zip()`` builtin within this model scope to keep the JSON contract
+    transparent for callers.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -200,7 +209,7 @@ class SalesOrderAddress(BaseModel):
     line_2: str | None = Field(default=None, description="Secondary address line")
     city: str | None = Field(default=None, description="City")
     state: str | None = Field(default=None, description="State or province")
-    zip_code: str | None = Field(default=None, description="Postal/ZIP code")
+    zip: str | None = Field(default=None, description="Postal/ZIP code")
     country: str | None = Field(
         default=None, description="Country code (e.g., US, CA, GB)"
     )
@@ -416,14 +425,14 @@ async def _create_sales_order_impl(
             )
             so_rows.append(row)
 
-        # Build addresses if provided
-        addresses_list: list[APISalesOrderAddress] | Unset = UNSET
+        # Build addresses if provided. Use the inline write-shaped DTO (no
+        # ``id`` / ``sales_order_id`` — those are server-assigned and rejected
+        # by the live API on inline create). See #772.
+        addresses_list: list[APICreateSORequestAddressesItem] | Unset = UNSET
         if request.addresses:
             addresses_list = []
             for addr in request.addresses:
-                api_addr = APISalesOrderAddress(
-                    id=0,  # Will be assigned by API
-                    sales_order_id=0,  # Will be assigned by API
+                api_addr = APICreateSORequestAddressesItem(
                     entity_type=AddressEntityType(addr.entity_type),
                     first_name=to_unset(addr.first_name),
                     last_name=to_unset(addr.last_name),
@@ -433,7 +442,7 @@ async def _create_sales_order_impl(
                     line_2=to_unset(addr.line_2),
                     city=to_unset(addr.city),
                     state=to_unset(addr.state),
-                    zip_=to_unset(addr.zip_code),
+                    zip_=to_unset(addr.zip),
                     country=to_unset(addr.country),
                 )
                 addresses_list.append(api_addr)

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -383,7 +383,7 @@ async def test_create_sales_order_with_addresses():
                     line_1="123 Main St",
                     city="Portland",
                     state="OR",
-                    zip_code="97201",
+                    zip="97201",
                     country="US",
                 ),
                 SalesOrderAddress(
@@ -393,7 +393,7 @@ async def test_create_sales_order_with_addresses():
                     line_1="456 Oak Ave",
                     city="Seattle",
                     state="WA",
-                    zip_code="98101",
+                    zip="98101",
                     country="US",
                 ),
             ],
@@ -411,6 +411,20 @@ async def test_create_sales_order_with_addresses():
         api_request = call_kwargs["body"]
         assert not isinstance(api_request.addresses, type(UNSET))
         assert len(api_request.addresses) == 2
+
+        # Outbound wire body must serialize ``zip`` (not ``zip_code``) and
+        # must NOT contain server-assigned ``id`` / ``sales_order_id`` fields
+        # — those are rejected by the live API on inline create (#772).
+        api_body_dict = api_request.to_dict()
+        for addr_dict in api_body_dict["addresses"]:
+            assert "zip" in addr_dict, "wire field must be 'zip', not 'zip_code'"
+            assert "zip_code" not in addr_dict
+            assert "id" not in addr_dict, "server-assigned 'id' must not be sent"
+            assert "sales_order_id" not in addr_dict, (
+                "server-assigned 'sales_order_id' must not be sent"
+            )
+        assert api_body_dict["addresses"][0]["zip"] == "97201"
+        assert api_body_dict["addresses"][1]["zip"] == "98101"
     finally:
         create_so_module.asyncio_detailed = original_asyncio_detailed
 

--- a/katana_public_api_client/api/sales_order/create_sales_order.py
+++ b/katana_public_api_client/api/sales_order/create_sales_order.py
@@ -86,18 +86,16 @@ def sync_detailed(
             [{'quantity': 3, 'variant_id': 2101, 'tax_rate_id': 301, 'location_id': 1,
             'price_per_unit': 599.99, 'total_discount': 50.0, 'attributes': [{'key': 'engrave_text',
             'value': 'Professional Kitchen'}, {'key': 'rush_order', 'value': 'true'}]}],
-            'tracking_number': None, 'tracking_number_url': None, 'addresses': [{'id': 1,
-            'sales_order_id': 2001, 'entity_type': 'billing', 'first_name': 'David', 'last_name':
-            'Wilson', 'company': "Wilson's Catering", 'line_1': '456 Commerce Ave', 'city': 'Seattle',
-            'state': 'WA', 'zip': '98101', 'country': 'US'}, {'id': 2, 'sales_order_id': 2001,
-            'entity_type': 'shipping', 'first_name': 'David', 'last_name': 'Wilson', 'company':
-            "Wilson's Catering", 'line_1': '789 Industrial Blvd', 'city': 'Seattle', 'state': 'WA',
-            'zip': '98102', 'country': 'US'}], 'order_created_date': '2024-01-16T09:00:00Z',
-            'delivery_date': '2024-01-23T15:00:00Z', 'currency': 'USD', 'location_id': 1, 'status':
-            'PENDING', 'additional_info': 'Customer prefers morning delivery', 'customer_ref': 'WC-
-            ORDER-2024-003', 'ecommerce_order_type': 'wholesale', 'ecommerce_store_name': 'B2B
-            Portal', 'ecommerce_order_id': 'B2B-7891-2024'}.
-
+            'tracking_number': None, 'tracking_number_url': None, 'addresses': [{'entity_type':
+            'billing', 'first_name': 'David', 'last_name': 'Wilson', 'company': "Wilson's Catering",
+            'line_1': '456 Commerce Ave', 'city': 'Seattle', 'state': 'WA', 'zip': '98101', 'country':
+            'US'}, {'entity_type': 'shipping', 'first_name': 'David', 'last_name': 'Wilson',
+            'company': "Wilson's Catering", 'line_1': '789 Industrial Blvd', 'city': 'Seattle',
+            'state': 'WA', 'zip': '98102', 'country': 'US'}], 'order_created_date':
+            '2024-01-16T09:00:00Z', 'delivery_date': '2024-01-23T15:00:00Z', 'currency': 'USD',
+            'location_id': 1, 'status': 'PENDING', 'additional_info': 'Customer prefers morning
+            delivery', 'customer_ref': 'WC-ORDER-2024-003', 'ecommerce_order_type': 'wholesale',
+            'ecommerce_store_name': 'B2B Portal', 'ecommerce_order_id': 'B2B-7891-2024'}.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -135,18 +133,16 @@ def sync(
             [{'quantity': 3, 'variant_id': 2101, 'tax_rate_id': 301, 'location_id': 1,
             'price_per_unit': 599.99, 'total_discount': 50.0, 'attributes': [{'key': 'engrave_text',
             'value': 'Professional Kitchen'}, {'key': 'rush_order', 'value': 'true'}]}],
-            'tracking_number': None, 'tracking_number_url': None, 'addresses': [{'id': 1,
-            'sales_order_id': 2001, 'entity_type': 'billing', 'first_name': 'David', 'last_name':
-            'Wilson', 'company': "Wilson's Catering", 'line_1': '456 Commerce Ave', 'city': 'Seattle',
-            'state': 'WA', 'zip': '98101', 'country': 'US'}, {'id': 2, 'sales_order_id': 2001,
-            'entity_type': 'shipping', 'first_name': 'David', 'last_name': 'Wilson', 'company':
-            "Wilson's Catering", 'line_1': '789 Industrial Blvd', 'city': 'Seattle', 'state': 'WA',
-            'zip': '98102', 'country': 'US'}], 'order_created_date': '2024-01-16T09:00:00Z',
-            'delivery_date': '2024-01-23T15:00:00Z', 'currency': 'USD', 'location_id': 1, 'status':
-            'PENDING', 'additional_info': 'Customer prefers morning delivery', 'customer_ref': 'WC-
-            ORDER-2024-003', 'ecommerce_order_type': 'wholesale', 'ecommerce_store_name': 'B2B
-            Portal', 'ecommerce_order_id': 'B2B-7891-2024'}.
-
+            'tracking_number': None, 'tracking_number_url': None, 'addresses': [{'entity_type':
+            'billing', 'first_name': 'David', 'last_name': 'Wilson', 'company': "Wilson's Catering",
+            'line_1': '456 Commerce Ave', 'city': 'Seattle', 'state': 'WA', 'zip': '98101', 'country':
+            'US'}, {'entity_type': 'shipping', 'first_name': 'David', 'last_name': 'Wilson',
+            'company': "Wilson's Catering", 'line_1': '789 Industrial Blvd', 'city': 'Seattle',
+            'state': 'WA', 'zip': '98102', 'country': 'US'}], 'order_created_date':
+            '2024-01-16T09:00:00Z', 'delivery_date': '2024-01-23T15:00:00Z', 'currency': 'USD',
+            'location_id': 1, 'status': 'PENDING', 'additional_info': 'Customer prefers morning
+            delivery', 'customer_ref': 'WC-ORDER-2024-003', 'ecommerce_order_type': 'wholesale',
+            'ecommerce_store_name': 'B2B Portal', 'ecommerce_order_id': 'B2B-7891-2024'}.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -179,18 +175,16 @@ async def asyncio_detailed(
             [{'quantity': 3, 'variant_id': 2101, 'tax_rate_id': 301, 'location_id': 1,
             'price_per_unit': 599.99, 'total_discount': 50.0, 'attributes': [{'key': 'engrave_text',
             'value': 'Professional Kitchen'}, {'key': 'rush_order', 'value': 'true'}]}],
-            'tracking_number': None, 'tracking_number_url': None, 'addresses': [{'id': 1,
-            'sales_order_id': 2001, 'entity_type': 'billing', 'first_name': 'David', 'last_name':
-            'Wilson', 'company': "Wilson's Catering", 'line_1': '456 Commerce Ave', 'city': 'Seattle',
-            'state': 'WA', 'zip': '98101', 'country': 'US'}, {'id': 2, 'sales_order_id': 2001,
-            'entity_type': 'shipping', 'first_name': 'David', 'last_name': 'Wilson', 'company':
-            "Wilson's Catering", 'line_1': '789 Industrial Blvd', 'city': 'Seattle', 'state': 'WA',
-            'zip': '98102', 'country': 'US'}], 'order_created_date': '2024-01-16T09:00:00Z',
-            'delivery_date': '2024-01-23T15:00:00Z', 'currency': 'USD', 'location_id': 1, 'status':
-            'PENDING', 'additional_info': 'Customer prefers morning delivery', 'customer_ref': 'WC-
-            ORDER-2024-003', 'ecommerce_order_type': 'wholesale', 'ecommerce_store_name': 'B2B
-            Portal', 'ecommerce_order_id': 'B2B-7891-2024'}.
-
+            'tracking_number': None, 'tracking_number_url': None, 'addresses': [{'entity_type':
+            'billing', 'first_name': 'David', 'last_name': 'Wilson', 'company': "Wilson's Catering",
+            'line_1': '456 Commerce Ave', 'city': 'Seattle', 'state': 'WA', 'zip': '98101', 'country':
+            'US'}, {'entity_type': 'shipping', 'first_name': 'David', 'last_name': 'Wilson',
+            'company': "Wilson's Catering", 'line_1': '789 Industrial Blvd', 'city': 'Seattle',
+            'state': 'WA', 'zip': '98102', 'country': 'US'}], 'order_created_date':
+            '2024-01-16T09:00:00Z', 'delivery_date': '2024-01-23T15:00:00Z', 'currency': 'USD',
+            'location_id': 1, 'status': 'PENDING', 'additional_info': 'Customer prefers morning
+            delivery', 'customer_ref': 'WC-ORDER-2024-003', 'ecommerce_order_type': 'wholesale',
+            'ecommerce_store_name': 'B2B Portal', 'ecommerce_order_id': 'B2B-7891-2024'}.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -226,18 +220,16 @@ async def asyncio(
             [{'quantity': 3, 'variant_id': 2101, 'tax_rate_id': 301, 'location_id': 1,
             'price_per_unit': 599.99, 'total_discount': 50.0, 'attributes': [{'key': 'engrave_text',
             'value': 'Professional Kitchen'}, {'key': 'rush_order', 'value': 'true'}]}],
-            'tracking_number': None, 'tracking_number_url': None, 'addresses': [{'id': 1,
-            'sales_order_id': 2001, 'entity_type': 'billing', 'first_name': 'David', 'last_name':
-            'Wilson', 'company': "Wilson's Catering", 'line_1': '456 Commerce Ave', 'city': 'Seattle',
-            'state': 'WA', 'zip': '98101', 'country': 'US'}, {'id': 2, 'sales_order_id': 2001,
-            'entity_type': 'shipping', 'first_name': 'David', 'last_name': 'Wilson', 'company':
-            "Wilson's Catering", 'line_1': '789 Industrial Blvd', 'city': 'Seattle', 'state': 'WA',
-            'zip': '98102', 'country': 'US'}], 'order_created_date': '2024-01-16T09:00:00Z',
-            'delivery_date': '2024-01-23T15:00:00Z', 'currency': 'USD', 'location_id': 1, 'status':
-            'PENDING', 'additional_info': 'Customer prefers morning delivery', 'customer_ref': 'WC-
-            ORDER-2024-003', 'ecommerce_order_type': 'wholesale', 'ecommerce_store_name': 'B2B
-            Portal', 'ecommerce_order_id': 'B2B-7891-2024'}.
-
+            'tracking_number': None, 'tracking_number_url': None, 'addresses': [{'entity_type':
+            'billing', 'first_name': 'David', 'last_name': 'Wilson', 'company': "Wilson's Catering",
+            'line_1': '456 Commerce Ave', 'city': 'Seattle', 'state': 'WA', 'zip': '98101', 'country':
+            'US'}, {'entity_type': 'shipping', 'first_name': 'David', 'last_name': 'Wilson',
+            'company': "Wilson's Catering", 'line_1': '789 Industrial Blvd', 'city': 'Seattle',
+            'state': 'WA', 'zip': '98102', 'country': 'US'}], 'order_created_date':
+            '2024-01-16T09:00:00Z', 'delivery_date': '2024-01-23T15:00:00Z', 'currency': 'USD',
+            'location_id': 1, 'status': 'PENDING', 'additional_info': 'Customer prefers morning
+            delivery', 'customer_ref': 'WC-ORDER-2024-003', 'ecommerce_order_type': 'wholesale',
+            'ecommerce_store_name': 'B2B Portal', 'ecommerce_order_id': 'B2B-7891-2024'}.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/katana_public_api_client/models/__init__.py
+++ b/katana_public_api_client/models/__init__.py
@@ -96,6 +96,9 @@ from .create_recipes_request_rows_item import CreateRecipesRequestRowsItem
 from .create_sales_order_address_request import CreateSalesOrderAddressRequest
 from .create_sales_order_fulfillment_request import CreateSalesOrderFulfillmentRequest
 from .create_sales_order_request import CreateSalesOrderRequest
+from .create_sales_order_request_addresses_item import (
+    CreateSalesOrderRequestAddressesItem,
+)
 from .create_sales_order_request_custom_fields_type_0 import (
     CreateSalesOrderRequestCustomFieldsType0,
 )
@@ -650,6 +653,7 @@ __all__ = (
     "CreateSalesOrderAddressRequest",
     "CreateSalesOrderFulfillmentRequest",
     "CreateSalesOrderRequest",
+    "CreateSalesOrderRequestAddressesItem",
     "CreateSalesOrderRequestCustomFieldsType0",
     "CreateSalesOrderRequestSalesOrderRowsItem",
     "CreateSalesOrderRequestSalesOrderRowsItemAttributesItem",

--- a/katana_public_api_client/models/create_sales_order_request.py
+++ b/katana_public_api_client/models/create_sales_order_request.py
@@ -14,13 +14,15 @@ from ..client_types import UNSET, Unset
 from ..models.create_sales_order_status import CreateSalesOrderStatus
 
 if TYPE_CHECKING:
+    from ..models.create_sales_order_request_addresses_item import (
+        CreateSalesOrderRequestAddressesItem,
+    )
     from ..models.create_sales_order_request_custom_fields_type_0 import (
         CreateSalesOrderRequestCustomFieldsType0,
     )
     from ..models.create_sales_order_request_sales_order_rows_item import (
         CreateSalesOrderRequestSalesOrderRowsItem,
     )
-    from ..models.sales_order_address import SalesOrderAddress
 
 
 T = TypeVar("T", bound="CreateSalesOrderRequest")
@@ -34,15 +36,14 @@ class CreateSalesOrderRequest:
         {'order_no': 'SO-2024-002', 'customer_id': 1501, 'sales_order_rows': [{'quantity': 3, 'variant_id': 2101,
             'tax_rate_id': 301, 'location_id': 1, 'price_per_unit': 599.99, 'total_discount': 50.0, 'attributes': [{'key':
             'engrave_text', 'value': 'Professional Kitchen'}, {'key': 'rush_order', 'value': 'true'}]}], 'tracking_number':
-            None, 'tracking_number_url': None, 'addresses': [{'id': 1, 'sales_order_id': 2001, 'entity_type': 'billing',
-            'first_name': 'David', 'last_name': 'Wilson', 'company': "Wilson's Catering", 'line_1': '456 Commerce Ave',
-            'city': 'Seattle', 'state': 'WA', 'zip': '98101', 'country': 'US'}, {'id': 2, 'sales_order_id': 2001,
-            'entity_type': 'shipping', 'first_name': 'David', 'last_name': 'Wilson', 'company': "Wilson's Catering",
-            'line_1': '789 Industrial Blvd', 'city': 'Seattle', 'state': 'WA', 'zip': '98102', 'country': 'US'}],
-            'order_created_date': '2024-01-16T09:00:00Z', 'delivery_date': '2024-01-23T15:00:00Z', 'currency': 'USD',
-            'location_id': 1, 'status': 'PENDING', 'additional_info': 'Customer prefers morning delivery', 'customer_ref':
-            'WC-ORDER-2024-003', 'ecommerce_order_type': 'wholesale', 'ecommerce_store_name': 'B2B Portal',
-            'ecommerce_order_id': 'B2B-7891-2024'}
+            None, 'tracking_number_url': None, 'addresses': [{'entity_type': 'billing', 'first_name': 'David', 'last_name':
+            'Wilson', 'company': "Wilson's Catering", 'line_1': '456 Commerce Ave', 'city': 'Seattle', 'state': 'WA', 'zip':
+            '98101', 'country': 'US'}, {'entity_type': 'shipping', 'first_name': 'David', 'last_name': 'Wilson', 'company':
+            "Wilson's Catering", 'line_1': '789 Industrial Blvd', 'city': 'Seattle', 'state': 'WA', 'zip': '98102',
+            'country': 'US'}], 'order_created_date': '2024-01-16T09:00:00Z', 'delivery_date': '2024-01-23T15:00:00Z',
+            'currency': 'USD', 'location_id': 1, 'status': 'PENDING', 'additional_info': 'Customer prefers morning
+            delivery', 'customer_ref': 'WC-ORDER-2024-003', 'ecommerce_order_type': 'wholesale', 'ecommerce_store_name':
+            'B2B Portal', 'ecommerce_order_id': 'B2B-7891-2024'}
 
     Attributes:
         customer_id (int): ID of the customer placing the order
@@ -52,7 +53,12 @@ class CreateSalesOrderRequest:
             auto-generates a sequential ``SO-N`` value when omitted.
         tracking_number (None | str | Unset): Shipping tracking number if already known
         tracking_number_url (None | str | Unset): URL for tracking shipment status
-        addresses (list[SalesOrderAddress] | Unset): Billing and shipping addresses for the order
+        addresses (list[CreateSalesOrderRequestAddressesItem] | Unset): Billing and shipping addresses for the order.
+            Inline-create shape —
+            ``sales_order_id`` is implicit (set by the parent sales-order create)
+            and server-assigned fields (``id`` / ``sales_order_id``) are rejected
+            by the live API on this endpoint. For the standalone create endpoint
+            (``POST /sales_order_addresses``) see ``CreateSalesOrderAddressRequest``.
         order_created_date (datetime.datetime | None | Unset): Date when the order was originally created (defaults to
             current time)
         delivery_date (datetime.datetime | None | Unset): Requested delivery date
@@ -82,7 +88,7 @@ class CreateSalesOrderRequest:
     order_no: str | Unset = UNSET
     tracking_number: None | str | Unset = UNSET
     tracking_number_url: None | str | Unset = UNSET
-    addresses: list[SalesOrderAddress] | Unset = UNSET
+    addresses: list[CreateSalesOrderRequestAddressesItem] | Unset = UNSET
     order_created_date: datetime.datetime | None | Unset = UNSET
     delivery_date: datetime.datetime | None | Unset = UNSET
     currency: None | str | Unset = UNSET
@@ -238,13 +244,15 @@ class CreateSalesOrderRequest:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.create_sales_order_request_addresses_item import (
+            CreateSalesOrderRequestAddressesItem,
+        )
         from ..models.create_sales_order_request_custom_fields_type_0 import (
             CreateSalesOrderRequestCustomFieldsType0,
         )
         from ..models.create_sales_order_request_sales_order_rows_item import (
             CreateSalesOrderRequestSalesOrderRowsItem,
         )
-        from ..models.sales_order_address import SalesOrderAddress
 
         d = dict(src_dict)
         customer_id = d.pop("customer_id")
@@ -281,11 +289,11 @@ class CreateSalesOrderRequest:
         )
 
         _addresses = d.pop("addresses", UNSET)
-        addresses: list[SalesOrderAddress] | Unset = UNSET
+        addresses: list[CreateSalesOrderRequestAddressesItem] | Unset = UNSET
         if _addresses is not UNSET:
             addresses = []
             for addresses_item_data in _addresses:
-                addresses_item = SalesOrderAddress.from_dict(
+                addresses_item = CreateSalesOrderRequestAddressesItem.from_dict(
                     cast(Mapping[str, Any], addresses_item_data)
                 )
 

--- a/katana_public_api_client/models/create_sales_order_request_addresses_item.py
+++ b/katana_public_api_client/models/create_sales_order_request_addresses_item.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..client_types import UNSET, Unset
+from ..models.address_entity_type import AddressEntityType
+
+T = TypeVar("T", bound="CreateSalesOrderRequestAddressesItem")
+
+
+@_attrs_define
+class CreateSalesOrderRequestAddressesItem:
+    entity_type: AddressEntityType
+    first_name: str | Unset = UNSET
+    last_name: str | Unset = UNSET
+    company: str | Unset = UNSET
+    line_1: str | Unset = UNSET
+    line_2: str | Unset = UNSET
+    city: str | Unset = UNSET
+    state: str | Unset = UNSET
+    zip_: str | Unset = UNSET
+    country: str | Unset = UNSET
+    phone: str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        entity_type = self.entity_type.value
+
+        first_name = self.first_name
+
+        last_name = self.last_name
+
+        company = self.company
+
+        line_1 = self.line_1
+
+        line_2 = self.line_2
+
+        city = self.city
+
+        state = self.state
+
+        zip_ = self.zip_
+
+        country = self.country
+
+        phone = self.phone
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "entity_type": entity_type,
+            }
+        )
+        if first_name is not UNSET:
+            field_dict["first_name"] = first_name
+        if last_name is not UNSET:
+            field_dict["last_name"] = last_name
+        if company is not UNSET:
+            field_dict["company"] = company
+        if line_1 is not UNSET:
+            field_dict["line_1"] = line_1
+        if line_2 is not UNSET:
+            field_dict["line_2"] = line_2
+        if city is not UNSET:
+            field_dict["city"] = city
+        if state is not UNSET:
+            field_dict["state"] = state
+        if zip_ is not UNSET:
+            field_dict["zip"] = zip_
+        if country is not UNSET:
+            field_dict["country"] = country
+        if phone is not UNSET:
+            field_dict["phone"] = phone
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        entity_type = AddressEntityType(d.pop("entity_type"))
+
+        first_name = d.pop("first_name", UNSET)
+
+        last_name = d.pop("last_name", UNSET)
+
+        company = d.pop("company", UNSET)
+
+        line_1 = d.pop("line_1", UNSET)
+
+        line_2 = d.pop("line_2", UNSET)
+
+        city = d.pop("city", UNSET)
+
+        state = d.pop("state", UNSET)
+
+        zip_ = d.pop("zip", UNSET)
+
+        country = d.pop("country", UNSET)
+
+        phone = d.pop("phone", UNSET)
+
+        create_sales_order_request_addresses_item = cls(
+            entity_type=entity_type,
+            first_name=first_name,
+            last_name=last_name,
+            company=company,
+            line_1=line_1,
+            line_2=line_2,
+            city=city,
+            state=state,
+            zip_=zip_,
+            country=country,
+            phone=phone,
+        )
+
+        return create_sales_order_request_addresses_item

--- a/katana_public_api_client/models_pydantic/_generated/sales_orders.py
+++ b/katana_public_api_client/models_pydantic/_generated/sales_orders.py
@@ -403,8 +403,32 @@ class SalesOrderRow1(KatanaPydanticBase):
     ] = None
 
 
-class Address1(SalesOrderAddress):
-    pass
+class Address1(KatanaPydanticBase):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    entity_type: Annotated[
+        AddressEntityType,
+        Field(
+            description="Whether this address is the shipping or billing address for the sales order"
+        ),
+    ]
+    first_name: Annotated[
+        str | None, Field(description="First name for the address contact")
+    ] = None
+    last_name: Annotated[
+        str | None, Field(description="Last name for the address contact")
+    ] = None
+    company: Annotated[
+        str | None, Field(description="Company name for the address")
+    ] = None
+    line_1: Annotated[str | None, Field(description="Primary address line")] = None
+    line_2: Annotated[str | None, Field(description="Secondary address line")] = None
+    city: Annotated[str | None, Field(description="City name")] = None
+    state: Annotated[str | None, Field(description="State or province")] = None
+    zip: Annotated[str | None, Field(description="Postal code")] = None
+    country: Annotated[str | None, Field(description="Country code")] = None
+    phone: Annotated[str | None, Field(description="Contact phone number")] = None
 
 
 class CreateSalesOrderRequest(KatanaPydanticBase):
@@ -431,7 +455,9 @@ class CreateSalesOrderRequest(KatanaPydanticBase):
     ] = None
     addresses: Annotated[
         list[Address1] | None,
-        Field(description="Billing and shipping addresses for the order"),
+        Field(
+            description="Billing and shipping addresses for the order. Inline-create shape —\n``sales_order_id`` is implicit (set by the parent sales-order create)\nand server-assigned fields (``id`` / ``sales_order_id``) are rejected\nby the live API on this endpoint. For the standalone create endpoint\n(``POST /sales_order_addresses``) see ``CreateSalesOrderAddressRequest``.\n"
+        ),
     ] = None
     order_created_date: Annotated[
         AwareDatetime | None,


### PR DESCRIPTION
## Summary

Closes #772. Passing `addresses` to `create_sales_order` was failing three different ways simultaneously — spec, generated client, and MCP wrapper all needed fixes for a one-call SO-with-addresses create to land. Same playbook as #770 (custom_fields shape divergence): trust the wire, fix the spec, regenerate, update the MCP wrapper, mark breaking.

## Spec (`docs/katana-openapi.yaml`)

`CreateSalesOrderRequest.addresses[]` was `$ref`'d to the read-side `SalesOrderAddress` schema, which legitimately carries `id` and `sales_order_id` (servers stamp them on read responses). Inline create rejects both — the live Katana API returns `422 unexpected property: 'id'` / `'sales_order_id'`.

Inlined a write-shaped object schema instead, matching `CreateSalesOrderAddressRequest` minus `sales_order_id` (which is implicit for inline create — the parent SO supplies it). Regen produces a new `CreateSalesOrderRequestAddressesItem` DTO with the right shape: `entity_type` required, no server-assigned fields, `zip_` keyword workaround serializing as `zip` on the wire.

Example block in the spec also updated to drop the rejected `id` / `sales_order_id` fields.

## Generated client

Regen produced a new model: `katana_public_api_client/models/create_sales_order_request_addresses_item.py`. The parent `CreateSalesOrderRequest.addresses` now types as `list[CreateSalesOrderRequestAddressesItem] | Unset` (was `list[SalesOrderAddress]`). The pydantic mirror under `_generated/sales_orders.py` follows.

## MCP (`katana_mcp_server/.../sales_orders.py`)

- Drop hardcoded `id=0, sales_order_id=0` at `:425-426` — those were the workaround for the wrong DTO ref and tripped the live API immediately. Switch construction to the new `CreateSalesOrderRequestAddressesItem`.
- Rename Pydantic field `SalesOrderAddress.zip_code` → `zip` so the read→write field name round-trips cleanly. The MCP-side `SalesOrderAddressInfo` (read model) and the modify sub-payloads (`SOAddressAdd` / `SOAddressUpdate`) already used `zip` — this brings the create path inline with that precedent. Field name intentionally shadows the `zip()` builtin within model scope (same as the existing read/modify models).
- Read from `addr.zip` (was `addr.zip_code`) when building the API body.

## Tests

Round-trip test now asserts the outbound wire body serializes `zip` (not `zip_code`) and contains no `id` / `sales_order_id` keys — the two surface bugs the live API previously rejected. Existing addresses test (`test_create_sales_order_with_addresses`) updated to use `zip=...` and extended with `api_request.to_dict()` wire assertions.

## Migration path for callers

In practice, **zero**:
- The wire-shaped `zip` was already rejected by the MCP Pydantic layer (`extra="forbid"`), so anyone who copied a `get_sales_order` response into a create payload was getting a validation error before the call left their process. Renaming `zip_code` → `zip` unbreaks that round-trip.
- The `id` / `sales_order_id` fields on inline addresses were always rejected by the live Katana API on inline create with `422 unexpected property`, so no caller had a working code path that supplied them.

## Test plan

- [x] `uv run poe regenerate-client` — clean regen, new `CreateSalesOrderRequestAddressesItem` model emitted
- [x] `uv run poe generate-pydantic` — pydantic mirror in sync
- [x] `uv run poe check` — 3305 passed + 2 skipped + 21 browser tests passed
- [x] `uv run poe agent-check` — pyright + ty + ruff + mdformat all clean
- [x] Round-trip test asserts wire body shape (no `id` / `sales_order_id`, `zip` not `zip_code`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)