### PR TITLE
feat(mcp)!: refactor MO fulfill to POST /manufacturing_order_productions (#790)

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -3411,9 +3411,14 @@ components:
             $ref: "#/components/schemas/ManufacturingOrderOperationRow"
         serial_numbers:
           type: array
-          description: Serial numbers to assign to produced items
+          description:
+            Pre-existing SerialNumber IDs (integers) to assign to the units
+            produced in this production run. Required when the
+            manufacturing order's finished-good variant is serial-tracked.
+            Katana silently drops IDs that do not exist — callers must mint
+            via `POST /serial_numbers` first.
           items:
-            type: string
+            type: integer
       example:
         manufacturing_order_id: 3001
         completed_quantity: 25

--- a/katana_mcp_server/src/katana_mcp/tools/_reopen.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_reopen.py
@@ -90,11 +90,17 @@ class MOProductionSnapshot:
     sequence in the original Shopify SP73000→SP73001 correction: Katana
     stamps the create with server-time, so the explicit PATCH is what
     actually backdates the production.
+
+    ``serial_numbers`` carries the integer ``SerialNumber.id`` values
+    captured from the prior production — the production POST body wants
+    pre-existing SN IDs (Katana silently drops unknown IDs, so capturing
+    the ID rather than the human-readable serial string is what allows
+    the restore to actually re-attach the original serials).
     """
 
     completed_quantity: float
     production_date: datetime | None
-    serial_numbers: list[str] = field(default_factory=list)
+    serial_numbers: list[int] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -106,21 +112,25 @@ class MOCloseState:
     productions: list[MOProductionSnapshot]
 
 
-def _serial_numbers_to_strs(value: Any) -> list[str]:
-    """Extract serial-number strings from an attrs ``list[SerialNumber]``.
+def _serial_numbers_to_ids(value: Any) -> list[int]:
+    """Extract integer ``SerialNumber.id`` values from an attrs
+    ``list[SerialNumber]``.
 
     The persisted entity carries ``SerialNumber`` objects; the create-body
-    field accepts a flat ``list[str]``. UNSET / None / missing
-    ``serial_number`` field on an item all fall through to "skip".
+    field accepts a flat ``list[int]`` of pre-existing SN IDs. UNSET /
+    None / missing ``id`` field on an item all fall through to "skip".
+    Spec drift fix in #790: the serial-number wire shape is integers, not
+    strings — Katana silently drops unknown IDs (and silently drops every
+    string that was previously passed through here).
     """
     items = unwrap_unset(value, None)
     if not items:
         return []
-    out: list[str] = []
+    out: list[int] = []
     for item in items:
-        sn = unwrap_unset(getattr(item, "serial_number", UNSET), None)
-        if isinstance(sn, str) and sn:
-            out.append(sn)
+        sn_id = unwrap_unset(getattr(item, "id", UNSET), None)
+        if isinstance(sn_id, int):
+            out.append(sn_id)
     return out
 
 
@@ -144,7 +154,7 @@ def snapshot_mo_close_state(
             MOProductionSnapshot(
                 completed_quantity=float(qty),
                 production_date=unwrap_unset(prod.production_date, None),
-                serial_numbers=_serial_numbers_to_strs(prod.serial_numbers),
+                serial_numbers=_serial_numbers_to_ids(prod.serial_numbers),
             )
         )
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -2590,8 +2590,15 @@ class MOProductionAdd(BaseModel):
         default=None,
         description="When true, marks this as the final production record",
     )
-    serial_numbers: list[str] | None = Field(
-        default=None, description="Serial numbers for serial-tracked variants"
+    serial_numbers: list[int] | None = Field(
+        default=None,
+        description=(
+            "Pre-existing SerialNumber IDs (integers) to attach to the units "
+            "produced in this production record. Required when the MO's "
+            "finished-good variant is serial-tracked. Katana silently drops "
+            "IDs that do not exist — callers must mint via "
+            "``POST /serial_numbers`` first."
+        ),
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -28,8 +28,8 @@ from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     ManufacturingOrder,
+    ManufacturingOrderProduction,
     SalesOrder,
-    UpdateManufacturingOrderRequest,
 )
 from katana_public_api_client.models_pydantic._generated import (
     CachedMaterial,
@@ -102,17 +102,17 @@ class FulfillOrderRequest(BaseModel):
         default=None,
         description=(
             "Backdated completion timestamp for catching up on a backlog. "
-            "For manufacturing orders, sets ``done_date``; for sales orders, "
-            "sets the fulfillment's ``picked_date``. ISO 8601 "
-            "(e.g. '2026-05-01T20:30:00Z'); naive datetimes are interpreted "
-            "as UTC. When omitted, Katana stamps server-time. Manufacturing "
-            "branch only: requires a second PATCH after the DONE transition "
-            "(Katana validates ``done_date`` against current status); the "
-            "tool emits both calls and surfaces a warning if the second one "
-            "fails. The MO's first-serial "
+            "For manufacturing orders, sets the production record's "
+            "``completed_date`` which Katana propagates verbatim to "
+            "``MO.done_date``; for sales orders, sets the fulfillment's "
+            "``picked_date``. ISO 8601 (e.g. '2026-05-01T20:30:00Z'); "
+            "naive datetimes are interpreted as UTC. When omitted, Katana "
+            "stamps server-time. Manufacturing branch: lands atomically via "
+            "a single ``POST /manufacturing_order_productions`` — no "
+            "follow-up PATCH needed. The MO's first-serial "
             "``SerialNumber.transaction_date`` is derived from "
-            "``done_date``, so the Traceability 'Production date' column "
-            "tracks this value."
+            "``done_date`` / ``completed_date``, so the Traceability "
+            "'Production date' column tracks this value."
         ),
     )
 
@@ -197,8 +197,9 @@ async def _fulfill_manufacturing_order(
         )
     if request.completed_at is not None:
         inventory_updates.append(
-            f"done_date will be set to {request.completed_at.isoformat()} "
-            "(via second PATCH after status flip)"
+            f"completed_date / done_date will be set to "
+            f"{request.completed_at.isoformat()} "
+            "(atomic via POST /manufacturing_order_productions)"
         )
 
     warnings: list[str] = []
@@ -283,51 +284,56 @@ async def _fulfill_manufacturing_order(
             ),
         )
 
-    from katana_public_api_client.api.manufacturing_order import (
-        update_manufacturing_order as api_update_manufacturing_order,
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production as api_create_production,
     )
-    from katana_public_api_client.models.manufacturing_order_status import (
-        ManufacturingOrderStatus,
+    from katana_public_api_client.models import (
+        CreateManufacturingOrderProductionRequest,
     )
 
-    update_req = UpdateManufacturingOrderRequest(
-        status=ManufacturingOrderStatus.DONE,
+    # Source ``completed_quantity`` from the MO's current ``actual_quantity``
+    # (Probe 3 / orders.py:177): partial completion is honored verbatim, and
+    # ``is_final=True`` is what flips status — not the planned/actual match.
+    # When ``actual_quantity`` is null/UNSET (MO never had a prior production),
+    # Katana stamps ``actual_quantity = completed_quantity``, so a sane
+    # default of 1 closes the MO at qty=1 (matches Katana's own "complete
+    # one" semantics in the UI).
+    completed_quantity = actual_quantity if actual_quantity else 1
+
+    production_req = CreateManufacturingOrderProductionRequest(
+        manufacturing_order_id=request.order_id,
+        completed_quantity=completed_quantity,
+        completed_date=to_unset(request.completed_at),
+        is_final=True,
         serial_numbers=to_unset(request.serial_numbers),
+        # ingredients / operations intentionally omitted — Katana auto-
+        # consumes from the MO's recipe (documented behavior).
     )
-    update_response = await api_update_manufacturing_order.asyncio_detailed(
-        id=request.order_id, client=services.client, body=update_req
+    production_response = await api_create_production.asyncio_detailed(
+        client=services.client, body=production_req
     )
-    updated_mo = unwrap_as(update_response, ManufacturingOrder)
-    new_status = updated_mo.status.value if updated_mo.status else "UNKNOWN"
+    # Raises APIError on non-2xx (unwrap_as on the response below) — preserves
+    # the existing fail-loud contract so callers see the upstream error.
+    unwrap_as(production_response, ManufacturingOrderProduction)
 
-    # Second PATCH to backdate ``done_date``. Katana validates the field
-    # against the *current* status, so it can only land after the
-    # ``status=DONE`` PATCH above. Mirrors the two-call chase in
-    # ``_build_close_mo_actions`` (corrections.py). Best-effort: a 422 here
-    # leaves the MO already-DONE with server-time ``done_date``; we surface
-    # a non-BLOCK warning rather than rolling back inventory (which Katana
-    # can't reopen cleanly anyway).
+    # Re-fetch the MO to surface post-mutation status / done_date. The
+    # production response doesn't carry the MO header; the MO does. This is
+    # the single full-entity fetch the cache-merge contract relies on
+    # (CLAUDE.md "verify and cache-merge once at the end via a single full-
+    # entity fetch — not per-action").
+    final_mo_response = await api_get_manufacturing_order.asyncio_detailed(
+        id=request.order_id, client=services.client
+    )
+    final_mo = unwrap_as(final_mo_response, ManufacturingOrder)
+    new_status = final_mo.status.value if final_mo.status else "UNKNOWN"
+
     next_actions = [
         f"Manufacturing order {order_number} completed",
         "Inventory has been updated",
         "Check stock levels for finished goods",
     ]
     if request.completed_at is not None:
-        date_req = UpdateManufacturingOrderRequest(done_date=request.completed_at)
-        date_response = await api_update_manufacturing_order.asyncio_detailed(
-            id=request.order_id, client=services.client, body=date_req
-        )
-        if unwrap(date_response, raise_on_error=False) is None:
-            warnings.append(
-                f"completed_at was not applied to MO {order_number} "
-                f"(HTTP {date_response.status_code}); the order is DONE but "
-                "done_date is server-time. Patch done_date manually in the "
-                "Katana UI if the backdated value is required."
-            )
-        else:
-            next_actions.insert(
-                1, f"done_date backdated to {request.completed_at.isoformat()}"
-            )
+        next_actions.insert(1, f"done_date set to {request.completed_at.isoformat()}")
 
     logger.info(f"Successfully marked manufacturing order {order_number} as DONE")
     return FulfillOrderResponse(
@@ -363,7 +369,6 @@ async def _fetch_missing_from_api(
     read fields uniformly across cache hits and API-fallback rows.
     """
     from katana_public_api_client.models import ErrorResponse
-    from katana_public_api_client.utils import unwrap
 
     missing = [eid for eid in needed_ids if eid not in cached]
     if not missing:

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -2930,7 +2930,7 @@ async def test_modify_mo_production_record_add_passes_through_to_api():
                 MOProductionAdd(
                     completed_quantity=10.0,
                     is_final=True,
-                    serial_numbers=["SN-001", "SN-002"],
+                    serial_numbers=[1001, 1002],
                 ),
             ],
             preview=False,
@@ -2943,7 +2943,7 @@ async def test_modify_mo_production_record_add_passes_through_to_api():
     assert body.manufacturing_order_id == 42
     assert body.completed_quantity == 10.0
     assert body.is_final is True
-    assert body.serial_numbers == ["SN-001", "SN-002"]
+    assert body.serial_numbers == [1001, 1002]
 
 
 @pytest.mark.asyncio

--- a/katana_mcp_server/tests/tools/test_orders.py
+++ b/katana_mcp_server/tests/tools/test_orders.py
@@ -71,39 +71,50 @@ async def test_fulfill_manufacturing_order_preview():
 
 @pytest.mark.asyncio
 async def test_fulfill_manufacturing_order_confirm():
-    """Test fulfill_order confirm mode for manufacturing order."""
+    """fulfill_order(manufacturing) apply path: single POST
+    /manufacturing_order_productions atomically marks the MO DONE (#790).
+    Replaces the prior two-call PATCH chase (#779).
+    """
     context, _lifespan_ctx = create_mock_context()
 
-    # Mock ManufacturingOrder for get
+    # Mock ManufacturingOrder for the initial get (pre-production).
     mock_mo = MagicMock(spec=ManufacturingOrder)
     mock_mo.order_no = "MO-002"
     mock_mo.status = ManufacturingOrderStatus.IN_PROGRESS
+    mock_mo.variant_id = None
+    mock_mo.actual_quantity = None
 
-    mock_get_response = MagicMock()
-    mock_get_response.status_code = 200
-    mock_get_response.parsed = mock_mo
+    mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
 
-    # Mock ManufacturingOrder for update
-    mock_updated_mo = MagicMock(spec=ManufacturingOrder)
-    mock_updated_mo.order_no = "MO-002"
-    mock_updated_mo.status = ManufacturingOrderStatus.DONE
+    # Mock ManufacturingOrderProduction returned from POST
+    # /manufacturing_order_productions.
+    from katana_public_api_client.models import ManufacturingOrderProduction
 
-    mock_update_response = MagicMock()
-    mock_update_response.status_code = 200
-    mock_update_response.parsed = mock_updated_mo
+    mock_production = MagicMock(spec=ManufacturingOrderProduction)
+    mock_production.id = 9001
+    mock_create_response = MagicMock(status_code=200, parsed=mock_production)
 
-    # Mock the API calls
+    # Mock ManufacturingOrder for the post-production re-fetch (cache-merge
+    # contract: a single full-entity fetch at the end).
+    mock_done_mo = MagicMock(spec=ManufacturingOrder)
+    mock_done_mo.order_no = "MO-002"
+    mock_done_mo.status = ManufacturingOrderStatus.DONE
+    mock_final_response = MagicMock(status_code=200, parsed=mock_done_mo)
+
     from katana_public_api_client.api.manufacturing_order import (
         get_manufacturing_order,
-        update_manufacturing_order,
+    )
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production,
     )
 
-    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
-        return_value=mock_get_response
-    )
-    cast(Any, update_manufacturing_order).asyncio_detailed = AsyncMock(
-        return_value=mock_update_response
-    )
+    # The pre-mutation get returns the IN_PROGRESS MO; the post-mutation
+    # get returns the DONE MO. Use side_effect to sequence them.
+    get_mock = AsyncMock(side_effect=[mock_get_response, mock_final_response])
+    cast(Any, get_manufacturing_order).asyncio_detailed = get_mock
+
+    create_mock = AsyncMock(return_value=mock_create_response)
+    cast(Any, create_manufacturing_order_production).asyncio_detailed = create_mock
 
     request = FulfillOrderRequest(
         order_id=1234, order_type="manufacturing", preview=False
@@ -118,8 +129,13 @@ async def test_fulfill_manufacturing_order_confirm():
     assert len(result.inventory_updates) > 0
     assert "marked" in result.message.lower() or "done" in result.message.lower()
 
-    # Verify update was called
-    cast(Any, update_manufacturing_order.asyncio_detailed).assert_called_once()
+    # The production POST was called exactly once with the expected body.
+    create_mock.assert_called_once()
+    sent_body = create_mock.call_args.kwargs["body"]
+    assert sent_body.manufacturing_order_id == 1234
+    assert sent_body.is_final is True
+    # actual_quantity was None → default to 1.
+    assert sent_body.completed_quantity == 1
 
 
 @pytest.mark.asyncio
@@ -535,33 +551,35 @@ async def test_fulfill_order_invalid_type():
 
 @pytest.mark.asyncio
 async def test_fulfill_manufacturing_order_api_error():
-    """Test fulfill_order when manufacturing order API returns error."""
+    """Apply path: a non-2xx from the production POST raises APIError, so
+    the fail-loud contract on the upstream production endpoint is preserved.
+    """
     context, _lifespan_ctx = create_mock_context()
 
     # Mock ManufacturingOrder
     mock_mo = MagicMock(spec=ManufacturingOrder)
     mock_mo.order_no = "MO-005"
     mock_mo.status = ManufacturingOrderStatus.IN_PROGRESS
+    mock_mo.variant_id = None
+    mock_mo.actual_quantity = None
 
-    mock_get_response = MagicMock()
-    mock_get_response.status_code = 200
-    mock_get_response.parsed = mock_mo
+    mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
 
-    # Mock update API returning error
-    mock_update_response = MagicMock()
-    mock_update_response.status_code = 500
-    mock_update_response.parsed = None
+    # Production POST returns 500 — no parsed payload → unwrap_as raises.
+    mock_create_response = MagicMock(status_code=500, parsed=None)
 
     from katana_public_api_client.api.manufacturing_order import (
         get_manufacturing_order,
-        update_manufacturing_order,
+    )
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production,
     )
 
     cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
         return_value=mock_get_response
     )
-    cast(Any, update_manufacturing_order).asyncio_detailed = AsyncMock(
-        return_value=mock_update_response
+    cast(Any, create_manufacturing_order_production).asyncio_detailed = AsyncMock(
+        return_value=mock_create_response
     )
 
     request = FulfillOrderRequest(
@@ -1119,28 +1137,39 @@ async def test_fulfill_manufacturing_order_preview_accepts_serial_numbers():
 
 @pytest.mark.asyncio
 async def test_fulfill_manufacturing_order_apply_passes_serials_to_api():
-    """Apply with serial_numbers → update_manufacturing_order body carries them."""
+    """Apply with serial_numbers → production POST body carries them as
+    list[int] (#790). Serial-tracked MO close-out: caller must mint via
+    ``POST /serial_numbers`` first; Katana silently drops unminted IDs.
+    """
     context, lifespan_ctx = create_mock_context()
     _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-V2")
 
     mock_mo = _make_serial_tracked_mo(order_no="MO-SN-3", actual_quantity=2.0)
     mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
 
-    mock_updated_mo = MagicMock(spec=ManufacturingOrder)
-    mock_updated_mo.order_no = "MO-SN-3"
-    mock_updated_mo.status = ManufacturingOrderStatus.DONE
-    mock_update_response = MagicMock(status_code=200, parsed=mock_updated_mo)
+    from katana_public_api_client.models import ManufacturingOrderProduction
+
+    mock_production = MagicMock(spec=ManufacturingOrderProduction)
+    mock_production.id = 9001
+    mock_create_response = MagicMock(status_code=200, parsed=mock_production)
+
+    mock_done_mo = MagicMock(spec=ManufacturingOrder)
+    mock_done_mo.order_no = "MO-SN-3"
+    mock_done_mo.status = ManufacturingOrderStatus.DONE
+    mock_final_response = MagicMock(status_code=200, parsed=mock_done_mo)
 
     from katana_public_api_client.api.manufacturing_order import (
         get_manufacturing_order,
-        update_manufacturing_order,
+    )
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production,
     )
 
-    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
-        return_value=mock_get_response
-    )
-    update_mock = AsyncMock(return_value=mock_update_response)
-    cast(Any, update_manufacturing_order).asyncio_detailed = update_mock
+    get_mock = AsyncMock(side_effect=[mock_get_response, mock_final_response])
+    cast(Any, get_manufacturing_order).asyncio_detailed = get_mock
+
+    create_mock = AsyncMock(return_value=mock_create_response)
+    cast(Any, create_manufacturing_order_production).asyncio_detailed = create_mock
 
     request = FulfillOrderRequest(
         order_id=42,
@@ -1152,10 +1181,12 @@ async def test_fulfill_manufacturing_order_apply_passes_serials_to_api():
 
     assert result.is_preview is False
     assert result.status == "DONE"
-    update_mock.assert_called_once()
-    assert update_mock.call_args is not None
-    sent_body = update_mock.call_args.kwargs["body"]
+    create_mock.assert_called_once()
+    sent_body = create_mock.call_args.kwargs["body"]
     assert sent_body.serial_numbers == [501, 502]
+    # completed_quantity sourced from the MO's actual_quantity.
+    assert sent_body.completed_quantity == 2.0
+    assert sent_body.is_final is True
 
 
 @pytest.mark.asyncio
@@ -1318,8 +1349,8 @@ async def test_fulfill_manufacturing_order_serial_tracked_detection_falls_back_t
 
 @pytest.mark.asyncio
 async def test_fulfill_manufacturing_order_non_serial_tracked_no_change():
-    """Non-serial-tracked MO + no serials → behaves as before (no BLOCK,
-    apply path passes UNSET for serial_numbers).
+    """Non-serial-tracked MO + no serials → no BLOCK, production POST body
+    carries UNSET for serial_numbers (not an empty list) (#790).
     """
     context, lifespan_ctx = create_mock_context()
 
@@ -1343,21 +1374,29 @@ async def test_fulfill_manufacturing_order_non_serial_tracked_no_change():
     mock_mo = _make_serial_tracked_mo(order_no="MO-SN-7", actual_quantity=2.0)
     mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
 
-    mock_updated_mo = MagicMock(spec=ManufacturingOrder)
-    mock_updated_mo.order_no = "MO-SN-7"
-    mock_updated_mo.status = ManufacturingOrderStatus.DONE
-    mock_update_response = MagicMock(status_code=200, parsed=mock_updated_mo)
+    from katana_public_api_client.models import ManufacturingOrderProduction
+
+    mock_production = MagicMock(spec=ManufacturingOrderProduction)
+    mock_production.id = 9001
+    mock_create_response = MagicMock(status_code=200, parsed=mock_production)
+
+    mock_done_mo = MagicMock(spec=ManufacturingOrder)
+    mock_done_mo.order_no = "MO-SN-7"
+    mock_done_mo.status = ManufacturingOrderStatus.DONE
+    mock_final_response = MagicMock(status_code=200, parsed=mock_done_mo)
 
     from katana_public_api_client.api.manufacturing_order import (
         get_manufacturing_order,
-        update_manufacturing_order,
+    )
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production,
     )
 
-    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
-        return_value=mock_get_response
-    )
-    update_mock = AsyncMock(return_value=mock_update_response)
-    cast(Any, update_manufacturing_order).asyncio_detailed = update_mock
+    get_mock = AsyncMock(side_effect=[mock_get_response, mock_final_response])
+    cast(Any, get_manufacturing_order).asyncio_detailed = get_mock
+
+    create_mock = AsyncMock(return_value=mock_create_response)
+    cast(Any, create_manufacturing_order_production).asyncio_detailed = create_mock
 
     request = FulfillOrderRequest(
         order_id=42, order_type="manufacturing", preview=False
@@ -1366,7 +1405,7 @@ async def test_fulfill_manufacturing_order_non_serial_tracked_no_change():
 
     assert result.status == "DONE"
     assert not [w for w in result.warnings if w.startswith("BLOCK:")]
-    sent_body = update_mock.call_args.kwargs["body"]
+    sent_body = create_mock.call_args.kwargs["body"]
     # serial_numbers should be UNSET (omitted from wire), not an empty list.
     from katana_public_api_client.client_types import UNSET
 
@@ -1374,7 +1413,7 @@ async def test_fulfill_manufacturing_order_non_serial_tracked_no_change():
 
 
 # ============================================================================
-# completed_at Backdating Tests (#778)
+# completed_at Backdating Tests (#778, refactored for #790)
 # ============================================================================
 #
 # Hybrid surface: ``FulfillOrderRequest.completed_at`` maps to two different
@@ -1382,13 +1421,18 @@ async def test_fulfill_manufacturing_order_non_serial_tracked_no_change():
 #
 # - SO: forwarded as ``picked_date`` on the single
 #   ``POST /sales_order_fulfillments`` call (one round-trip).
-# - MO: requires a two-call PATCH chase (Katana 422s if ``done_date`` and
-#   ``status=DONE`` ship in the same body — see corrections.py).
+# - MO: forwarded as ``completed_date`` on the single
+#   ``POST /manufacturing_order_productions`` call (one round-trip). Katana
+#   propagates ``completed_date`` verbatim to ``MO.done_date``. Refactored
+#   from the prior two-call PATCH chase in #790.
 
 
 @pytest.mark.asyncio
-async def test_fulfill_mo_with_completed_at_two_call_succeeds():
-    """MO apply with completed_at: two PATCHes fire (status then done_date)."""
+async def test_fulfill_mo_with_completed_at_one_call_succeeds():
+    """MO apply with completed_at: one POST
+    /manufacturing_order_productions fires with completed_date in the body
+    (#790). No follow-up PATCH.
+    """
     context, _lifespan_ctx = create_mock_context()
 
     mock_mo = MagicMock(spec=ManufacturingOrder)
@@ -1399,27 +1443,29 @@ async def test_fulfill_mo_with_completed_at_two_call_succeeds():
 
     mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
 
-    mock_updated_mo = MagicMock(spec=ManufacturingOrder)
-    mock_updated_mo.order_no = "MO-CA-1"
-    mock_updated_mo.status = ManufacturingOrderStatus.DONE
-    mock_status_response = MagicMock(status_code=200, parsed=mock_updated_mo)
+    from katana_public_api_client.models import ManufacturingOrderProduction
 
-    # Second PATCH (done_date) — Katana returns the mutated MO on success.
-    mock_dated_mo = MagicMock(spec=ManufacturingOrder)
-    mock_dated_mo.order_no = "MO-CA-1"
-    mock_dated_mo.status = ManufacturingOrderStatus.DONE
-    mock_date_response = MagicMock(status_code=200, parsed=mock_dated_mo)
+    mock_production = MagicMock(spec=ManufacturingOrderProduction)
+    mock_production.id = 9001
+    mock_create_response = MagicMock(status_code=200, parsed=mock_production)
+
+    mock_done_mo = MagicMock(spec=ManufacturingOrder)
+    mock_done_mo.order_no = "MO-CA-1"
+    mock_done_mo.status = ManufacturingOrderStatus.DONE
+    mock_final_response = MagicMock(status_code=200, parsed=mock_done_mo)
 
     from katana_public_api_client.api.manufacturing_order import (
         get_manufacturing_order,
-        update_manufacturing_order,
+    )
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production,
     )
 
-    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
-        return_value=mock_get_response
-    )
-    update_mock = AsyncMock(side_effect=[mock_status_response, mock_date_response])
-    cast(Any, update_manufacturing_order).asyncio_detailed = update_mock
+    get_mock = AsyncMock(side_effect=[mock_get_response, mock_final_response])
+    cast(Any, get_manufacturing_order).asyncio_detailed = get_mock
+
+    create_mock = AsyncMock(return_value=mock_create_response)
+    cast(Any, create_manufacturing_order_production).asyncio_detailed = create_mock
 
     completed = datetime(2026, 5, 1, 20, 30, tzinfo=UTC)
     request = FulfillOrderRequest(
@@ -1432,29 +1478,23 @@ async def test_fulfill_mo_with_completed_at_two_call_succeeds():
 
     assert result.is_preview is False
     assert result.status == "DONE"
-    # Two PATCH calls fired in order.
-    assert update_mock.call_count == 2
-    first_body = update_mock.call_args_list[0].kwargs["body"]
-    second_body = update_mock.call_args_list[1].kwargs["body"]
-    # First call: status=DONE (no done_date — Katana would 422 otherwise).
-    assert first_body.status == ManufacturingOrderStatus.DONE
-    from katana_public_api_client.client_types import UNSET
-
-    assert first_body.done_date is UNSET
-    # Second call: done_date set, status UNSET.
-    assert second_body.done_date == completed
-    assert second_body.status is UNSET
+    # Single production POST carries completed_date directly.
+    create_mock.assert_called_once()
+    sent_body = create_mock.call_args.kwargs["body"]
+    assert sent_body.completed_date == completed
+    assert sent_body.is_final is True
     # next_actions surfaces the backdate confirmation.
-    assert any("backdated" in a for a in result.next_actions)
-    assert any(completed.isoformat() in a for a in result.next_actions)
+    assert any(
+        "done_date set to" in a and completed.isoformat() in a
+        for a in result.next_actions
+    )
 
 
 @pytest.mark.asyncio
-async def test_fulfill_mo_without_completed_at_is_single_call():
-    """No completed_at: only the status PATCH fires; no spurious second call.
-
-    Regression guard — if the second PATCH is fired with an empty body it
-    would clear ``done_date`` to None on success (Katana wipe-on-omit).
+async def test_fulfill_mo_completed_at_omitted_when_absent():
+    """No completed_at: production POST body's completed_date stays UNSET
+    (omitted from wire). Regression guard against accidentally clearing
+    done_date to null.
     """
     context, _lifespan_ctx = create_mock_context()
 
@@ -1466,21 +1506,29 @@ async def test_fulfill_mo_without_completed_at_is_single_call():
 
     mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
 
-    mock_updated_mo = MagicMock(spec=ManufacturingOrder)
-    mock_updated_mo.order_no = "MO-CA-2"
-    mock_updated_mo.status = ManufacturingOrderStatus.DONE
-    mock_update_response = MagicMock(status_code=200, parsed=mock_updated_mo)
+    from katana_public_api_client.models import ManufacturingOrderProduction
+
+    mock_production = MagicMock(spec=ManufacturingOrderProduction)
+    mock_production.id = 9001
+    mock_create_response = MagicMock(status_code=200, parsed=mock_production)
+
+    mock_done_mo = MagicMock(spec=ManufacturingOrder)
+    mock_done_mo.order_no = "MO-CA-2"
+    mock_done_mo.status = ManufacturingOrderStatus.DONE
+    mock_final_response = MagicMock(status_code=200, parsed=mock_done_mo)
 
     from katana_public_api_client.api.manufacturing_order import (
         get_manufacturing_order,
-        update_manufacturing_order,
+    )
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production,
     )
 
-    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
-        return_value=mock_get_response
-    )
-    update_mock = AsyncMock(return_value=mock_update_response)
-    cast(Any, update_manufacturing_order).asyncio_detailed = update_mock
+    get_mock = AsyncMock(side_effect=[mock_get_response, mock_final_response])
+    cast(Any, get_manufacturing_order).asyncio_detailed = get_mock
+
+    create_mock = AsyncMock(return_value=mock_create_response)
+    cast(Any, create_manufacturing_order_production).asyncio_detailed = create_mock
 
     request = FulfillOrderRequest(
         order_id=1234, order_type="manufacturing", preview=False
@@ -1489,49 +1537,59 @@ async def test_fulfill_mo_without_completed_at_is_single_call():
 
     assert result.is_preview is False
     assert result.status == "DONE"
-    update_mock.assert_called_once()
+    create_mock.assert_called_once()
+    from katana_public_api_client.client_types import UNSET
+
+    sent_body = create_mock.call_args.kwargs["body"]
+    assert sent_body.completed_date is UNSET
     # No backdate next-action when completed_at is absent.
-    assert not any("backdated" in a for a in result.next_actions)
+    assert not any("done_date set to" in a for a in result.next_actions)
 
 
 @pytest.mark.asyncio
-async def test_fulfill_mo_completed_at_second_patch_422_surfaces_warning():
-    """Second PATCH 422: MO is DONE, warning surfaces, no exception bubbles.
-
-    Per the WS-H umbrella: Katana isn't transactional across endpoints; fail
-    forward with diagnostic context rather than rolling back inventory. The
-    user's primary intent (close the MO) landed; the backdate failure is a
-    secondary concern.
+async def test_fulfill_mo_apply_emits_no_patch_calls():
+    """Regression guard: apply path must NOT emit any PATCH /manufacturing_
+    orders/{id} calls. Catches accidental re-introduction of the pre-#790
+    two-call PATCH chain.
     """
     context, _lifespan_ctx = create_mock_context()
 
     mock_mo = MagicMock(spec=ManufacturingOrder)
-    mock_mo.order_no = "MO-CA-3"
+    mock_mo.order_no = "MO-NOPATCH"
     mock_mo.status = ManufacturingOrderStatus.IN_PROGRESS
     mock_mo.variant_id = None
     mock_mo.actual_quantity = None
 
     mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
 
-    mock_updated_mo = MagicMock(spec=ManufacturingOrder)
-    mock_updated_mo.order_no = "MO-CA-3"
-    mock_updated_mo.status = ManufacturingOrderStatus.DONE
-    mock_status_response = MagicMock(status_code=200, parsed=mock_updated_mo)
+    from katana_public_api_client.models import ManufacturingOrderProduction
 
-    # Second PATCH 422s — no parsed body so unwrap(raise_on_error=False)
-    # returns None.
-    mock_422 = MagicMock(status_code=422, parsed=None)
+    mock_production = MagicMock(spec=ManufacturingOrderProduction)
+    mock_production.id = 9001
+    mock_create_response = MagicMock(status_code=200, parsed=mock_production)
+
+    mock_done_mo = MagicMock(spec=ManufacturingOrder)
+    mock_done_mo.order_no = "MO-NOPATCH"
+    mock_done_mo.status = ManufacturingOrderStatus.DONE
+    mock_final_response = MagicMock(status_code=200, parsed=mock_done_mo)
 
     from katana_public_api_client.api.manufacturing_order import (
         get_manufacturing_order,
         update_manufacturing_order,
     )
-
-    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
-        return_value=mock_get_response
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production,
     )
-    update_mock = AsyncMock(side_effect=[mock_status_response, mock_422])
-    cast(Any, update_manufacturing_order).asyncio_detailed = update_mock
+
+    get_mock = AsyncMock(side_effect=[mock_get_response, mock_final_response])
+    cast(Any, get_manufacturing_order).asyncio_detailed = get_mock
+
+    # Wire the PATCH endpoint to a mock that records calls — must stay at 0.
+    patch_mock = AsyncMock()
+    cast(Any, update_manufacturing_order).asyncio_detailed = patch_mock
+
+    create_mock = AsyncMock(return_value=mock_create_response)
+    cast(Any, create_manufacturing_order_production).asyncio_detailed = create_mock
 
     request = FulfillOrderRequest(
         order_id=1234,
@@ -1541,16 +1599,113 @@ async def test_fulfill_mo_completed_at_second_patch_422_surfaces_warning():
     )
     result = await _fulfill_order_impl(request, context)
 
-    # MO is still DONE — the close landed even though the backdate didn't.
-    assert result.is_preview is False
     assert result.status == "DONE"
-    # Warning surfaces with the HTTP code and the actionable hint.
-    assert any("completed_at was not applied" in w for w in result.warnings)
-    assert any("HTTP 422" in w for w in result.warnings)
-    # No BLOCK prefix — this is a soft warning, not a refusal.
-    assert not any(w.startswith("BLOCK:") for w in result.warnings)
-    # next_actions doesn't claim the backdate succeeded.
-    assert not any("backdated" in a for a in result.next_actions)
+    create_mock.assert_called_once()
+    # Zero PATCH calls — the whole point of the #790 refactor.
+    patch_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fulfill_mo_completed_quantity_defaults_to_one_when_actual_unset():
+    """When actual_quantity is None (MO never had a prior production),
+    completed_quantity defaults to 1 in the production POST body.
+
+    Katana stamps actual_quantity = completed_quantity on the MO when there's
+    no prior production, so 1 closes the MO at qty=1 (matches the Katana
+    UI's "complete one" semantics).
+    """
+    context, _lifespan_ctx = create_mock_context()
+
+    mock_mo = MagicMock(spec=ManufacturingOrder)
+    mock_mo.order_no = "MO-QTY1"
+    mock_mo.status = ManufacturingOrderStatus.IN_PROGRESS
+    mock_mo.variant_id = None
+    mock_mo.actual_quantity = None
+
+    mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
+
+    from katana_public_api_client.models import ManufacturingOrderProduction
+
+    mock_production = MagicMock(spec=ManufacturingOrderProduction)
+    mock_production.id = 9001
+    mock_create_response = MagicMock(status_code=200, parsed=mock_production)
+
+    mock_done_mo = MagicMock(spec=ManufacturingOrder)
+    mock_done_mo.order_no = "MO-QTY1"
+    mock_done_mo.status = ManufacturingOrderStatus.DONE
+    mock_final_response = MagicMock(status_code=200, parsed=mock_done_mo)
+
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+    )
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production,
+    )
+
+    get_mock = AsyncMock(side_effect=[mock_get_response, mock_final_response])
+    cast(Any, get_manufacturing_order).asyncio_detailed = get_mock
+
+    create_mock = AsyncMock(return_value=mock_create_response)
+    cast(Any, create_manufacturing_order_production).asyncio_detailed = create_mock
+
+    request = FulfillOrderRequest(
+        order_id=1234, order_type="manufacturing", preview=False
+    )
+    await _fulfill_order_impl(request, context)
+
+    sent_body = create_mock.call_args.kwargs["body"]
+    assert sent_body.completed_quantity == 1
+
+
+@pytest.mark.asyncio
+async def test_fulfill_mo_completed_quantity_sourced_from_actual_quantity():
+    """When actual_quantity is set (e.g., partial completion of a 5-unit MO
+    with 3 already produced), completed_quantity in the body matches.
+
+    Per Probe 3: Katana honors the lower actual quantity with is_final=True
+    (closes the MO at the partial value rather than refusing). #790.
+    """
+    context, _lifespan_ctx = create_mock_context()
+
+    mock_mo = MagicMock(spec=ManufacturingOrder)
+    mock_mo.order_no = "MO-QTY3"
+    mock_mo.status = ManufacturingOrderStatus.IN_PROGRESS
+    mock_mo.variant_id = None
+    mock_mo.actual_quantity = 3.0
+
+    mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
+
+    from katana_public_api_client.models import ManufacturingOrderProduction
+
+    mock_production = MagicMock(spec=ManufacturingOrderProduction)
+    mock_production.id = 9001
+    mock_create_response = MagicMock(status_code=200, parsed=mock_production)
+
+    mock_done_mo = MagicMock(spec=ManufacturingOrder)
+    mock_done_mo.order_no = "MO-QTY3"
+    mock_done_mo.status = ManufacturingOrderStatus.DONE
+    mock_final_response = MagicMock(status_code=200, parsed=mock_done_mo)
+
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+    )
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production,
+    )
+
+    get_mock = AsyncMock(side_effect=[mock_get_response, mock_final_response])
+    cast(Any, get_manufacturing_order).asyncio_detailed = get_mock
+
+    create_mock = AsyncMock(return_value=mock_create_response)
+    cast(Any, create_manufacturing_order_production).asyncio_detailed = create_mock
+
+    request = FulfillOrderRequest(
+        order_id=1234, order_type="manufacturing", preview=False
+    )
+    await _fulfill_order_impl(request, context)
+
+    sent_body = create_mock.call_args.kwargs["body"]
+    assert sent_body.completed_quantity == 3.0
 
 
 @pytest.mark.asyncio
@@ -1604,7 +1759,7 @@ async def test_fulfill_mo_preview_with_completed_at_surfaces_in_inventory_update
 
     assert result.is_preview is True
     assert any(
-        "done_date will be set to" in u and completed.isoformat() in u
+        "completed_date / done_date will be set to" in u and completed.isoformat() in u
         for u in result.inventory_updates
     )
 
@@ -1774,17 +1929,15 @@ async def test_completed_at_validator_rejects_invalid_string():
 
 @pytest.mark.asyncio
 async def test_fulfill_mo_completed_at_propagates_to_serial_transaction_date():
-    """Integration-style: the second PATCH carrying ``done_date`` is the same
-    timestamp the Traceability column's ``SerialNumber.transaction_date`` is
-    derived from.
+    """Integration-style: the single production POST carries both
+    ``serial_numbers`` and ``completed_date`` in one body — Katana
+    propagates ``completed_date`` to ``MO.done_date``, which derives the
+    ``SerialNumber.transaction_date`` shown in the Traceability column.
 
     This test pins the **emitter side**: the tool sends Katana exactly one
-    ``done_date`` value via the second PATCH. The **consumer side** (Katana
-    deriving ``SerialNumber.transaction_date`` from ``done_date``) is
-    asserted in the issue body (#778) against a live-API observation
-    (WEB20387) and can only be verified live — flagged as a known-unknown
-    in the PR body. If Katana ever changes that derivation, the symptom
-    surfaces in production, not here.
+    ``completed_date`` value via the production POST. The **consumer side**
+    (Katana deriving ``SerialNumber.transaction_date`` from
+    ``completed_date`` → ``done_date``) is asserted live (Probe 2 in #790).
     """
     context, lifespan_ctx = create_mock_context()
     _wire_serial_tracked_cache(lifespan_ctx, variant_id=100, sku="WIDGET-SN")
@@ -1792,26 +1945,29 @@ async def test_fulfill_mo_completed_at_propagates_to_serial_transaction_date():
     mock_mo = _make_serial_tracked_mo(order_no="MO-CA-SN", actual_quantity=1.0)
     mock_get_response = MagicMock(status_code=200, parsed=mock_mo)
 
-    mock_updated_mo = MagicMock(spec=ManufacturingOrder)
-    mock_updated_mo.order_no = "MO-CA-SN"
-    mock_updated_mo.status = ManufacturingOrderStatus.DONE
-    mock_status_response = MagicMock(status_code=200, parsed=mock_updated_mo)
+    from katana_public_api_client.models import ManufacturingOrderProduction
 
-    mock_dated_mo = MagicMock(spec=ManufacturingOrder)
-    mock_dated_mo.order_no = "MO-CA-SN"
-    mock_dated_mo.status = ManufacturingOrderStatus.DONE
-    mock_date_response = MagicMock(status_code=200, parsed=mock_dated_mo)
+    mock_production = MagicMock(spec=ManufacturingOrderProduction)
+    mock_production.id = 9001
+    mock_create_response = MagicMock(status_code=200, parsed=mock_production)
+
+    mock_done_mo = MagicMock(spec=ManufacturingOrder)
+    mock_done_mo.order_no = "MO-CA-SN"
+    mock_done_mo.status = ManufacturingOrderStatus.DONE
+    mock_final_response = MagicMock(status_code=200, parsed=mock_done_mo)
 
     from katana_public_api_client.api.manufacturing_order import (
         get_manufacturing_order,
-        update_manufacturing_order,
+    )
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production,
     )
 
-    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
-        return_value=mock_get_response
-    )
-    update_mock = AsyncMock(side_effect=[mock_status_response, mock_date_response])
-    cast(Any, update_manufacturing_order).asyncio_detailed = update_mock
+    get_mock = AsyncMock(side_effect=[mock_get_response, mock_final_response])
+    cast(Any, get_manufacturing_order).asyncio_detailed = get_mock
+
+    create_mock = AsyncMock(return_value=mock_create_response)
+    cast(Any, create_manufacturing_order_production).asyncio_detailed = create_mock
 
     completed = datetime(2026, 5, 1, 20, 30, tzinfo=UTC)
     request = FulfillOrderRequest(
@@ -1824,12 +1980,9 @@ async def test_fulfill_mo_completed_at_propagates_to_serial_transaction_date():
     result = await _fulfill_order_impl(request, context)
 
     assert result.is_preview is False
-    assert update_mock.call_count == 2
-    # First PATCH carries serials (per the existing #586 contract).
-    first_body = update_mock.call_args_list[0].kwargs["body"]
-    assert first_body.serial_numbers == [501]
-    # Second PATCH carries the exact done_date Katana derives
-    # transaction_date from. This is the value that lands on the
-    # serial via the Katana-side derivation.
-    second_body = update_mock.call_args_list[1].kwargs["body"]
-    assert second_body.done_date == completed
+    create_mock.assert_called_once()
+    sent_body = create_mock.call_args.kwargs["body"]
+    # Serials + completed_date land in the same body — atomic close (#790).
+    assert sent_body.serial_numbers == [501]
+    assert sent_body.completed_date == completed
+    assert sent_body.is_final is True

--- a/katana_public_api_client/models/create_manufacturing_order_production_request.py
+++ b/katana_public_api_client/models/create_manufacturing_order_production_request.py
@@ -45,7 +45,7 @@ class CreateManufacturingOrderProductionRequest:
     batch_transaction: BatchTransaction | Unset = UNSET
     ingredients: list[ManufacturingOrderProductionIngredient] | Unset = UNSET
     operations: list[ManufacturingOrderOperationRow] | Unset = UNSET
-    serial_numbers: list[str] | Unset = UNSET
+    serial_numbers: list[int] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -77,7 +77,7 @@ class CreateManufacturingOrderProductionRequest:
                 operations_item = operations_item_data.to_dict()
                 operations.append(operations_item)
 
-        serial_numbers: list[str] | Unset = UNSET
+        serial_numbers: list[int] | Unset = UNSET
         if not isinstance(self.serial_numbers, Unset):
             serial_numbers = self.serial_numbers
 
@@ -157,7 +157,7 @@ class CreateManufacturingOrderProductionRequest:
 
                 operations.append(operations_item)
 
-        serial_numbers = cast(list[str], d.pop("serial_numbers", UNSET))
+        serial_numbers = cast(list[int], d.pop("serial_numbers", UNSET))
 
         create_manufacturing_order_production_request = cls(
             manufacturing_order_id=manufacturing_order_id,

--- a/katana_public_api_client/models_pydantic/_generated/manufacturing.py
+++ b/katana_public_api_client/models_pydantic/_generated/manufacturing.py
@@ -1000,8 +1000,10 @@ class CreateManufacturingOrderProductionRequest(KatanaPydanticBase):
         Field(description="Operations performed during this production run"),
     ] = None
     serial_numbers: Annotated[
-        list[str] | None,
-        Field(description="Serial numbers to assign to produced items"),
+        list[int] | None,
+        Field(
+            description="Pre-existing SerialNumber IDs (integers) to assign to the units produced in this production run. Required when the manufacturing order's finished-good variant is serial-tracked. Katana silently drops IDs that do not exist — callers must mint via `POST /serial_numbers` first."
+        ),
     ] = None
 
 

--- a/tests/test_models_pydantic.py
+++ b/tests/test_models_pydantic.py
@@ -396,6 +396,57 @@ class TestVariantNullSku:
         assert pydantic_product.variants[1].sku is None
 
 
+class TestProductionSerialNumbers:
+    """Wire-shape pin for ``CreateManufacturingOrderProductionRequest.serial_numbers``.
+
+    Spec drift fix in #790: Katana's `POST /manufacturing_order_productions`
+    schema previously declared ``serial_numbers: array<string>`` but the live
+    API rejects strings with HTTP 422 ("must be of type: number") and accepts
+    only integer ``SerialNumber.id`` values. The spec was corrected to
+    ``array<integer>`` in this PR; this test pins the regenerated wire shape
+    so a future spec-regen can't silently revert it.
+
+    Worse, when an unknown integer ID was passed (e.g., from a future-mint
+    flow that handed the production POST an unminted ID), Katana would
+    return HTTP 200 with ``serial_numbers: []`` — a silent drop. Catching
+    that footgun lives in the MCP tool layer (``_fulfill_manufacturing_order``);
+    this test only pins the wire-type contract.
+    """
+
+    def test_serial_numbers_is_list_of_int(self) -> None:
+        from katana_public_api_client.models_pydantic._generated import (
+            CreateManufacturingOrderProductionRequest,
+        )
+
+        # Integer IDs round-trip cleanly.
+        req = CreateManufacturingOrderProductionRequest(
+            manufacturing_order_id=3001,
+            completed_quantity=25,
+            serial_numbers=[101, 102, 103],
+        )
+        assert req.serial_numbers == [101, 102, 103]
+
+    def test_serial_numbers_rejects_string_values(self) -> None:
+        from pydantic import ValidationError
+
+        from katana_public_api_client.models_pydantic._generated import (
+            CreateManufacturingOrderProductionRequest,
+        )
+
+        # Strings (the pre-#790 wrong type) now raise at the model boundary.
+        # Routes through ``model_validate`` so the test stays type-clean —
+        # raw string values are a wire-layer concern (MCP clients pass JSON),
+        # not a static-type one.
+        with pytest.raises(ValidationError):
+            CreateManufacturingOrderProductionRequest.model_validate(
+                {
+                    "manufacturing_order_id": 3001,
+                    "completed_quantity": 25,
+                    "serial_numbers": ["SN-001", "SN-002"],
+                }
+            )
+
+
 class TestWireNullTolerance:
     """Generated ``from_dict`` parsers must tolerate ``null`` for spec-nullable fields.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.84.0"
+version = "0.85.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Refactor `fulfill_order(manufacturing)` to use a single `POST /manufacturing_order_productions` call instead of the prior two-call PATCH chase. The production POST with `is_final: true` atomically marks the MO DONE, auto-consumes BOM, and propagates `completed_date` → `MO.done_date` — eliminating the validation-against-current-status trap that #523/#773/#779 each had to engineer around.
- Fix incidental spec drift on `CreateManufacturingOrderProductionRequest.serial_numbers`: schema was `array<string>` but the live API requires `array<integer>` (#784's open drift). Corrected in the OpenAPI spec, regenerated client + pydantic models. `MOProductionAdd.serial_numbers` and `MOProductionSnapshot.serial_numbers` follow suit.
- Net round-trip reduction: non-serial-tracked MO close drops from 2 → 1 calls; non-serial-tracked SO close-out drops from 3 → 2.

## Round-trip impact (per the issue's table)

| Workflow | Before | After |
|---|---|---|
| Non-serial-tracked MO close + backdate | 2 calls | **1 call** |
| Non-serial-tracked SO close-out (full) | 3 calls | **2 calls** |
| Serial-tracked SO close-out (full) | 4 calls | **3 calls** |
| Partial-failure surface on done_date | Existed | **Gone** |

## Probe findings preserved as inline comments + tests

- **Probe 1 (silent-drop of unminted SN IDs)**: `_serial_numbers_to_ids` in `_reopen.py` now captures `SerialNumber.id` (integer) rather than `.serial_number` (string). The pre-#790 close-state-restore path was passing strings, which the live API silently dropped — so restored productions actually had zero serials attached. Capturing IDs makes the restore re-attach the originals (Probe 1 confirmed the IDs round-trip when they exist; only *unminted* IDs get silently dropped). The `#547` BLOCK guard for serial-tracked MO without `serial_numbers` stays as a user-safety net, which is more valuable now that the API silently no-ops on bad IDs.
- **Probe 2 (`completed_date` → `done_date` exact propagation)**: pinned via `test_fulfill_mo_completed_at_propagates_to_serial_transaction_date` and `test_fulfill_mo_with_completed_at_one_call_succeeds`.
- **Probe 3 (partial completion honored with `is_final=true`)**: sourcing `completed_quantity` from MO's current `actual_quantity` pinned by `test_fulfill_mo_completed_quantity_sourced_from_actual_quantity`. Fallback to 1 for un-touched MOs pinned by `test_fulfill_mo_completed_quantity_defaults_to_one_when_actual_unset`.
- **Regression guard for the old PATCH chain**: `test_fulfill_mo_apply_emits_no_patch_calls` asserts ZERO calls to `update_manufacturing_order.asyncio_detailed` during apply. Catches accidental re-introduction.

## Wire-shape pin (Option A from the plan)

`tests/test_models_pydantic.py::TestProductionSerialNumbers` pins the regenerated `list[int]` contract:
- Positive: integers round-trip cleanly.
- Negative: strings raise `ValidationError` at the pydantic boundary (catches a future spec-regen that reverts to `array<string>`).

## Breaking change scope

`CreateManufacturingOrderProductionRequest.serial_numbers` is now `list[int]` instead of `list[str]`. Same for `MOProductionAdd.serial_numbers` (modify_manufacturing_order's add_productions slot) and `MOProductionSnapshot.serial_numbers` (close-state-restore path).

This is a wire-correctness fix — the prior `list[str]` shape was wrong (Katana 422s on strings; silently drops anyway when accepted). **No working code path could have depended on the old type** because the live API rejected it. Any caller that thought they were passing strings was silently failing. The breaking-change marker is mechanical correctness, not a real downstream break.

## Files changed

- `docs/katana-openapi.yaml` — spec fix: `serial_numbers` items type `string` → `integer` with documentation about silent-drop behavior
- `katana_public_api_client/models/create_manufacturing_order_production_request.py` — regenerated
- `katana_public_api_client/models_pydantic/_generated/manufacturing.py` — regenerated
- `katana_mcp_server/src/katana_mcp/tools/foundation/orders.py` — `_fulfill_manufacturing_order` switches to production POST
- `katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py` — `MOProductionAdd.serial_numbers: list[str] | None` → `list[int] | None`
- `katana_mcp_server/src/katana_mcp/tools/_reopen.py` — `MOProductionSnapshot.serial_numbers: list[str]` → `list[int]`; `_serial_numbers_to_strs` → `_serial_numbers_to_ids` (now captures `SerialNumber.id`)
- `katana_mcp_server/tests/tools/test_orders.py` — 8 existing MO-branch tests retargeted at the production-POST endpoint; 3 new tests for quantity defaulting, no-PATCH regression guard
- `katana_mcp_server/tests/tools/test_manufacturing_orders.py` — `add_productions` test serial_numbers fixture updated to `list[int]`
- `tests/test_models_pydantic.py` — new `TestProductionSerialNumbers` wire-shape pin

## Test plan

- [x] `uv run poe quick-check` — lint/format clean
- [x] `uv run poe agent-check` — adds pyright/ty pass (1 type error fixed in `corrections.py` via `_reopen.py` shape change)
- [x] `uv run poe test` — 3353 passing, 2 skipped (no regressions)
- [x] `uv run poe check` — full suite including 21 browser-render tests (188s) all passing
- [x] Probes were run end-to-end by the planning agent against SDT-tagged live fixtures (Probes 1-4 + bonus, see issue comment 4484456881). No re-probe needed.

## Follow-ups

- `#784` reduces to skill-only changes after this lands — the spec drift it documented is fixed here, and the production-POST endpoint is now the central abstraction for both serial-tracked MO close-outs and reopen-restore.
- Open question about non-final-production SN transfer (raised by #784) is unaffected by this PR — `fulfill_order` only sets `is_final=true`.

Closes #790
Refs #784, #779, #778, #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)