### PR TITLE
feat(mcp): redesign fulfill card with Tier 2 metrics + per-row breakdown (#553)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -25,6 +25,7 @@ from katana_mcp.tools.tool_result_utils import (
     make_tool_result,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
+from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.domain.converters import to_unset, unwrap_unset
 from katana_public_api_client.models import (
     ManufacturingOrder,
@@ -117,6 +118,56 @@ class FulfillOrderRequest(BaseModel):
     )
 
 
+class FulfilledRowInfo(BaseModel):
+    """Per-row fulfillment detail surfaced on the fulfill card (#553).
+
+    Joins the row's identity (variant SKU + ``display_name`` from the
+    typed cache) with the fulfillment payload (quantity, serial numbers,
+    batch transactions, line total) so the agent can verify *what* is
+    being shipped before confirming. Mirrors ``ReceivedItemInfo`` from
+    ``foundation/purchase_orders.py``.
+
+    The shape is intentionally uniform across the sales + manufacturing
+    branches — the manufacturing branch fills a single row representing
+    the MO's finished good, with ``row_id`` set to ``None`` (an MO has
+    no row IDs the way an SO does) and ``quantity`` populated from the
+    MO's ``actual_quantity``.
+    """
+
+    row_id: int | None = Field(
+        default=None,
+        description=(
+            "Sales-order-row ID for SO fulfillments. ``None`` for MO "
+            "fulfillments (the MO header carries one variant, not a row)."
+        ),
+    )
+    variant_id: int | None = None
+    sku: str | None = None
+    display_name: str | None = None
+    quantity: float
+    serial_numbers: list[int] = Field(
+        default_factory=list,
+        description=(
+            "SerialNumber IDs being attached on this fulfillment "
+            "(serial-tracked rows only)."
+        ),
+    )
+    batch_summary: str | None = Field(
+        default=None,
+        description=(
+            "Pre-formatted batch allocations (e.g., 'batch 42x30, batch 51x22') "
+            "for batch-tracked variants. ``None`` when the row carries no "
+            "batch transactions."
+        ),
+    )
+    price_per_unit: float | None = None
+    row_total: float | None = Field(
+        default=None,
+        description="quantity * price_per_unit in the order currency.",
+    )
+    currency: str | None = None
+
+
 class FulfillOrderResponse(BaseModel):
     """Response from fulfilling an order."""
 
@@ -133,6 +184,50 @@ class FulfillOrderResponse(BaseModel):
         default_factory=list, description="Suggested next steps"
     )
     message: str
+
+    # ---- Tier 2 metrics + Tier 3 per-row breakdown (#553) ----
+    fulfilled_rows: list[FulfilledRowInfo] = Field(
+        default_factory=list,
+        description=(
+            "Per-row breakdown of what's being fulfilled — variant identity, "
+            "quantity, serials, batch allocations. Drives the Tier 3 "
+            "DataTable on the fulfillment card."
+        ),
+    )
+    rows_count: int = Field(
+        default=0,
+        description=(
+            "Count of rows being fulfilled. For sales orders this is the "
+            "number of SO rows; for manufacturing orders it's always 1 "
+            "(the MO's finished good)."
+        ),
+    )
+    total_quantity: float = Field(
+        default=0.0,
+        description=(
+            "Sum of quantities across all fulfilled rows. Surfaced as a "
+            "Tier 2 metric on the card."
+        ),
+    )
+    total_value: float | None = Field(
+        default=None,
+        description=(
+            "Sum of ``row_total`` across all fulfilled rows (in the "
+            "order's currency). ``None`` when no row carries a price "
+            "(e.g., manufacturing orders — MOs track cost, not price)."
+        ),
+    )
+    currency: str | None = Field(
+        default=None,
+        description="ISO 4217 currency code (sales orders only).",
+    )
+    katana_url: str | None = Field(
+        default=None,
+        description=(
+            "Deep link to the order in the Katana web UI. Drives the "
+            "Tier 4 'View in Katana' action on the success card."
+        ),
+    )
 
 
 def _fulfill_response_to_tool_result(response: FulfillOrderResponse) -> ToolResult:
@@ -223,6 +318,24 @@ async def _fulfill_manufacturing_order(
         )
     )
 
+    # Tier 3 enrichment (#553): single row representing the MO's finished
+    # good. Built before the preview/apply branches so both surfaces share
+    # the same payload — the success card's table shouldn't differ from
+    # the preview's except for the date timestamp the API stamped.
+    mo_batch_transactions = unwrap_unset(getattr(mo, "batch_transactions", None), None)
+    fulfilled_rows = [
+        _build_fulfilled_row_manufacturing(
+            variant_id=variant_id,
+            sku=sku,
+            display_name=display_name,
+            actual_quantity=actual_quantity,
+            serial_numbers=request.serial_numbers,
+            batch_transactions=mo_batch_transactions,
+        )
+    ]
+    rows_count, total_qty, total_value = _summarize_fulfilled_rows(fulfilled_rows)
+    katana_url = katana_web_url("manufacturing_order", request.order_id)
+
     if request.preview:
         has_block = any(w.startswith(BLOCK_WARNING_PREFIX) for w in warnings)
         if current_status == "DONE":
@@ -247,6 +360,11 @@ async def _fulfill_manufacturing_order(
             warnings=warnings,
             next_actions=next_actions,
             message=f"Preview: Would mark manufacturing order {order_number} as DONE (currently {current_status})",
+            fulfilled_rows=fulfilled_rows,
+            rows_count=rows_count,
+            total_quantity=total_qty,
+            total_value=total_value,
+            katana_url=katana_url,
         )
 
     # Refuse on apply if any BLOCK warning is present — the preview would have
@@ -264,6 +382,7 @@ async def _fulfill_manufacturing_order(
             warnings=warnings,
             next_actions=["Order is already completed"],
             message=f"Manufacturing order {order_number} is already completed",
+            katana_url=katana_url,
         )
     if has_block:
         return FulfillOrderResponse(
@@ -282,6 +401,7 @@ async def _fulfill_manufacturing_order(
                 f"{sum(1 for w in warnings if w.startswith(BLOCK_WARNING_PREFIX))} "
                 "issue(s); no status change made."
             ),
+            katana_url=katana_url,
         )
 
     from katana_public_api_client.api.manufacturing_order_production import (
@@ -335,6 +455,29 @@ async def _fulfill_manufacturing_order(
     if request.completed_at is not None:
         next_actions.insert(1, f"done_date set to {request.completed_at.isoformat()}")
 
+    # Rebuild the row from the *final* MO so the success card reflects the
+    # post-mutation ``actual_quantity`` Katana stamped (matters when the
+    # MO had no prior production and Katana wrote ``actual_quantity =
+    # completed_quantity``). batch_transactions also lift from the final
+    # MO so any production-time batch allocations surface on the card.
+    final_actual_quantity = unwrap_unset(final_mo.actual_quantity, None)
+    final_batch_transactions = unwrap_unset(
+        getattr(final_mo, "batch_transactions", None), None
+    )
+    success_rows = [
+        _build_fulfilled_row_manufacturing(
+            variant_id=variant_id,
+            sku=sku,
+            display_name=display_name,
+            actual_quantity=final_actual_quantity,
+            serial_numbers=request.serial_numbers,
+            batch_transactions=final_batch_transactions,
+        )
+    ]
+    success_rows_count, success_total_qty, success_total_value = (
+        _summarize_fulfilled_rows(success_rows)
+    )
+
     logger.info(f"Successfully marked manufacturing order {order_number} as DONE")
     return FulfillOrderResponse(
         order_id=request.order_id,
@@ -346,6 +489,11 @@ async def _fulfill_manufacturing_order(
         warnings=warnings,
         next_actions=next_actions,
         message=f"Successfully marked manufacturing order {order_number} as DONE",
+        fulfilled_rows=success_rows,
+        rows_count=success_rows_count,
+        total_quantity=success_total_qty,
+        total_value=success_total_value,
+        katana_url=katana_url,
     )
 
 
@@ -569,6 +717,160 @@ async def _resolve_variant_serial_info(
     return bool(parent and _attr(parent, "serial_tracked")), sku, display_name
 
 
+def _format_batch_summary(batch_transactions: Any) -> str | None:
+    """Render a list of ``BatchTransaction``-like objects as a one-line
+    summary (e.g., ``"batch 42x30, batch 51x20"``).
+
+    Returns ``None`` when the input is empty / UNSET so the card column
+    renders as blank rather than a literal string ``"None"``. Uses ASCII
+    ``"x"`` (not the multiplication sign) so ruff's RUF001 (ambiguous-
+    unicode) stays clean — matches the convention pinned by the receipt
+    card (#556 / PR #793).
+    """
+    txs = unwrap_unset(batch_transactions, None) or []
+    if not txs:
+        return None
+    parts: list[str] = []
+    for tx in txs:
+        batch_id = unwrap_unset(getattr(tx, "batch_id", None), None)
+        qty = unwrap_unset(getattr(tx, "quantity", None), None)
+        if batch_id is None or qty is None:
+            continue
+        parts.append(f"batch {batch_id}x{qty:g}")
+    return ", ".join(parts) if parts else None
+
+
+def _build_fulfilled_rows_sales(
+    so_rows: list[Any],
+    *,
+    overrides_by_row: dict[int, list[int]],
+    sku_by_row: dict[int, str],
+    display_name_by_row: dict[int, str],
+    currency: str | None,
+) -> list[FulfilledRowInfo]:
+    """Build per-row ``FulfilledRowInfo`` entries for a sales-order fulfillment.
+
+    Pulls identity from the resolved SKU + display_name maps (which the
+    sales branch already builds for serial-tracking detection — no extra
+    cache round-trip needed) and pulls the receive payload (qty, batch
+    transactions, serial overrides) from each SO row. Price comes from
+    ``row.price_per_unit`` (stringly-typed in the wire model; cast to
+    float when present so the card can compute ``row_total`` cleanly).
+    """
+    rows: list[FulfilledRowInfo] = []
+    for row in so_rows:
+        rid = row.id
+        vid = row.variant_id
+        qty = row.quantity
+        serials = overrides_by_row.get(rid) or []
+        batch_summary = _format_batch_summary(getattr(row, "batch_transactions", None))
+        # ``price_per_unit`` is ``str | UNSET`` on the wire model — coerce
+        # to float so the card can multiply for the line total. Skip the
+        # row total when no price is present (rare on a sales order; safe
+        # for non-priced rows like free samples).
+        raw_ppu = unwrap_unset(getattr(row, "price_per_unit", None), None)
+        ppu: float | None
+        try:
+            ppu = float(raw_ppu) if raw_ppu is not None else None
+        except (TypeError, ValueError):
+            ppu = None
+        # Defensive coerce: qty should be a float on the wire, but test
+        # fixtures occasionally leave it as the default MagicMock.
+        qty_f: float = float(qty) if isinstance(qty, int | float) else 0.0
+        row_total = ppu * qty_f if ppu is not None else None
+        # Coerce non-string identity fields to None — a MagicMock leaking
+        # through ``_resolve_row_serial_info`` (test fixtures that don't
+        # set ``variant.display_name``) would otherwise trip the Pydantic
+        # validator. The card falls back to SKU / variant id in that case.
+        sku_raw = sku_by_row.get(rid)
+        display_raw = display_name_by_row.get(rid)
+        rows.append(
+            FulfilledRowInfo(
+                row_id=rid if isinstance(rid, int) else None,
+                variant_id=vid if isinstance(vid, int) else None,
+                sku=sku_raw if isinstance(sku_raw, str) else None,
+                display_name=display_raw
+                if isinstance(display_raw, str) and display_raw
+                else None,
+                quantity=qty_f,
+                serial_numbers=serials,
+                batch_summary=batch_summary,
+                price_per_unit=ppu,
+                row_total=row_total,
+                currency=currency,
+            )
+        )
+    return rows
+
+
+def _build_fulfilled_row_manufacturing(
+    *,
+    variant_id: int | None,
+    sku: str,
+    display_name: str,
+    actual_quantity: float | None,
+    serial_numbers: list[int] | None,
+    batch_transactions: Any,
+) -> FulfilledRowInfo:
+    """Build the single ``FulfilledRowInfo`` for a manufacturing-order
+    completion.
+
+    An MO header carries one variant, not a row list — so we synthesize
+    one fulfilled-row entry with ``row_id=None``. Quantity falls back to
+    ``1`` to match the apply path's ``completed_quantity`` default
+    (``actual_quantity or 1``) so the card's Tier 2 "total qty" metric
+    matches what's actually being produced.
+
+    ``price_per_unit`` / ``row_total`` are deliberately left ``None`` —
+    MOs track cost, not price, and the cost ledger lives on a separate
+    surface. The card hides the Line Total column for MO branches.
+    """
+    qty_f: float = (
+        float(actual_quantity) if isinstance(actual_quantity, int | float) else 1.0
+    )
+    # SKU resolution already coerces to ``f"variant {id}"`` on miss — keep
+    # the same sentinel here so the column doesn't show a bare integer.
+    # Defensive coerce on string fields: test fixtures that miss the SKU
+    # / display_name setup leak MagicMocks through ``_resolve_variant_
+    # serial_info``; Pydantic's validator rejects those, so coerce to
+    # None and let the card fall back to ``variant {id}`` rendering.
+    sku_safe = sku if isinstance(sku, str) and not sku.startswith("variant ") else None
+    display_safe = (
+        display_name if isinstance(display_name, str) and display_name else None
+    )
+    return FulfilledRowInfo(
+        row_id=None,
+        variant_id=variant_id if isinstance(variant_id, int) else None,
+        sku=sku_safe,
+        display_name=display_safe,
+        quantity=qty_f,
+        serial_numbers=list(serial_numbers or []),
+        batch_summary=_format_batch_summary(batch_transactions),
+        price_per_unit=None,
+        row_total=None,
+        currency=None,
+    )
+
+
+def _summarize_fulfilled_rows(
+    rows: list[FulfilledRowInfo],
+) -> tuple[int, float, float | None]:
+    """Return ``(rows_count, total_quantity, total_value)`` for the card's
+    Tier 2 metrics row.
+
+    ``total_value`` is ``None`` when *no* row carries a ``row_total``
+    (e.g., MO fulfillment — no price) so the card can render a 2-metric
+    row instead of a "—"-filled third metric. When at least one row has
+    a total, missing values are treated as ``0`` (the sum represents
+    "what's priced is X", not "every row priced").
+    """
+    rows_count = len(rows)
+    total_qty = sum(r.quantity for r in rows)
+    priced = [r.row_total for r in rows if r.row_total is not None]
+    total_value: float | None = sum(priced) if priced else None
+    return rows_count, total_qty, total_value
+
+
 def _build_mo_serial_warnings(
     *,
     order_number: str,
@@ -773,6 +1075,26 @@ async def _fulfill_sales_order(
         )
     )
 
+    # Tier 3 enrichment (#553): per-row breakdown for the card so the
+    # operator can verify *what* is being shipped without reading the raw
+    # tool-call blob. Reuses the SKU + display_name maps that the
+    # serial-tracking detection already built — no extra cache round-trip.
+    raw_currency = unwrap_unset(so.currency, None)
+    # Defensive: ``unwrap_unset`` only filters the UNSET sentinel — a test
+    # fixture that forgot to stub ``.currency`` leaks a MagicMock through,
+    # which Pydantic rejects on ``FulfilledRowInfo.currency``. Coerce
+    # anything non-string to ``None`` so the response model validates.
+    currency = raw_currency if isinstance(raw_currency, str) else None
+    fulfilled_rows = _build_fulfilled_rows_sales(
+        so_rows,
+        overrides_by_row=overrides_by_row,
+        sku_by_row=sku_by_row,
+        display_name_by_row=display_name_by_row,
+        currency=currency,
+    )
+    rows_count, total_qty, total_value = _summarize_fulfilled_rows(fulfilled_rows)
+    katana_url = katana_web_url("sales_order", request.order_id)
+
     if request.preview:
         has_block = any(w.startswith(BLOCK_WARNING_PREFIX) for w in warnings)
         next_actions = (
@@ -796,6 +1118,12 @@ async def _fulfill_sales_order(
                 f"Preview: Would fulfill sales order {order_number} "
                 f"({len(so_rows)} row(s), currently {current_status})"
             ),
+            fulfilled_rows=fulfilled_rows,
+            rows_count=rows_count,
+            total_quantity=total_qty,
+            total_value=total_value,
+            currency=currency,
+            katana_url=katana_url,
         )
 
     # Refuse on apply if any BLOCK warning is present — the preview would have
@@ -816,6 +1144,7 @@ async def _fulfill_sales_order(
                 f"Sales order {order_number} is already {current_status}; refusing "
                 "to create a duplicate fulfillment"
             ),
+            katana_url=katana_url,
         )
     if not so_rows:
         return FulfillOrderResponse(
@@ -831,6 +1160,7 @@ async def _fulfill_sales_order(
                 f"Refused: Sales order {order_number} has no rows to fulfill; "
                 "no fulfillment created."
             ),
+            katana_url=katana_url,
         )
     if has_block:
         return FulfillOrderResponse(
@@ -849,6 +1179,7 @@ async def _fulfill_sales_order(
                 f"{sum(1 for w in warnings if w.startswith(BLOCK_WARNING_PREFIX))} "
                 "issue(s); no fulfillment created."
             ),
+            katana_url=katana_url,
         )
 
     from katana_public_api_client.api.sales_order_fulfillment import (
@@ -902,6 +1233,12 @@ async def _fulfill_sales_order(
             f"Successfully fulfilled sales order {order_number} "
             f"({len(fulfill_rows)} row(s), fulfillment id={fulfillment.id})"
         ),
+        fulfilled_rows=fulfilled_rows,
+        rows_count=rows_count,
+        total_quantity=total_qty,
+        total_value=total_value,
+        currency=currency,
+        katana_url=katana_url,
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -3518,6 +3518,115 @@ def _render_inventory_updates(
             Text(content=f"  {update}")
 
 
+def _build_fulfill_row_display(row: dict[str, Any]) -> dict[str, Any]:
+    """Flatten one ``FulfilledRowInfo`` dict into DataTable-ready strings.
+
+    Parallel to ``_build_receipt_row_display`` (#556 / PR #793): the
+    iframe template renders pure strings, so the builder owns money /
+    qty / serial / batch formatting. Display rules:
+
+    - ``quantity`` renders via ``:g`` so ``5.0 -> '5'`` while preserving
+      ``2.5``.
+    - ``serial_numbers`` collapses the list to its count when it grows
+      past 5 (``[1, 2, ..., 99]`` would blow out the column width); short
+      lists render verbatim so the operator can sanity-check the IDs.
+    - ``row_total`` renders through :func:`_format_money` (USD fallback)
+      so the column stays consistent across currencies. Empty string when
+      the row carries no price (MO branch).
+    """
+
+    def _serials_display() -> str:
+        serials = row.get("serial_numbers") or []
+        if not serials:
+            return ""
+        if len(serials) <= 5:
+            return ", ".join(str(s) for s in serials)
+        return f"{len(serials)} serial(s)"
+
+    row_total = row.get("row_total")
+    qty = row.get("quantity")
+    return {
+        "display_name": row.get("display_name") or "",
+        "sku": row.get("sku") or "",
+        "quantity": f"{qty:g}" if isinstance(qty, int | float) else "",
+        "serials": _serials_display(),
+        "batch_summary": row.get("batch_summary") or "",
+        "row_total": (
+            _format_money(row_total, row.get("currency"))
+            if row_total is not None
+            else ""
+        ),
+    }
+
+
+def _render_fulfill_metrics(response: dict[str, Any]) -> None:
+    """Render the Tier 2 metric row for the fulfill card (#553).
+
+    Three metrics:
+    - **Rows** — count of rows being fulfilled (always present, never zero
+      on a real response — the MO branch synthesizes a single-row entry).
+    - **Total Qty** — sum of quantities across rows, rendered via ``:g``.
+    - **Total Value** — sum of ``row_total`` across rows, formatted via
+      babel. Omitted when no row carries a price (MO branch — MOs track
+      cost, not price; the cost ledger lives on a separate surface).
+
+    Skipped entirely when the response carries no enrichment
+    (back-compat with older payloads that pre-dated #553).
+    """
+    rows_count = response.get("rows_count")
+    if rows_count is None:
+        return
+    total_qty = response.get("total_quantity")
+    total_value = response.get("total_value")
+    currency = response.get("currency")
+    with Row(gap=4):
+        Metric(label="Rows", value=str(rows_count))
+        if isinstance(total_qty, int | float):
+            Metric(label="Total Qty", value=f"{total_qty:g}")
+        if total_value is not None:
+            Metric(label="Total Value", value=_format_money(total_value, currency))
+
+
+def _render_fulfill_per_row_table(
+    fulfilled_rows_display: list[dict[str, Any]],
+    *,
+    order_type: str,
+    is_preview: bool,
+) -> None:
+    """Render the Tier 3 per-row DataTable for the fulfill card (#553).
+
+    Skipped when ``fulfilled_rows_display`` is empty (back-compat for older
+    payloads that pre-dated this enrichment).
+
+    The column set varies by order type:
+    - **Sales** orders carry a Line Total column (price * qty in the
+      order currency) — the operator's most-asked decision context is
+      "what does this fulfillment commit to".
+    - **Manufacturing** orders drop the Line Total column (MOs track
+      cost on a separate surface) and re-allocate that space to the
+      serials column for the serial-tracked-finished-good case.
+    """
+    if not fulfilled_rows_display:
+        return
+    Separator()
+    if is_preview:
+        Muted(content="Rows being fulfilled:")
+    else:
+        Muted(content="Rows fulfilled:")
+    columns: list[Any] = [
+        DataTableColumn(key="display_name", header="Item", sortable=True),
+        DataTableColumn(key="sku", header="SKU", sortable=True),
+        DataTableColumn(key="quantity", header="Qty", align="right"),
+        DataTableColumn(key="serials", header="Serials"),
+        DataTableColumn(key="batch_summary", header="Batch"),
+    ]
+    if order_type == "sales":
+        columns.append(
+            DataTableColumn(key="row_total", header="Line Total", align="right")
+        )
+    DataTable(columns=columns, rows="{{ fulfilled_rows }}")
+
+
 def build_fulfill_preview_ui(
     response: dict[str, Any],
 ) -> PrefabApp:
@@ -3526,6 +3635,16 @@ def build_fulfill_preview_ui(
     The "Confirm Fulfillment" button re-invokes ``fulfill_order`` with
     ``preview=False`` and the original ``order_id`` / ``order_type``
     inlined from the response. No LLM round-trip.
+
+    Layout follows the #537 four-tier framework (#553):
+
+    - **Tier 1** — title + order number badge + status badge.
+    - **Tier 2** — Metric row: Rows / Total Qty / Total Value. Skipped on
+      back-compat payloads that lack ``rows_count``.
+    - **Tier 3** — per-row DataTable (Item / SKU / Qty / Serials / Batch
+      [/ Line Total]). Skipped when ``fulfilled_rows`` is empty.
+    - **Tier 4** — Confirm / Cancel button rail (driven by ``BLOCK:``
+      warnings — disabled when any are present).
     """
     from katana_mcp.tools.foundation.orders import FulfillOrderRequest
 
@@ -3549,7 +3668,18 @@ def build_fulfill_preview_ui(
     cancel_action = _build_cancel_action(
         f"the {raw_order_type} order {order_number} fulfillment"
     )
-    state = {"response": response, "pending": False, "cancelled": False}
+
+    # Pre-flatten per-row rendering into state so the iframe template
+    # never sees raw floats / lists — see #553 / PR #793.
+    fulfilled_rows = response.get("fulfilled_rows") or []
+    fulfilled_rows_display = [_build_fulfill_row_display(r) for r in fulfilled_rows]
+
+    state = {
+        "response": response,
+        "fulfilled_rows": fulfilled_rows_display,
+        "pending": False,
+        "cancelled": False,
+    }
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
@@ -3558,7 +3688,13 @@ def build_fulfill_preview_ui(
             Badge(label=status, variant="secondary")
 
         with CardContent(), Column(gap=2):
+            _render_fulfill_metrics(response)
             _render_inventory_updates(response)
+            _render_fulfill_per_row_table(
+                fulfilled_rows_display,
+                order_type=raw_order_type,
+                is_preview=True,
+            )
 
             if block_warnings or regular_warnings:
                 Separator()
@@ -3580,10 +3716,33 @@ def build_fulfill_preview_ui(
 def build_fulfill_success_ui(
     response: dict[str, Any],
 ) -> PrefabApp:
-    """Build a fulfillment success card."""
-    order_type, order_number, status = _extract_fulfill_fields(response)
+    """Build a fulfillment success card.
 
-    with PrefabApp(state={"response": response}, css_class="p-4") as app, Card():
+    Mirrors :func:`build_fulfill_preview_ui` minus the Confirm/Cancel
+    rail, plus an expanded Tier 4 action set (#553):
+
+    - **View in Katana** — deep-links to the order via ``katana_url``
+      (omitted when the response carries no URL).
+    - **Check Inventory** — the legacy follow-up; remains the default
+      next action when no URL is available.
+    """
+    order_type, order_number, status = _extract_fulfill_fields(response)
+    raw_order_type = response.get("order_type", "sales")
+    katana_url = response.get("katana_url")
+
+    # Pre-flatten the per-row rendering into state, same as the preview
+    # path — the success card surfaces *what landed* on the wire, which
+    # answers the agent's next-most-likely question ("did the right
+    # serials attach?") without forcing a second tool call.
+    fulfilled_rows = response.get("fulfilled_rows") or []
+    fulfilled_rows_display = [_build_fulfill_row_display(r) for r in fulfilled_rows]
+
+    state: dict[str, Any] = {
+        "response": response,
+        "fulfilled_rows": fulfilled_rows_display,
+    }
+
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
             CardTitle(content=f"{order_type} Order Fulfilled")
             Badge(label=order_number, variant="outline")
@@ -3592,11 +3751,27 @@ def build_fulfill_success_ui(
         with CardContent(), Column(gap=2):
             if response.get("message"):
                 Text(content=response["message"])
+            _render_fulfill_metrics(response)
             if response.get("inventory_updates"):
                 Separator()
             _render_inventory_updates(response, label="Inventory Updates:")
+            _render_fulfill_per_row_table(
+                fulfilled_rows_display,
+                order_type=raw_order_type,
+                is_preview=False,
+            )
 
-        with CardFooter():
+        with CardFooter(), Row(gap=2):
+            # Tier 4 actions (#553): two follow-ups. View in Katana wins
+            # the primary slot when a deep-link is available (operator's
+            # most common next move on a successful fulfill is to verify
+            # in the web UI); inventory check stays the secondary action.
+            if katana_url:
+                Button(
+                    label="View in Katana",
+                    variant="default",
+                    on_click=SendMessage(f"Open {katana_url} in the Katana web UI"),
+                )
             Button(
                 label="Check Inventory",
                 variant="outline",

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -2589,6 +2589,284 @@ class TestBuildFulfillSuccessUI:
         _assert_valid_prefab(app)
 
 
+class TestBuildFulfillUI:
+    """Tier 2 metrics + Tier 3 per-row breakdown + Tier 4 actions on the
+    fulfillment card (#553). Mirrors :class:`TestBuildReceiptUI` for the
+    receipt-card sibling that landed in #556 / PR #793.
+    """
+
+    def _so_response(
+        self,
+        *,
+        is_preview: bool = True,
+        with_rows: bool = True,
+        with_metrics: bool = True,
+        currency: str | None = "USD",
+    ) -> dict[str, Any]:
+        """Minimal SO fulfillment response covering the full Tier 2 + Tier 3
+        rendering path. Tests opt rows / metrics in or out to exercise the
+        empty-state branches."""
+        response: dict[str, Any] = {
+            "order_type": "sales",
+            "order_number": "SO-001",
+            "order_id": 123,
+            "status": "NOT_SHIPPED" if is_preview else "DELIVERED",
+            "message": "Preview" if is_preview else "Fulfilled",
+            "is_preview": is_preview,
+            "katana_url": "https://factory.katanamrp.com/salesorder/123",
+        }
+        if with_rows:
+            response["fulfilled_rows"] = [
+                {
+                    "row_id": 501,
+                    "variant_id": 100,
+                    "sku": "WIDGET-100",
+                    "display_name": "Big Widget / Red",
+                    "quantity": 5.0,
+                    "serial_numbers": [],
+                    "batch_summary": None,
+                    "price_per_unit": 10.0,
+                    "row_total": 50.0,
+                    "currency": currency,
+                },
+                {
+                    "row_id": 502,
+                    "variant_id": 200,
+                    "sku": "WIDGET-200",
+                    "display_name": "Small Widget / Blue",
+                    "quantity": 2.0,
+                    "serial_numbers": [9001, 9002],
+                    "batch_summary": None,
+                    "price_per_unit": 25.0,
+                    "row_total": 50.0,
+                    "currency": currency,
+                },
+            ]
+        if with_metrics:
+            response["rows_count"] = 2 if with_rows else 0
+            response["total_quantity"] = 7.0 if with_rows else 0.0
+            response["total_value"] = 100.0 if with_rows else None
+            response["currency"] = currency
+        return response
+
+    # ------------------------------------------------------------------
+    # Back-compat: legacy payloads without enrichment must keep working
+    # ------------------------------------------------------------------
+
+    def test_preview_back_compat_no_rows_omits_table(self):
+        """Older payloads predating #553 (no ``fulfilled_rows`` /
+        ``rows_count``) must NOT render an empty per-row DataTable.
+        Same back-compat shape as ``TestBuildReceiptUI``."""
+        response = {
+            "order_type": "sales",
+            "order_number": "SO-001",
+            "order_id": 123,
+            "status": "NOT_SHIPPED",
+            "message": "Ready to fulfill",
+            "is_preview": True,
+        }
+        envelope = build_fulfill_preview_ui(response).to_json()
+        assert not _has_node_of_type(envelope, "DataTable"), (
+            "Empty fulfilled_rows must NOT emit a DataTable."
+        )
+
+    def test_success_back_compat_no_rows_omits_table(self):
+        """Symmetric back-compat for the success card."""
+        response = {
+            "order_type": "sales",
+            "order_number": "SO-001",
+            "status": "DELIVERED",
+            "message": "Order fulfilled",
+            "is_preview": False,
+        }
+        envelope = build_fulfill_success_ui(response).to_json()
+        assert not _has_node_of_type(envelope, "DataTable")
+
+    # ------------------------------------------------------------------
+    # Tier 2 metrics
+    # ------------------------------------------------------------------
+
+    def test_preview_renders_tier2_metrics(self):
+        """Three-Metric row: Rows / Total Qty / Total Value.
+
+        Pinned by #553: the operator's most-asked decision context is
+        "what's the commitment". Each Metric is its own component so a
+        future card rearrangement can drop one without disturbing the
+        others.
+        """
+        envelope = build_fulfill_preview_ui(self._so_response()).to_json()
+        metrics = _find_components_by_type(envelope, "Metric")
+        labels = [m.get("label") for m in metrics]
+        assert "Rows" in labels
+        assert "Total Qty" in labels
+        assert "Total Value" in labels
+
+    def test_mo_response_omits_total_value(self):
+        """Manufacturing orders track cost, not price — the card must
+        skip the Total Value metric when no row carries a price (the
+        ``total_value=None`` signal from the backend)."""
+        response = {
+            "order_type": "manufacturing",
+            "order_number": "MO-001",
+            "order_id": 456,
+            "status": "IN_PROGRESS",
+            "message": "Preview",
+            "is_preview": True,
+            "rows_count": 1,
+            "total_quantity": 3.0,
+            "total_value": None,
+            "currency": None,
+            "fulfilled_rows": [
+                {
+                    "row_id": None,
+                    "variant_id": 555,
+                    "sku": "FG-001",
+                    "display_name": "Finished Good",
+                    "quantity": 3.0,
+                    "serial_numbers": [],
+                    "batch_summary": None,
+                    "price_per_unit": None,
+                    "row_total": None,
+                    "currency": None,
+                }
+            ],
+        }
+        envelope = build_fulfill_preview_ui(response).to_json()
+        metrics = _find_components_by_type(envelope, "Metric")
+        labels = [m.get("label") for m in metrics]
+        assert "Rows" in labels
+        assert "Total Qty" in labels
+        assert "Total Value" not in labels, (
+            "MO branch must not render Total Value — MOs don't track price."
+        )
+
+    # ------------------------------------------------------------------
+    # Tier 3 per-row table
+    # ------------------------------------------------------------------
+
+    def test_preview_renders_tier3_table_with_expected_columns(self):
+        """Sales-order DataTable surfaces six columns:
+        Item / SKU / Qty / Serials / Batch / Line Total. Manufacturing
+        skips Line Total (covered by ``test_mo_card_drops_line_total``).
+        """
+        envelope = build_fulfill_preview_ui(self._so_response()).to_json()
+        tables = _find_components_by_type(envelope, "DataTable")
+        assert len(tables) == 1
+        headers = [c.get("header") for c in tables[0].get("columns", [])]
+        assert headers == [
+            "Item",
+            "SKU",
+            "Qty",
+            "Serials",
+            "Batch",
+            "Line Total",
+        ]
+
+    def test_mo_card_drops_line_total(self):
+        """MO branch table drops the Line Total column (no price on the
+        MO surface). Pinned so a future "always show all 6 columns" edit
+        breaks loudly instead of silently rendering a blank column."""
+        response = {
+            "order_type": "manufacturing",
+            "order_number": "MO-001",
+            "order_id": 456,
+            "status": "IN_PROGRESS",
+            "is_preview": True,
+            "rows_count": 1,
+            "total_quantity": 1.0,
+            "total_value": None,
+            "fulfilled_rows": [
+                {
+                    "row_id": None,
+                    "variant_id": 555,
+                    "sku": "FG-001",
+                    "display_name": "Finished Good",
+                    "quantity": 1.0,
+                    "serial_numbers": [],
+                    "batch_summary": None,
+                    "price_per_unit": None,
+                    "row_total": None,
+                    "currency": None,
+                }
+            ],
+        }
+        envelope = build_fulfill_preview_ui(response).to_json()
+        tables = _find_components_by_type(envelope, "DataTable")
+        headers = [c.get("header") for c in tables[0].get("columns", [])]
+        assert "Line Total" not in headers
+        # Identity columns + qty/serials/batch are still present.
+        assert headers == ["Item", "SKU", "Qty", "Serials", "Batch"]
+
+    def test_per_row_table_flattens_strings_into_state(self):
+        """``DataTable.rows`` is a state-bound mustache reference. Builder
+        must pre-format the per-row dicts (qty via ``:g``, money via
+        babel, serials list collapsed) so the iframe template only sees
+        strings. See :func:`_build_fulfill_row_display`.
+        """
+        envelope = build_fulfill_preview_ui(self._so_response()).to_json()
+        state = envelope.get("state") or envelope.get("$prefab", {}).get("state", {})
+        rows = state.get("fulfilled_rows")
+        assert isinstance(rows, list) and len(rows) == 2
+        row_a, row_b = rows
+        assert row_a["display_name"] == "Big Widget / Red"
+        assert row_a["sku"] == "WIDGET-100"
+        assert row_a["quantity"] == "5"  # :g trims trailing .0
+        assert row_a["serials"] == ""  # empty list -> empty string
+        assert row_a["row_total"] == "$50.00"
+        # Row B has serial overrides — short list renders verbatim.
+        assert row_b["serials"] == "9001, 9002"
+
+    def test_long_serial_list_collapses_to_count(self):
+        """A row attaching more than 5 serials would blow out the column
+        width; the builder collapses to ``"N serial(s)"`` so the card
+        stays readable.
+        """
+        response = self._so_response()
+        response["fulfilled_rows"][0]["serial_numbers"] = list(range(1, 11))
+        envelope = build_fulfill_preview_ui(response).to_json()
+        state = envelope.get("state") or envelope.get("$prefab", {}).get("state", {})
+        assert state["fulfilled_rows"][0]["serials"] == "10 serial(s)"
+
+    def test_batch_summary_renders_pre_formatted(self):
+        """Batch-tracked rows surface the batch allocation in human-
+        readable form, paralleling the receipt card (#556)."""
+        response = self._so_response()
+        response["fulfilled_rows"][0]["batch_summary"] = "batch 42x30, batch 51x20"
+        envelope = build_fulfill_preview_ui(response).to_json()
+        state = envelope.get("state") or envelope.get("$prefab", {}).get("state", {})
+        assert state["fulfilled_rows"][0]["batch_summary"] == "batch 42x30, batch 51x20"
+
+    # ------------------------------------------------------------------
+    # Tier 4 success-side actions
+    # ------------------------------------------------------------------
+
+    def test_success_renders_view_in_katana_when_url_present(self):
+        """Tier 4 expansion (#553): the success card now offers two
+        follow-ups instead of the legacy single Check Inventory button.
+        View in Katana wins the primary slot when a deep-link is present.
+        """
+        envelope = build_fulfill_success_ui(
+            self._so_response(is_preview=False)
+        ).to_json()
+        buttons = _find_components_by_type(envelope, "Button")
+        labels = [b.get("label") for b in buttons]
+        assert "View in Katana" in labels
+        assert "Check Inventory" in labels
+
+    def test_success_omits_view_in_katana_when_url_missing(self):
+        """No ``katana_url`` on the response (older payload) → fall back
+        to the legacy single Check Inventory button. Pinned for
+        back-compat with previous test fixtures that don't include the
+        URL field."""
+        response = self._so_response(is_preview=False)
+        response.pop("katana_url", None)
+        envelope = build_fulfill_success_ui(response).to_json()
+        buttons = _find_components_by_type(envelope, "Button")
+        labels = [b.get("label") for b in buttons]
+        assert "View in Katana" not in labels
+        assert "Check Inventory" in labels
+
+
 class TestBuildVerificationUI:
     def test_match(self):
         response = {

--- a/katana_mcp_server/tests/tools/test_orders.py
+++ b/katana_mcp_server/tests/tools/test_orders.py
@@ -1986,3 +1986,377 @@ async def test_fulfill_mo_completed_at_propagates_to_serial_transaction_date():
     assert sent_body.serial_numbers == [501]
     assert sent_body.completed_date == completed
     assert sent_body.is_final is True
+
+
+# ============================================================================
+# Tier 2 metrics + Tier 3 per-row enrichment (#553)
+# ============================================================================
+
+
+def _make_so_row_with_price(
+    row_id: int,
+    variant_id: int,
+    quantity: float,
+    price_per_unit: str,
+    *,
+    batch_transactions: Any = None,
+) -> MagicMock:
+    """Like ``_make_so_row`` but pins the fields the #553 enrichment reads.
+
+    Sets ``price_per_unit`` as a string (matches the wire model — the
+    Katana API returns prices as strings to preserve precision) and
+    optionally a ``batch_transactions`` list so the batch_summary branch
+    can be exercised.
+    """
+    from katana_public_api_client.client_types import UNSET
+
+    row = MagicMock()
+    row.id = row_id
+    row.variant_id = variant_id
+    row.quantity = quantity
+    row.price_per_unit = price_per_unit
+    row.batch_transactions = (
+        batch_transactions if batch_transactions is not None else UNSET
+    )
+    return row
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_preview_enriches_fulfilled_rows():
+    """Preview path enriches ``fulfilled_rows`` with PO row + cache data (#553).
+
+    Pinned by the receipt-card sibling pattern (#556 / PR #793). Joins:
+    - request row overrides (serial_numbers)
+    - SO rows (quantity, variant_id, price_per_unit, batch_transactions)
+    - typed cache variants (sku, display_name)
+
+    Plus computes the Tier 2 metric aggregates (rows_count, total_quantity,
+    total_value) that drive the Metric row on the card.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-T2-001"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.currency = "USD"
+    mock_so.sales_order_rows = [
+        _make_so_row_with_price(1, 100, 5.0, "10.00"),
+        _make_so_row_with_price(2, 200, 2.0, "25.00"),
+    ]
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    # Seed the typed cache so each variant resolves to a canonical
+    # display_name; the enrichment lifts this verbatim into the row.
+    def _mk_cached(vid, sku, display_name):
+        m = MagicMock()
+        m.id = vid
+        m.sku = sku
+        m.display_name = display_name
+        m.product_id = None
+        m.material_id = None
+        m.config_attributes = []
+        return m
+
+    async def _get_many(model_cls, ids, **_kw):
+        if model_cls is CachedVariant:
+            data = {
+                100: _mk_cached(100, "WIDGET-100", "Big Widget / Red"),
+                200: _mk_cached(200, "WIDGET-200", "Small Widget / Blue"),
+            }
+            return {vid: data[vid] for vid in ids if vid in data}
+        return {}
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(side_effect=_get_many)
+
+    request = FulfillOrderRequest(
+        order_id=5678,
+        order_type="sales",
+        preview=True,
+        rows=[FulfillRowOverride(sales_order_row_id=2, serial_numbers=[9001, 9002])],
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    # ---- Tier 3 enrichment ----
+    assert len(result.fulfilled_rows) == 2
+    by_row = {r.row_id: r for r in result.fulfilled_rows}
+
+    row_a = by_row[1]
+    assert row_a.variant_id == 100
+    assert row_a.sku == "WIDGET-100"
+    assert row_a.display_name == "Big Widget / Red"
+    assert row_a.quantity == 5.0
+    assert row_a.price_per_unit == 10.0
+    assert row_a.row_total == 50.0
+    assert row_a.currency == "USD"
+    assert row_a.serial_numbers == []
+    assert row_a.batch_summary is None
+
+    row_b = by_row[2]
+    assert row_b.variant_id == 200
+    assert row_b.sku == "WIDGET-200"
+    assert row_b.quantity == 2.0
+    assert row_b.row_total == 50.0
+    # Serial overrides from the request land on the enriched row.
+    assert row_b.serial_numbers == [9001, 9002]
+
+    # ---- Tier 2 metrics ----
+    assert result.rows_count == 2
+    assert result.total_quantity == 7.0
+    assert result.total_value == 100.0
+    assert result.currency == "USD"
+    # Tier 4: deep link is on the preview response so the success card
+    # can pre-bind the View in Katana button.
+    assert result.katana_url is not None
+    assert result.katana_url.endswith("/salesorder/5678")
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_preview_batch_summary_renders():
+    """Batch-tracked rows surface the allocation in human-readable form
+    (``"batch 42x30, batch 51x20"``). Pinned for the receipt-card sibling
+    parity (#556) so a future change to the format keeps the two cards
+    in step.
+    """
+    context, _lifespan_ctx = create_mock_context()
+
+    # Batch transaction objects mirroring the wire model shape.
+    bt1 = MagicMock()
+    bt1.batch_id = 42
+    bt1.quantity = 30.0
+    bt2 = MagicMock()
+    bt2.batch_id = 51
+    bt2.quantity = 20.0
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-BATCH"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.currency = "USD"
+    mock_so.sales_order_rows = [
+        _make_so_row_with_price(1, 300, 50.0, "5.00", batch_transactions=[bt1, bt2]),
+    ]
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    request = FulfillOrderRequest(order_id=9999, order_type="sales", preview=True)
+    result = await _fulfill_order_impl(request, context)
+
+    assert len(result.fulfilled_rows) == 1
+    assert result.fulfilled_rows[0].batch_summary == "batch 42x30, batch 51x20"
+
+
+@pytest.mark.asyncio
+async def test_fulfill_manufacturing_order_preview_enriches_fulfilled_row():
+    """MO preview enriches a single ``FulfilledRowInfo`` (the MO carries
+    one variant, not a row list). Tier 2 metrics: rows_count=1, total_qty
+    is ``actual_quantity``, total_value is ``None`` (MOs track cost, not
+    price). ``katana_url`` deep-links to the MO page.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    mock_mo = MagicMock(spec=ManufacturingOrder)
+    mock_mo.order_no = "MO-T2-001"
+    mock_mo.status = ManufacturingOrderStatus.IN_PROGRESS
+    mock_mo.variant_id = 555
+    mock_mo.actual_quantity = 3.0
+
+    mock_response = MagicMock(status_code=200, parsed=mock_mo)
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+    )
+
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        return_value=mock_response
+    )
+
+    cached_variant = MagicMock()
+    cached_variant.id = 555
+    cached_variant.sku = "FG-001"
+    cached_variant.display_name = "Premium Widget / Large"
+    cached_variant.product_id = None
+    cached_variant.material_id = None
+    cached_variant.config_attributes = []
+
+    async def _get_many(model_cls, ids, **_kw):
+        if model_cls is CachedVariant and 555 in set(ids):
+            return {555: cached_variant}
+        return {}
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(side_effect=_get_many)
+
+    request = FulfillOrderRequest(
+        order_id=8888, order_type="manufacturing", preview=True
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    # ---- Tier 3 enrichment ----
+    assert len(result.fulfilled_rows) == 1
+    row = result.fulfilled_rows[0]
+    assert row.row_id is None  # MO has no row IDs the way SO does
+    assert row.variant_id == 555
+    assert row.sku == "FG-001"
+    assert row.display_name == "Premium Widget / Large"
+    assert row.quantity == 3.0
+    # Price not surfaced on the MO branch.
+    assert row.price_per_unit is None
+    assert row.row_total is None
+    assert row.currency is None
+
+    # ---- Tier 2 metrics ----
+    assert result.rows_count == 1
+    assert result.total_quantity == 3.0
+    # No price on any row → total_value omitted (None signals the card
+    # to skip the Total Value metric).
+    assert result.total_value is None
+
+    # ---- Tier 4 deep link ----
+    assert result.katana_url is not None
+    assert result.katana_url.endswith("/manufacturingorder/8888")
+
+
+@pytest.mark.asyncio
+async def test_fulfill_manufacturing_order_confirm_carries_enrichment():
+    """Success path rebuilds enrichment from the *post-mutation* MO so the
+    success card reflects what Katana actually stamped (matters when the
+    MO had no prior production and Katana sets ``actual_quantity =
+    completed_quantity``).
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    # Initial fetch: pre-production MO with no actual_quantity yet.
+    mock_pre_mo = MagicMock(spec=ManufacturingOrder)
+    mock_pre_mo.order_no = "MO-T2-CONFIRM"
+    mock_pre_mo.status = ManufacturingOrderStatus.IN_PROGRESS
+    mock_pre_mo.variant_id = 555
+    mock_pre_mo.actual_quantity = None
+    mock_get_response = MagicMock(status_code=200, parsed=mock_pre_mo)
+
+    from katana_public_api_client.models import ManufacturingOrderProduction
+
+    mock_production = MagicMock(spec=ManufacturingOrderProduction)
+    mock_production.id = 9001
+    mock_create_response = MagicMock(status_code=200, parsed=mock_production)
+
+    # Post-mutation MO: Katana stamped actual_quantity = 1 (the default).
+    mock_post_mo = MagicMock(spec=ManufacturingOrder)
+    mock_post_mo.order_no = "MO-T2-CONFIRM"
+    mock_post_mo.status = ManufacturingOrderStatus.DONE
+    mock_post_mo.variant_id = 555
+    mock_post_mo.actual_quantity = 1.0
+    mock_final_response = MagicMock(status_code=200, parsed=mock_post_mo)
+
+    from katana_public_api_client.api.manufacturing_order import (
+        get_manufacturing_order,
+    )
+    from katana_public_api_client.api.manufacturing_order_production import (
+        create_manufacturing_order_production,
+    )
+
+    cast(Any, get_manufacturing_order).asyncio_detailed = AsyncMock(
+        side_effect=[mock_get_response, mock_final_response]
+    )
+    cast(Any, create_manufacturing_order_production).asyncio_detailed = AsyncMock(
+        return_value=mock_create_response
+    )
+
+    cached_variant = MagicMock()
+    cached_variant.id = 555
+    cached_variant.sku = "FG-001"
+    cached_variant.display_name = "Premium Widget"
+    cached_variant.product_id = None
+    cached_variant.material_id = None
+    cached_variant.config_attributes = []
+
+    async def _get_many(model_cls, ids, **_kw):
+        if model_cls is CachedVariant and 555 in set(ids):
+            return {555: cached_variant}
+        return {}
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(side_effect=_get_many)
+
+    request = FulfillOrderRequest(
+        order_id=8888, order_type="manufacturing", preview=False
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.is_preview is False
+    assert result.status == "DONE"
+    # Quantity reflects post-mutation state (the API-stamped actual_quantity=1),
+    # not the pre-mutation None.
+    assert len(result.fulfilled_rows) == 1
+    assert result.fulfilled_rows[0].quantity == 1.0
+    assert result.rows_count == 1
+    assert result.total_quantity == 1.0
+    # Deep link present on the success response so the View in Katana
+    # button can wire up without an extra round-trip.
+    assert result.katana_url is not None
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_confirm_carries_enrichment():
+    """Success path on the SO branch also carries the enriched rows +
+    metrics + deep link so the success card matches the preview card's
+    information density.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-T2-CONFIRM"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.currency = "USD"
+    mock_so.sales_order_rows = [_make_so_row_with_price(1, 100, 5.0, "10.00")]
+
+    mock_get_response = MagicMock(status_code=200, parsed=mock_so)
+
+    from katana_public_api_client.api.sales_order import get_sales_order
+    from katana_public_api_client.api.sales_order_fulfillment import (
+        create_sales_order_fulfillment,
+    )
+    from katana_public_api_client.models import SalesOrderFulfillment
+
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+
+    fulfillment_obj = MagicMock(spec=SalesOrderFulfillment)
+    fulfillment_obj.id = 7777
+    mock_create_response = MagicMock(status_code=201, parsed=fulfillment_obj)
+    cast(Any, create_sales_order_fulfillment).asyncio_detailed = AsyncMock(
+        return_value=mock_create_response
+    )
+
+    cached_variant = MagicMock()
+    cached_variant.id = 100
+    cached_variant.sku = "WIDGET-100"
+    cached_variant.display_name = "Big Widget / Red"
+    cached_variant.product_id = None
+    cached_variant.material_id = None
+    cached_variant.config_attributes = []
+
+    async def _get_many(model_cls, ids, **_kw):
+        if model_cls is CachedVariant and 100 in set(ids):
+            return {100: cached_variant}
+        return {}
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(side_effect=_get_many)
+
+    request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=False)
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.is_preview is False
+    assert result.status == "DELIVERED"
+    assert len(result.fulfilled_rows) == 1
+    assert result.fulfilled_rows[0].sku == "WIDGET-100"
+    assert result.fulfilled_rows[0].row_total == 50.0
+    assert result.rows_count == 1
+    assert result.total_quantity == 5.0
+    assert result.total_value == 50.0
+    assert result.currency == "USD"
+    assert result.katana_url is not None
+    assert result.katana_url.endswith("/salesorder/5678")

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.87.0"
+version = "0.87.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Closes #553. The fulfillment card (`build_fulfill_preview_ui` + `build_fulfill_success_ui`) was a Tier 1 + inventory-text-list summary — agents had to read the raw `rows=[...]` tool-call blob below the card to verify *what* was being shipped before clicking **Confirm Fulfillment**. This delivers the #537 four-tier framework sub-issue that was previously gated on #547 (serial-tracked detection — closed 2026-05-07). Pattern mirrors the receipt-card redesign (PR #793 / commit c371ea41).

- **Backend** — `FulfilledRowInfo` joins per-row variant identity (SKU + canonical `display_name` from the typed cache) with the fulfillment payload (`quantity`, `serial_numbers`, `batch_transactions`, `row_total`). The sales branch builds one entry per SO row via `_build_fulfilled_rows_sales`; the MO branch synthesizes a single entry for the finished good via `_build_fulfilled_row_manufacturing`. `FulfillOrderResponse` gains five new fields: `fulfilled_rows`, `rows_count`, `total_quantity`, `total_value`, `currency`, plus `katana_url` for the Tier 4 deep link. Helpers defensively coerce non-string identity fields so test fixtures that leak MagicMocks through `_resolve_row_serial_info` don't trip the Pydantic validator. Confirm path on the MO branch rebuilds enrichment from the *post-mutation* MO so the success card reflects the Katana-stamped `actual_quantity` (matters when the MO had no prior production and Katana writes `actual_quantity = completed_quantity`).
- **UI** — Both builders render a Tier 2 `Metric` row (Rows / Total Qty / Total Value — Total Value omitted on the MO branch since MOs track cost, not price) and a Tier 3 DataTable (Item / SKU / Qty / Serials / Batch [/ Line Total]). Pre-flattens display strings into iframe state (qty via `:g`, money via babel, long serial lists collapsed to `N serial(s)`). Skipped when `fulfilled_rows` is empty so older payloads stay compatible. Success card gains a Tier 4 **View in Katana** button when `katana_url` is present, paralleling the receipt card's `View in Katana` pattern from the modification rail. The legacy **Check Inventory** button stays as the secondary action.
- **Tests** — 11 new `TestBuildFulfillUI` tests covering empty-state back-compat (both branches), populated DataTable + column ordering, MO/SO branch differences (Line Total dropped for MO), state flattening, long-serial collapse, batch summary, and Tier 4 button rail (View in Katana with + without `katana_url`). 5 new impl tests covering SO + MO enrichment on both preview and confirm paths, including the post-mutation refetch path for MO confirm. All 44 existing fulfill tests still pass.

## Test plan

- [x] `uv run pytest katana_mcp_server/tests/tools/test_orders.py` — 49 pass (44 existing + 5 new)
- [x] `uv run pytest katana_mcp_server/tests/test_prefab_ui.py::TestBuildFulfillUI` — 11 pass (new)
- [x] `uv run pytest katana_mcp_server/tests/test_prefab_ui.py` — 214 pass (full UI suite, no regressions)
- [x] `uv run poe agent-check` — format + lint + type all clean
- [x] `uv run poe test` — 3405 pass / 2 skipped (full non-browser suite)
- [ ] Visually inspect the rendered preview card in Claude Desktop for a real SO with batch-tracked + serial-tracked rows — confirm Serials column shows the override IDs and Batch column shows `batch Nx{qty}`
- [ ] Visually inspect a manufacturing-order fulfillment card — confirm Total Value metric is hidden and Line Total column is absent

## Design decisions worth flagging

- **MagicMock-defensive coercion in the enrichment helpers.** Many existing fulfill tests stub SO rows / MOs via `MagicMock(spec=...)` without explicitly setting `currency` / `display_name` / `price_per_unit`. The strict path would require updating each fixture (the receipt-card PR did this for purchase orders). I chose to make the helpers defensive instead — non-string identity fields coerce to `None` so the response model validates either way. This keeps the PR focused on the redesign and avoids a multi-fixture sweep across tests that aren't otherwise being modified. The receipt card uses raw `getattr` reads without coercion, which works because `ReceivedItemInfo` doesn't have a `quantity: float` field that gets MagicMock'd — the wire-data path is different.
- **Total Value column absent for MO branch.** MOs track cost on a separate surface (the cost ledger). Showing a blank Line Total column would imply price data was missing rather than intentionally orthogonal — the card drops the column entirely instead. Same reasoning skips the `Total Value` Metric when no row carries a price.
- **Long-serial-list collapse at 5 entries.** A row attaching 50+ serials would blow out the Serials column. The threshold is a soft heuristic — short lists keep their verbatim IDs so the operator can sanity-check; long lists collapse to a count so the column stays readable.