### PR TITLE
fix(mcp): overlay PATCH response on cache merge to defeat read-replica lag

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -189,6 +189,13 @@ class ActionResult(BaseModel):
     verified: bool | None = None
     actual_after: dict[str, Any] | None = None
 
+    # Internal-only carrier for the PATCH/POST response body so the
+    # dispatcher can overlay fresh-by-construction field values onto the
+    # cache-merge GET refetch (defeats Katana's read-replica lag, see
+    # ``_post_apply_cache_merge``). Excluded from serialization so it
+    # never reaches Prefab clients or test snapshots.
+    apply_outcome: Any = Field(default=None, exclude=True, repr=False)
+
     # Derived display fields — computed from succeeded/verified/changes/operation
     # so client renderers (Prefab cards) bind directly without recomputing.
     # Travels with every preview AND apply response, so the live-tick path

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -77,10 +77,17 @@ from katana_mcp.tools._modification import (
     make_response_verifier,
 )
 from katana_mcp.web_urls import EntityKind, katana_web_url
+from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.domain.converters import to_unset
 from katana_public_api_client.utils import is_success, unwrap, unwrap_as
 
 logger = get_logger(__name__)
+
+
+# Sentinel for "attribute not present on this object" — distinguishes a
+# missing attribute from a present-but-None value in attribute walks over
+# generated attrs models that may have diverging PATCH/GET shapes.
+_MISSING: Any = object()
 
 
 # ``apply`` callable: returns whatever the API call yields (typically the
@@ -260,6 +267,7 @@ async def execute_plan(plan: list[ActionSpec]) -> list[ActionResult]:
                 succeeded=True,
                 verified=verified,
                 actual_after=actual_after,
+                apply_outcome=outcome,
             )
         )
 
@@ -831,11 +839,13 @@ async def run_modify_plan(
         and actions
         and not any(a.succeeded is False for a in actions)
     ):
+        parent_field_overlay = _collect_parent_field_overlay(actions, request.id)
         try:
             await _post_apply_cache_merge(
                 cache_merge=cache_merge,
                 entity_type=entity_type,
                 entity_id=request.id,
+                parent_field_overlay=parent_field_overlay,
             )
         except asyncio.CancelledError:
             # Cooperative cancellation (request timeout, shutdown) must
@@ -861,17 +871,62 @@ async def run_modify_plan(
     )
 
 
+def _collect_parent_field_overlay(
+    actions: list[ActionResult],
+    entity_id: int | str,
+) -> dict[str, Any]:
+    """Build the {field: fresh_value} overlay for ``_post_apply_cache_merge``.
+
+    Bug #2b (2026-05-18): the post-apply parent refetch can hit a Katana
+    read replica that lags behind the writer, returning pre-modify values
+    for fields we *just* asked to change. Merging that response would
+    overwrite the cache with stale data even though the write landed. The
+    PATCH response body is fresh by construction, so for each
+    parent-targeted action's diff field we read the value off
+    ``apply_outcome`` and feed it into the overlay. The merge step layers
+    these values onto the GET refetch right before writing through.
+
+    Parent-only: actions whose ``target_id`` does not match ``entity_id``
+    are skipped — their fields belong on a different (row) class. UNSET
+    values are skipped so we never clobber a non-UNSET GET value with a
+    sentinel.
+    """
+    overlay: dict[str, Any] = {}
+    for action in actions:
+        if action.succeeded is not True:
+            continue
+        if action.target_id != entity_id:
+            continue
+        outcome = action.apply_outcome
+        if outcome is None:
+            continue
+        for change in action.changes:
+            value = getattr(outcome, change.field, _MISSING)
+            if value is _MISSING or value is UNSET:
+                continue
+            overlay[change.field] = value
+    return overlay
+
+
 async def _post_apply_cache_merge(
     *,
     cache_merge: CacheMerge,
     entity_type: str,
     entity_id: int,
+    parent_field_overlay: dict[str, Any] | None = None,
 ) -> None:
     """Re-fetch the modified entity from Katana and merge into the typed cache.
 
     Looks up the ``EntitySpec`` by ``entity_type`` in ``ENTITY_SPECS`` —
     entity types that aren't cached (no spec) skip silently. Returns
     quietly if the parent refetch yields no entity (deleted, race, etc.).
+
+    ``parent_field_overlay`` carries field values pulled from the PATCH
+    response body — fresh-by-construction, used to defeat read-replica
+    lag where the refetch GET would otherwise return pre-modify values
+    for fields we just asked to change. See the call-site comment in
+    ``run_modify_plan`` for the full reasoning. Empty/None means no
+    overlay; the unmodified GET result merges through.
 
     For entities whose ``EntitySpec.related_specs`` reference data at
     separate API endpoints (MO recipe rows, sibling row-watermarks), the
@@ -891,6 +946,14 @@ async def _post_apply_cache_merge(
     parent = await cache_merge.refetch_for_merge(entity_id)
     if parent is None:
         return  # fetch returned nothing (e.g., the entity was deleted)
+
+    # Overlay fresh PATCH-response values onto the (possibly stale) GET
+    # refetch. Generated attrs models are mutable (no ``frozen=True``);
+    # the ``_MISSING`` sentinel tolerates future PATCH/GET shape divergence.
+    if parent_field_overlay:
+        for field_name, fresh_value in parent_field_overlay.items():
+            if getattr(parent, field_name, _MISSING) is not _MISSING:
+                setattr(parent, field_name, fresh_value)
 
     await merge_filtered_fetch(cache_merge.cache, spec, [parent])
 

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -52,6 +52,21 @@ class _SampleRequest(ConfirmableRequest):
     # ``True``; no need to re-declare here.
 
 
+class _AttrsStub:
+    """Mutable stand-in for a generated attrs response model.
+
+    Used in the post-apply overlay tests where we need the dispatcher's
+    ``getattr``/``setattr`` contract to behave like a real attrs class —
+    ``MagicMock(spec=...)`` answers ``hasattr`` truthy for arbitrary
+    attributes and would mask the very ``_MISSING`` sentinel guard the
+    overlay relies on.
+    """
+
+    def __init__(self, **kw: Any) -> None:
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
 def test_compute_field_diff_skips_id_and_preview_by_default():
     request = _SampleRequest(id=1, name="x", preview=False)
     diff = compute_field_diff(None, request)
@@ -791,6 +806,189 @@ async def test_run_modify_plan_post_apply_merge_fires_on_success(monkeypatch):
         "attrs_objs": [refetched_parent],
         "refetched_id": 42,
     }
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_overlays_patch_response_on_stale_refetch(monkeypatch):
+    """Bug #2b: defeat Katana read-replica lag on the post-apply refetch.
+
+    Setup: the PATCH apply returns a fresh outcome with ``name="FRESH"``,
+    but the cache-merge refetch (simulating a stale read replica) returns
+    a parent with ``name="STALE"``. Without the overlay the cache would be
+    silently corrupted with the pre-modify value — the regression we saw
+    on 2026-05-18 in the supplier-code session.
+
+    Asserts: the attrs object passed to ``merge_filtered_fetch`` carries
+    the FRESH value, because the dispatcher copied it from the PATCH
+    response body onto the stale GET refetch before merge.
+    """
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    fresh_outcome = _AttrsStub(name="FRESH")
+    stale_parent = _AttrsStub(name="STALE")
+
+    captured: dict[str, Any] = {}
+
+    async def fake_merge(cache, spec, attrs_objs):
+        captured["attrs_objs"] = list(attrs_objs)
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return fresh_outcome
+
+    async def fake_refetch(_eid: int):
+        return stale_parent
+
+    request = _SampleRequest(id=42, name="FRESH", preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_header",
+            target_id=42,  # matches request.id — parent-level action
+            diff=[FieldChange(field="name", old="STALE", new="FRESH")],
+            apply=fake_apply,
+            verify=None,
+        )
+    ]
+
+    fake_cache = cast(TypedCacheEngine, object())
+    await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 42",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(cache=fake_cache, refetch_for_merge=fake_refetch),
+    )
+
+    # The merged object IS the stale refetch (same identity), but its
+    # ``name`` attribute has been overwritten in-place by the overlay.
+    merged = captured["attrs_objs"][0]
+    assert merged is stale_parent
+    assert merged.name == "FRESH"
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_overlay_skips_row_level_actions(monkeypatch):
+    """Parent overlay only applies to actions whose ``target_id`` matches
+    the request's entity id. Row-level actions (e.g. ``update_row`` on a
+    PO row, target_id=row_id != po_id) must NOT contribute to the parent
+    overlay — their fields belong on a row class, not the parent class.
+    """
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    # Outcome from a row-level PATCH — has a ``quantity`` field that
+    # happens to also exist on the parent (coincidence). If we naively
+    # overlaid, the parent's quantity would be clobbered by the row's.
+    row_outcome = _AttrsStub(quantity=999)
+    parent_refetch = _AttrsStub(quantity=42)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_merge(cache, spec, attrs_objs):
+        captured["attrs_objs"] = list(attrs_objs)
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return row_outcome
+
+    async def fake_refetch(_eid: int):
+        return parent_refetch
+
+    request = _SampleRequest(id=42, qty=10, preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_row",
+            target_id=999,  # row id — does NOT match request.id (42)
+            diff=[FieldChange(field="quantity", old=42, new=999)],
+            apply=fake_apply,
+            verify=None,
+        )
+    ]
+
+    fake_cache = cast(TypedCacheEngine, object())
+    await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 42",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(cache=fake_cache, refetch_for_merge=fake_refetch),
+    )
+
+    merged = captured["attrs_objs"][0]
+    assert merged is parent_refetch
+    assert merged.quantity == 42  # untouched — overlay skipped the row action
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_overlay_skips_unset_values(monkeypatch):
+    """UNSET on the PATCH response means "Katana didn't echo this field"
+    — we should NOT overlay UNSET onto the GET value. The GET stays.
+    """
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    # Outcome echoes ``name`` but not ``qty`` (qty is UNSET — Katana
+    # didn't include it in the response body for some reason).
+    outcome = _AttrsStub(name="FRESH_NAME", qty=UNSET)
+    refetched = _AttrsStub(name="STALE_NAME", qty=7)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_merge(cache, spec, attrs_objs):
+        captured["attrs_objs"] = list(attrs_objs)
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return outcome
+
+    async def fake_refetch(_eid: int):
+        return refetched
+
+    request = _SampleRequest(id=42, name="FRESH_NAME", qty=7, preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_header",
+            target_id=42,
+            diff=[
+                FieldChange(field="name", old="STALE_NAME", new="FRESH_NAME"),
+                FieldChange(field="qty", old=7, new=7, is_unchanged=True),
+            ],
+            apply=fake_apply,
+            verify=None,
+        )
+    ]
+
+    fake_cache = cast(TypedCacheEngine, object())
+    await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 42",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(cache=fake_cache, refetch_for_merge=fake_refetch),
+    )
+
+    merged = captured["attrs_objs"][0]
+    assert merged.name == "FRESH_NAME"  # overlaid (non-UNSET)
+    assert merged.qty == 7  # UNSET in outcome — GET value preserved
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.86.0"
+version = "0.87.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

After a successful `modify_*` apply, `_post_apply_cache_merge` issues a fresh GET to capture server-side cascades (header-date → row-date, etc.) and merges the result into the typed cache. When Katana's read API is behind its writer (read-replica lag), that GET returns *pre-modify* values for fields we just asked to change and the merge **silently overwrites the cache with stale data** — even though the write itself landed cleanly and the `(verified)` suffix correctly reflected the PATCH response body.

**Observed:**
- 2026-05-12 supplier PO-reconciliation session — 10+ min lag on `supplier_item_codes` (already documented in `CacheMerge` docstring as Bug #2)
- 2026-05-18 supplier-code session — three variants modified in batch, only one's cache row reflected the new codes immediately; `rebuild_cache` later confirmed all three writes had landed on Katana

**Fix:** capture the PATCH outcome on each `ActionResult` (new internal-only field `apply_outcome`, excluded from serialization). In `run_modify_plan`, collect a `{field: fresh_value}` overlay across parent-targeted actions and pass it to `_post_apply_cache_merge`, which applies it in-place onto the refetched parent before `merge_filtered_fetch`. PATCH response is fresh by construction; the GET still drives cascades on fields we didn't touch.

**Scope:** parent-level fields only. Row-level cascades (PO rows, MO recipe rows) stay on the unmodified GET path — no confirmed bug there yet and a row-level overlay would be a much bigger change.

## Files changed

- `katana_mcp_server/src/katana_mcp/tools/_modification.py` — `apply_outcome: Any = Field(default=None, exclude=True, repr=False)` on `ActionResult`
- `katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py` — capture outcome in `execute_plan`; new `_collect_parent_field_overlay` helper; `_post_apply_cache_merge` applies overlay before merge; module-level `_MISSING` sentinel
- `katana_mcp_server/tests/tools/test_modification.py` — module-level `_AttrsStub` helper; three new tests (happy path, row-action skip, UNSET skip)
- `uv.lock` — pre-existing v0.85.0 → v0.86.0 drift, bundled per `COMMIT_STANDARDS.md`

## Test plan

- [x] `uv run poe agent-check` — lint, format, typecheck all clean
- [x] `uv run poe test` — 3352 passed, 2 skipped (pre-existing unrelated skips)
- [x] `uv run poe check` — full pre-PR including browser tier (21 render tests passed)
- [ ] CI green on this PR
- [ ] Real-world sanity check: run a `modify_item` with `supplier_item_codes` change, then immediately call `get_variant_details` — codes should appear without needing `rebuild_cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)