### PR TITLE
feat(scripts): add SafeClient guard for probe mutations (#781)

### DIFF
--- a/scripts/_safety.py
+++ b/scripts/_safety.py
@@ -1,0 +1,659 @@
+"""Safety guard for spec-drift probe scripts.
+
+The ``scripts/spec_drift_verify.py`` harness mints SDT-prefixed identities
+and records every mutation in a ledger so cleanup can reverse it. Both
+disciplines are opt-in — there's nothing at the wire boundary preventing
+a probe from mutating a real customer record by accident (see issue #781
+near-miss with ``#WEB20604``).
+
+This module adds that boundary. ``SafeClient`` is a drop-in
+``httpx.Client`` subclass that:
+
+1. Refuses ``POST`` / ``PATCH`` / ``DELETE`` requests when the target
+   record's identity field doesn't carry the ``SDT-`` prefix and the
+   record's ID isn't in the local ledger. ``UnsafeMutationError`` is
+   raised before the wire call.
+2. Optionally fires per-endpoint **verify hooks** after a 2xx mutation
+   response — used to assert that the wire result matches caller intent
+   (e.g. ``POST /manufacturing_order_productions`` silently dropping
+   unminted serial IDs returns 200 OK with ``serial_numbers: []``).
+   Verify-hook failures raise ``SilentDropError``.
+
+Both errors are ``RuntimeError`` subclasses so probes that want graceful
+degradation can ``except`` them; the default behavior is "process dies,
+operator sees the boundary log."
+
+The ledger-membership lookup keys on ``(endpoint, entity_id)`` because
+different Katana entities share ID spaces (a sales order and a material
+can both have ID 42). The lookup builds an in-process set from
+``read_ledger()`` at ``SafeClient`` construction time; ``record_artifact()``
+keeps the in-memory set fresh as the run progresses.
+
+Endpoints listed in ``NO_GET_BY_ID`` fall back to a ledger-only check —
+no pre-fetch is possible (the live API only exposes list / parent-scoped
+reads), so the only guard is "the parent record was created by this
+run." Treat ``NO_GET_BY_ID`` as the source of truth and update it
+directly when a new endpoint is observed to 404 on GET-by-id.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+# Identity field per top-level collection. ``None`` means the endpoint has
+# no SDT-discoverable top-level identity on the request body — child /
+# transactional collections that only carry FKs to a parent. POSTs to
+# these endpoints fall back to the FK-in-ledger check via
+# ``CHILD_PARENT_FIELDS`` below.
+IDENTITY_FIELDS: dict[str, str | None] = {
+    "/sales_orders": "order_no",
+    "/manufacturing_orders": "order_no",
+    "/purchase_orders": "order_no",
+    "/stock_transfers": "stock_transfer_number",
+    "/products": "name",
+    "/materials": "name",
+    "/services": "name",
+    "/variants": "sku",
+    "/suppliers": "name",
+    "/customers": "name",
+    "/locations": "name",
+    "/bin_locations": "name",
+    "/custom_field_definitions": "label",
+    "/webhooks": "url",
+    # Child / transactional endpoints — no top-level identity on the body.
+    "/sales_order_rows": None,
+    "/sales_order_fulfillments": None,
+    "/manufacturing_order_recipe_rows": None,
+    "/manufacturing_order_productions": None,
+    "/stock_adjustments": None,
+    "/variant_bin_locations": None,
+}
+
+# For endpoints whose POST body carries a parent FK rather than a
+# top-level identity, this map names the FK field. The parent must
+# already be in the ledger for the POST to be allowed (or
+# ``allow_unsafe=True`` must be set at SafeClient construction).
+CHILD_PARENT_FIELDS: dict[str, tuple[str, str]] = {
+    "/sales_order_rows": ("sales_order_id", "/sales_orders"),
+    "/sales_order_fulfillments": ("sales_order_id", "/sales_orders"),
+    "/manufacturing_order_recipe_rows": (
+        "manufacturing_order_id",
+        "/manufacturing_orders",
+    ),
+    "/manufacturing_order_productions": (
+        "manufacturing_order_id",
+        "/manufacturing_orders",
+    ),
+    "/stock_adjustments": ("location_id", "/locations"),
+    "/variant_bin_locations": ("variant_id", "/variants"),
+}
+
+# Endpoints where ``GET /<collection>/{id}`` returns 404 — the live API
+# only exposes list / parent-scoped reads. For PATCH/DELETE against
+# these, ledger membership is the only available guard.
+NO_GET_BY_ID: frozenset[str] = frozenset(
+    {
+        "/stock_transfers",
+        "/stock_adjustments",
+        "/sales_order_rows",
+        "/sales_order_fulfillments",
+        "/manufacturing_order_recipe_rows",
+        "/manufacturing_order_productions",
+        "/variant_bin_locations",
+    }
+)
+
+# Identity values matching this pattern are considered SDT-tagged. The
+# probe scripts produce ``SDT-<yyyy-mm-dd>-<suffix>`` (via ``tagged()``)
+# or ``[SDT-<yyyy-mm-dd>] <free text>`` (via ``label()``); both variants
+# place the literal ``SDT-`` marker at the very start. Anchored to
+# start-of-string so substrings like ``MySDT-foo`` don't slip through.
+_SDT_RE = re.compile(r"^\[?SDT-")
+
+
+def _is_sdt_tagged(value: Any) -> bool:
+    """Return True if ``value`` is a string carrying an SDT- prefix.
+
+    Accepts both ``tagged()`` form (bare ``SDT-…`` prefix) and ``label()``
+    form (``[SDT-…] …`` wrapper). Non-string values return False.
+    """
+    if not isinstance(value, str):
+        return False
+    return _SDT_RE.search(value) is not None
+
+
+class UnsafeMutationError(RuntimeError):
+    """Raised when a mutation targets a non-SDT, non-ledger record.
+
+    Attributes give the operator everything they need to triage:
+    ``method`` (POST/PATCH/DELETE), ``endpoint`` (the collection path),
+    ``target_id`` (the record being touched, ``None`` for POST),
+    ``identity_field`` + ``identity_value`` for the field we inspected,
+    and ``reason`` (free text describing which check failed).
+    """
+
+    def __init__(
+        self,
+        *,
+        method: str,
+        endpoint: str,
+        target_id: str | int | None,
+        identity_field: str | None,
+        identity_value: Any,
+        reason: str,
+    ) -> None:
+        self.method = method
+        self.endpoint = endpoint
+        self.target_id = target_id
+        self.identity_field = identity_field
+        self.identity_value = identity_value
+        self.reason = reason
+        target = f"/{target_id}" if target_id is not None else ""
+        ident = (
+            f" ({identity_field}={identity_value!r})"
+            if identity_field is not None
+            else ""
+        )
+        super().__init__(
+            f"Refusing {method} {endpoint}{target}{ident}: {reason}. "
+            "Set allow_unsafe=True on the SafeClient to bypass."
+        )
+
+
+class SilentDropError(RuntimeError):
+    """Raised when a 2xx response contradicts the caller's intent.
+
+    Sibling of ``UnsafeMutationError`` for the post-mutation verify hook.
+    ``endpoint`` + ``method`` identify the call; ``reason`` is the
+    hook's failure message (e.g. "requested 3 serials, response carries
+    0"). The original request body and parsed response body are attached
+    for debugging.
+    """
+
+    def __init__(
+        self,
+        *,
+        method: str,
+        endpoint: str,
+        reason: str,
+        request_body: Any = None,
+        response_body: Any = None,
+    ) -> None:
+        self.method = method
+        self.endpoint = endpoint
+        self.reason = reason
+        self.request_body = request_body
+        self.response_body = response_body
+        super().__init__(
+            f"Silent drop on {method} {endpoint}: {reason}. "
+            "The wire returned 2xx but the response state contradicts the request."
+        )
+
+
+VerifyHook = Callable[[httpx.Request, httpx.Response], None]
+
+
+class SafeClient(httpx.Client):
+    """``httpx.Client`` that refuses mutations against non-SDT records.
+
+    Constructor takes the same args as ``httpx.Client`` plus:
+
+    - ``allow_unsafe`` (default ``False``) — bypass all checks. Used
+      internally by ``spec_drift_verify.cleanup()`` where the ledger
+      already pre-vetted the targets, and by ``_resolve_factory_id()``
+      where the call is read-only.
+    - ``ledger_keys`` (default empty) — initial set of ``(endpoint,
+      str(entity_id))`` tuples that count as "this run created it."
+      ``register_artifact()`` extends the set live.
+
+    Verify hooks register via ``register_verify(method, endpoint, hook)``
+    and fire after a 2xx response. A hook raises ``SilentDropError`` to
+    fail the run.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        allow_unsafe: bool = False,
+        ledger_keys: set[tuple[str, str]] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._allow_unsafe = allow_unsafe
+        self._ledger_keys: set[tuple[str, str]] = set(ledger_keys or ())
+        self._verify_hooks: dict[tuple[str, str], list[VerifyHook]] = {}
+
+    # ------------------------------------------------------------------
+    # Ledger membership — kept in sync by ``register_artifact`` calls
+    # ------------------------------------------------------------------
+
+    def register_artifact(self, endpoint: str, entity_id: int | str) -> None:
+        """Record that ``entity_id`` at ``endpoint`` was created by this run.
+
+        Called by ``spec_drift_verify.record_artifact()`` so subsequent
+        PATCH/DELETE against the freshly-created record passes the
+        ledger-membership check without a pre-fetch round-trip.
+        """
+        self._ledger_keys.add((endpoint, str(entity_id)))
+
+    def in_ledger(self, endpoint: str, entity_id: int | str) -> bool:
+        """Return True if ``(endpoint, entity_id)`` is in the local ledger."""
+        return (endpoint, str(entity_id)) in self._ledger_keys
+
+    # ------------------------------------------------------------------
+    # Verify hooks — post-mutation assertions
+    # ------------------------------------------------------------------
+
+    def register_verify(
+        self,
+        method: str,
+        endpoint: str,
+        hook: VerifyHook,
+    ) -> None:
+        """Register ``hook`` to run after every 2xx ``METHOD endpoint`` response.
+
+        Hook signature: ``(request, response) -> None``. Raise
+        ``SilentDropError`` to fail; any other exception bubbles. Multiple
+        hooks on the same ``(method, endpoint)`` run in registration order.
+        """
+        key = (method.upper(), endpoint)
+        self._verify_hooks.setdefault(key, []).append(hook)
+
+    # ------------------------------------------------------------------
+    # Request interception
+    # ------------------------------------------------------------------
+
+    def request(
+        self,
+        method: str,
+        url: httpx.URL | str,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        method_upper = method.upper()
+        is_mutation = method_upper in {"POST", "PATCH", "DELETE"}
+        if is_mutation and not self._allow_unsafe:
+            self._check_mutation(method_upper, url, kwargs)
+        response = super().request(method, url, **kwargs)
+        if is_mutation and 200 <= response.status_code < 300:
+            self._run_verify_hooks(method_upper, url, response)
+        return response
+
+    # ------------------------------------------------------------------
+    # Guard logic
+    # ------------------------------------------------------------------
+
+    def _check_mutation(
+        self,
+        method: str,
+        url: httpx.URL | str,
+        kwargs: dict[str, Any],
+    ) -> None:
+        endpoint, target_id = _split_path(url)
+        if method == "POST":
+            self._check_post(endpoint, kwargs)
+            return
+        # PATCH / DELETE — must have an ID
+        if target_id is None:
+            raise UnsafeMutationError(
+                method=method,
+                endpoint=endpoint,
+                target_id=None,
+                identity_field=None,
+                identity_value=None,
+                reason=f"{method} requires a target ID in the path",
+            )
+        self._check_patch_or_delete(method, endpoint, target_id)
+
+    def _check_post(self, endpoint: str, kwargs: dict[str, Any]) -> None:
+        body = kwargs.get("json")
+        if body is None:
+            # No body or non-JSON body — probably a multipart upload; not
+            # currently a probe pattern, refuse rather than guess.
+            raise UnsafeMutationError(
+                method="POST",
+                endpoint=endpoint,
+                target_id=None,
+                identity_field=None,
+                identity_value=None,
+                reason="POST has no JSON body to inspect",
+            )
+        # Array bodies (some endpoints accept ``[{...}, ...]``) — inspect
+        # every element. If any element fails, the whole POST fails.
+        items: list[Any] = body if isinstance(body, list) else [body]
+        for item in items:
+            self._check_post_item(endpoint, item)
+
+    def _check_post_item(self, endpoint: str, item: Any) -> None:
+        if not isinstance(item, dict):
+            raise UnsafeMutationError(
+                method="POST",
+                endpoint=endpoint,
+                target_id=None,
+                identity_field=None,
+                identity_value=item,
+                reason="POST body element is not a JSON object",
+            )
+        identity_field = IDENTITY_FIELDS.get(endpoint)
+        if identity_field is not None:
+            if identity_field not in item:
+                # Server-generated identity (e.g. SO without ``order_no``)
+                # — the caller is asking Katana to mint the field. Lean
+                # permissive: the probe records the created ID into the
+                # ledger and every subsequent mutation is then guarded.
+                # Note: this only covers KEY-ABSENT; an explicit
+                # ``{order_no: None}`` falls through to the SDT check
+                # below and fails closed, because explicit null is a
+                # different caller intent (a real customer's record
+                # could plausibly have a null identity column).
+                return
+            value = item[identity_field]
+            if not _is_sdt_tagged(value):
+                raise UnsafeMutationError(
+                    method="POST",
+                    endpoint=endpoint,
+                    target_id=None,
+                    identity_field=identity_field,
+                    identity_value=value,
+                    reason=(
+                        f"{identity_field}={value!r} has no SDT- prefix; "
+                        "POST would land on a non-test record"
+                    ),
+                )
+            return
+        # No top-level identity. Try the parent-FK route.
+        parent = CHILD_PARENT_FIELDS.get(endpoint)
+        if parent is None:
+            # Unknown endpoint — refuse rather than guess.
+            raise UnsafeMutationError(
+                method="POST",
+                endpoint=endpoint,
+                target_id=None,
+                identity_field=None,
+                identity_value=None,
+                reason=(
+                    f"endpoint {endpoint} is not in IDENTITY_FIELDS; "
+                    "add it before mutating from a probe"
+                ),
+            )
+        fk_field, parent_endpoint = parent
+        fk_value = item.get(fk_field)
+        if fk_value is None:
+            raise UnsafeMutationError(
+                method="POST",
+                endpoint=endpoint,
+                target_id=None,
+                identity_field=fk_field,
+                identity_value=None,
+                reason=(
+                    f"child POST is missing parent FK {fk_field!r}; "
+                    "cannot verify parent is SDT-tagged"
+                ),
+            )
+        if not self.in_ledger(parent_endpoint, fk_value):
+            raise UnsafeMutationError(
+                method="POST",
+                endpoint=endpoint,
+                target_id=None,
+                identity_field=fk_field,
+                identity_value=fk_value,
+                reason=(
+                    f"parent {parent_endpoint}/{fk_value} is not in the "
+                    "local ledger — refuse to attach a child to a record "
+                    "this run didn't create"
+                ),
+            )
+
+    def _check_patch_or_delete(
+        self,
+        method: str,
+        endpoint: str,
+        target_id: str,
+    ) -> None:
+        if self.in_ledger(endpoint, target_id):
+            return
+        if endpoint in NO_GET_BY_ID:
+            # No pre-fetch available; ledger membership is our only signal.
+            raise UnsafeMutationError(
+                method=method,
+                endpoint=endpoint,
+                target_id=target_id,
+                identity_field=None,
+                identity_value=None,
+                reason=(
+                    f"{endpoint} does not support GET-by-id and "
+                    f"{target_id} is not in the local ledger"
+                ),
+            )
+        identity_field = IDENTITY_FIELDS.get(endpoint)
+        if identity_field is None:
+            raise UnsafeMutationError(
+                method=method,
+                endpoint=endpoint,
+                target_id=target_id,
+                identity_field=None,
+                identity_value=None,
+                reason=(
+                    f"endpoint {endpoint} has no known identity field; "
+                    "refusing to verify via GET"
+                ),
+            )
+        # Pre-fetch and check identity. ``send`` directly to skip the
+        # request() override (read-only GET — no need to re-validate).
+        try:
+            req = self.build_request("GET", f"{endpoint}/{target_id}")
+            response = self.send(req)
+        except Exception as exc:
+            raise UnsafeMutationError(
+                method=method,
+                endpoint=endpoint,
+                target_id=target_id,
+                identity_field=identity_field,
+                identity_value=None,
+                reason=f"pre-fetch GET failed: {exc!r}",
+            ) from exc
+        if response.status_code == 404:
+            # DELETE is idempotent — let a 404 through so the caller can
+            # record the "already gone" result. PATCH, by contrast, must
+            # fail closed: a 404 means we never confirmed the target's
+            # identity, so the SDT check never ran.
+            if method == "DELETE":
+                return
+            raise UnsafeMutationError(
+                method=method,
+                endpoint=endpoint,
+                target_id=target_id,
+                identity_field=identity_field,
+                identity_value=None,
+                reason=(
+                    "pre-fetch GET returned 404; PATCH cannot proceed "
+                    "without identity-verifying the target (use "
+                    "allow_unsafe=True if the ledger has pre-vetted it)"
+                ),
+            )
+        if not response.is_success:
+            raise UnsafeMutationError(
+                method=method,
+                endpoint=endpoint,
+                target_id=target_id,
+                identity_field=identity_field,
+                identity_value=None,
+                reason=f"pre-fetch GET returned {response.status_code}",
+            )
+        try:
+            data = response.json()
+        except Exception as exc:
+            raise UnsafeMutationError(
+                method=method,
+                endpoint=endpoint,
+                target_id=target_id,
+                identity_field=identity_field,
+                identity_value=None,
+                reason=f"pre-fetch GET body not JSON: {exc!r}",
+            ) from exc
+        identity_value = data.get(identity_field) if isinstance(data, dict) else None
+        if not _is_sdt_tagged(identity_value):
+            raise UnsafeMutationError(
+                method=method,
+                endpoint=endpoint,
+                target_id=target_id,
+                identity_field=identity_field,
+                identity_value=identity_value,
+                reason=(
+                    f"target {endpoint}/{target_id} has no SDT- prefix "
+                    f"({identity_field}={identity_value!r}) "
+                    "and is not in the local ledger"
+                ),
+            )
+
+    def _run_verify_hooks(
+        self,
+        method: str,
+        url: httpx.URL | str,
+        response: httpx.Response,
+    ) -> None:
+        endpoint, _ = _split_path(url)
+        hooks = self._verify_hooks.get((method, endpoint), [])
+        if not hooks:
+            return
+        for hook in hooks:
+            hook(response.request, response)
+
+
+# ----------------------------------------------------------------------
+# Path parsing
+# ----------------------------------------------------------------------
+
+
+def _split_path(url: httpx.URL | str) -> tuple[str, str | None]:
+    """Return ``(collection, id)`` from a request URL.
+
+    ``/sales_orders``       → ``("/sales_orders", None)``
+    ``/sales_orders/42``    → ``("/sales_orders", "42")``
+    ``/sales_orders/42/x``  → ``("/sales_orders", "42")`` — sub-resources
+    fall through to the parent collection; not a current probe pattern.
+
+    Both absolute and relative inputs are accepted: ``"sales_orders/42"``
+    parses the same as ``"/sales_orders/42"``. Relative inputs reach this
+    function when httpx attaches a base URL at send-time; the guard runs
+    at request-build time on whatever the caller passed in.
+    """
+    if isinstance(url, httpx.URL):
+        path = url.path
+    else:
+        # Accept absolute or relative URL strings.
+        path = urlparse(str(url)).path if "://" in str(url) else str(url)
+    # Drop query string and normalize: collapse extra slashes, ensure a
+    # leading ``/`` so the ``split('/')`` produces a stable
+    # ``['', collection, id?]`` shape regardless of input form.
+    path = path.split("?", 1)[0].strip("/")
+    if not path:
+        return ("", None)
+    parts = path.split("/")
+    # After ``strip('/')`` + ``split('/')``:
+    # ``"sales_orders"``     -> ['sales_orders']
+    # ``"sales_orders/42"``  -> ['sales_orders', '42']
+    if len(parts) == 1:
+        return ("/" + parts[0], None)
+    return ("/" + parts[0], parts[1])
+
+
+# ----------------------------------------------------------------------
+# Discovery helper — pick SDT-tagged fixtures, never a real customer
+# ----------------------------------------------------------------------
+
+
+def discover_sdt_fixture(
+    client: httpx.Client,
+    endpoint: str,
+    identity_field: str,
+    *,
+    limit: int = 50,
+    max_pages: int = 5,
+) -> dict[str, Any] | None:
+    """Paginate ``endpoint`` and return the first SDT-tagged record.
+
+    Use this in probe-script ``discover_fixtures()`` instead of "grab the
+    first customer" — the latter is exactly the WEB20604 incident's root
+    cause. Returns ``None`` when no SDT-tagged record exists; caller
+    decides whether to create one or skip the probe.
+
+    Filters client-side because Katana list filters are exact-match
+    only; ``?order_no=SDT-…`` returns zero rows because no record's
+    full order_no matches the prefix alone.
+    """
+    page = 1
+    while page <= max_pages:
+        resp = client.get(f"{endpoint}?limit={limit}&page={page}")
+        if not resp.is_success:
+            return None
+        rows = resp.json().get("data", [])
+        if not rows:
+            return None
+        for row in rows:
+            if _is_sdt_tagged(row.get(identity_field)):
+                return row
+        if len(rows) < limit:
+            return None
+        page += 1
+    return None
+
+
+# ----------------------------------------------------------------------
+# Example verify hook for the silent-drop concern (issue #781 follow-up)
+# ----------------------------------------------------------------------
+
+
+def verify_production_serial_numbers_match(
+    request: httpx.Request,
+    response: httpx.Response,
+) -> None:
+    """Verify ``POST /manufacturing_order_productions`` didn't drop serials.
+
+    The live API returns 200 OK with ``serial_numbers: []`` when the
+    posted serial IDs reference unminted SerialNumber records. Detect by
+    comparing requested vs returned counts and raise ``SilentDropError``
+    when they disagree.
+
+    Probes register this via ``client.register_verify("POST",
+    "/manufacturing_order_productions", verify_production_serial_numbers_match)``.
+    """
+    try:
+        req_body = _decode_request_json(request)
+    except ValueError:
+        return  # not a JSON body — can't verify
+    requested = req_body.get("serial_numbers") if isinstance(req_body, dict) else None
+    if not isinstance(requested, list) or not requested:
+        return  # caller didn't ask for serials → nothing to verify
+    try:
+        resp_body = response.json()
+    except ValueError:
+        return  # 2xx without JSON body — unusual; let caller assert shape
+    landed = resp_body.get("serial_numbers") if isinstance(resp_body, dict) else None
+    if not isinstance(landed, list):
+        landed = []
+    if len(landed) != len(requested):
+        raise SilentDropError(
+            method="POST",
+            endpoint="/manufacturing_order_productions",
+            reason=(
+                f"requested {len(requested)} serial(s), "
+                f"response carries {len(landed)} — Katana silently "
+                "dropped unminted SerialNumber IDs"
+            ),
+            request_body=req_body,
+            response_body=resp_body,
+        )
+
+
+def _decode_request_json(request: httpx.Request) -> Any:
+    """Best-effort decode a request's body as JSON for verify hooks."""
+    import json
+
+    if request.content is None:
+        raise ValueError("no request body")
+    return json.loads(request.content)

--- a/scripts/probe_remaining_issues.py
+++ b/scripts/probe_remaining_issues.py
@@ -26,6 +26,7 @@ import httpx
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from scripts.spec_drift_verify import (
+    discover_sdt_fixture,
     label,
     make_client,
     pp_response,
@@ -34,20 +35,58 @@ from scripts.spec_drift_verify import (
 )
 
 
+def _ensure_sdt_customer(client: httpx.Client) -> int:
+    """Find or create an SDT-tagged customer for use as a probe target.
+
+    The probe pattern previously was "grab the first customer the API
+    returns" — exactly the WEB20604 incident's root cause (the first
+    customer was a real Shopify record). Use ``discover_sdt_fixture``
+    to filter for SDT-prefixed names; create a fresh SDT customer when
+    none exist. The fresh customer hits the ledger and gets cleaned up
+    on the next ``spec_drift_verify.py cleanup`` run.
+    """
+    found = discover_sdt_fixture(client, "/customers", "name")
+    if found is not None:
+        return int(found["id"])
+    payload = {
+        "name": label("probe-customer"),
+        "company": label("probe-customer"),
+    }
+    resp = client.post("/customers", json=payload)
+    if not resp.is_success:
+        print(f"  ✗  could not create SDT customer: {pp_response(resp, 200)}")
+        sys.exit(1)
+    created = resp.json()
+    record_artifact(
+        endpoint="/customers",
+        entity_id=created["id"],
+        issue="probe-fixture",
+        sku_or_name=payload["name"],
+    )
+    return int(created["id"])
+
+
 def discover_fixtures(client: httpx.Client) -> dict[str, Any]:
-    """Pre-fetch a location, customer, supplier, and sellable variant.
+    """Pre-fetch a location, customer, and sellable variant.
 
     Resolves the sales-enabled location via ``GET /factory`` (its
     ``default_sales_location_id`` is authoritative). Other locations
     on the tenant may have ``purchase_allowed: false`` and the live
     API rejects SO creates against them ("Location has selling
-    disabled"). Bails if any fixture is missing.
+    disabled"). Bails (``sys.exit(1)``) when ``default_sales_location_id``
+    is missing or no sellable variant is available; ``_ensure_sdt_customer``
+    bails on its own if neither lookup nor creation succeeds.
+
+    The customer is filtered for the SDT- prefix so probes never target
+    a real customer record (root cause of the 2026-05-19 WEB20604
+    near-miss — see issue #781). When no SDT-tagged customer exists, a
+    fresh one is created and recorded to the ledger. Variants are still
+    picked by "first sellable" because they're read-only fixtures (not
+    the target of any mutation in this probe).
     """
     print("\n=== Discovering shared fixtures ===")
     factory = client.get("/factory").json()
     locations = client.get("/locations?limit=10").json().get("data", [])
-    customers = client.get("/customers?limit=1").json().get("data", [])
-    suppliers = client.get("/suppliers?limit=1").json().get("data", [])
     variants = client.get("/variants?limit=20").json().get("data", [])
     sellable = [v for v in variants if v.get("sales_price") is not None][:1]
 
@@ -61,18 +100,16 @@ def discover_fixtures(client: httpx.Client) -> dict[str, Any]:
     if not sales_location_id:
         print("  ✗  factory.default_sales_location_id missing; aborting")
         sys.exit(1)
-    if not customers:
-        print("  ✗  no customers available; aborting")
-        sys.exit(1)
     if not sellable:
         print("  ✗  no sellable variant available; aborting")
         sys.exit(1)
 
+    customer_id = _ensure_sdt_customer(client)
+
     fx = {
         "location_id": sales_location_id,
         "second_location_id": other,
-        "customer_id": customers[0]["id"],
-        "supplier_id": suppliers[0]["id"] if suppliers else None,
+        "customer_id": customer_id,
         "variant_id": sellable[0]["id"],
     }
     print(f"  fixtures: {fx}")

--- a/scripts/spec_drift_verify.py
+++ b/scripts/spec_drift_verify.py
@@ -50,7 +50,33 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
-import httpx
+from scripts._safety import (
+    SafeClient,
+    SilentDropError,
+    UnsafeMutationError,
+    discover_sdt_fixture,
+    verify_production_serial_numbers_match,
+)
+
+__all__ = [
+    "BASE_URL",
+    "LEDGER_PATH",
+    "SDT_PREFIX",
+    "LedgerRow",
+    "SafeClient",
+    "SilentDropError",
+    "UnsafeMutationError",
+    "cleanup",
+    "discover_sdt_fixture",
+    "format_422",
+    "label",
+    "make_client",
+    "pp_response",
+    "read_ledger",
+    "record_artifact",
+    "tagged",
+    "verify_production_serial_numbers_match",
+]
 
 # Date-stamped prefix so concurrent runs on different days don't collide
 # and so a glance at any tagged record reveals when it was created.
@@ -100,18 +126,91 @@ def _api_key() -> str:
     return key
 
 
-def make_client() -> httpx.Client:
-    """Build a bearer-auth httpx client pointed at the live Katana API.
+def _initial_ledger_keys() -> set[tuple[str, str]]:
+    """Build the in-memory ``(endpoint, entity_id)`` set from the on-disk ledger.
+
+    **Tenant-scoped, fail-closed.** A row is admitted only when both
+    ``base_url`` and ``factory_id`` are present AND match the current
+    credential's tenant. The pre-fingerprint era admitted unscoped rows
+    on the theory that the per-mutation pre-fetch + identity check was
+    a sufficient final layer — but that doesn't hold for ledger-only
+    guard paths: ``NO_GET_BY_ID`` endpoints (e.g. ``/stock_transfers``)
+    skip the pre-fetch entirely, and child POSTs that vet only the
+    parent's ledger membership (e.g. ``POST
+    /manufacturing_order_productions`` against a parent MO) have no
+    per-record identity check on the target. Admitting an unscoped row
+    on those paths would let a stale cross-tenant entry act as an
+    allow-list bypass.
+
+    The cost is that older ledger files (written before fingerprinting
+    landed) won't restore on the next run; the probe re-mints SDT
+    artifacts and the new rows carry the fingerprint. Cleanup pairs
+    this with its own tenant filter so cross-tenant rows aren't deleted
+    either.
+
+    Read once at ``SafeClient`` construction; subsequent
+    ``record_artifact`` calls keep both the file and the client's
+    in-memory copy in sync via ``SafeClient.register_artifact``.
+    """
+    keys: set[tuple[str, str]] = set()
+    current_factory_id = _resolve_factory_id()
+    for row in read_ledger():
+        endpoint = row.get("endpoint")
+        entity_id = row.get("entity_id")
+        if endpoint is None or entity_id is None:
+            continue
+        row_base = row.get("base_url")
+        row_factory = row.get("factory_id")
+        # Fail closed on pre-fingerprint rows: with no tenant signal we
+        # can't prove they belong to the current credential.
+        if row_base is None or row_factory is None:
+            continue
+        # Tenant fingerprint must match exactly. Any divergence means a
+        # different tenant; refuse to seed the ledger from foreign rows.
+        if row_base != BASE_URL:
+            continue
+        if current_factory_id is None or row_factory != current_factory_id:
+            continue
+        keys.add((str(endpoint), str(entity_id)))
+    return keys
+
+
+# Process-local registry of every SafeClient ``make_client`` has handed
+# out. ``record_artifact`` walks this list to keep each open client's
+# in-memory ledger fresh as the run creates new artifacts. Weak-ref-free
+# because probes hold their client open for the whole run; the small
+# leak (one entry per ``with make_client()`` block) is bounded.
+_LIVE_CLIENTS: list[SafeClient] = []
+
+
+def make_client(*, allow_unsafe: bool = False) -> SafeClient:
+    """Build a bearer-auth ``SafeClient`` pointed at the live Katana API.
 
     Shared by every probe script so they all hit the same base URL with
-    the same auth header and timeout. Bails with exit-2 when
-    ``KATANA_API_KEY`` is missing.
+    the same auth header and timeout. The returned client refuses any
+    ``POST`` / ``PATCH`` / ``DELETE`` whose target doesn't carry the
+    SDT- prefix or doesn't appear in the local ledger (see
+    ``scripts/_safety.py``). Bails with exit-2 when ``KATANA_API_KEY``
+    is missing.
+
+    ``allow_unsafe=True`` bypasses every check — reserved for cleanup
+    paths where the ledger has already pre-vetted the target and for
+    read-only internal helpers like ``_resolve_factory_id``. When set,
+    ledger initialization is skipped entirely: the guard isn't engaged,
+    so the (potentially expensive, factory-id-resolving) read is wasted
+    work, and skipping breaks the bootstrap chicken-and-egg where
+    ``_initial_ledger_keys`` itself calls ``_resolve_factory_id`` which
+    needs a SafeClient to GET ``/factory``.
     """
-    return httpx.Client(
+    client = SafeClient(
         base_url=BASE_URL,
         headers={"Authorization": f"Bearer {_api_key()}"},
         timeout=30.0,
+        allow_unsafe=allow_unsafe,
+        ledger_keys=set() if allow_unsafe else _initial_ledger_keys(),
     )
+    _LIVE_CLIENTS.append(client)
+    return client
 
 
 def format_422(response: Any) -> str:
@@ -188,19 +287,23 @@ class LedgerRow:
 
 
 @cache
-def _resolve_factory_id() -> int | None:
-    """Look up the active credential's ``Factory.factory_id`` once.
+def _factory_id_for_key(api_key: str) -> int | None:
+    """Inner GET /factory lookup, cached on ``api_key`` so a key rotation
+    busts the cache naturally. Callers must reach this through
+    ``_resolve_factory_id()``, which reads the current env key on every
+    call and routes here; never call this directly with a stale key.
 
-    ``@cache`` memoizes the result so the ``record_artifact`` fast path
-    doesn't hit ``GET /factory`` for every artifact. Returns ``None`` on
-    lookup failure; on the record side, the ledger row simply has no
-    fingerprint (cleanup proceeds with only the URL check for those
-    rows). On the cleanup side, ``None`` is treated as "tenant
-    unverifiable" — rows that *do* carry a stored ``factory_id`` are
-    refused rather than delete-anyway-and-hope.
-    """
+    Note: ``api_key`` is consumed by ``lru_cache`` as the cache key.
+    The function body doesn't reference it (``make_client`` re-reads
+    ``KATANA_API_KEY`` from env, which is correct because the env is
+    always the fresh value at cache-miss time)."""
+    del api_key  # used as the lru_cache key only; see docstring
     try:
-        with make_client() as client:
+        # ``allow_unsafe=True``: read-only GET, no need to engage the
+        # mutation guard (which also has a startup cost from reading the
+        # ledger). This call is the *guard's own dependency* in some
+        # paths — keep it cheap and side-effect-free.
+        with make_client(allow_unsafe=True) as client:
             data = client.get("/factory").json()
     except Exception:
         return None
@@ -209,6 +312,25 @@ def _resolve_factory_id() -> int | None:
         if isinstance(fid, int):
             return fid
     return None
+
+
+def _resolve_factory_id() -> int | None:
+    """Look up the active credential's ``Factory.factory_id`` once per key.
+
+    Reads ``KATANA_API_KEY`` fresh on every call and dispatches to
+    ``_factory_id_for_key``, which memoizes on the key value. So the
+    ``record_artifact`` fast path doesn't hit ``GET /factory`` for every
+    artifact, AND an API-key rotation mid-process busts the cache
+    naturally (closing the cross-tenant trap where a stale factory_id
+    would be matched against fresh-tenant ledger rows).
+
+    Returns ``None`` on lookup failure; on the record side, the ledger
+    row simply has no fingerprint (cleanup proceeds with only the URL
+    check for those rows). On the cleanup side, ``None`` is treated as
+    "tenant unverifiable" — rows that *do* carry a stored ``factory_id``
+    are refused rather than delete-anyway-and-hope.
+    """
+    return _factory_id_for_key(_api_key())
 
 
 def record_artifact(
@@ -237,6 +359,12 @@ def record_artifact(
     LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
     with LEDGER_PATH.open("a") as f:
         f.write(row.to_json() + "\n")
+    # Keep every open SafeClient's in-memory ledger fresh so subsequent
+    # PATCH/DELETE against this freshly-created record bypass the
+    # pre-fetch round-trip via the ledger-membership fast path.
+    for client in _LIVE_CLIENTS:
+        if not client.is_closed:
+            client.register_artifact(endpoint, entity_id)
     return row
 
 
@@ -281,7 +409,11 @@ def cleanup(*, dry_run: bool = False) -> int:
     deleted: list[dict[str, Any]] = []
     skipped_tenant: list[dict[str, Any]] = []
     current_factory_id = _resolve_factory_id()
-    with make_client() as client:
+    # ``allow_unsafe=True``: cleanup deliberately mutates ledger-recorded
+    # rows that the harness itself created. Each row already passed the
+    # factory/base_url tenant-fingerprint guard above, and the SafeClient
+    # mutation guard would just re-check the same thing.
+    with make_client(allow_unsafe=True) as client:
         for r in reversed(pending):
             row_base = r.get("base_url")
             row_factory = r.get("factory_id")

--- a/tests/test_spec_drift_safety.py
+++ b/tests/test_spec_drift_safety.py
@@ -1,0 +1,1192 @@
+"""Tests for ``scripts/_safety.py`` — the ``SafeClient`` mutation guard.
+
+Covers the pre-mutation identity guard, ledger-membership fallback,
+``NO_GET_BY_ID`` ledger-only enforcement, ``allow_unsafe`` bypass,
+post-mutation verify hooks (silent-drop detection), and the
+``discover_sdt_fixture`` discovery helper.
+
+All tests use ``httpx.MockTransport`` to avoid live API calls — the
+guard logic is wire-shape-only and doesn't require a real tenant.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+from scripts._safety import (
+    SafeClient,
+    SilentDropError,
+    UnsafeMutationError,
+    _is_sdt_tagged,
+    _split_path,
+    discover_sdt_fixture,
+    verify_production_serial_numbers_match,
+)
+
+Handler = Callable[[httpx.Request], httpx.Response]
+
+
+def _build_safe_client(
+    handler: Handler,
+    *,
+    allow_unsafe: bool = False,
+    ledger_keys: set[tuple[str, str]] | None = None,
+) -> SafeClient:
+    """Construct a ``SafeClient`` backed by ``httpx.MockTransport``."""
+    return SafeClient(
+        base_url="https://api.katana.test",
+        transport=httpx.MockTransport(handler),
+        allow_unsafe=allow_unsafe,
+        ledger_keys=ledger_keys,
+    )
+
+
+# ----------------------------------------------------------------------
+# POST guard — top-level identity check
+# ----------------------------------------------------------------------
+
+
+class TestPostIdentityGuard:
+    """POST mutations are gated on the body's identity field carrying SDT-."""
+
+    def test_post_with_sdt_identity_allowed(self) -> None:
+        called: dict[str, bool] = {"sent": False}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            called["sent"] = True
+            return httpx.Response(200, json={"id": 1, "order_no": "SDT-2026-05-19-A"})
+
+        client = _build_safe_client(handler)
+        try:
+            resp = client.post("/sales_orders", json={"order_no": "SDT-2026-05-19-A"})
+            assert resp.status_code == 200
+            assert called["sent"]
+        finally:
+            client.close()
+
+    def test_post_with_label_form_identity_allowed(self) -> None:
+        """``label()`` produces ``[SDT-…] free text`` — the bracketed form."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"id": 7, "name": "ok"})
+
+        client = _build_safe_client(handler)
+        try:
+            resp = client.post(
+                "/materials", json={"name": "[SDT-2026-05-19] Test Material"}
+            )
+            assert resp.status_code == 200
+        finally:
+            client.close()
+
+    def test_post_without_sdt_identity_refused(self) -> None:
+        """The WEB20604 class: identity field is set but doesn't carry SDT-."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            pytest.fail("guard should refuse the request before the wire call")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.post("/sales_orders", json={"order_no": "#WEB20604"})
+            assert exc_info.value.method == "POST"
+            assert exc_info.value.endpoint == "/sales_orders"
+            assert exc_info.value.identity_field == "order_no"
+            assert exc_info.value.identity_value == "#WEB20604"
+        finally:
+            client.close()
+
+    def test_post_with_server_generated_identity_allowed(self) -> None:
+        """Identity field absent from body → server generates it. Permit."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, json={"id": 1, "order_no": "Katana-generated-no"}
+            )
+
+        client = _build_safe_client(handler)
+        try:
+            # No ``order_no`` — caller relies on Katana minting one.
+            resp = client.post("/sales_orders", json={"customer_id": 42})
+            assert resp.status_code == 200
+        finally:
+            client.close()
+
+    def test_post_to_unknown_endpoint_refused(self) -> None:
+        """Defense-in-depth: unknown endpoints can't be mutated until mapped."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            pytest.fail("guard should refuse on unknown endpoint")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.post("/unknown_endpoint", json={"name": "SDT-x"})
+            assert "not in IDENTITY_FIELDS" in exc_info.value.reason
+        finally:
+            client.close()
+
+    def test_post_without_body_refused(self) -> None:
+        """A POST that omits ``json=`` has nothing to inspect — fail closed
+        rather than wire the empty payload (which Katana would 422)."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            pytest.fail("guard should refuse before the wire call")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.post("/sales_orders")
+            assert "no JSON body" in exc_info.value.reason
+        finally:
+            client.close()
+
+    def test_post_with_explicit_null_identity_refused(self) -> None:
+        """``{"order_no": None, ...}`` is NOT the same as omitting the
+        field. Explicit null is caller intent and must not be treated as
+        "server-generated" — a real customer's record could plausibly
+        have a null identity column, so we fail closed."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            pytest.fail("guard should refuse explicit-null identity")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.post(
+                    "/sales_orders",
+                    json={"order_no": None, "customer_id": 1, "location_id": 2},
+                )
+            assert "order_no" in exc_info.value.reason
+            assert "no SDT- prefix" in exc_info.value.reason
+        finally:
+            client.close()
+
+    def test_post_with_omitted_identity_allowed(self) -> None:
+        """Key-absent (genuine server-generated identity request) is
+        permissive — the probe records the resulting ID into the ledger
+        and every subsequent mutation is then ledger-protected. This
+        pairs with ``test_post_with_explicit_null_identity_refused`` to
+        document the absent-vs-null asymmetry."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json={"id": 99, "order_no": "auto-gen"})
+
+        client = _build_safe_client(handler)
+        try:
+            resp = client.post(
+                "/sales_orders",
+                json={"customer_id": 1, "location_id": 2},  # no order_no key
+            )
+            assert resp.status_code == 201
+        finally:
+            client.close()
+
+
+# ----------------------------------------------------------------------
+# POST guard — child endpoints (no top-level identity)
+# ----------------------------------------------------------------------
+
+
+class TestPostChildEndpoint:
+    """POST to child endpoints (e.g. ``/sales_order_fulfillments``)
+    requires the parent ID to be in the local ledger."""
+
+    def test_post_child_with_parent_in_ledger_allowed(self) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"id": 99})
+
+        client = _build_safe_client(handler, ledger_keys={("/sales_orders", "42")})
+        try:
+            resp = client.post(
+                "/sales_order_fulfillments",
+                json={"sales_order_id": 42, "status": "PACKED"},
+            )
+            assert resp.status_code == 200
+        finally:
+            client.close()
+
+    def test_post_child_with_parent_missing_from_ledger_refused(self) -> None:
+        """Exactly the WEB20604 failure mode: ``sales_order_id`` came
+        from ``discover_fixtures()`` without an SDT discipline."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            pytest.fail("guard should refuse on missing parent")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.post(
+                    "/sales_order_fulfillments",
+                    json={"sales_order_id": 9999, "status": "PACKED"},
+                )
+            assert exc_info.value.identity_field == "sales_order_id"
+            assert "not in the local ledger" in exc_info.value.reason
+        finally:
+            client.close()
+
+    def test_post_child_missing_parent_fk_refused(self) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            pytest.fail("guard should refuse on missing parent FK")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.post("/sales_order_fulfillments", json={"status": "PACKED"})
+            assert "missing parent FK" in exc_info.value.reason
+        finally:
+            client.close()
+
+
+# ----------------------------------------------------------------------
+# PATCH / DELETE guard — ledger membership + pre-fetch check
+# ----------------------------------------------------------------------
+
+
+class TestPatchDeleteGuard:
+    def test_patch_id_in_ledger_skips_prefetch(self) -> None:
+        """Ledger membership bypasses the pre-fetch round-trip."""
+        calls: list[tuple[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append((request.method, request.url.path))
+            return httpx.Response(200, json={"id": 7})
+
+        client = _build_safe_client(handler, ledger_keys={("/materials", "7")})
+        try:
+            resp = client.patch("/materials/7", json={"name": "anything"})
+            assert resp.status_code == 200
+            # Only the PATCH itself — no pre-fetch GET.
+            assert calls == [("PATCH", "/materials/7")]
+        finally:
+            client.close()
+
+    def test_patch_id_not_in_ledger_fetches_and_accepts_sdt_prefix(self) -> None:
+        """Pre-fetch fires; identity field carries SDT- → allow."""
+        calls: list[tuple[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append((request.method, request.url.path))
+            if request.method == "GET":
+                return httpx.Response(200, json={"id": 9, "name": "[SDT-2026-05-19] X"})
+            return httpx.Response(200, json={"id": 9})
+
+        client = _build_safe_client(handler)
+        try:
+            resp = client.patch("/materials/9", json={"name": "[SDT-…] Y"})
+            assert resp.status_code == 200
+            assert calls == [("GET", "/materials/9"), ("PATCH", "/materials/9")]
+        finally:
+            client.close()
+
+    def test_patch_id_not_in_ledger_refused_when_prefix_missing(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET":
+                return httpx.Response(
+                    200, json={"id": 9, "name": "Real Customer Order"}
+                )
+            pytest.fail("PATCH should not be sent")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.patch("/materials/9", json={"name": "anything"})
+            assert exc_info.value.target_id == "9"
+            assert exc_info.value.identity_value == "Real Customer Order"
+        finally:
+            client.close()
+
+    def test_delete_id_not_in_ledger_404_treated_idempotent(self) -> None:
+        """Pre-fetch returns 404 → already gone, let DELETE proceed."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET":
+                return httpx.Response(404, json={"error": "not found"})
+            return httpx.Response(204)
+
+        client = _build_safe_client(handler)
+        try:
+            resp = client.delete("/materials/123")
+            assert resp.status_code == 204
+        finally:
+            client.close()
+
+    def test_patch_id_not_in_ledger_404_refused(self) -> None:
+        """PATCH must fail closed on a 404 pre-fetch — unlike DELETE
+        (idempotent), a 404 PATCH means the SDT identity check never
+        ran, so we can't prove the target was ever an SDT record."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET":
+                return httpx.Response(404, json={"error": "not found"})
+            pytest.fail("guard should refuse PATCH before issuing the mutation")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.patch("/materials/123", json={"name": "anything"})
+            assert "404" in exc_info.value.reason
+            assert "PATCH cannot proceed" in exc_info.value.reason
+        finally:
+            client.close()
+
+    def test_patch_prefetch_5xx_refused(self) -> None:
+        """A 5xx pre-fetch (or 401/403) means the identity check never
+        completed — fail closed rather than let the PATCH through."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET":
+                return httpx.Response(500, json={"error": "internal"})
+            pytest.fail("PATCH should not be sent on failed pre-fetch")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.patch("/materials/9", json={"name": "anything"})
+            assert "500" in exc_info.value.reason
+        finally:
+            client.close()
+
+    def test_patch_prefetch_network_error_refused(self) -> None:
+        """A transport-layer exception on pre-fetch (timeout, connect
+        error) MUST fail closed — the most important fallback path of
+        the entire guard, since a "let it through on transport error"
+        bug would silently disable the SDT check for any flaky network."""
+        import httpx as _httpx
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            raise _httpx.ConnectError("simulated network failure")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.patch("/materials/9", json={"name": "anything"})
+            assert "pre-fetch GET failed" in exc_info.value.reason
+        finally:
+            client.close()
+
+    def test_patch_no_get_by_id_endpoint_ledger_only_refused(self) -> None:
+        """``/stock_transfers`` has no GET-by-id; without ledger
+        membership the guard has nothing left to check → refuse."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            pytest.fail("guard should refuse on NO_GET_BY_ID without ledger")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.patch("/stock_transfers/55", json={"status": "received"})
+            assert "does not support GET-by-id" in exc_info.value.reason
+        finally:
+            client.close()
+
+    def test_patch_no_get_by_id_endpoint_with_ledger_allowed(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append((request.method, request.url.path))
+            return httpx.Response(200, json={"id": 55})
+
+        client = _build_safe_client(handler, ledger_keys={("/stock_transfers", "55")})
+        try:
+            resp = client.patch("/stock_transfers/55", json={"status": "received"})
+            assert resp.status_code == 200
+            assert calls == [("PATCH", "/stock_transfers/55")]
+        finally:
+            client.close()
+
+    def test_delete_no_path_id_refused(self) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            pytest.fail("guard should refuse DELETE without an id")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError) as exc_info:
+                client.delete("/materials")
+            assert "requires a target ID" in exc_info.value.reason
+        finally:
+            client.close()
+
+
+# ----------------------------------------------------------------------
+# ``allow_unsafe`` bypass
+# ----------------------------------------------------------------------
+
+
+class TestAllowUnsafe:
+    def test_allow_unsafe_bypasses_all_checks(self) -> None:
+        """Used by cleanup paths where the ledger pre-vetted the target."""
+        sent: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            sent.append(request.method)
+            return httpx.Response(204)
+
+        client = _build_safe_client(handler, allow_unsafe=True)
+        try:
+            # Would normally raise: no SDT in body, no ledger entry.
+            client.post("/sales_orders", json={"order_no": "#WEB20604"})
+            client.delete("/materials/12345")
+            client.patch("/stock_transfers/55", json={"status": "received"})
+            assert sent == ["POST", "DELETE", "PATCH"]
+        finally:
+            client.close()
+
+
+# ----------------------------------------------------------------------
+# Ledger registration — keeps the in-memory ledger fresh
+# ----------------------------------------------------------------------
+
+
+class TestLedgerRegistration:
+    def test_register_artifact_extends_in_memory_ledger(self) -> None:
+        """A freshly-created record should be PATCHable without a
+        pre-fetch — the in-memory ledger is the fast path."""
+        get_called = False
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal get_called
+            if request.method == "GET":
+                get_called = True
+            return httpx.Response(200, json={"id": 11})
+
+        client = _build_safe_client(handler)
+        try:
+            client.register_artifact("/materials", 11)
+            client.patch("/materials/11", json={"name": "[SDT-…]"})
+            assert not get_called, "register_artifact should bypass pre-fetch"
+        finally:
+            client.close()
+
+    def test_register_artifact_handles_int_and_str_ids(self) -> None:
+        """``CustomFieldDefinition.id`` is a UUID string; others are ints."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(204)
+
+        client = _build_safe_client(handler)
+        try:
+            client.register_artifact("/custom_field_definitions", "abc-123-uuid")
+            assert client.in_ledger("/custom_field_definitions", "abc-123-uuid")
+            client.register_artifact("/materials", 42)
+            # Both string and int IDs resolve under the same canonical key.
+            assert client.in_ledger("/materials", 42)
+            assert client.in_ledger("/materials", "42")
+        finally:
+            client.close()
+
+
+# ----------------------------------------------------------------------
+# Read-only methods bypass the guard
+# ----------------------------------------------------------------------
+
+
+class TestReadOnlyBypass:
+    def test_get_is_unrestricted(self) -> None:
+        sent: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            sent.append(request.method)
+            return httpx.Response(200, json={"data": []})
+
+        client = _build_safe_client(handler)
+        try:
+            client.get("/sales_orders")
+            client.get("/sales_orders/99")  # arbitrary ID — no guard
+            assert sent == ["GET", "GET"]
+        finally:
+            client.close()
+
+
+# ----------------------------------------------------------------------
+# Verify hooks — post-mutation silent-drop detection
+# ----------------------------------------------------------------------
+
+
+class TestVerifyHook:
+    def test_verify_hook_fires_on_2xx_and_can_raise(self) -> None:
+        """Hook registered on ``(POST, /materials)`` runs after 2xx."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"id": 1})
+
+        def assertion_hook(_req: httpx.Request, _resp: httpx.Response) -> None:
+            raise SilentDropError(
+                method="POST",
+                endpoint="/materials",
+                reason="synthetic",
+            )
+
+        client = _build_safe_client(handler)
+        client.register_verify("POST", "/materials", assertion_hook)
+        try:
+            with pytest.raises(SilentDropError):
+                client.post("/materials", json={"name": "[SDT-…]"})
+        finally:
+            client.close()
+
+    def test_verify_hook_does_not_fire_on_non_2xx(self) -> None:
+        """422 / 5xx — no silent drop, hook should not run (the
+        response itself signals the failure)."""
+        hook_called = False
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(422, json={"error": "validation"})
+
+        def hook(_req: httpx.Request, _resp: httpx.Response) -> None:
+            nonlocal hook_called
+            hook_called = True
+
+        client = _build_safe_client(handler)
+        client.register_verify("POST", "/materials", hook)
+        try:
+            client.post("/materials", json={"name": "[SDT-…]"})
+            assert not hook_called
+        finally:
+            client.close()
+
+    def test_production_serial_drop_hook_detects_mismatch(self) -> None:
+        """The companion-comment use case: ``POST /manufacturing_order_productions``
+        with serial IDs that Katana silently drops on the wire."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            # Caller asked for 3 serials, response carries 0 — the
+            # silent-drop wire shape we're guarding against.
+            return httpx.Response(200, json={"id": 1, "serial_numbers": []})
+
+        client = _build_safe_client(
+            handler,
+            ledger_keys={("/manufacturing_orders", "77")},
+        )
+        client.register_verify(
+            "POST",
+            "/manufacturing_order_productions",
+            verify_production_serial_numbers_match,
+        )
+        try:
+            with pytest.raises(SilentDropError) as exc_info:
+                client.post(
+                    "/manufacturing_order_productions",
+                    json={
+                        "manufacturing_order_id": 77,
+                        "serial_numbers": [101, 102, 103],
+                    },
+                )
+            assert "requested 3" in exc_info.value.reason
+            assert "carries 0" in exc_info.value.reason
+        finally:
+            client.close()
+
+    def test_production_serial_hook_accepts_matching_counts(self) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"id": 1, "serial_numbers": [{"id": 101}, {"id": 102}]},
+            )
+
+        client = _build_safe_client(
+            handler,
+            ledger_keys={("/manufacturing_orders", "77")},
+        )
+        client.register_verify(
+            "POST",
+            "/manufacturing_order_productions",
+            verify_production_serial_numbers_match,
+        )
+        try:
+            resp = client.post(
+                "/manufacturing_order_productions",
+                json={"manufacturing_order_id": 77, "serial_numbers": [101, 102]},
+            )
+            assert resp.status_code == 200
+        finally:
+            client.close()
+
+    def test_verify_hook_does_not_fire_on_get(self) -> None:
+        """Hooks are post-mutation only; GET responses bypass them even
+        if a hook is registered on ``("GET", endpoint)`` (defensive: the
+        registration API doesn't reject non-mutation methods, but
+        ``request()`` must not invoke them on reads)."""
+        hook_called = False
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": []})
+
+        def hook(_req: httpx.Request, _resp: httpx.Response) -> None:
+            nonlocal hook_called
+            hook_called = True
+
+        client = _build_safe_client(handler)
+        client.register_verify("GET", "/customers", hook)
+        try:
+            resp = client.get("/customers")
+            assert resp.status_code == 200
+            assert not hook_called
+        finally:
+            client.close()
+
+
+# ----------------------------------------------------------------------
+# ``_is_sdt_tagged`` / ``_SDT_RE`` — anchored prefix match
+# ----------------------------------------------------------------------
+
+
+class TestSdtRegexAnchoring:
+    """``_SDT_RE`` only accepts ``SDT-`` at the very start of the string
+    (bare or wrapped in ``[…]``). Substrings like ``MySDT-foo`` must
+    NOT match — otherwise a real customer named e.g.
+    ``"Acme [SDT-Subdivision] Co"`` would slip the guard."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "SDT-2026-05-19-customer",
+            "[SDT-2026-05-19] probe-customer",
+            "[SDT-…] free text",
+        ],
+    )
+    def test_accepts_prefix_forms(self, value: str) -> None:
+        assert _is_sdt_tagged(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "MySDT-something",  # SDT- not at start (bare form)
+            "Acme [SDT-Sub] Co",  # [SDT- embedded mid-string
+            "prefix SDT-tail",  # SDT- preceded by whitespace
+            "",  # empty
+            "SDT",  # missing trailing hyphen
+            "[SDT]",  # missing trailing hyphen
+        ],
+    )
+    def test_rejects_non_prefix_forms(self, value: str) -> None:
+        assert not _is_sdt_tagged(value)
+
+    def test_rejects_non_strings(self) -> None:
+        assert not _is_sdt_tagged(None)
+        assert not _is_sdt_tagged(42)
+        assert not _is_sdt_tagged(["SDT-foo"])
+
+
+# ----------------------------------------------------------------------
+# ``discover_sdt_fixture`` — replaces "grab first customer" with
+# "grab first SDT- customer"
+# ----------------------------------------------------------------------
+
+
+class TestDiscoverSdtFixture:
+    def test_returns_first_sdt_row_filtered_clientside(self) -> None:
+        """Katana list filters are exact-match; client-side filter is the only path."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"id": 1, "name": "Real Customer"},
+                        {"id": 2, "name": "Another Real One"},
+                        {"id": 3, "name": "[SDT-2026-05-19] probe-customer"},
+                        {"id": 4, "name": "[SDT-…] another"},
+                    ]
+                },
+            )
+
+        client = _build_safe_client(handler)
+        try:
+            row = discover_sdt_fixture(client, "/customers", "name")
+            assert row is not None
+            assert row["id"] == 3
+        finally:
+            client.close()
+
+    def test_returns_none_when_no_sdt_row_exists(self) -> None:
+        """Empty result is a deliberate ``None`` so the caller decides
+        whether to create one or skip."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"id": 1, "name": "Real A"},
+                        {"id": 2, "name": "Real B"},
+                    ]
+                },
+            )
+
+        client = _build_safe_client(handler)
+        try:
+            assert discover_sdt_fixture(client, "/customers", "name") is None
+        finally:
+            client.close()
+
+    def test_paginates_through_results(self) -> None:
+        """Walks pages until it finds an SDT row or runs out."""
+        pages_hit: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            pages_hit.append(str(request.url.params))
+            params = request.url.params
+            page = int(params.get("page", "1"))
+            limit = int(params.get("limit", "50"))
+            if page == 1:
+                # Full page of non-SDT rows — must paginate.
+                return httpx.Response(
+                    200,
+                    json={
+                        "data": [{"id": i, "name": f"Real {i}"} for i in range(limit)]
+                    },
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"id": 100, "name": "[SDT-…] probe"},
+                    ]
+                },
+            )
+
+        client = _build_safe_client(handler)
+        try:
+            row = discover_sdt_fixture(client, "/customers", "name", limit=10)
+            assert row is not None
+            assert row["id"] == 100
+            assert len(pages_hit) == 2
+        finally:
+            client.close()
+
+    def test_returns_none_when_list_endpoint_errors(self) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"error": "boom"})
+
+        client = _build_safe_client(handler)
+        try:
+            assert discover_sdt_fixture(client, "/customers", "name") is None
+        finally:
+            client.close()
+
+
+# ----------------------------------------------------------------------
+# Custom-field definition: UUID string IDs (the only non-int identity)
+# ----------------------------------------------------------------------
+
+
+class TestCustomFieldUuidIds:
+    def test_patch_custom_field_definition_uuid_in_ledger(self) -> None:
+        """Custom field IDs are UUID strings; the ledger key must
+        round-trip them as strings, not ints."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"id": "abc-123-uuid"})
+
+        ledger = {("/custom_field_definitions", "abc-123-uuid")}
+        client = _build_safe_client(handler, ledger_keys=ledger)
+        try:
+            resp = client.patch(
+                "/custom_field_definitions/abc-123-uuid",
+                json={"label": "[SDT-…]"},
+            )
+            assert resp.status_code == 200
+        finally:
+            client.close()
+
+
+# ----------------------------------------------------------------------
+# Verify hook decode helper — request body parsing
+# ----------------------------------------------------------------------
+
+
+class TestVerifyHookDecode:
+    def test_production_hook_silently_returns_on_empty_request(self) -> None:
+        """No ``serial_numbers`` in the request → nothing to verify."""
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"id": 1, "serial_numbers": []})
+
+        client = _build_safe_client(
+            handler, ledger_keys={("/manufacturing_orders", "77")}
+        )
+        client.register_verify(
+            "POST",
+            "/manufacturing_order_productions",
+            verify_production_serial_numbers_match,
+        )
+        try:
+            # Caller didn't request serials → response shape doesn't matter.
+            resp = client.post(
+                "/manufacturing_order_productions",
+                json={"manufacturing_order_id": 77, "quantity": 1},
+            )
+            assert resp.status_code == 200
+        finally:
+            client.close()
+
+
+# ----------------------------------------------------------------------
+# POST array-body inspection (some endpoints accept ``[{...}, ...]``)
+# ----------------------------------------------------------------------
+
+
+class TestArrayBodyInspection:
+    def test_post_array_body_all_items_must_pass(self) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            pytest.fail("guard should refuse on first failing item")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError):
+                client.post(
+                    "/sales_orders",
+                    json=[
+                        {"order_no": "SDT-2026-05-19-A"},
+                        {"order_no": "#WEB20604"},  # second one fails
+                    ],
+                )
+        finally:
+            client.close()
+
+
+# ----------------------------------------------------------------------
+# Encoding sanity — body is sent JSON-encoded, hooks see it decoded.
+# ----------------------------------------------------------------------
+
+
+class TestSplitPathNormalization:
+    """``_split_path`` must accept absolute and relative URL forms.
+
+    httpx attaches ``base_url`` at send-time, so the guard sees whatever
+    the caller passed in — including relative strings like
+    ``sales_orders/42``. The pre-fix code assumed a leading ``/`` and
+    would IndexError or mis-attribute the collection name on relative
+    inputs, silently bypassing the identity check.
+    """
+
+    def test_absolute_path_collection_only(self) -> None:
+        assert _split_path("/sales_orders") == ("/sales_orders", None)
+
+    def test_absolute_path_with_id(self) -> None:
+        assert _split_path("/sales_orders/42") == ("/sales_orders", "42")
+
+    def test_relative_path_collection_only(self) -> None:
+        assert _split_path("sales_orders") == ("/sales_orders", None)
+
+    def test_relative_path_with_id(self) -> None:
+        assert _split_path("sales_orders/42") == ("/sales_orders", "42")
+
+    def test_trailing_slash_stripped(self) -> None:
+        assert _split_path("/sales_orders/") == ("/sales_orders", None)
+        assert _split_path("sales_orders/") == ("/sales_orders", None)
+
+    def test_query_string_ignored(self) -> None:
+        assert _split_path("/sales_orders/42?include=rows") == (
+            "/sales_orders",
+            "42",
+        )
+
+    def test_full_url_with_scheme(self) -> None:
+        assert _split_path("https://api.katana.test/sales_orders/42") == (
+            "/sales_orders",
+            "42",
+        )
+
+    def test_sub_resource_falls_through_to_parent(self) -> None:
+        # ``/sales_orders/42/rows`` — guard targets the parent SO id.
+        assert _split_path("/sales_orders/42/rows") == ("/sales_orders", "42")
+
+    def test_empty_path_returns_empty(self) -> None:
+        assert _split_path("") == ("", None)
+        assert _split_path("/") == ("", None)
+
+
+class TestLedgerTenantScoping:
+    """``_initial_ledger_keys`` must filter rows by tenant.
+
+    If an API-key swap happens but the on-disk ledger still has rows
+    from the previous tenant, those rows must NOT seed the in-memory
+    ledger fast-path — otherwise the SafeClient would let through a
+    PATCH/DELETE targeting an ID that belongs to a *real* record on
+    the new tenant.
+
+    Mirrors the cleanup-side filter in ``cleanup()``.
+    """
+
+    def test_filters_out_rows_with_different_base_url(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        from scripts import spec_drift_verify as sdv
+
+        ledger = tmp_path / "ledger.jsonl"
+        ledger.write_text(
+            "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "endpoint": "/sales_orders",
+                            "entity_id": 1,
+                            "base_url": "https://api.katana.test",
+                            "factory_id": 100,
+                            "issue": "x",
+                            "method": "POST",
+                            "created_at": "2026-01-01T00:00:00",
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "endpoint": "/sales_orders",
+                            "entity_id": 2,
+                            "base_url": "https://other-tenant.katana.example",
+                            "factory_id": 200,
+                            "issue": "x",
+                            "method": "POST",
+                            "created_at": "2026-01-01T00:00:00",
+                        }
+                    ),
+                ]
+            )
+            + "\n"
+        )
+        monkeypatch.setattr(sdv, "LEDGER_PATH", ledger)
+        monkeypatch.setattr(sdv, "BASE_URL", "https://api.katana.test")
+        sdv._factory_id_for_key.cache_clear()
+        monkeypatch.setattr(sdv, "_resolve_factory_id", lambda: 100)
+
+        keys = sdv._initial_ledger_keys()
+        assert keys == {("/sales_orders", "1")}
+
+    def test_filters_out_rows_with_different_factory_id(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """Same base_url, different API key → different factory_id → exclude."""
+        from scripts import spec_drift_verify as sdv
+
+        ledger = tmp_path / "ledger.jsonl"
+        ledger.write_text(
+            "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "endpoint": "/sales_orders",
+                            "entity_id": 10,
+                            "base_url": "https://api.katana.test",
+                            "factory_id": 100,
+                            "issue": "x",
+                            "method": "POST",
+                            "created_at": "2026-01-01T00:00:00",
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "endpoint": "/sales_orders",
+                            "entity_id": 11,
+                            "base_url": "https://api.katana.test",
+                            "factory_id": 999,  # other tenant
+                            "issue": "x",
+                            "method": "POST",
+                            "created_at": "2026-01-01T00:00:00",
+                        }
+                    ),
+                ]
+            )
+            + "\n"
+        )
+        monkeypatch.setattr(sdv, "LEDGER_PATH", ledger)
+        monkeypatch.setattr(sdv, "BASE_URL", "https://api.katana.test")
+        sdv._factory_id_for_key.cache_clear()
+        monkeypatch.setattr(sdv, "_resolve_factory_id", lambda: 100)
+
+        keys = sdv._initial_ledger_keys()
+        assert keys == {("/sales_orders", "10")}
+
+    def test_fail_closed_when_current_factory_id_unresolvable(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """Row carries factory_id, current credential can't resolve one → exclude.
+
+        Same fail-closed posture as ``cleanup()`` — when the active
+        tenant is unverifiable, refuse to admit fingerprinted rows
+        rather than admit them and hope.
+        """
+        from scripts import spec_drift_verify as sdv
+
+        ledger = tmp_path / "ledger.jsonl"
+        ledger.write_text(
+            json.dumps(
+                {
+                    "endpoint": "/sales_orders",
+                    "entity_id": 5,
+                    "base_url": "https://api.katana.test",
+                    "factory_id": 100,
+                    "issue": "x",
+                    "method": "POST",
+                    "created_at": "2026-01-01T00:00:00",
+                }
+            )
+            + "\n"
+        )
+        monkeypatch.setattr(sdv, "LEDGER_PATH", ledger)
+        monkeypatch.setattr(sdv, "BASE_URL", "https://api.katana.test")
+        sdv._factory_id_for_key.cache_clear()
+        monkeypatch.setattr(sdv, "_resolve_factory_id", lambda: None)
+
+        keys = sdv._initial_ledger_keys()
+        assert keys == set()
+
+    def test_pre_fingerprint_rows_rejected(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """Pre-fingerprint rows (no ``base_url`` / ``factory_id``) MUST
+        be dropped — without a tenant signal we can't prove they belong
+        to the current credential, and ledger-only guard paths
+        (``NO_GET_BY_ID`` endpoints + child POSTs that only check parent
+        ledger membership) would otherwise accept them as a cross-tenant
+        allow-list bypass."""
+        from scripts import spec_drift_verify as sdv
+
+        ledger = tmp_path / "ledger.jsonl"
+        ledger.write_text(
+            json.dumps(
+                {
+                    "endpoint": "/sales_orders",
+                    "entity_id": 7,
+                    "issue": "x",
+                    "method": "POST",
+                    "created_at": "2026-01-01T00:00:00",
+                }
+            )
+            + "\n"
+        )
+        monkeypatch.setattr(sdv, "LEDGER_PATH", ledger)
+        monkeypatch.setattr(sdv, "BASE_URL", "https://api.katana.test")
+        sdv._factory_id_for_key.cache_clear()
+        monkeypatch.setattr(sdv, "_resolve_factory_id", lambda: 100)
+
+        keys = sdv._initial_ledger_keys()
+        assert keys == set()
+
+
+class TestMakeClientAllowUnsafeSkipsLedger:
+    """``make_client(allow_unsafe=True)`` must NOT read the ledger.
+
+    ``allow_unsafe`` bypasses the guard, so the ledger-keys aren't
+    consulted at runtime. Skipping the initial read removes the
+    wasted I/O AND breaks a chicken-and-egg bootstrap:
+    ``_initial_ledger_keys`` calls ``_resolve_factory_id``, which itself
+    constructs a SafeClient via ``make_client(allow_unsafe=True)`` to
+    GET ``/factory``. Without the skip, that path would recurse.
+    """
+
+    def test_allow_unsafe_does_not_call_initial_ledger_keys(
+        self,
+        monkeypatch,
+    ) -> None:
+        from scripts import spec_drift_verify as sdv
+
+        called = {"n": 0}
+
+        def fake_ledger_keys() -> set[tuple[str, str]]:
+            called["n"] += 1
+            return set()
+
+        monkeypatch.setattr(sdv, "_initial_ledger_keys", fake_ledger_keys)
+        monkeypatch.setattr(sdv, "_api_key", lambda: "fake-key")
+        # Drain the live-client registry between tests so leak doesn't
+        # cross test boundaries.
+        monkeypatch.setattr(sdv, "_LIVE_CLIENTS", [])
+
+        client = sdv.make_client(allow_unsafe=True)
+        client.close()
+        assert called["n"] == 0
+
+    def test_default_does_call_initial_ledger_keys(
+        self,
+        monkeypatch,
+    ) -> None:
+        """Sanity: the skip only kicks in for ``allow_unsafe=True``."""
+        from scripts import spec_drift_verify as sdv
+
+        called = {"n": 0}
+
+        def fake_ledger_keys() -> set[tuple[str, str]]:
+            called["n"] += 1
+            return set()
+
+        monkeypatch.setattr(sdv, "_initial_ledger_keys", fake_ledger_keys)
+        monkeypatch.setattr(sdv, "_api_key", lambda: "fake-key")
+        monkeypatch.setattr(sdv, "_LIVE_CLIENTS", [])
+
+        client = sdv.make_client()
+        client.close()
+        assert called["n"] == 1
+
+
+class TestRelativePathGuardIntegration:
+    """The mutation guard must engage on relative paths too.
+
+    Regression for the ``_split_path`` IndexError-on-relative bug: if the
+    guard fell over on a relative URL, the request would short-circuit
+    or worse, silently slip through. Verify both refusal-on-bad-identity
+    and ledger-allow paths work with relative inputs.
+    """
+
+    def test_post_relative_path_with_sdt_identity_allowed(self) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": {"id": 99}})
+
+        client = _build_safe_client(handler)
+        try:
+            response = client.post(
+                "sales_orders",
+                json={"order_no": "SDT-2026-05-19-RELATIVE"},
+            )
+            assert response.status_code == 200
+        finally:
+            client.close()
+
+    def test_post_relative_path_without_sdt_identity_refused(self) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            pytest.fail("guard should refuse before the wire call")
+
+        client = _build_safe_client(handler)
+        try:
+            with pytest.raises(UnsafeMutationError):
+                client.post("sales_orders", json={"order_no": "#WEB20604"})
+        finally:
+            client.close()
+
+
+class TestRequestBodyDecoding:
+    def test_verify_hook_sees_dict_request_body(self) -> None:
+        captured: dict[str, object] = {}
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"id": 1, "serial_numbers": [1, 2]})
+
+        def hook(req: httpx.Request, _resp: httpx.Response) -> None:
+            captured["body"] = json.loads(req.content)
+
+        client = _build_safe_client(
+            handler, ledger_keys={("/manufacturing_orders", "77")}
+        )
+        client.register_verify("POST", "/manufacturing_order_productions", hook)
+        try:
+            client.post(
+                "/manufacturing_order_productions",
+                json={"manufacturing_order_id": 77, "serial_numbers": [1, 2]},
+            )
+            assert captured["body"] == {
+                "manufacturing_order_id": 77,
+                "serial_numbers": [1, 2],
+            }
+        finally:
+            client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.90.0"
+version = "0.90.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Adds `SafeClient` (new `scripts/_safety.py`), an `httpx.Client` subclass that refuses POST/PATCH/DELETE mutations against records that aren't SDT-prefixed or in the local ledger. Closes the 2026-05-19 WEB20604 near-miss class.
- Adds the post-mutation **verify hook** surface from the silent-data-loss companion comment — probes can register per-endpoint assertions that fire on 2xx and raise `SilentDropError` when wire state contradicts caller intent. Ships with `verify_production_serial_numbers_match` as a concrete example for `POST /manufacturing_order_productions`.
- Migrates `probe_remaining_issues.discover_fixtures()` to the new `discover_sdt_fixture()` helper for customer/supplier lookup (the "grab first customer" pattern was the WEB20604 root cause).

## Guard layers

- **POST** — inspect the body's identity field per-endpoint (`order_no`, `name`, `sku`, `label`, etc.). Child / transactional endpoints without a top-level identity fall back to a parent-FK ledger-membership check (e.g. `POST /sales_order_fulfillments` requires `sales_order_id` to be in the ledger).
- **PATCH / DELETE** — fast path via ledger membership; fallback is a pre-fetch GET that checks the identity field carries `SDT-`. For endpoints without GET-by-id (`/stock_transfers`, `/stock_adjustments`, `/sales_order_rows`, `/sales_order_fulfillments`, `/manufacturing_order_recipe_rows`, `/manufacturing_order_productions`, `/variant_bin_locations`), ledger membership is the only signal.
- **All checks** raise `UnsafeMutationError` *before* the wire call. `allow_unsafe=True` at construction time bypasses everything — used internally by `cleanup()` (ledger pre-vetted the targets) and `_resolve_factory_id()` (read-only).

## Migration impact

- `probe_shape_only.py`, `probe_issue_737.py`, `probe_remaining_issues.py` (other than `discover_fixtures`), and `verify_drift.py` are unchanged — their existing SDT discipline (`tagged()` / `label()`) already passes the guard. `probe_client_error_handling.py` goes through `KatanaClient`, not `make_client()`, and is left as-is per the plan's option-B fallback (its mutations are 422-designed, risk is contained).
- The `record_artifact()` ledger-write also updates every live `SafeClient`'s in-memory ledger so subsequent PATCH/DELETE against freshly-created records skip the pre-fetch round-trip.

## Drive-by

- `uv.lock` bumped to reflect the already-shipped `katana-mcp-server` 0.87.1 version drift from the release process (uv detected the drift on `uv sync`).

## Test plan

- [x] 31 new unit tests under `tests/test_spec_drift_safety.py` using `httpx.MockTransport` — no live API calls. Covers every guard path, the `allow_unsafe` bypass, hook registration / firing semantics, the discovery helper's pagination, and UUID-string-id handling for `/custom_field_definitions`.
- [x] `uv run poe quick-check` clean
- [x] `uv run poe agent-check` clean
- [x] `uv run poe check` clean (3420 tests pass)
- [x] No `# type: ignore`, `# noqa`, or `--no-verify`. No new dependencies.

Closes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)