### PR TITLE
fix(mcp): filter tombstones from get_manufacturing_order_recipe + treat DELETE 404 as success

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -493,10 +493,29 @@ def make_delete_apply(endpoint: Any, services: Any, target_id: int) -> ApplyCall
     Used by every ``delete_*`` action and the ``delete_<entity>`` tools.
     DELETE endpoints return 204 No Content on success; ``is_success`` +
     ``unwrap`` translates non-success into a typed error.
+
+    **404 on DELETE is treated as success** (idempotent semantics). The
+    caller's intent is "ensure this row is gone" — if Katana reports
+    404, the row is already gone and the target state is satisfied. The
+    Katana DELETE endpoints are not idempotent server-side (a second
+    DELETE on the same id returns 404, see issue #777), so this
+    conflation happens here at the dispatch layer so every entity
+    benefits uniformly: PO rows, SO rows, MO recipe rows, MO operation
+    rows, productions, and the top-level ``delete_<entity>`` tools.
     """
 
     async def apply() -> None:
         response = await endpoint.asyncio_detailed(id=target_id, client=services.client)
+        if response.status_code == 404:
+            # Idempotent semantics: row already gone is the desired end state.
+            endpoint_label = getattr(endpoint, "__name__", repr(endpoint))
+            logger.info(
+                "DELETE %s id=%s returned 404 — treating as success "
+                "(row already deleted).",
+                endpoint_label,
+                target_id,
+            )
+            return None
         if not is_success(response):
             unwrap(response)
         return None

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -986,9 +986,32 @@ def _serial_number_info_from_attrs(sn: Any) -> SerialNumberInfo:
 
 
 async def _fetch_mo_recipe_row_attrs(
+    services: Any, manufacturing_order_id: int, *, include_deleted: bool
+) -> list[Any]:
+    """Underlying recipe-row fetch — callers pick tombstone visibility.
+
+    Don't call this directly from new code: use one of the two named
+    wrappers below so the call-site documents intent at the read /
+    cache-merge boundary (issue #777).
+    """
+    from katana_public_api_client.api.manufacturing_order_recipe import (
+        get_all_manufacturing_order_recipe_rows,
+    )
+    from katana_public_api_client.utils import unwrap_data
+
+    response = await get_all_manufacturing_order_recipe_rows.asyncio_detailed(
+        client=services.client,
+        manufacturing_order_id=manufacturing_order_id,
+        limit=250,
+        include_deleted=include_deleted,
+    )
+    return unwrap_data(response, default=[])
+
+
+async def _fetch_mo_recipe_row_attrs_for_cache_merge(
     services: Any, manufacturing_order_id: int
 ) -> list[Any]:
-    """Return raw attrs ``ManufacturingOrderRecipeRow`` list for an MO.
+    """Return raw attrs ``ManufacturingOrderRecipeRow`` list including tombstones.
 
     Thin wrapper used by ``modify_manufacturing_order``'s post-apply
     cache merge: recipe rows live at the separate
@@ -1004,26 +1027,57 @@ async def _fetch_mo_recipe_row_attrs(
     action would land at Katana but the cached row would persist as a
     ghost until the next watermark sync — same trap the typed-cache
     spec already documents on its row-watermark setup.
-    """
-    from katana_public_api_client.api.manufacturing_order_recipe import (
-        get_all_manufacturing_order_recipe_rows,
-    )
-    from katana_public_api_client.utils import unwrap_data
 
-    response = await get_all_manufacturing_order_recipe_rows.asyncio_detailed(
-        client=services.client,
-        manufacturing_order_id=manufacturing_order_id,
-        limit=250,
-        include_deleted=True,
+    **Do not call this from agent-facing reads** — tombstones leaking
+    through a read tool surface naive callers' delete plans with
+    already-gone IDs, producing a 404 storm at apply time (issue #777).
+    Use :func:`_fetch_mo_recipe_row_attrs_live_only` for read tools.
+    """
+    return await _fetch_mo_recipe_row_attrs(
+        services, manufacturing_order_id, include_deleted=True
     )
-    return unwrap_data(response, default=[])
+
+
+async def _fetch_mo_recipe_row_attrs_live_only(
+    services: Any, manufacturing_order_id: int
+) -> list[Any]:
+    """Return raw attrs ``ManufacturingOrderRecipeRow`` list, live rows only.
+
+    Sibling of :func:`_fetch_mo_recipe_row_attrs_for_cache_merge` for
+    agent-facing reads (``get_manufacturing_order_recipe`` and the
+    recipe rows inlined in ``get_manufacturing_order``'s response).
+    Agents only want live rows: a row with ``deleted_at`` set is not a
+    valid delete target — surfacing it as one leads to apply-time 404s
+    when the agent batches it into ``delete_recipe_row_ids`` (issue
+    #777).
+
+    Passes ``include_deleted=False`` explicitly (the API default, made
+    explicit here for clarity). The caller layer also applies a
+    client-side ``deleted_at`` filter as a defense-in-depth in case
+    Katana's server-side filter ever regresses.
+    """
+    return await _fetch_mo_recipe_row_attrs(
+        services, manufacturing_order_id, include_deleted=False
+    )
 
 
 async def _fetch_mo_recipe_rows(
     services: Any, manufacturing_order_id: int
 ) -> list[RecipeRowInfo]:
-    """Fetch every recipe row for the MO and enrich with cached SKU."""
-    raw_rows = await _fetch_mo_recipe_row_attrs(services, manufacturing_order_id)
+    """Fetch every recipe row for the MO and enrich with cached SKU.
+
+    Tombstones (rows with ``deleted_at`` populated) are filtered both
+    server-side (``include_deleted=False``) and client-side (defense-in-
+    depth) — agents reading the recipe should never see soft-deleted
+    rows as legitimate delete targets (issue #777).
+    """
+    raw_rows = await _fetch_mo_recipe_row_attrs_live_only(
+        services, manufacturing_order_id
+    )
+    # Defense-in-depth: drop any row Katana didn't filter server-side.
+    # Historically ``include_deleted=false`` has been unreliable on some
+    # list endpoints — see the note on the cache-merge fetcher above.
+    raw_rows = [row for row in raw_rows if unwrap_unset(row.deleted_at, None) is None]
 
     # One batched IN-clause SQLite read instead of one read per recipe row —
     # a multi-component MO has ~30 rows, all looked up by variant_id.
@@ -3050,7 +3104,9 @@ async def _modify_manufacturing_order_impl(
             refetch_related=(
                 (
                     "manufacturing_order_recipe_row",
-                    lambda eid: _fetch_mo_recipe_row_attrs(services, eid),
+                    lambda eid: _fetch_mo_recipe_row_attrs_for_cache_merge(
+                        services, eid
+                    ),
                 ),
             ),
         ),

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -694,6 +694,170 @@ async def test_get_manufacturing_order_recipe_empty():
 
 
 @pytest.mark.asyncio
+async def test_get_mo_recipe_requests_live_only_from_api():
+    """Regression for #777: read tool MUST call the recipe-rows endpoint with
+    ``include_deleted=False`` — otherwise tombstoned rows leak through and
+    naive agents batch them into ``delete_recipe_row_ids``, producing
+    apply-time 404s.
+    """
+    # Arrange
+    context, _ = create_mock_context()
+
+    def _mk_row(row_id: int) -> MagicMock:
+        m = MagicMock()
+        m.id = row_id
+        m.variant_id = UNSET
+        m.planned_quantity_per_unit = 1.0
+        m.total_actual_quantity = 0.0
+        m.ingredient_availability = "IN_STOCK"
+        m.notes = None
+        m.cost = 0.0
+        m.manufacturing_order_id = UNSET
+        m.total_consumed_quantity = UNSET
+        m.total_remaining_quantity = UNSET
+        m.ingredient_expected_date = UNSET
+        m.batch_transactions = UNSET
+        m.created_at = UNSET
+        m.updated_at = UNSET
+        m.deleted_at = UNSET
+        return m
+
+    api_mock = AsyncMock()
+    with (
+        patch(
+            f"{_RECIPE_API}.get_all_manufacturing_order_recipe_rows.asyncio_detailed",
+            new=api_mock,
+        ),
+        patch(_UNWRAP_DATA, return_value=[_mk_row(5001)]),
+    ):
+        request = GetManufacturingOrderRecipeRequest(manufacturing_order_id=9999)
+        # Act
+        await _get_manufacturing_order_recipe_impl(request, context)
+
+    # Assert
+    api_mock.assert_called_once()
+    assert api_mock.call_args.kwargs["include_deleted"] is False
+    assert api_mock.call_args.kwargs["manufacturing_order_id"] == 9999
+
+
+@pytest.mark.asyncio
+async def test_get_mo_recipe_excludes_tombstoned_rows():
+    """Regression for #777: ``get_manufacturing_order_recipe`` must not
+    surface tombstoned rows. With ``include_deleted=False`` plus the
+    client-side defense-in-depth filter, agents see only live rows.
+    """
+    # Arrange — three live + two tombstones (simulates Katana returning
+    # tombstones even though we asked for live-only).
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(return_value={})
+
+    def _mk_row(row_id: int, deleted_at: Any = UNSET) -> MagicMock:
+        m = MagicMock()
+        m.id = row_id
+        m.variant_id = UNSET
+        m.planned_quantity_per_unit = 1.0
+        m.total_actual_quantity = 0.0
+        m.ingredient_availability = "IN_STOCK"
+        m.notes = None
+        m.cost = 0.0
+        m.manufacturing_order_id = UNSET
+        m.total_consumed_quantity = UNSET
+        m.total_remaining_quantity = UNSET
+        m.ingredient_expected_date = UNSET
+        m.batch_transactions = UNSET
+        m.created_at = UNSET
+        m.updated_at = UNSET
+        m.deleted_at = deleted_at
+        return m
+
+    tombstone_ts = datetime(2026, 4, 16, 12, 0, tzinfo=UTC)
+    raw_rows = [
+        _mk_row(5001),
+        _mk_row(5002),
+        _mk_row(5003, deleted_at=tombstone_ts),
+        _mk_row(5004),
+        _mk_row(5005, deleted_at=tombstone_ts),
+    ]
+
+    with (
+        patch(
+            f"{_RECIPE_API}.get_all_manufacturing_order_recipe_rows.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        patch(_UNWRAP_DATA, return_value=raw_rows),
+    ):
+        request = GetManufacturingOrderRecipeRequest(manufacturing_order_id=9999)
+        # Act
+        result = await _get_manufacturing_order_recipe_impl(request, context)
+
+    # Assert — only live rows surface; tombstones are dropped.
+    assert result.total_count == 3
+    surfaced_ids = {row.id for row in result.rows}
+    assert surfaced_ids == {5001, 5002, 5004}
+    assert all(row.deleted_at is None for row in result.rows)
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_cache_merge_uses_tombstone_aware_fetcher():
+    """Regression for #777: the cache-merge fan-out MUST still see
+    tombstones (so it can evict deleted cached rows). The split must
+    not regress that.
+    """
+    # Arrange — assert by inspecting the dispatch wiring: the
+    # ``refetch_related`` lambda used by ``CacheMerge`` must call the
+    # ``_for_cache_merge`` fetcher, not the ``_live_only`` sibling.
+    import inspect
+
+    from katana_mcp.tools.foundation import manufacturing_orders as mo_mod
+
+    # Act — read the source of the impl that registers the cache merge.
+    src = inspect.getsource(mo_mod._modify_manufacturing_order_impl)
+
+    # Assert — the cache merge wiring references the tombstone-aware
+    # fetcher, NOT the live-only sibling. (If a future refactor moves
+    # this elsewhere, the test will still catch a regression in spirit
+    # because we'd lose the symbol entirely.)
+    assert "_fetch_mo_recipe_row_attrs_for_cache_merge" in src
+    assert "_fetch_mo_recipe_row_attrs_live_only" not in src
+    # Sanity: the live-only fetcher exists separately for read-paths.
+    assert hasattr(mo_mod, "_fetch_mo_recipe_row_attrs_live_only")
+    assert hasattr(mo_mod, "_fetch_mo_recipe_row_attrs_for_cache_merge")
+
+
+@pytest.mark.asyncio
+async def test_fetch_mo_recipe_row_attrs_for_cache_merge_includes_tombstones():
+    """The cache-merge fetcher MUST call the API with
+    ``include_deleted=True`` — otherwise the cache can't evict
+    just-deleted rows after a ``delete_recipe_row`` modify action.
+    """
+    # Arrange
+    from katana_mcp.tools.foundation.manufacturing_orders import (
+        _fetch_mo_recipe_row_attrs_for_cache_merge,
+    )
+
+    services = MagicMock()
+    services.client = MagicMock()
+
+    api_mock = AsyncMock()
+    with (
+        patch(
+            f"{_RECIPE_API}.get_all_manufacturing_order_recipe_rows.asyncio_detailed",
+            new=api_mock,
+        ),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        # Act
+        await _fetch_mo_recipe_row_attrs_for_cache_merge(
+            services=services, manufacturing_order_id=12345
+        )
+
+    # Assert
+    api_mock.assert_called_once()
+    assert api_mock.call_args.kwargs["include_deleted"] is True
+    assert api_mock.call_args.kwargs["manufacturing_order_id"] == 12345
+
+
+@pytest.mark.asyncio
 async def test_create_manufacturing_order_make_to_order_preview():
     """Make-to-order preview mode: sales_order_row_id only, no other fields required."""
     from katana_public_api_client.models import SalesOrderRow

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import cast
-from unittest.mock import MagicMock
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from katana_mcp.tools._modification import (
@@ -523,6 +523,165 @@ async def test_execute_plan_verification_exception_marks_unverified():
     assert results[0].succeeded is True
     assert results[0].verified is False
     assert results[0].actual_after is None
+
+
+# ============================================================================
+# make_delete_apply — idempotent 404 semantics (#777)
+# ============================================================================
+
+
+def _build_delete_endpoint_mock(*, status_code: int, name: str = "delete_endpoint"):
+    """Build a fake DELETE endpoint module exposing ``asyncio_detailed``.
+
+    Mirrors the shape :func:`make_delete_apply` expects: an object with
+    a ``__name__`` and an ``asyncio_detailed`` async callable returning a
+    ``Response``-like object whose ``status_code`` matches the scenario.
+    """
+    from http import HTTPStatus
+
+    from katana_public_api_client.client_types import Response
+
+    response: Response[Any] = Response(
+        status_code=HTTPStatus(status_code),
+        content=b"",
+        headers={},
+        parsed=None,
+    )
+    endpoint = MagicMock()
+    endpoint.__name__ = name
+    endpoint.asyncio_detailed = AsyncMock(return_value=response)
+    return endpoint, response
+
+
+def _build_services_mock():
+    services = MagicMock()
+    services.client = MagicMock()
+    return services
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "endpoint_name",
+    [
+        "delete_purchase_order_row",
+        "delete_sales_order_row",
+        "delete_manufacturing_order_recipe_row",
+    ],
+)
+async def test_make_delete_apply_treats_404_as_success(endpoint_name: str):
+    """Regression for #777: 404 on DELETE means the row is already gone,
+    which is the desired end state. ``apply()`` must return None
+    (not raise), so a fail-fast plan can keep marching.
+
+    Parametrized across endpoint names to confirm the conflation lives
+    at the dispatch layer and applies uniformly across every entity
+    that routes through :func:`make_delete_apply`.
+    """
+    # Arrange
+    from katana_mcp.tools._modification_dispatch import make_delete_apply
+
+    services = _build_services_mock()
+    endpoint, _response = _build_delete_endpoint_mock(
+        status_code=404, name=endpoint_name
+    )
+
+    # Act
+    apply = make_delete_apply(endpoint, services, target_id=42)
+    result = await apply()
+
+    # Assert
+    assert result is None
+    endpoint.asyncio_detailed.assert_awaited_once()
+    call_kwargs = endpoint.asyncio_detailed.await_args.kwargs
+    assert call_kwargs["id"] == 42
+    assert call_kwargs["client"] is services.client
+
+
+@pytest.mark.asyncio
+async def test_make_delete_apply_204_remains_success():
+    """Control case: a normal 204 No Content still returns None and the
+    fast-path (no error) is preserved.
+    """
+    from katana_mcp.tools._modification_dispatch import make_delete_apply
+
+    services = _build_services_mock()
+    endpoint, _response = _build_delete_endpoint_mock(status_code=204)
+
+    apply = make_delete_apply(endpoint, services, target_id=7)
+    result = await apply()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_make_delete_apply_400_still_raises():
+    """Control case: 4xx that isn't 404 must still surface as an error
+    so the dispatcher can fail-fast — only 404 gets the idempotent
+    treatment.
+    """
+    from katana_mcp.tools._modification_dispatch import make_delete_apply
+
+    from katana_public_api_client.utils import APIError
+
+    services = _build_services_mock()
+    endpoint, _response = _build_delete_endpoint_mock(status_code=400)
+
+    apply = make_delete_apply(endpoint, services, target_id=7)
+
+    with pytest.raises(APIError):
+        await apply()
+
+
+@pytest.mark.asyncio
+async def test_make_delete_apply_500_still_raises():
+    """Control case: server errors (5xx) must still surface so the
+    dispatcher fails fast and the caller learns Katana is unhappy.
+    """
+    from katana_mcp.tools._modification_dispatch import make_delete_apply
+
+    from katana_public_api_client.utils import APIError
+
+    services = _build_services_mock()
+    endpoint, _response = _build_delete_endpoint_mock(status_code=500)
+
+    apply = make_delete_apply(endpoint, services, target_id=7)
+
+    with pytest.raises(APIError):
+        await apply()
+
+
+@pytest.mark.asyncio
+async def test_execute_plan_with_mixed_204_and_404_marks_both_succeeded():
+    """Integration-ish: with two deletes where the first lands at 204
+    and the second hits 404 (already gone), both ActionResults should
+    show ``succeeded=True``. This is the bug-report scenario from #777
+    — stale tombstone IDs in a delete batch should no longer abort the
+    plan.
+    """
+    from katana_mcp.tools._modification_dispatch import make_delete_apply
+
+    services = _build_services_mock()
+    live_endpoint, _ = _build_delete_endpoint_mock(status_code=204, name="delete_live")
+    gone_endpoint, _ = _build_delete_endpoint_mock(status_code=404, name="delete_gone")
+
+    plan = [
+        ActionSpec(
+            operation="delete_recipe_row",
+            target_id=5001,
+            apply=make_delete_apply(live_endpoint, services, target_id=5001),
+        ),
+        ActionSpec(
+            operation="delete_recipe_row",
+            target_id=5002,
+            apply=make_delete_apply(gone_endpoint, services, target_id=5002),
+        ),
+    ]
+
+    results = await execute_plan(plan)
+
+    assert len(results) == 2
+    assert all(r.succeeded is True for r in results)
+    assert all(r.error is None for r in results)
 
 
 def test_plan_to_preview_results_has_all_succeeded_none():

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.83.0"
+version = "0.84.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Two orthogonal fixes for #777. The user reported a `modify_manufacturing_order` delete batch where 5 recipe-row IDs were sent and the response framed it as a near-total failure. Investigation (full diagnosis in the [plan comment](https://github.com/dougborg/katana-openapi-client/issues/777#issuecomment-4483823978)) found:

- **4 of the 5 IDs were tombstones** from soft-deletes weeks before the session, surfaced by the read tool feeding the agent's delete plan.
- **Katana's DELETE on `/manufacturing_order_recipe_rows/{id}` is not idempotent** — first DELETE returns 204, second on the same id returns 404. So even after fixing the read leak, any agent batching stale IDs (from a prior session, a UI scrape, or another agent) would trip the same 404-mid-plan failure.

### Part 1 — stop surfacing tombstones via `get_manufacturing_order_recipe`

`_fetch_mo_recipe_row_attrs` was dual-purpose: serving both the `modify_manufacturing_order` cache-merge fan-out (needs `include_deleted=True` so the typed cache can evict deleted rows) AND the agent-facing read path (must NOT surface tombstones as valid delete targets). Split into two named wrappers around a single inner fetcher:

- `_fetch_mo_recipe_row_attrs_for_cache_merge` — wired into `CacheMerge.refetch_related`; keeps `include_deleted=True`.
- `_fetch_mo_recipe_row_attrs_live_only` — wired into `_fetch_mo_recipe_rows`, the path consumed by `get_manufacturing_order_recipe` and `get_manufacturing_order`'s inlined recipe.

The read path also applies a client-side `deleted_at` filter as defense-in-depth in case Katana's `include_deleted=false` ever regresses server-side.

Surveyed other foundation tools (`grep -n 'include_deleted=True'`) — PO and SO already follow this pattern with their `_for_merge`-suffixed fetchers, and `list_blocking_ingredients` filters tombstones via SQL `deleted_at.is_(None)`. The dual-purpose trap was unique to MO recipe rows; no follow-up issue needed.

### Part 2 — treat 404 on DELETE as success in `make_delete_apply`

Belt-and-suspenders defense across every entity that routes through the shared dispatch helper: PO rows, SO rows, MO recipe rows, MO operation rows, productions, and the top-level `delete_<entity>` tools. The caller's intent on DELETE is "ensure this row is gone" — if Katana reports 404, the row is already gone and the target state is satisfied.

Logs an `INFO` line with the endpoint name and id when this conflation fires, so the behavior remains visible without polluting the response surface.

## Test plan

- [x] Part 1: `test_get_mo_recipe_requests_live_only_from_api` — read tool MUST pass `include_deleted=False`.
- [x] Part 1: `test_get_mo_recipe_excludes_tombstoned_rows` — client-side filter drops tombstones even if Katana returns them.
- [x] Part 1: `test_modify_mo_cache_merge_uses_tombstone_aware_fetcher` — pins cache-merge wiring to the `_for_cache_merge` fetcher.
- [x] Part 1: `test_fetch_mo_recipe_row_attrs_for_cache_merge_includes_tombstones` — confirms the cache-merge fetcher still passes `include_deleted=True`.
- [x] Part 2: `test_make_delete_apply_treats_404_as_success` — parametrized across PO row / SO row / MO recipe row endpoint names.
- [x] Part 2: `test_make_delete_apply_204_remains_success` / `_400_still_raises` / `_500_still_raises` — control cases.
- [x] Part 2: `test_execute_plan_with_mixed_204_and_404_marks_both_succeeded` — integration-ish: the #777 bug-report scenario end-to-end, both deletes now succeed.
- [x] `uv run poe check` green end-to-end (3339 unit tests + 21 browser tests + lint + types).

Closes #777