### PR TITLE
feat(mcp): batch recipe update card per-row diff overlay (#557)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -4440,6 +4440,219 @@ def build_receipt_ui(
 # ============================================================================
 
 
+def _format_batch_transactions_summary(
+    transactions: list[dict[str, Any]] | None,
+) -> str:
+    """Collapse a ``batch_transactions`` list into a single display string.
+
+    Wire shape is ``[{batch_id: int, quantity: float}, ...]``. The summary
+    renders as ``"batch 42x30, batch 51x20"`` (ASCII ``x`` per the
+    RUF001 / RUF002 ambiguous-unicode rule; the multiplication sign
+    U+00D7 trips the linter). Empty / missing transactions return the
+    empty string — callers decide whether to render the empty cell or
+    skip the column.
+    """
+    if not transactions:
+        return ""
+    parts: list[str] = []
+    for bt in transactions:
+        if not isinstance(bt, dict):
+            continue
+        batch_id = bt.get("batch_id")
+        qty = bt.get("quantity")
+        if batch_id is None:
+            continue
+        qty_str = f"{qty:g}" if isinstance(qty, (int, float)) else str(qty or "")
+        parts.append(f"batch {batch_id}x{qty_str}" if qty_str else f"batch {batch_id}")
+    return ", ".join(parts)
+
+
+def _format_serial_numbers_summary(serials: list[Any] | None) -> str:
+    """Collapse a serial-number list into a single display string.
+
+    Mirrors :func:`_format_batch_transactions_summary` shape — empty input
+    returns the empty string. Non-string serials are coerced via ``str``
+    for defensiveness against odd inputs (the wire model is ``list[str]``).
+    """
+    if not serials:
+        return ""
+    return ", ".join(str(s) for s in serials if s is not None and str(s).strip())
+
+
+def _build_recipe_row_diff_view(
+    field: str,
+    *,
+    op_type: str,
+    before: Any,
+    after: Any,
+    label: str,
+) -> FieldChangeView | None:
+    """Project a per-row before/after pair onto a ``FieldChangeView``.
+
+    Maps the recipe-row ``op_type`` (``add`` / ``update`` / ``delete``)
+    onto :class:`FieldChangeView`'s ``kind`` discriminator so the diff
+    string formatter can share the rendering rules used by the modify-
+    card entity views:
+
+    - ``add`` → ``kind="added"`` with ``before=None``
+    - ``delete`` → ``kind="removed"`` with ``after=None``
+    - ``update`` → ``kind="changed"`` when ``before != after``,
+      ``kind="unchanged"`` when they match (the row was sent but the
+      field wasn't actually patched — surfaces as an empty-string cell)
+
+    Returns ``None`` when the before/after pair has nothing to render
+    (both unset and not an add/delete signal) so the caller can drop
+    the cell to an empty string rather than emit ``(unset) -> (unset)``.
+    """
+    op_norm = (op_type or "").lower()
+    if op_norm == "add":
+        if after is None and not (isinstance(after, (list, str)) and len(after) == 0):
+            return None
+        return FieldChangeView(
+            field=field, before=None, after=after, kind="added", label=label
+        )
+    if op_norm == "delete":
+        if before is None and not (
+            isinstance(before, (list, str)) and len(before) == 0
+        ):
+            return None
+        return FieldChangeView(
+            field=field, before=before, after=None, kind="removed", label=label
+        )
+    # ``update`` (and unknown op_types fall through here so the caller
+    # still gets a diff if both sides are populated).
+    if before is None and after is None:
+        return None
+    if _diff_values_equal(before, after):
+        return FieldChangeView(
+            field=field, before=before, after=after, kind="unchanged", label=label
+        )
+    return FieldChangeView(
+        field=field, before=before, after=after, kind="changed", label=label
+    )
+
+
+def _diff_values_equal(before: Any, after: Any) -> bool:
+    """Loose equality for diff-pair comparison.
+
+    Lists compare element-wise after coercing each side to its display
+    string (so ``[{batch_id: 1, quantity: 5}]`` == ``[{batch_id: 1,
+    quantity: 5}]`` even when one came from a Pydantic model_dump and
+    the other from a raw dict).
+    """
+    if before == after:
+        return True
+    if isinstance(before, list) and isinstance(after, list):
+        if len(before) != len(after):
+            return False
+        return all(b == a for b, a in zip(before, after, strict=True))
+    return False
+
+
+def _format_recipe_row_diff(
+    change: FieldChangeView | None,
+    *,
+    formatter: Any = None,
+) -> str:
+    """Render a per-row diff projection as a single DataTable cell string.
+
+    Unlike :func:`_render_field_diff_line` (which emits a ``Text``
+    component into a Column layout), this returns a flat string suitable
+    for embedding in a DataTable cell. Output shapes:
+
+    - ``change is None`` → ``""`` (no signal, empty cell).
+    - ``kind == "added"`` → ``"+ after"``.
+    - ``kind == "removed"`` → ``"- before"``.
+    - ``kind == "unchanged"`` → ``"after"`` (the field rode along on the
+      patch but didn't change — render the current value, not a no-op
+      diff).
+    - ``kind == "changed"`` → ``"before -> after"`` (ASCII arrow, since
+      this string lands in a DataTable cell rather than a ``Text``
+      component, and the cell text is sometimes copy-pasted into ops
+      scripts where the unicode arrow is less ergonomic).
+
+    ``formatter`` overrides :func:`_format_diff_value` for value-side
+    rendering — used to render ``batch_transactions`` and
+    ``serial_numbers`` via their list formatters instead of the
+    generic ``repr`` fallback.
+    """
+    if change is None:
+        return ""
+    fmt = formatter if formatter is not None else _format_diff_value
+    if change.kind == "added":
+        return f"+ {fmt(change.after)}"
+    if change.kind == "removed":
+        return f"- {fmt(change.before)}"
+    if change.kind == "unchanged":
+        return fmt(change.after) if change.after is not None else fmt(change.before)
+    # ``changed``. ASCII arrow keeps the cell copy-paste friendly and
+    # sidesteps RUF001 entirely for this string-valued cell path.
+    return f"{fmt(change.before)} -> {fmt(change.after)}"
+
+
+def _build_batch_recipe_row(op: dict[str, Any], *, group_label: str) -> dict[str, Any]:
+    """Flatten a result-op dict into the DataTable row shape.
+
+    Splits out the per-row qty / batch_transactions / serial_numbers
+    diffs via :class:`FieldChangeView` so the cell strings reuse the
+    same projection vocabulary the modify-card entity views consume.
+    """
+    op_type = op.get("op_type") or ""
+    display = (
+        op.get("display_name")
+        or op.get("sku")
+        or (f"variant {op['variant_id']}" if op.get("variant_id") else "")
+    )
+
+    qty_after = op.get("planned_quantity_per_unit")
+    qty_before = op.get("before_planned_quantity_per_unit")
+    qty_change = _build_recipe_row_diff_view(
+        "planned_quantity_per_unit",
+        op_type=op_type,
+        before=qty_before,
+        after=qty_after,
+        label="Qty",
+    )
+
+    batch_after = op.get("batch_transactions")
+    batch_before = op.get("before_batch_transactions")
+    batch_change = _build_recipe_row_diff_view(
+        "batch_transactions",
+        op_type=op_type,
+        before=batch_before,
+        after=batch_after,
+        label="Batch",
+    )
+
+    serial_after = op.get("serial_numbers")
+    serial_before = op.get("before_serial_numbers")
+    serial_change = _build_recipe_row_diff_view(
+        "serial_numbers",
+        op_type=op_type,
+        before=serial_before,
+        after=serial_after,
+        label="Serials",
+    )
+
+    return {
+        "group": group_label,
+        "mo_id": op.get("manufacturing_order_id"),
+        "action": op_type.upper(),
+        "row_id": op.get("recipe_row_id") or "(new)",
+        "sku": op.get("sku") or "",
+        "item": display,
+        "qty": _format_recipe_row_diff(qty_change),
+        "batch": _format_recipe_row_diff(
+            batch_change, formatter=_format_batch_transactions_summary
+        ),
+        "serials": _format_recipe_row_diff(
+            serial_change, formatter=_format_serial_numbers_summary
+        ),
+        "status": (op.get("status") or "pending").upper(),
+        "error": op.get("error") or "",
+    }
+
+
 def build_batch_recipe_update_ui(
     response: dict[str, Any],
     *,
@@ -4450,6 +4663,29 @@ def build_batch_recipe_update_ui(
 
     Shows one row per planned sub-op grouped by replacement group_label.
     Preview mode shows all ops as PENDING; executed mode shows SUCCESS/FAILED/SKIPPED.
+
+    Per-row diff columns surface what each sub-op changes about the
+    underlying recipe row:
+
+    - ``Qty`` — ``planned_quantity_per_unit`` before vs after. ``add``
+      ops show ``+ N``; ``delete`` ops show ``- N`` (when the upstream
+      enricher resolved the prior value); ``update`` ops show
+      ``before -> after``.
+    - ``Batch`` — ``batch_transactions`` allocations, post-#518. Same
+      diff shape as Qty, formatted as ``batch <id>x<qty>, ...``.
+    - ``Serials`` — ``serial_numbers``, formatted as comma-joined.
+
+    The diff overlay uses :class:`FieldChangeView` internally so the
+    projection logic shares vocabulary with the modify-card entity
+    views (PR #755). DataTable cells render flat strings rather than
+    components — see :func:`_format_recipe_row_diff` for the
+    ``+`` / ``-`` / ``before -> after`` shapes.
+
+    Back-compat: per-row diff inputs (``before_planned_quantity_per_unit``,
+    ``before_batch_transactions``, ``before_serial_numbers``) are
+    optional. Result ops without a ``before`` snapshot still render —
+    the diff cells just show ``+ after`` (for add) or empty (for
+    delete with no captured prior).
 
     On the preview branch, pass ``confirm_request`` (the original Pydantic
     input) and ``confirm_tool`` (the matching tool name) to wire the
@@ -4473,28 +4709,21 @@ def build_batch_recipe_update_ui(
     # ``parent / value1 / value2`` built upstream via
     # ``build_variant_display_name``), then SKU, then a ``variant {id}``
     # fallback so the row always renders something meaningful even on
-    # cold-cache calls where neither is resolved.
+    # cold-cache calls where neither is resolved. Per-row diff columns
+    # (qty / batch / serials) are projected via ``FieldChangeView`` —
+    # see :func:`_build_batch_recipe_row`.
     flat_rows: list[dict[str, Any]] = []
     for label, ops in groups.items():
         for op in ops:
-            display = (
-                op.get("display_name")
-                or op.get("sku")
-                or (f"variant {op['variant_id']}" if op.get("variant_id") else "")
-            )
-            flat_rows.append(
-                {
-                    "group": label,
-                    "mo_id": op.get("manufacturing_order_id"),
-                    "action": (op.get("op_type") or "").upper(),
-                    "row_id": op.get("recipe_row_id") or "(new)",
-                    "sku": op.get("sku") or "",
-                    "item": display,
-                    "qty": op.get("planned_quantity_per_unit") or "",
-                    "status": (op.get("status") or "pending").upper(),
-                    "error": op.get("error") or "",
-                }
-            )
+            flat_rows.append(_build_batch_recipe_row(op, group_label=label))
+
+    # Decide whether to render the optional ``Batch`` / ``Serials`` columns.
+    # Most batch recipe payloads don't touch batch tracking or serial
+    # tracking; padding every card with two empty columns is a waste of
+    # horizontal real estate. Render the column only when at least one
+    # row carries a non-empty cell.
+    has_batch_signal = any(r["batch"] for r in flat_rows)
+    has_serial_signal = any(r["serials"] for r in flat_rows)
 
     total = response.get("total_ops", 0)
     success = response.get("success_count", 0)
@@ -4525,6 +4754,26 @@ def build_batch_recipe_update_ui(
         f"the batch recipe update ({total} planned operation(s))"
     )
 
+    columns = [
+        DataTableColumn(key="group", header="Group", sortable=True),
+        DataTableColumn(key="mo_id", header="MO", sortable=True),
+        DataTableColumn(key="action", header="Action"),
+        DataTableColumn(key="row_id", header="Row ID"),
+        DataTableColumn(key="item", header="Item"),
+        DataTableColumn(key="sku", header="SKU"),
+        DataTableColumn(key="qty", header="Qty"),
+    ]
+    if has_batch_signal:
+        columns.append(DataTableColumn(key="batch", header="Batch"))
+    if has_serial_signal:
+        columns.append(DataTableColumn(key="serials", header="Serials"))
+    columns.extend(
+        [
+            DataTableColumn(key="status", header="Status", sortable=True),
+            DataTableColumn(key="error", header="Error"),
+        ]
+    )
+
     with (
         PrefabApp(
             state=state,
@@ -4548,18 +4797,11 @@ def build_batch_recipe_update_ui(
         # ``Item`` shows the canonical Katana-UI display name (parent / value1
         # / value2) when the upstream caller resolved a variant; ``SKU`` keeps
         # the raw SKU as a secondary identity column for ops + scripts.
+        # The ``Qty`` / ``Batch`` / ``Serials`` columns carry the per-row
+        # diff overlay (old -> new) so the agent can verify each sub-op's
+        # effect before clicking Execute.
         DataTable(
-            columns=[
-                DataTableColumn(key="group", header="Group", sortable=True),
-                DataTableColumn(key="mo_id", header="MO", sortable=True),
-                DataTableColumn(key="action", header="Action"),
-                DataTableColumn(key="row_id", header="Row ID"),
-                DataTableColumn(key="item", header="Item"),
-                DataTableColumn(key="sku", header="SKU"),
-                DataTableColumn(key="qty", header="Qty", align="right"),
-                DataTableColumn(key="status", header="Status", sortable=True),
-                DataTableColumn(key="error", header="Error"),
-            ],
+            columns=columns,
             rows="{{ rows }}",
             search=True,
             paginated=True,

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -4506,15 +4506,13 @@ def _build_recipe_row_diff_view(
     """
     op_norm = (op_type or "").lower()
     if op_norm == "add":
-        if after is None and not (isinstance(after, (list, str)) and len(after) == 0):
+        if after is None:
             return None
         return FieldChangeView(
             field=field, before=None, after=after, kind="added", label=label
         )
     if op_norm == "delete":
-        if before is None and not (
-            isinstance(before, (list, str)) and len(before) == 0
-        ):
+        if before is None:
             return None
         return FieldChangeView(
             field=field, before=before, after=None, kind="removed", label=label
@@ -4533,12 +4531,13 @@ def _build_recipe_row_diff_view(
 
 
 def _diff_values_equal(before: Any, after: Any) -> bool:
-    """Loose equality for diff-pair comparison.
+    """Equality check for diff-pair comparison.
 
-    Lists compare element-wise after coercing each side to its display
-    string (so ``[{batch_id: 1, quantity: 5}]`` == ``[{batch_id: 1,
-    quantity: 5}]`` even when one came from a Pydantic model_dump and
-    the other from a raw dict).
+    Returns ``True`` when ``before == after`` directly, or — for two
+    same-length lists where top-level ``==`` returned ``False`` — when
+    every element pair compares equal individually. The list fallback
+    catches cases where iteration order or list identity differs but
+    members are structurally equal.
     """
     if before == after:
         return True
@@ -4761,7 +4760,7 @@ def build_batch_recipe_update_ui(
         DataTableColumn(key="row_id", header="Row ID"),
         DataTableColumn(key="item", header="Item"),
         DataTableColumn(key="sku", header="SKU"),
-        DataTableColumn(key="qty", header="Qty"),
+        DataTableColumn(key="qty", header="Qty", align="right"),
     ]
     if has_batch_signal:
         columns.append(DataTableColumn(key="batch", header="Batch"))

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -4498,7 +4498,8 @@ def _build_recipe_row_diff_view(
     - ``delete`` → ``kind="removed"`` with ``after=None``
     - ``update`` → ``kind="changed"`` when ``before != after``,
       ``kind="unchanged"`` when they match (the row was sent but the
-      field wasn't actually patched — surfaces as an empty-string cell)
+      field wasn't actually patched — the formatter renders the current
+      value rather than the noisy ``"N -> N"``).
 
     Returns ``None`` when the before/after pair has nothing to render
     (both unset and not an add/delete signal) so the caller can drop
@@ -4521,31 +4522,13 @@ def _build_recipe_row_diff_view(
     # still gets a diff if both sides are populated).
     if before is None and after is None:
         return None
-    if _diff_values_equal(before, after):
+    if before == after:
         return FieldChangeView(
             field=field, before=before, after=after, kind="unchanged", label=label
         )
     return FieldChangeView(
         field=field, before=before, after=after, kind="changed", label=label
     )
-
-
-def _diff_values_equal(before: Any, after: Any) -> bool:
-    """Equality check for diff-pair comparison.
-
-    Returns ``True`` when ``before == after`` directly, or — for two
-    same-length lists where top-level ``==`` returned ``False`` — when
-    every element pair compares equal individually. The list fallback
-    catches cases where iteration order or list identity differs but
-    members are structurally equal.
-    """
-    if before == after:
-        return True
-    if isinstance(before, list) and isinstance(after, list):
-        if len(before) != len(after):
-            return False
-        return all(b == a for b, a in zip(before, after, strict=True))
-    return False
 
 
 def _format_recipe_row_diff(
@@ -4560,15 +4543,22 @@ def _format_recipe_row_diff(
     for embedding in a DataTable cell. Output shapes:
 
     - ``change is None`` → ``""`` (no signal, empty cell).
-    - ``kind == "added"`` → ``"+ after"``.
-    - ``kind == "removed"`` → ``"- before"``.
+    - ``kind == "added"`` → ``"+ after"`` (or ``""`` when the formatter
+      returns an empty string — e.g. ``batch_transactions=[]`` — so the
+      optional column drop-out still kicks in).
+    - ``kind == "removed"`` → ``"- before"`` (same empty-cell rule).
     - ``kind == "unchanged"`` → ``"after"`` (the field rode along on the
       patch but didn't change — render the current value, not a no-op
       diff).
-    - ``kind == "changed"`` → ``"before -> after"`` (ASCII arrow, since
-      this string lands in a DataTable cell rather than a ``Text``
-      component, and the cell text is sometimes copy-pasted into ops
-      scripts where the unicode arrow is less ergonomic).
+    - ``kind == "changed"`` with ``before is None`` → ``"after"``. This
+      is the back-compat path for ``update`` ops emitted before the
+      ``before_*`` enricher landed: we don't know the prior value, so we
+      render only the after side rather than implying the prior was
+      actually unset (``"(unset) -> 4.0"``).
+    - ``kind == "changed"`` otherwise → ``"before -> after"`` (ASCII
+      arrow, since this string lands in a DataTable cell rather than a
+      ``Text`` component, and the cell text is sometimes copy-pasted
+      into ops scripts where the unicode arrow is less ergonomic).
 
     ``formatter`` overrides :func:`_format_diff_value` for value-side
     rendering — used to render ``batch_transactions`` and
@@ -4579,13 +4569,20 @@ def _format_recipe_row_diff(
         return ""
     fmt = formatter if formatter is not None else _format_diff_value
     if change.kind == "added":
-        return f"+ {fmt(change.after)}"
+        formatted = fmt(change.after)
+        return f"+ {formatted}" if formatted else ""
     if change.kind == "removed":
-        return f"- {fmt(change.before)}"
+        formatted = fmt(change.before)
+        return f"- {formatted}" if formatted else ""
     if change.kind == "unchanged":
         return fmt(change.after) if change.after is not None else fmt(change.before)
-    # ``changed``. ASCII arrow keeps the cell copy-paste friendly and
-    # sidesteps RUF001 entirely for this string-valued cell path.
+    # ``changed``. Back-compat: when the prior snapshot wasn't threaded
+    # through (``before is None``) for an ``update`` op, render only the
+    # after value — claiming the prior was ``(unset)`` is misleading.
+    if change.before is None:
+        return fmt(change.after)
+    # ASCII arrow keeps the cell copy-paste friendly and sidesteps RUF001
+    # entirely for this string-valued cell path.
     return f"{fmt(change.before)} -> {fmt(change.after)}"
 
 

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -433,21 +433,83 @@ def _item_detail_app() -> PrefabApp:
 
 
 def _batch_recipe_update_app() -> PrefabApp:
-    """build_batch_recipe_update_ui with 5 sub-ops — exercises rows='{{ rows }}'."""
+    """build_batch_recipe_update_ui with mixed sub-ops — exercises the
+    per-row diff overlay (Qty / Batch / Serials columns) across all three
+    op_types (add / delete / update) including batch-tracked + serial-
+    tracked materials. See #557 for the design contract.
+    """
     response = {
         "is_preview": True,
+        "total_ops": 5,
+        "success_count": 0,
+        "failed_count": 0,
+        "skipped_count": 0,
         "message": "5 sub-ops planned",
         "warnings": [],
         "results": [
+            # Simple add — no batch / serial tracking.
             {
+                "op_type": "add",
                 "group_label": "Replace bolt with nut",
-                "sub_op": "delete",
-                "sku": f"SKU-OLD-{i}",
-                "qty": 1,
-                "status": "PENDING",
-                "error": None,
-            }
-            for i in range(5)
+                "manufacturing_order_id": 9999,
+                "variant_id": 200,
+                "sku": "SKU-NEW-NUT",
+                "display_name": "M6 nut / 1.0mm pitch / Stainless",
+                "planned_quantity_per_unit": 2.0,
+                "status": "pending",
+            },
+            # Delete with captured prior qty — exercises the "- N" shape.
+            {
+                "op_type": "delete",
+                "group_label": "Replace bolt with nut",
+                "manufacturing_order_id": 9999,
+                "recipe_row_id": 5001,
+                "variant_id": 100,
+                "sku": "SKU-OLD-BOLT",
+                "display_name": "M6 bolt / 25mm / Stainless",
+                "before_planned_quantity_per_unit": 2.0,
+                "status": "pending",
+            },
+            # Update with full diff — exercises the "before -> after" shape.
+            {
+                "op_type": "update",
+                "group_label": "Resize gasket",
+                "manufacturing_order_id": 9999,
+                "recipe_row_id": 5002,
+                "variant_id": 101,
+                "sku": "SKU-GASKET",
+                "display_name": "Rubber gasket / 30mm",
+                "before_planned_quantity_per_unit": 1.0,
+                "planned_quantity_per_unit": 4.0,
+                "status": "pending",
+            },
+            # Batch-tracked add — exercises the Batch column.
+            {
+                "op_type": "add",
+                "group_label": "Add batch-tracked ingredient",
+                "manufacturing_order_id": 9999,
+                "variant_id": 202,
+                "sku": "SKU-BATCH-MAT",
+                "display_name": "Premixed solvent / 1L",
+                "planned_quantity_per_unit": 50.0,
+                "batch_transactions": [
+                    {"batch_id": 42, "quantity": 30.0},
+                    {"batch_id": 51, "quantity": 20.0},
+                ],
+                "status": "pending",
+            },
+            # Serial-tracked add — exercises the Serials column.
+            {
+                "op_type": "add",
+                "group_label": "Add serial-tracked ingredient",
+                "manufacturing_order_id": 9999,
+                "variant_id": 203,
+                "sku": "SKU-SERIAL-MAT",
+                "display_name": "Motor controller / rev B",
+                "planned_quantity_per_unit": 2.0,
+                "serial_numbers": ["SN-001", "SN-002"],
+                "status": "pending",
+            },
         ],
     }
     return build_batch_recipe_update_ui(response)

--- a/katana_mcp_server/tests/browser/test_other_cards_render.py
+++ b/katana_mcp_server/tests/browser/test_other_cards_render.py
@@ -131,14 +131,29 @@ class TestOtherCardsRender:
 
     def test_batch_recipe_update_renders(self, render_scenario):
         """``build_batch_recipe_update_ui`` — rows='{{ rows }}' over 5
-        sub-ops grouped by ``group_label``.
+        mixed sub-ops grouped by ``group_label``, exercising the per-row
+        diff overlay (Qty / Batch / Serials columns) added by #557.
         """
         frame = render_scenario("batch_recipe_update")
         assert frame.locator("table").count() == 1
         # 5 sub-ops + header.
         assert frame.locator("table tr").count() >= 6
-        # SKU strings from the test fixture.
-        assert frame.locator("text=SKU-OLD-0").count() >= 1
+        # SKU strings from the test fixture — covers add, delete, update,
+        # and batch / serial-tracked variants.
+        assert frame.locator("text=SKU-NEW-NUT").count() >= 1
+        assert frame.locator("text=SKU-OLD-BOLT").count() >= 1
+        # Diff overlay rendering: ``+ N`` for adds, ``- N`` for deletes,
+        # ``before -> after`` for updates. Cell text uses ASCII arrow.
+        assert frame.locator("text=+ 2.0").count() >= 1
+        assert frame.locator("text=- 2.0").count() >= 1
+        # Update diff renders ``before -> after`` (the literal hyphen-arrow
+        # is split into multiple text nodes by the DataTable cell — match
+        # on a single half to confirm the cell content rendered).
+        assert frame.locator("text=1.0").count() >= 1
+        assert frame.locator("text=4.0").count() >= 1
+        # Optional columns surface when at least one row supplies a value.
+        assert frame.locator("text=batch 42x30").count() >= 1
+        assert frame.locator("text=SN-001").count() >= 1
 
 
 class TestDataTableRowClickBinding:

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -3819,6 +3819,42 @@ class TestBuildBatchRecipeUpdateUI:
         # value, just without a meaningful prior side.
         assert "4.0" in rows[0]["qty"]
 
+    def test_delete_with_no_prior_renders_empty_qty_cell(self):
+        """Back-compat: ``delete`` ops emitted without a captured
+        ``before_planned_quantity_per_unit`` (the upstream enricher
+        couldn't resolve the prior row) still render — the diff cell
+        falls through to empty rather than ``"- (unset)"``. Documented
+        in ``build_batch_recipe_update_ui``'s docstring: "delete with no
+        captured prior" → empty cell.
+        """
+        response = {
+            "is_preview": True,
+            "total_ops": 1,
+            "success_count": 0,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "op_type": "delete",
+                    "manufacturing_order_id": 9999,
+                    "recipe_row_id": 5003,
+                    "variant_id": 102,
+                    "sku": "DELETE-NO-PRIOR",
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+            ],
+            "warnings": [],
+            "message": "preview",
+        }
+        app = build_batch_recipe_update_ui(response)
+        _assert_valid_prefab(app)
+        rows = app.to_json()["state"]["rows"]
+        # No before_* on the wire for a delete — the diff cell is empty
+        # (no signal to render). Status / action still surface.
+        assert rows[0]["qty"] == ""
+        assert rows[0]["action"] == "DELETE"
+
     def test_update_with_unchanged_value_renders_current(self):
         """When a row was sent in ``update_recipe_rows`` but a field's
         before == after (a no-op patch — e.g. the agent included a field

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -3577,6 +3577,314 @@ class TestBuildBatchRecipeUpdateUI:
         # Neither display_name nor sku — falls through to ``variant {id}``.
         assert state_rows[1]["item"] == "variant 301"
 
+    def test_per_row_qty_diff_overlay(self):
+        """The per-row ``Qty`` cell carries an old → new diff via
+        :class:`FieldChangeView`. Maps the three op_types to the three
+        diff shapes the renderer cares about:
+
+        - ``add`` → ``"+ N"``
+        - ``delete`` → ``"- N"`` (when the upstream enricher captured the
+          prior qty via ``before_planned_quantity_per_unit``)
+        - ``update`` → ``"before -> after"`` (ASCII arrow — DataTable
+          cells are flat strings).
+        """
+        response = {
+            "is_preview": True,
+            "total_ops": 3,
+            "success_count": 0,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "op_type": "add",
+                    "manufacturing_order_id": 9999,
+                    "variant_id": 200,
+                    "sku": "NEW-PART",
+                    "planned_quantity_per_unit": 2.0,
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+                {
+                    "op_type": "delete",
+                    "manufacturing_order_id": 9999,
+                    "recipe_row_id": 5001,
+                    "variant_id": 100,
+                    "sku": "OLD-PART",
+                    "before_planned_quantity_per_unit": 3.0,
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+                {
+                    "op_type": "update",
+                    "manufacturing_order_id": 9999,
+                    "recipe_row_id": 5002,
+                    "variant_id": 101,
+                    "sku": "RESIZE-PART",
+                    "before_planned_quantity_per_unit": 1.0,
+                    "planned_quantity_per_unit": 4.0,
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+            ],
+            "warnings": [],
+            "message": "preview",
+        }
+        app = build_batch_recipe_update_ui(response)
+        _assert_valid_prefab(app)
+        rows = app.to_json()["state"]["rows"]
+        assert rows[0]["qty"] == "+ 2.0"
+        assert rows[1]["qty"] == "- 3.0"
+        assert rows[2]["qty"] == "1.0 -> 4.0"
+
+    def test_per_row_batch_transactions_diff_overlay(self):
+        """Post-#518, ``MORecipeRowAdd`` / ``Update`` carry
+        ``batch_transactions``. The renderer surfaces these inline with
+        the same diff shape as Qty, via
+        :func:`_format_batch_transactions_summary` —
+        ``batch <id>xN, batch <id>xM`` per allocation. The ``Batch``
+        column only renders when at least one row carries a non-empty
+        cell.
+        """
+        response = {
+            "is_preview": True,
+            "total_ops": 2,
+            "success_count": 0,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "op_type": "add",
+                    "manufacturing_order_id": 9999,
+                    "variant_id": 200,
+                    "sku": "BATCH-TRACKED",
+                    "planned_quantity_per_unit": 50.0,
+                    "batch_transactions": [
+                        {"batch_id": 42, "quantity": 30.0},
+                        {"batch_id": 51, "quantity": 20.0},
+                    ],
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+                {
+                    "op_type": "update",
+                    "manufacturing_order_id": 9999,
+                    "recipe_row_id": 5001,
+                    "variant_id": 201,
+                    "sku": "RESIZE-BATCH",
+                    "before_batch_transactions": [
+                        {"batch_id": 42, "quantity": 10.0},
+                    ],
+                    "batch_transactions": [
+                        {"batch_id": 42, "quantity": 15.0},
+                    ],
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+            ],
+            "warnings": [],
+            "message": "preview",
+        }
+        app = build_batch_recipe_update_ui(response)
+        _assert_valid_prefab(app)
+        envelope = app.to_json()
+        rows = envelope["state"]["rows"]
+        assert rows[0]["batch"] == "+ batch 42x30, batch 51x20"
+        assert rows[1]["batch"] == "batch 42x10 -> batch 42x15"
+
+        # The Batch column must be present in the rendered columns because
+        # at least one row has a non-empty cell.
+        columns = _walk_view_tree(envelope["view"])
+        batch_col_keys = {
+            c.get("key")
+            for tab in columns
+            if tab.get("type") == "DataTable"
+            for c in (tab.get("columns") or [])
+        }
+        assert "batch" in batch_col_keys
+
+    def test_per_row_serial_numbers_diff_overlay(self):
+        """Serial-tracked variants surface their serial list as a
+        comma-joined cell. ``add`` ops render ``"+ sn1, sn2"``;
+        ``update`` ops render ``"before -> after"``.
+        """
+        response = {
+            "is_preview": True,
+            "total_ops": 1,
+            "success_count": 0,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "op_type": "add",
+                    "manufacturing_order_id": 9999,
+                    "variant_id": 200,
+                    "sku": "SERIAL-TRACKED",
+                    "planned_quantity_per_unit": 2.0,
+                    "serial_numbers": ["SN-001", "SN-002"],
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+            ],
+            "warnings": [],
+            "message": "preview",
+        }
+        app = build_batch_recipe_update_ui(response)
+        _assert_valid_prefab(app)
+        envelope = app.to_json()
+        rows = envelope["state"]["rows"]
+        assert rows[0]["serials"] == "+ SN-001, SN-002"
+
+        # Serials column must be rendered for this card (at least one
+        # non-empty cell).
+        column_keys = {
+            c.get("key")
+            for tab in _walk_view_tree(envelope["view"])
+            if tab.get("type") == "DataTable"
+            for c in (tab.get("columns") or [])
+        }
+        assert "serials" in column_keys
+
+    def test_optional_columns_dropped_when_no_signal(self):
+        """The ``Batch`` and ``Serials`` columns are dropped when no row
+        carries a non-empty cell. Keeps the all-qty (non-batch, non-serial)
+        case from padding two empty columns across every row.
+        """
+        response = {
+            "is_preview": True,
+            "total_ops": 1,
+            "success_count": 0,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "op_type": "add",
+                    "manufacturing_order_id": 9999,
+                    "variant_id": 200,
+                    "sku": "PLAIN-PART",
+                    "planned_quantity_per_unit": 1.0,
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+            ],
+            "warnings": [],
+            "message": "preview",
+        }
+        app = build_batch_recipe_update_ui(response)
+        envelope = app.to_json()
+        column_keys = {
+            c.get("key")
+            for tab in _walk_view_tree(envelope["view"])
+            if tab.get("type") == "DataTable"
+            for c in (tab.get("columns") or [])
+        }
+        # Core columns always render…
+        assert "qty" in column_keys
+        # …but the optional Batch / Serials columns drop out when empty.
+        assert "batch" not in column_keys
+        assert "serials" not in column_keys
+
+    def test_update_with_no_prior_renders_just_after_value(self):
+        """Back-compat: ops emitted before the ``before_*`` enrichment
+        landed (no ``before_planned_quantity_per_unit`` on the wire) still
+        render — the diff cell shows just the after value for the
+        ``update`` shape (kind="changed" with before=None falls through
+        the ``_format_recipe_row_diff`` path that uses
+        ``_format_diff_value(None) == "(unset)"``).
+        """
+        response = {
+            "is_preview": True,
+            "total_ops": 1,
+            "success_count": 0,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "op_type": "update",
+                    "manufacturing_order_id": 9999,
+                    "recipe_row_id": 5002,
+                    "variant_id": 101,
+                    "sku": "NO-PRIOR",
+                    "planned_quantity_per_unit": 4.0,
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+            ],
+            "warnings": [],
+            "message": "preview",
+        }
+        app = build_batch_recipe_update_ui(response)
+        _assert_valid_prefab(app)
+        rows = app.to_json()["state"]["rows"]
+        # No before_* on the wire — the diff cell still renders the after
+        # value, just without a meaningful prior side.
+        assert "4.0" in rows[0]["qty"]
+
+    def test_update_with_unchanged_value_renders_current(self):
+        """When a row was sent in ``update_recipe_rows`` but a field's
+        before == after (a no-op patch — e.g. the agent included a field
+        for clarity but didn't actually change it), the diff cell shows
+        the current value rather than ``"3.0 -> 3.0"`` (visual noise).
+        """
+        response = {
+            "is_preview": True,
+            "total_ops": 1,
+            "success_count": 0,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "op_type": "update",
+                    "manufacturing_order_id": 9999,
+                    "recipe_row_id": 5002,
+                    "variant_id": 101,
+                    "sku": "NOOP",
+                    "before_planned_quantity_per_unit": 3.0,
+                    "planned_quantity_per_unit": 3.0,
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+            ],
+            "warnings": [],
+            "message": "preview",
+        }
+        app = build_batch_recipe_update_ui(response)
+        rows = app.to_json()["state"]["rows"]
+        assert rows[0]["qty"] == "3.0"
+
+    def test_qty_diff_survives_failed_status(self):
+        """A failed result still renders the planned diff so the operator
+        can see what was attempted. ``status="failed"`` only controls the
+        Status column + error column — not the diff overlay.
+        """
+        response = {
+            "is_preview": False,
+            "total_ops": 1,
+            "success_count": 0,
+            "failed_count": 1,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "op_type": "update",
+                    "manufacturing_order_id": 9999,
+                    "recipe_row_id": 5002,
+                    "variant_id": 101,
+                    "sku": "FAILED-RESIZE",
+                    "before_planned_quantity_per_unit": 1.0,
+                    "planned_quantity_per_unit": 4.0,
+                    "status": "failed",
+                    "error": "422 validation error",
+                    "group_label": "g1",
+                },
+            ],
+            "warnings": [],
+            "message": "1 failed",
+        }
+        app = build_batch_recipe_update_ui(response)
+        rows = app.to_json()["state"]["rows"]
+        assert rows[0]["qty"] == "1.0 -> 4.0"
+        assert rows[0]["status"] == "FAILED"
+        assert rows[0]["error"] == "422 validation error"
+
 
 def _confirm_button_on_click(envelope: dict, label: str) -> list[dict]:
     """Return the on_click action list for the Confirm button matching ``label``.

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -3783,13 +3783,57 @@ class TestBuildBatchRecipeUpdateUI:
         assert "batch" not in column_keys
         assert "serials" not in column_keys
 
+    def test_empty_batch_or_serials_does_not_emit_prefix_only_cell(self):
+        """When ``batch_transactions=[]`` / ``serial_numbers=[]`` is on the
+        wire (e.g. a non-batch-tracked add that still sent an empty list
+        for shape consistency), the cell must render as ``""`` rather
+        than ``"+ "``. Otherwise the truthy prefix-only string keeps the
+        column visible with no meaningful content.
+        """
+        response = {
+            "is_preview": True,
+            "total_ops": 1,
+            "success_count": 0,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "op_type": "add",
+                    "manufacturing_order_id": 9999,
+                    "variant_id": 200,
+                    "sku": "EMPTY-LISTS",
+                    "planned_quantity_per_unit": 1.0,
+                    "batch_transactions": [],
+                    "serial_numbers": [],
+                    "status": "pending",
+                    "group_label": "g1",
+                },
+            ],
+            "warnings": [],
+            "message": "preview",
+        }
+        app = build_batch_recipe_update_ui(response)
+        envelope = app.to_json()
+        rows = envelope["state"]["rows"]
+        assert rows[0]["batch"] == ""
+        assert rows[0]["serials"] == ""
+        # And the optional columns drop out since every cell is empty.
+        column_keys = {
+            c.get("key")
+            for tab in _walk_view_tree(envelope["view"])
+            if tab.get("type") == "DataTable"
+            for c in (tab.get("columns") or [])
+        }
+        assert "batch" not in column_keys
+        assert "serials" not in column_keys
+
     def test_update_with_no_prior_renders_just_after_value(self):
         """Back-compat: ops emitted before the ``before_*`` enrichment
         landed (no ``before_planned_quantity_per_unit`` on the wire) still
-        render — the diff cell shows just the after value for the
-        ``update`` shape (kind="changed" with before=None falls through
-        the ``_format_recipe_row_diff`` path that uses
-        ``_format_diff_value(None) == "(unset)"``).
+        render — the diff cell shows *only* the after value rather than
+        claiming the prior was actually unset (``"(unset) -> 4.0"``).
+        ``_format_recipe_row_diff`` special-cases ``kind="changed"`` with
+        ``before is None`` to render after-only.
         """
         response = {
             "is_preview": True,
@@ -3815,9 +3859,9 @@ class TestBuildBatchRecipeUpdateUI:
         app = build_batch_recipe_update_ui(response)
         _assert_valid_prefab(app)
         rows = app.to_json()["state"]["rows"]
-        # No before_* on the wire — the diff cell still renders the after
-        # value, just without a meaningful prior side.
-        assert "4.0" in rows[0]["qty"]
+        # No before_* on the wire — the diff cell renders the after value
+        # alone, with no ``(unset) -> `` prefix.
+        assert rows[0]["qty"] == "4.0"
 
     def test_delete_with_no_prior_renders_empty_qty_cell(self):
         """Back-compat: ``delete`` ops emitted without a captured

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.87.1"
+version = "0.88.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Closes #557. Adds the per-row diff overlay (old → new) to the existing Tier 3 DataTable in `build_batch_recipe_update_ui`. The card was already at ~85% (Tier 1/2/3/4 in place); this is the remaining "what does each sub-op actually change" surface the design contract called out.

## What lands

- **Per-row diff columns** in the existing DataTable — `Qty`, `Batch`, `Serials` — driven by `FieldChangeView` (the shared diff projection from PR #755). Each sub-op's row carries its own old → new pair without redesigning Tier 1/2/4.
  - `add` → `"+ N"`
  - `delete` → `"- N"` (when the upstream enricher captures `before_planned_quantity_per_unit`)
  - `update` → `"before -> after"` (ASCII arrow — DataTable cells are flat strings; ASCII keeps copy-paste friendly + sidesteps RUF001 / RUF002)
  - `unchanged` (no-op patch) → just the current value, not `"N -> N"` visual noise.

- **`batch_transactions` surface** — post-#518, `MORecipeRowAdd` / `MORecipeRowUpdate` carry batch allocations. `_format_batch_transactions_summary` collapses them to `"batch 42x30, batch 51x20"` per cell.

- **`serial_numbers` surface** — comma-joined via `_format_serial_numbers_summary`. Drops cleanly through the same diff projection.

- **Optional-column drop-out** — the `Batch` and `Serials` columns are emitted only when at least one row supplies a non-empty cell. Pure-qty cards stay narrow.

## Why reuse `FieldChangeView` despite the type mismatch

The renderer-facing diff vocabulary is `FieldChangeView` (PR #755). The original sibling `_render_field_diff_line` emits a `Text` component into a Column layout — the wrong primitive for a DataTable cell (cells are pure strings). Rather than fork the abstraction, the new `_format_recipe_row_diff` consumes the same `FieldChangeView` input and returns a flat string. The projection logic stays shared; only the output surface diverges.

The card defines a small helper `_build_recipe_row_diff_view(field, op_type, before, after, label)` that maps each sub-op's `op_type` onto a `FieldChangeView.kind` (`add → "added"`, `delete → "removed"`, `update → "changed"` / `"unchanged"`). This is the only meaningful extension — projecting from "batch op_type" onto "modify-card diff kind".

## What this PR does NOT touch

- **Live wiring** — `build_batch_recipe_update_ui` is currently a dormant renderer. The original `batch_update_manufacturing_order_recipes` tool was retired during the unified `modify_<entity>` refactor (#464). The renderer is the long-lived surface; any future batch-update caller (composite tool or workflow) inherits the diff overlay for free.
- **Impl-side `before` snapshot threading** — no live impl exists to thread `before_*` data through. The renderer treats these inputs as optional + back-compat: missing snapshots render as `+ after` (for add) or empty (for delete with no prior).
- **Tier 1/2/4 of the card** — already in place per the issue body; this PR is strictly the Tier 3 DataTable changes.

## Tests

- **`TestBuildBatchRecipeUpdateUI`** — 7 new cases:
  - `test_per_row_qty_diff_overlay` — pins the three op_type → diff-string mappings
  - `test_per_row_batch_transactions_diff_overlay` — pins batch summary formatting + optional-column emission
  - `test_per_row_serial_numbers_diff_overlay` — pins serial summary + optional-column emission
  - `test_optional_columns_dropped_when_no_signal` — pins the drop-out behavior for pure-qty cards
  - `test_update_with_no_prior_renders_just_after_value` — pins back-compat for ops missing `before_*`
  - `test_update_with_unchanged_value_renders_current` — pins the no-op-patch elision
  - `test_qty_diff_survives_failed_status` — pins diff rendering independent of action status

- **Browser fixture** (`render_test_server.py::_batch_recipe_update_app`) rebuilt to exercise add / delete / update + batch + serial across 5 rows. `test_other_cards_render::test_batch_recipe_update_renders` asserts on the diff cell text directly.

- **No impl-side test changes needed** — there's no live impl path consuming the renderer's new `before_*` keys yet (see "What this PR does NOT touch" above).

## Test plan
- [x] `uv run poe check` clean (3396 unit + 21 browser tests pass)
- [x] `uv run pyright` clean on touched files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)