### PR TITLE
feat(mcp): redesign build_low_stock_ui per #537 four-tier framework

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -677,8 +677,15 @@ async def _list_low_stock_items_impl(
         variant_ids = [variant_id for variant_id, _ in limited]
 
         catalog = services.typed_cache.catalog
+        # ``include_archived=True`` matches ``ensure_variants_synced``'s
+        # ingest semantics — archived variants live in the cache, so
+        # bulk-reading without the flag would force the per-ID fallback
+        # for every archived row in the low-stock set.
         cached_variants: dict[int, Any] = await catalog.get_many_by_ids(
-            CachedVariant, variant_ids, include_deleted=True
+            CachedVariant,
+            variant_ids,
+            include_archived=True,
+            include_deleted=True,
         )
 
         # Resolve cache misses in parallel via the per-variant API

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -583,17 +583,11 @@ class LowStockRequest(BaseModel):
 class LowStockItem(BaseModel):
     """Low stock item information.
 
-    Carries the fields the four-tier card surface needs (#537 / #550):
-    the rendered ``display_name`` and a ``variant_id`` drill-in key, plus
-    enrichment from the parent product/material (``uom``,
-    ``default_supplier_id``, ``default_supplier_name``) and per-variant
-    procurement signals (``lead_time_days``, ``minimum_order_quantity``).
-
-    ``lead_time`` and ``minimum_order_quantity`` are sourced from
-    ``CachedVariant`` — they exist on the variant for both product- and
-    material-parented variants. The parent's ``lead_time`` (products only;
-    materials don't carry one) is not used here so the field is uniform
-    across both parent types.
+    ``lead_time_days`` and ``minimum_order_quantity`` come from
+    ``CachedVariant`` so the field is uniform across product- and
+    material-parented variants — only products carry a parent-level
+    ``lead_time``, so reading from the variant keeps both shapes
+    symmetric.
     """
 
     sku: str
@@ -651,7 +645,10 @@ async def _list_low_stock_items_impl(
     )
 
     try:
-        from katana_mcp.tools.foundation.items import _fetch_variant_by_id
+        from katana_mcp.tools.foundation.items import (
+            _enrich_variants_with_parent,
+            _fetch_variant_by_id,
+        )
         from katana_public_api_client.api.inventory import get_all_inventory_point
         from katana_public_api_client.utils import unwrap_data
 
@@ -684,71 +681,42 @@ async def _list_low_stock_items_impl(
             CachedVariant, variant_ids, include_deleted=True
         )
 
-        # Resolve any cache misses with the per-variant API fallback
-        # before the bulk parent/supplier fetches, so the parent ID
-        # collection is complete even on a cold cache.
-        resolved_variants: dict[int, Any] = {}
-        for variant_id in variant_ids:
-            variant: Any = cached_variants.get(variant_id)
-            if variant is None:
-                variant = await _fetch_variant_by_id(services, variant_id)
-            resolved_variants[variant_id] = variant
+        # Resolve cache misses in parallel via the per-variant API
+        # fallback so the parent collection is complete even on a cold
+        # cache. Sequential awaits would serialize N HTTP round-trips.
+        missing_ids = [vid for vid in variant_ids if cached_variants.get(vid) is None]
+        if missing_ids:
+            fetched = await asyncio.gather(
+                *(_fetch_variant_by_id(services, vid) for vid in missing_ids)
+            )
+            for vid, v in zip(missing_ids, fetched, strict=True):
+                cached_variants[vid] = v
 
-        # Bulk-fetch parent products + materials. IDs are split by
-        # parent kind because product and material IDs aren't globally
-        # unique — see ``_enrich_variants_with_parent`` for the same
-        # pattern in items.py.
-        product_ids = {
-            pid for v in resolved_variants.values() if (pid := _attr(v, "product_id"))
-        }
-        material_ids = {
-            mid for v in resolved_variants.values() if (mid := _attr(v, "material_id"))
-        }
-        products_by_id, materials_by_id = await asyncio.gather(
-            catalog.get_many_by_ids(
-                CachedProduct,
-                product_ids,
-                include_archived=True,
-                include_deleted=True,
-            ),
-            catalog.get_many_by_ids(
-                CachedMaterial,
-                material_ids,
-                include_archived=True,
-                include_deleted=True,
-            ),
+        # Enrich parents + suppliers via the shared helper so the
+        # product/material ID-collision split and the cold-cache
+        # nested-parent graft stay in lockstep with the items.py path.
+        (
+            products_by_id,
+            materials_by_id,
+            supplier_by_id,
+        ) = await _enrich_variants_with_parent(
+            services, [v for v in cached_variants.values() if v is not None]
         )
 
-        # Build a variant_id → parent map for fast lookup in the row
-        # construction loop below.
-        parent_by_variant_id: dict[int, Any] = {}
-        for variant_id, v in resolved_variants.items():
-            pid = _attr(v, "product_id")
-            mid = _attr(v, "material_id")
-            if (pid and (parent := products_by_id.get(pid)) is not None) or (
-                mid and (parent := materials_by_id.get(mid)) is not None
-            ):
-                parent_by_variant_id[variant_id] = parent
-
-        # Bulk-resolve supplier names from the parent rows. Usually a
-        # small unique set — most low-stock results share suppliers.
-        supplier_ids = {
-            sid
-            for parent in parent_by_variant_id.values()
-            if (sid := _attr(parent, "default_supplier_id"))
-        }
-        supplier_by_id = await catalog.get_many_by_ids(
-            CachedSupplier, supplier_ids, include_deleted=True
-        )
+        def _parent_for(v: Any) -> Any | None:
+            if (pid := _attr(v, "product_id")) is not None:
+                return products_by_id.get(pid)
+            if (mid := _attr(v, "material_id")) is not None:
+                return materials_by_id.get(mid)
+            return None
 
         items: list[LowStockItem] = []
         for variant_id, total in limited:
-            variant = resolved_variants.get(variant_id)
-            sku = _attr(variant, "sku") or ""
+            variant = cached_variants.get(variant_id)
             display_name = (
                 _attr(variant, "display_name") or _attr(variant, "name") or ""
             )
-            parent = parent_by_variant_id.get(variant_id)
+            parent = _parent_for(variant)
             default_supplier_id = _attr(parent, "default_supplier_id")
             supplier = (
                 supplier_by_id.get(default_supplier_id)
@@ -757,7 +725,7 @@ async def _list_low_stock_items_impl(
             )
             items.append(
                 LowStockItem(
-                    sku=sku,
+                    sku=_attr(variant, "sku") or "",
                     product_name=display_name,
                     current_stock=total,
                     threshold=request.threshold,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -43,6 +43,9 @@ from katana_public_api_client.models.get_all_inventory_movements_resource_type i
 )
 from katana_public_api_client.models_pydantic._generated import (
     CachedLocation,
+    CachedMaterial,
+    CachedProduct,
+    CachedSupplier,
     CachedVariant,
 )
 from katana_public_api_client.utils import unwrap_data
@@ -578,12 +581,32 @@ class LowStockRequest(BaseModel):
 
 
 class LowStockItem(BaseModel):
-    """Low stock item information."""
+    """Low stock item information.
+
+    Carries the fields the four-tier card surface needs (#537 / #550):
+    the rendered ``display_name`` and a ``variant_id`` drill-in key, plus
+    enrichment from the parent product/material (``uom``,
+    ``default_supplier_id``, ``default_supplier_name``) and per-variant
+    procurement signals (``lead_time_days``, ``minimum_order_quantity``).
+
+    ``lead_time`` and ``minimum_order_quantity`` are sourced from
+    ``CachedVariant`` — they exist on the variant for both product- and
+    material-parented variants. The parent's ``lead_time`` (products only;
+    materials don't carry one) is not used here so the field is uniform
+    across both parent types.
+    """
 
     sku: str
     product_name: str
     current_stock: float
     threshold: int
+    display_name: str | None = None
+    variant_id: int
+    uom: str | None = None
+    lead_time_days: int | None = None
+    default_supplier_id: int | None = None
+    default_supplier_name: str | None = None
+    minimum_order_quantity: float | None = None
 
 
 class LowStockResponse(BaseModel):
@@ -656,27 +679,95 @@ async def _list_low_stock_items_impl(
         limited = low_stock[: request.limit]
         variant_ids = [variant_id for variant_id, _ in limited]
 
-        cached_variants: dict[
-            int, Any
-        ] = await services.typed_cache.catalog.get_many_by_ids(
+        catalog = services.typed_cache.catalog
+        cached_variants: dict[int, Any] = await catalog.get_many_by_ids(
             CachedVariant, variant_ids, include_deleted=True
+        )
+
+        # Resolve any cache misses with the per-variant API fallback
+        # before the bulk parent/supplier fetches, so the parent ID
+        # collection is complete even on a cold cache.
+        resolved_variants: dict[int, Any] = {}
+        for variant_id in variant_ids:
+            variant: Any = cached_variants.get(variant_id)
+            if variant is None:
+                variant = await _fetch_variant_by_id(services, variant_id)
+            resolved_variants[variant_id] = variant
+
+        # Bulk-fetch parent products + materials. IDs are split by
+        # parent kind because product and material IDs aren't globally
+        # unique — see ``_enrich_variants_with_parent`` for the same
+        # pattern in items.py.
+        product_ids = {
+            pid for v in resolved_variants.values() if (pid := _attr(v, "product_id"))
+        }
+        material_ids = {
+            mid for v in resolved_variants.values() if (mid := _attr(v, "material_id"))
+        }
+        products_by_id, materials_by_id = await asyncio.gather(
+            catalog.get_many_by_ids(
+                CachedProduct,
+                product_ids,
+                include_archived=True,
+                include_deleted=True,
+            ),
+            catalog.get_many_by_ids(
+                CachedMaterial,
+                material_ids,
+                include_archived=True,
+                include_deleted=True,
+            ),
+        )
+
+        # Build a variant_id → parent map for fast lookup in the row
+        # construction loop below.
+        parent_by_variant_id: dict[int, Any] = {}
+        for variant_id, v in resolved_variants.items():
+            pid = _attr(v, "product_id")
+            mid = _attr(v, "material_id")
+            if (pid and (parent := products_by_id.get(pid)) is not None) or (
+                mid and (parent := materials_by_id.get(mid)) is not None
+            ):
+                parent_by_variant_id[variant_id] = parent
+
+        # Bulk-resolve supplier names from the parent rows. Usually a
+        # small unique set — most low-stock results share suppliers.
+        supplier_ids = {
+            sid
+            for parent in parent_by_variant_id.values()
+            if (sid := _attr(parent, "default_supplier_id"))
+        }
+        supplier_by_id = await catalog.get_many_by_ids(
+            CachedSupplier, supplier_ids, include_deleted=True
         )
 
         items: list[LowStockItem] = []
         for variant_id, total in limited:
-            variant: Any = cached_variants.get(variant_id)
-            if variant is None:
-                variant = await _fetch_variant_by_id(services, variant_id)
+            variant = resolved_variants.get(variant_id)
             sku = _attr(variant, "sku") or ""
-            product_name = (
+            display_name = (
                 _attr(variant, "display_name") or _attr(variant, "name") or ""
+            )
+            parent = parent_by_variant_id.get(variant_id)
+            default_supplier_id = _attr(parent, "default_supplier_id")
+            supplier = (
+                supplier_by_id.get(default_supplier_id)
+                if default_supplier_id is not None
+                else None
             )
             items.append(
                 LowStockItem(
                     sku=sku,
-                    product_name=product_name,
+                    product_name=display_name,
                     current_stock=total,
                     threshold=request.threshold,
+                    display_name=display_name or None,
+                    variant_id=variant_id,
+                    uom=_attr(parent, "uom"),
+                    lead_time_days=_attr(variant, "lead_time"),
+                    default_supplier_id=default_supplier_id,
+                    default_supplier_name=_attr(supplier, "name"),
+                    minimum_order_quantity=_attr(variant, "minimum_order_quantity"),
                 )
             )
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -616,7 +616,7 @@ class LowStockResponse(BaseModel):
     total_count: int
 
 
-@cache_read(CachedVariant)
+@cache_read(CachedVariant, CachedProduct, CachedMaterial, CachedSupplier)
 async def _list_low_stock_items_impl(
     request: LowStockRequest, context: Context
 ) -> LowStockResponse:

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -1744,11 +1744,15 @@ def build_low_stock_ui(
             )
             return app
 
+        # All three Tier 2 metrics describe the rendered rows so the
+        # populations stay internally consistent — when ``total_count >
+        # len(items)`` (request.limit truncated the full set), the
+        # full count still surfaces on the Tier 1 badge above.
         # ``Critically low`` uses ``trendSentiment="negative"`` for the
         # destructive visual on stock-outs; Metric has no ``variant``
         # parameter like Badge does.
         with Row(gap=2):
-            Metric(label="Below threshold", value=str(total_count))
+            Metric(label="Below threshold", value=str(len(items)))
             Metric(
                 label="Critically low",
                 value=str(critically_low_count),

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -1700,13 +1700,26 @@ def build_low_stock_ui(
     threshold: int,
     total_count: int,
 ) -> PrefabApp:
-    """Build a low stock report with table and reorder action.
+    """Build a low stock report following the four-tier card framework (#537).
 
-    When ``total_count == 0``, drops the DataTable and "Create Restock
-    Orders" button — they reference nonexistent items — and renders a
-    friendly "all clear" hint instead. Bundled with the #470 search empty-
-    state fix because the pattern is identical.
+    Tier 1 — Header with title, threshold + count badges.
+    Tier 2 — Three at-a-glance Metric widgets (below threshold, critically
+    low, suppliers involved) for a fast snapshot of restock urgency.
+    Tier 3 — DataTable enriched with item, SKU, UoM, stock, threshold,
+    lead time, supplier, and minimum-order-quantity columns.
+    Tier 4 — Action row: "Create Restock Orders" + "Check Inventory".
+
+    When ``total_count == 0``, drops the metrics row, DataTable, and
+    action buttons — they reference nonexistent items — and renders a
+    friendly "all clear" hint instead.
     """
+    # Tier 2 metric inputs — derived from the row set rather than the
+    # impl, so the builder stays self-contained for testing.
+    critically_low_count = sum(1 for item in items if item.get("current_stock") == 0)
+    supplier_count = len(
+        {sid for item in items if (sid := item.get("default_supplier_id")) is not None}
+    )
+
     with (
         PrefabApp(
             state={"items": items},
@@ -1731,20 +1744,46 @@ def build_low_stock_ui(
             )
             return app
 
+        # Tier 2 — at-a-glance restock metrics. ``critically_low`` uses
+        # ``trendSentiment="negative"`` for the destructive visual when
+        # there's at least one stock-out; Metric doesn't expose a
+        # ``variant`` parameter the way Badge does.
+        with Row(gap=2):
+            Metric(label="Below threshold", value=str(total_count))
+            Metric(
+                label="Critically low",
+                value=str(critically_low_count),
+                trendSentiment="negative" if critically_low_count > 0 else "neutral",
+            )
+            Metric(label="Suppliers involved", value=str(supplier_count))
+
+        # Tier 3 — enriched DataTable. Column order follows the
+        # decision sequence: identify the item (name, SKU, UoM), see
+        # the depletion signal (in stock vs threshold), then act
+        # (lead time + supplier + MOQ).
         DataTable(
             columns=[
+                DataTableColumn(key="display_name", header="Item", sortable=True),
                 DataTableColumn(key="sku", header="SKU", sortable=True),
-                DataTableColumn(key="product_name", header="Product", sortable=True),
+                DataTableColumn(key="uom", header="UoM"),
                 DataTableColumn(
                     key="current_stock",
-                    header="Current Stock",
+                    header="In Stock",
+                    sortable=True,
+                    align="right",
+                ),
+                DataTableColumn(key="threshold", header="Threshold", align="right"),
+                DataTableColumn(
+                    key="lead_time_days",
+                    header="Lead Time (d)",
                     sortable=True,
                     align="right",
                 ),
                 DataTableColumn(
-                    key="threshold",
-                    header="Threshold",
-                    align="right",
+                    key="default_supplier_name", header="Supplier", sortable=True
+                ),
+                DataTableColumn(
+                    key="minimum_order_quantity", header="Min Order", align="right"
                 ),
             ],
             rows="{{ items }}",
@@ -1752,13 +1791,24 @@ def build_low_stock_ui(
             paginated=True,
         )
 
-        Button(
-            label="Create Restock Orders",
-            variant="default",
-            on_click=SendMessage(
-                "Create purchase orders to restock all low-stock items"
-            ),
-        )
+        # Tier 4 — actions. Restock kicks off the PO flow; Check
+        # Inventory is the obvious diagnostic next step when the
+        # numbers look surprising.
+        with Row(gap=2):
+            Button(
+                label="Create Restock Orders",
+                variant="default",
+                on_click=SendMessage(
+                    "Create purchase orders to restock all low-stock items"
+                ),
+            )
+            Button(
+                label="Check Inventory",
+                variant="default",
+                on_click=SendMessage(
+                    "Check inventory details for these low-stock items"
+                ),
+            )
     return app
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -1713,8 +1713,8 @@ def build_low_stock_ui(
     action buttons — they reference nonexistent items — and renders a
     friendly "all clear" hint instead.
     """
-    # Tier 2 metric inputs — derived from the row set rather than the
-    # impl, so the builder stays self-contained for testing.
+    # Tier 2 metric inputs — derived from the row set so the builder
+    # stays self-contained for testing.
     critically_low_count = sum(1 for item in items if item.get("current_stock") == 0)
     supplier_count = len(
         {sid for item in items if (sid := item.get("default_supplier_id")) is not None}
@@ -1744,10 +1744,9 @@ def build_low_stock_ui(
             )
             return app
 
-        # Tier 2 — at-a-glance restock metrics. ``critically_low`` uses
-        # ``trendSentiment="negative"`` for the destructive visual when
-        # there's at least one stock-out; Metric doesn't expose a
-        # ``variant`` parameter the way Badge does.
+        # ``Critically low`` uses ``trendSentiment="negative"`` for the
+        # destructive visual on stock-outs; Metric has no ``variant``
+        # parameter like Badge does.
         with Row(gap=2):
             Metric(label="Below threshold", value=str(total_count))
             Metric(
@@ -1757,10 +1756,9 @@ def build_low_stock_ui(
             )
             Metric(label="Suppliers involved", value=str(supplier_count))
 
-        # Tier 3 — enriched DataTable. Column order follows the
-        # decision sequence: identify the item (name, SKU, UoM), see
-        # the depletion signal (in stock vs threshold), then act
-        # (lead time + supplier + MOQ).
+        # Column order follows the decision sequence: identify (name,
+        # SKU, UoM), see the depletion signal (stock vs threshold),
+        # then act (lead time + supplier + MOQ).
         DataTable(
             columns=[
                 DataTableColumn(key="display_name", header="Item", sortable=True),
@@ -1791,9 +1789,6 @@ def build_low_stock_ui(
             paginated=True,
         )
 
-        # Tier 4 — actions. Restock kicks off the PO flow; Check
-        # Inventory is the obvious diagnostic next step when the
-        # numbers look surprising.
         with Row(gap=2):
             Button(
                 label="Create Restock Orders",

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -1384,6 +1384,115 @@ class TestBuildLowStockUI:
             f"Empty-state hint must echo the threshold value; got {hint!r}"
         )
 
+    def test_low_stock_renders_tier_2_metrics_row(self):
+        """#550 — four-tier redesign Tier 2 — exactly three Metric widgets
+        with the expected labels render in the populated card.
+        """
+        items = [
+            {
+                "sku": "SKU-001",
+                "display_name": "Widget A",
+                "current_stock": 3,
+                "threshold": 10,
+                "default_supplier_id": 100,
+            },
+        ]
+        app = build_low_stock_ui(items, 10, 1)
+        envelope = app.to_json()
+        metrics = _find_components_by_type(envelope, "Metric")
+        labels = [m.get("label") for m in metrics]
+        assert labels == [
+            "Below threshold",
+            "Critically low",
+            "Suppliers involved",
+        ], f"Expected the three Tier 2 metric labels; got {labels!r}"
+
+    def test_low_stock_critically_low_count_excludes_threshold_rows(self):
+        """#550 — Tier 2 "Critically low" Metric counts only stock-out
+        rows (``current_stock == 0``), not every row below threshold.
+        """
+        items = [
+            # Two stock-outs.
+            {"sku": "A", "current_stock": 0, "threshold": 10},
+            {"sku": "B", "current_stock": 0, "threshold": 10},
+            # Below threshold but not stock-out — must be excluded.
+            {"sku": "C", "current_stock": 4, "threshold": 10},
+        ]
+        app = build_low_stock_ui(items, 10, 3)
+        envelope = app.to_json()
+        metrics = _find_components_by_type(envelope, "Metric")
+        crit = next(m for m in metrics if m.get("label") == "Critically low")
+        assert crit.get("value") == "2", (
+            f"Critically low Metric should count only stock==0 rows; got {crit!r}"
+        )
+
+    def test_low_stock_suppliers_involved_count_dedupes_by_supplier_id(self):
+        """#550 — Tier 2 "Suppliers involved" Metric is the distinct count
+        of ``default_supplier_id`` across the row set, ignoring ``None``.
+        """
+        items = [
+            {"sku": "A", "current_stock": 1, "default_supplier_id": 100},
+            {"sku": "B", "current_stock": 2, "default_supplier_id": 100},  # dupe
+            {"sku": "C", "current_stock": 3, "default_supplier_id": 200},
+            {"sku": "D", "current_stock": 4, "default_supplier_id": None},  # ignored
+            {"sku": "E", "current_stock": 5},  # missing — ignored
+        ]
+        app = build_low_stock_ui(items, 10, 5)
+        envelope = app.to_json()
+        metrics = _find_components_by_type(envelope, "Metric")
+        suppliers = next(m for m in metrics if m.get("label") == "Suppliers involved")
+        assert suppliers.get("value") == "2", (
+            f"Suppliers involved should dedupe by supplier_id and ignore None; "
+            f"got {suppliers!r}"
+        )
+
+    def test_low_stock_datatable_includes_supplier_and_lead_time_columns(self):
+        """#550 — Tier 3 — pin the full column set of the enriched
+        DataTable so the four-tier redesign's columns don't silently
+        regress.
+        """
+        items = [
+            {
+                "sku": "SKU-001",
+                "display_name": "Widget A",
+                "current_stock": 3,
+                "threshold": 10,
+                "uom": "pcs",
+                "lead_time_days": 7,
+                "default_supplier_name": "Acme",
+                "minimum_order_quantity": 50.0,
+            },
+        ]
+        app = build_low_stock_ui(items, 10, 1)
+        envelope = app.to_json()
+        tables = _find_components_by_type(envelope, "DataTable")
+        assert len(tables) == 1
+        column_keys = [c.get("key") for c in tables[0].get("columns", [])]
+        assert column_keys == [
+            "display_name",
+            "sku",
+            "uom",
+            "current_stock",
+            "threshold",
+            "lead_time_days",
+            "default_supplier_name",
+            "minimum_order_quantity",
+        ], f"Tier 3 DataTable column set drifted; got {column_keys!r}"
+
+    def test_low_stock_renders_check_inventory_action_button(self):
+        """#550 — Tier 4 adds a "Check Inventory" button alongside the
+        existing "Create Restock Orders" trigger.
+        """
+        items = [
+            {"sku": "A", "current_stock": 1, "threshold": 10},
+        ]
+        app = build_low_stock_ui(items, 10, 1)
+        envelope = app.to_json()
+        check_buttons = _find_buttons_by_label(envelope, "Check Inventory")
+        assert len(check_buttons) == 1, (
+            "Populated low-stock report must render the 'Check Inventory' button."
+        )
+
 
 class TestBuildPOCreateUI:
     """``build_po_create_ui`` handles both preview and applied states for

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -2278,6 +2278,7 @@ async def test_list_low_stock_items_format_json_returns_json():
                     product_name="Low Item",
                     current_stock=2,
                     threshold=10,
+                    variant_id=1001,
                 )
             ],
             total_count=1,

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -388,6 +388,136 @@ async def test_list_low_stock_cache_miss_fallback():
 
 
 @pytest.mark.asyncio
+async def test_list_low_stock_enriches_with_parent_uom_and_supplier():
+    """#550 — low-stock items now carry parent-derived ``uom`` /
+    ``default_supplier_*`` and per-variant ``lead_time_days`` /
+    ``minimum_order_quantity`` to power the four-tier card.
+    """
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedMaterial,
+        CachedProduct,
+        CachedSupplier,
+        CachedVariant,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+
+    inventory_rows = [_mock_inventory_row(7001, "4")]
+
+    # Variant carries product_id (→ product parent), lead_time, MOQ, sku, display_name.
+    variant_row = {
+        "id": 7001,
+        "sku": "PROD-001",
+        "display_name": "Enriched Widget",
+        "product_id": 8001,
+        "material_id": None,
+        "lead_time": 14,
+        "minimum_order_quantity": 25.0,
+    }
+    product_row = {
+        "id": 8001,
+        "name": "Enriched Widget Parent",
+        "uom": "pcs",
+        "default_supplier_id": 9001,
+    }
+    supplier_row = {"id": 9001, "name": "Acme Supplies"}
+
+    # The conftest mock collapses all six CatalogQueries methods onto one
+    # AsyncMock; switch ``get_many_by_ids`` to a side_effect so each
+    # ``Cached*`` query returns the right table.
+    async def get_many_by_ids(model, ids, **_kwargs):
+        if model is CachedVariant:
+            return {7001: variant_row} if 7001 in ids else {}
+        if model is CachedProduct:
+            return {8001: product_row} if 8001 in ids else {}
+        if model is CachedMaterial:
+            return {}
+        if model is CachedSupplier:
+            return {9001: supplier_row} if 9001 in ids else {}
+        return {}
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        side_effect=get_many_by_ids
+    )
+
+    with (
+        patch(f"{_INVENTORY_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=inventory_rows),
+    ):
+        request = LowStockRequest(threshold=10)
+        result = await _list_low_stock_items_impl(request, context)
+
+    assert len(result.items) == 1
+    item = result.items[0]
+    assert item.sku == "PROD-001"
+    assert item.variant_id == 7001
+    assert item.display_name == "Enriched Widget"
+    assert item.uom == "pcs"
+    assert item.lead_time_days == 14
+    assert item.default_supplier_id == 9001
+    assert item.default_supplier_name == "Acme Supplies"
+    assert item.minimum_order_quantity == 25.0
+
+
+@pytest.mark.asyncio
+async def test_list_low_stock_handles_missing_parent_gracefully():
+    """#550 — on parent cache miss, the new enrichment fields stay
+    ``None`` rather than raising. Pins the tolerance contract so a
+    cold cache can't crash the low-stock card.
+    """
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedMaterial,
+        CachedProduct,
+        CachedSupplier,
+        CachedVariant,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+
+    inventory_rows = [_mock_inventory_row(7100, "2")]
+
+    # Variant exists but parent is missing from the cache.
+    variant_row = {
+        "id": 7100,
+        "sku": "ORPHAN-001",
+        "display_name": "Orphan Widget",
+        "product_id": 8100,
+        "material_id": None,
+        "lead_time": None,
+        "minimum_order_quantity": None,
+    }
+
+    async def get_many_by_ids(model, ids, **_kwargs):
+        if model is CachedVariant:
+            return {7100: variant_row} if 7100 in ids else {}
+        # All parent + supplier lookups miss.
+        if model in (CachedProduct, CachedMaterial, CachedSupplier):
+            return {}
+        return {}
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        side_effect=get_many_by_ids
+    )
+
+    with (
+        patch(f"{_INVENTORY_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=inventory_rows),
+    ):
+        request = LowStockRequest(threshold=10)
+        result = await _list_low_stock_items_impl(request, context)
+
+    assert len(result.items) == 1
+    item = result.items[0]
+    assert item.sku == "ORPHAN-001"
+    assert item.variant_id == 7100
+    assert item.uom is None
+    assert item.lead_time_days is None
+    assert item.default_supplier_id is None
+    assert item.default_supplier_name is None
+    assert item.minimum_order_quantity is None
+
+
+@pytest.mark.asyncio
 async def test_search_items():
     """Test search_items tool with cached data."""
     context, lifespan_ctx = create_mock_context()


### PR DESCRIPTION
## Summary

- Applies the #537 four-tier card framework to `build_low_stock_ui`:
  - **Tier 1** — header (unchanged).
  - **Tier 2** — three at-a-glance Metric widgets (Below threshold,
    Critically low, Suppliers involved) for fast restock urgency.
  - **Tier 3** — DataTable expanded to display_name, SKU, UoM,
    In Stock, Threshold, Lead Time (d), Supplier, Min Order.
  - **Tier 4** — keeps "Create Restock Orders" and adds a new
    "Check Inventory" action for diagnostic drill-in.
- Extends `LowStockItem` with `display_name`, `variant_id`, `uom`,
  `lead_time_days`, `default_supplier_id`, `default_supplier_name`,
  `minimum_order_quantity`. Sources `lead_time` / `minimum_order_quantity`
  from `CachedVariant` directly so the field stays uniform across
  product- and material-parented variants (materials carry no `lead_time`).
- `_list_low_stock_items_impl` now bulk-fetches parent products /
  materials and suppliers via the same `get_many_by_ids` pattern as
  `_enrich_variants_with_parent` in `items.py` — no new API calls,
  two extra cache reads. The `@cache_read` decorator syncs all four
  cached types so a cold cache still populates the enrichment fields.

## Test plan

- [x] `uv run poe check` — 3510 unit tests + 21 browser tests pass.
- [x] Added two impl tests:
  - `test_list_low_stock_enriches_with_parent_uom_and_supplier`
  - `test_list_low_stock_handles_missing_parent_gracefully`
- [x] Added five builder tests:
  - `test_low_stock_renders_tier_2_metrics_row`
  - `test_low_stock_critically_low_count_excludes_threshold_rows`
  - `test_low_stock_suppliers_involved_count_dedupes_by_supplier_id`
  - `test_low_stock_datatable_includes_supplier_and_lead_time_columns`
  - `test_low_stock_renders_check_inventory_action_button`
- [x] Pre-existing low-stock tests still pass (empty-state guard,
  cache-miss fallback, multi-location summing, threshold filtering).

## Notes

- Critically-low Metric uses `trendSentiment="negative"` for the
  destructive visual when there's at least one stock-out — Metric
  doesn't expose a `variant` parameter the way Badge does, so this
  is the equivalent semantic on the component.

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)