### PR TITLE
refactor(mcp): migrate apply/cancel rail from SendMessage to CallTool+UpdateContext

### DIFF
--- a/docs/adr/0015-confirmation-pattern-for-write-tools.md
+++ b/docs/adr/0015-confirmation-pattern-for-write-tools.md
@@ -2,9 +2,23 @@
 
 ## Status
 
-Accepted
+**Superseded by
+[ADR-0021](../../katana_mcp_server/docs/adr/0021-unified-direct-apply-rail.md)**
 
-Date: 2026-05-06
+Date: 2026-05-06 Superseded: 2026-05-21
+
+The "Confirm button fires `SendMessage` so the agent re-issues the call" rail described
+below was the right answer when MCP had no way for an iframe to push a structured result
+back to the agent's model context. The 2026-01-26 MCP Apps spec (SEP-1865,
+`ui/update-model-context`) removed that constraint: the iframe can now fire `tools/call`
+directly *and* deliver the structured response into model context. The SendMessage chat
+indirection is no longer load-bearing.
+
+ADR-0021 unifies every preview tool onto that direct-apply rail (the shape this ADR's
+"Alternative 2: Card-morphing" rejected — now feasible because the agent *does* see the
+structured response).
+
+The history below is preserved verbatim for the architectural narrative.
 
 Closes the action items from issue #316; supersedes the iframe-direct-apply shape that
 #491, #495, #545, #559 were filed against.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,7 +39,11 @@ We use the format proposed by Michael Nygard in his article
 
 - [ADR-0009: Migrate from Poetry to uv Package Manager](0009-migrate-from-poetry-to-uv.md)
 - [ADR-0013: Module-Local Documentation Structure](0013-module-local-documentation.md)
-- [ADR-0014: GitHub Copilot Custom Agents with Three-Tier Architecture](0014-github-copilot-custom-agents.md) — **superseded** by harness-kit + `.claude/`
+- [ADR-0014: GitHub Copilot Custom Agents with Three-Tier Architecture](0014-github-copilot-custom-agents.md)
+  — **superseded** by harness-kit + `.claude/`
+- [ADR-0015: Confirmation Pattern for Write Tools (preview→apply, agent re-issued)](0015-confirmation-pattern-for-write-tools.md)
+  — **superseded** by
+  [ADR-0021 (MCP)](../../katana_mcp_server/docs/adr/0021-unified-direct-apply-rail.md)
 
 ## Creating a New ADR
 
@@ -68,17 +72,13 @@ We use the format proposed by Michael Nygard in his article
 ADRs are numbered sequentially starting from 0001, with a **single shared sequence
 across all three ADR directories**:
 
-- `katana_public_api_client/docs/adr/` — client package decisions (0001-0008,
-  0011-0012)
-- `docs/adr/` — shared / monorepo-level decisions (0009, 0013-0014)
-- `katana_mcp_server/docs/adr/` — MCP-server-specific decisions (0010,
-  0016-0019)
+- `katana_public_api_client/docs/adr/` — client package decisions (0001-0008, 0011-0012)
+- `docs/adr/` — shared / monorepo-level decisions (0009, 0013-0015)
+- `katana_mcp_server/docs/adr/` — MCP-server-specific decisions (0010, 0016-0021)
 
-The sequence interleaves across the three directories. When you write a new
-ADR, take the next number across **all three** directories — don't restart per
-package, and don't reuse historical numbers (0015 is a dead draft, but reusing
-it would create ambiguous references). Leave gaps if needed; numbers are
-monotonic.
+The sequence interleaves across the three directories. When you write a new ADR, take
+the next number across **all three** directories — don't restart per package, and don't
+reuse historical numbers. Leave gaps if needed; numbers are monotonic.
 
 ## Related Documentation
 

--- a/katana_mcp_server/docs/adr/0021-unified-direct-apply-rail.md
+++ b/katana_mcp_server/docs/adr/0021-unified-direct-apply-rail.md
@@ -1,0 +1,174 @@
+# ADR-0021: Unified Direct-Apply Rail for Preview→Apply Cards
+
+## Status
+
+Accepted
+
+Date: 2026-05-21
+
+Supersedes [ADR-0015](../../../docs/adr/0015-confirmation-pattern-for-write-tools.md)
+(the `SendMessage` re-issue rail) for the apply-button rail. ADR-0015's
+`destructiveHint` policy table remains in force.
+
+## Context
+
+ADR-0015 settled the preview→apply pattern with a two-step UI: a preview card with
+Confirm/Cancel buttons whose `on_click` fired
+
+- `SetState("pending", True)` +
+  `SendMessage("Apply: call <tool>(<args>, preview=False)")` on Confirm — instructing
+  the agent to re-issue the apply tool call,
+- `SetState("cancelled", True)` + `SendMessage("Cancel: do not apply <description>.")`
+  on Cancel — telling the agent the user opted out.
+
+The reason for the agent round-trip — explained in ADR-0015 — was that the 2025-11-25
+MCP Tools spec routed an iframe-initiated `tools/call` result back to the iframe, not to
+the agent's model context. Without agent re-issue, successes and errors never reached
+the agent: closing #545 and #559 required the agent to *be* the caller.
+
+That constraint dissolved with the **MCP Apps spec, SEP-1865 (2026-01-26)**. The new
+`ui/update-model-context` notification lets an iframe push structured content into the
+agent's model context for the agent's next turn. The iframe can now fire the apply call
+*and* deliver the structured response — both of the things ADR-0015 said were
+impossible.
+
+Once `ui/update-model-context` shipped, we ran a controlled rollout of the new rail (the
+"direct-apply rail") on `create_purchase_order` and the `modify_*` / `delete_*` /
+`correct_*` / stock-adjustment write tools. It worked, so we extended it to most tools —
+but `fulfill_order`, `receive_purchase_order`, `create_stock_transfer`, and the
+batch-recipe-update card stayed on the SendMessage rail (the ADR-0015 default), giving
+us two visibly different rails:
+
+- Direct-apply rail: Confirm fires
+  `CallTool(... preview=False, on_success=[..., UpdateContext($result), ...])` → iframe
+  morphs to the applied card in place; agent sees the result on its next turn via
+  `ui/update-model-context`. No chat indirection.
+- SendMessage rail: Confirm fires `SendMessage("Apply: call <tool>(...)")` → agent
+  recognizes the prefix and re-issues; iframe is replaced by whatever the apply's
+  response card looks like. Always at least one agent round-trip; verbose chat lines on
+  large applies; ~400 tokens of dual-rail coaching in every preview tool's description.
+
+PR #807 then migrated **drill-in / view-in-Katana / open-ended** follow-up buttons (the
+*other* SendMessage uses across `prefab_ui.py`) to `CallTool` / `OpenLink` /
+`UpdateContext`. After #807 the only SendMessage instances left in the apply-card
+surface were `_build_apply_action` (Confirm) and `_build_cancel_action` (Cancel) — the
+rail this ADR finishes migrating.
+
+## Decision
+
+**The Confirm and Cancel buttons on every preview card fire deterministic actions via
+the same rail:**
+
+- **Confirm button** fires:
+  1. `SetState("pending", True)` — disables both buttons immediately (in-flight click
+     guard against double-fire).
+  1. `CallTool(<apply_tool>, arguments={<original args>, preview: False}, on_success=[…], on_error=[…])`
+     — calls the apply tool from the iframe with `preview=False`.
+     - `on_success` runs `SetState("result", $result)`, `SetState("applied", True)`, and
+       `UpdateContext(content=$result)` — the third action pushes the structured result
+       into the agent's model context for its next turn.
+     - `on_error` runs `SetState("error", $error)`, a `ShowToast`, and
+       `UpdateContext(content="Apply failed: $error")` — the agent sees the failure
+       reason.
+- **Cancel button** fires:
+  1. `SetState("cancelled", True)` — flips the card to a "Cancelled" pill, locks both
+     buttons.
+  1. `UpdateContext(content="User cancelled the <description> preview.")` — the agent's
+     context picks up the opt-out without a chat line.
+
+`_build_apply_action` and `_build_apply_action_direct` collapse into a single
+`_build_apply_action` function. `_render_apply_button_row` loses its `direct_apply` flag
+— the state machine is the same for every tool (Preview → Pending →
+Applied/Error/Cancelled). `register_preview_tool` and `with_preview_coaching` lose their
+`direct=` flag and ship one coaching variant; the `PREVIEW_APPLY_DIRECT_COACHING`
+constant goes away.
+
+The `_build_apply_message` helper (which produced the
+`Apply: call <tool>(<args>, preview=False)` chat-string format) is deleted — no longer
+reachable.
+
+## Consequences
+
+### Positive Consequences
+
+- **Architectural symmetry.** The apply rail and the rest of `prefab_ui` (post-#807) now
+  use the same primitives: `CallTool` for deterministic re-invocation, `UpdateContext`
+  for context signals, `OpenLink` for navigation. The mental model is uniform.
+- **One fewer round-trip per apply.** ADR-0015 explicitly noted "one extra LLM
+  round-trip per apply, ~2–5s and a few hundred tokens" as the cost of the SendMessage
+  rail. Removed.
+- **No more dual-rail tax in tool descriptions.** Every preview-mode write tool's
+  description was carrying ~400 tokens of dual-rail coaching (one branch for
+  SendMessage, one for direct-apply). Single coaching variant now.
+- **No `Apply: call <tool>(<args>...)` chat lines.** Verbose, parseable-but-ugly.
+  Replaced by an `UpdateContext` notification that doesn't pollute the chat history.
+- **Determinism.** The iframe builds the apply args at preview-build time and bakes
+  `preview=False` into the `CallTool.arguments` dict. There is no agent transcription
+  step to drop a field or re-format a value (#491 territory).
+- **Same chosen Confirm/Cancel UX.** Button labels still say "Confirm X" / "Cancel"; the
+  user-visible flow is identical. Only the underlying action mechanism changed.
+
+### Negative Consequences
+
+- **Cross-host coverage tied to MCP Apps support.** The direct-apply rail requires
+  `ui/update-model-context` (SEP-1865, 2026-01-26). Hosts that render iframes but not
+  MCP Apps would not deliver the apply result back to the agent. The set of hosts in
+  that category appears to be empty in practice (Claude Desktop, Claude.ai, Cowork all
+  support MCP Apps), but the surface is narrower than ADR-0015's "works on every host
+  that renders Prefab cards" guarantee. The no-iframe fallback
+  (host-doesn't-render-iframes path in the coaching) handles CLI clients the same way as
+  before.
+- **One agent-coaching block to maintain instead of two.** Removed, not just merged —
+  `with_preview_coaching` and `register_preview_tool` shrunk.
+
+### Neutral Consequences
+
+- **`destructiveHint` policy unchanged.** ADR-0015's per-tool `destructiveHint` table
+  (delete/modify True, create False, etc.) carries forward; this ADR doesn't touch
+  annotation policy.
+- **The `_render_apply_button_row` state machine is unchanged in behavior** — Pending →
+  Applied → Cancelled transitions worked the same way on both rails, and the SendMessage
+  rail's "no applied/error states" was a degenerate case of the same machine.
+
+## Alternatives Considered
+
+### Alternative 1: Keep both rails, document the split
+
+- **Description.** Leave `_build_apply_action` (SendMessage) and
+  `_build_apply_action_direct` (CallTool+UpdateContext) as separate functions, with
+  `direct=True` opt-in per tool. The dual-rail tool descriptions stay.
+- **Why rejected.** No remaining reason for the split. The SendMessage rail was a
+  workaround for a now-resolved spec gap. PR #807 already collapsed the *other*
+  SendMessage uses in `prefab_ui`; leaving the apply rail behind perpetuates
+  inconsistency.
+
+### Alternative 2: Restore `context.elicit()`
+
+- **Description.** Replace iframe Confirm/Cancel with server-initiated elicitation
+  dialogs.
+- **Why rejected.** Same reason as ADR-0015's Alternative 1: most candidate hosts don't
+  support elicitation; the spec restricts schema to flat primitives; it'd raise on
+  unsupported hosts.
+
+### Alternative 3: Drop the iframe rail entirely; chat-only "yes"
+
+- **Description.** No buttons; preview ends the turn, user types "yes" to apply, agent
+  re-issues.
+- **Why rejected.** Same reason as ADR-0015's Alternative 3: works, but loses the
+  one-click affordance. The unified direct-apply rail delivers the same fidelity *and*
+  keeps the button.
+
+## References
+
+- ADR-0015 (superseded) — original SendMessage-rail rationale + the `destructiveHint`
+  policy table that carries forward
+- PR #807 — `SendMessage → CallTool/OpenLink/UpdateContext` migration for drill-in /
+  view-in-Katana / open-ended buttons (13 CallTool, 5 OpenLink, 21 UpdateContext sites;
+  precedent for this ADR)
+- [MCP Apps spec, SEP-1865](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1865)
+  — `ui/update-model-context` notification (2026-01-26)
+- [MCP Tools spec 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)
+- #316 — confirmation-pattern decision (the parent thread for ADR-0015)
+- #491 — Confirm-button arguments dropped (closed by #493) — the template-binding
+  fragility the direct rail also avoids by inlining args into `CallTool.arguments` at
+  card-build time

--- a/katana_mcp_server/docs/adr/0021-unified-direct-apply-rail.md
+++ b/katana_mcp_server/docs/adr/0021-unified-direct-apply-rail.md
@@ -73,8 +73,11 @@ the same rail:**
 - **Cancel button** fires:
   1. `SetState("cancelled", True)` — flips the card to a "Cancelled" pill, locks both
      buttons.
-  1. `UpdateContext(content="User cancelled the <description> preview.")` — the agent's
-     context picks up the opt-out without a chat line.
+  1. `UpdateContext(content="User cancelled <description> preview.")` — the agent's
+     context picks up the opt-out without a chat line. `<description>` is a noun phrase
+     that already carries its own determiner (e.g. `"the stock adjustment"`,
+     `"that purchase order"`, `"those purchase order changes"`); the template does not
+     add a leading article, so call sites must supply one to read naturally.
 
 `_build_apply_action` and `_build_apply_action_direct` collapse into a single
 `_build_apply_action` function. `_render_apply_button_row` loses its `direct_apply` flag

--- a/katana_mcp_server/docs/adr/README.md
+++ b/katana_mcp_server/docs/adr/README.md
@@ -35,6 +35,9 @@ We use the format proposed by Michael Nygard in his article
 - [ADR-0017: Automated Tool Documentation](0017-automated-tool-documentation.md)
 - [ADR-0018: SQLModel-backed Typed Cache for Transactional List Tools](0018-sqlmodel-typed-cache.md)
 - [ADR-0019: MCP Tool Description and Batch-Field Conventions](0019-tool-description-batch-conventions.md)
+- [ADR-0021: Unified Direct-Apply Rail for Preview→Apply Cards](0021-unified-direct-apply-rail.md)
+  — supersedes
+  [ADR-0015 (monorepo)](../../../docs/adr/0015-confirmation-pattern-for-write-tools.md)
 
 ### Proposed Architecture Decisions
 

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -139,10 +139,13 @@ result (acknowledge completion, suggest next steps).
 
 The Cancel button pushes an `UpdateContext` notification of the form
 
-    User cancelled the <description> preview.
+    User cancelled <description> preview.
 
-into the agent's context. Acknowledge briefly without re-issuing. The
-user can ask again later if they want to retry.
+into the agent's context, where `<description>` is a noun phrase that
+already carries its own determiner — e.g. `the stock adjustment`,
+`that purchase order`, `the receipt for PO-123`, `those purchase order
+changes`. Acknowledge briefly without re-issuing. The user can ask
+again later if they want to retry.
 
 ## Unified-Modify Pattern
 

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -127,34 +127,22 @@ prior evidence iframes have rendered in this session.
 **2. Hosts that DO render iframes** (Claude Desktop, Claude.ai, Cowork).
 The card has Confirm and Cancel buttons the user clicks. **Do not
 re-narrate the card or ask for confirmation in chat** — the buttons
-handle that. End your turn after the preview response. The Confirm-click
-behavior depends on which rail the tool is on:
+handle that. End your turn after the preview response.
 
-*SendMessage rail (ADR-0015) — default for tools that don't opt into
-direct-apply.* The iframe sends a chat message of the form:
+*Unified direct-apply rail (ADR-0021, supersedes ADR-0015).* The
+Confirm click fires the apply `tools/call` directly from the iframe
+with the original args + `preview=False`, and the iframe pushes the
+structured result back to the agent's model context via
+`ui/update-model-context`. The agent sees the apply response on its
+next turn without re-issuing — treat it as you would any tool-call
+result (acknowledge completion, suggest next steps).
 
-    Apply: call <tool_name>(<arg>=<value>, ..., preview=False)
+The Cancel button pushes an `UpdateContext` notification of the form
 
-Recognize the `Apply:` prefix and re-issue the tool call **exactly as
-written**, with all inlined arguments preserved. Re-issuing through the
-agent's tool-calling loop is what lets the agent see the structured
-apply response on this rail; the iframe-initiated call alone routes its
-result back to the iframe, not to the agent.
+    User cancelled the <description> preview.
 
-*Direct-apply rail (ADR-0016) — used by `create_purchase_order`,
-`create_sales_order`, `create_manufacturing_order`, the unified
-`modify_<entity>` / `delete_<entity>` family, the `correct_*` family,
-and the stock-adjustment write tools.* The Confirm click fires the
-apply `tools/call` directly and the iframe pushes the structured result
-back to the agent's model context via `ui/update-model-context`. The
-agent sees the apply response on its next turn without re-issuing.
-
-Cancel behavior is the same on both rails: the iframe sends
-
-    Cancel: do not apply <description>.
-
-Acknowledge briefly without re-issuing. The user can ask again later if
-they want to retry.
+into the agent's context. Acknowledge briefly without re-issuing. The
+user can ask again later if they want to retry.
 
 ## Unified-Modify Pattern
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/bom.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/bom.py
@@ -620,5 +620,4 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"catalog", "write"},
         annotations=_modify,
         meta=UI_META,
-        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
@@ -1692,7 +1692,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "manufacturing", "write", "correction"},
         annotations=_correct,
         meta=UI_META,
-        direct=True,
     )
     register_preview_tool(
         mcp,
@@ -1700,7 +1699,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "sales", "write", "correction"},
         annotations=_correct,
         meta=UI_META,
-        direct=True,
     )
     register_preview_tool(
         mcp,
@@ -1708,5 +1706,4 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "purchasing", "write", "correction"},
         annotations=_correct,
         meta=UI_META,
-        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -2373,7 +2373,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"inventory", "write"},
         annotations=_create,
         meta=UI_META,
-        direct=True,
     )
     register_preview_tool(
         mcp,
@@ -2381,7 +2380,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"inventory", "write"},
         annotations=_destructive_write,
         meta=UI_META,
-        direct=True,
     )
     register_preview_tool(
         mcp,
@@ -2389,5 +2387,4 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"inventory", "write"},
         annotations=_destructive_write,
         meta=UI_META,
-        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -2246,7 +2246,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"catalog", "write"},
         annotations=_modify,
         meta=UI_META,
-        direct=True,
     )
     register_preview_tool(
         mcp,
@@ -2254,7 +2253,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"catalog", "write", "destructive"},
         annotations=_destructive,
         meta=UI_META,
-        direct=True,
     )
     mcp.tool(tags={"catalog", "read"}, annotations=_read, meta=UI_META)(
         get_variant_details

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -3231,7 +3231,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "manufacturing", "write"},
         annotations=_create,
         meta=UI_META,
-        direct=True,
     )
     mcp.tool(
         tags={"orders", "manufacturing", "read"},
@@ -3255,7 +3254,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "manufacturing", "write"},
         annotations=_modify,
         meta=UI_META,
-        direct=True,
     )
     register_preview_tool(
         mcp,
@@ -3263,5 +3261,4 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "manufacturing", "write", "destructive"},
         annotations=_destructive_write,
         meta=UI_META,
-        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -3179,7 +3179,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "purchasing", "write"},
         annotations=_create,
         meta=UI_META,
-        direct=True,
     )
     register_preview_tool(
         mcp,
@@ -3205,7 +3204,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "purchasing", "write"},
         annotations=_modify,
         meta=UI_META,
-        direct=True,
     )
     register_preview_tool(
         mcp,
@@ -3213,5 +3211,4 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "purchasing", "write", "destructive"},
         annotations=_destructive,
         meta=UI_META,
-        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -2296,7 +2296,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "sales", "write"},
         annotations=_create,
         meta=UI_META,
-        direct=True,
     )
     mcp.tool(tags={"orders", "sales", "read"}, annotations=_read)(list_sales_orders)
     mcp.tool(tags={"orders", "sales", "read"}, annotations=_read)(get_sales_order)
@@ -2306,7 +2305,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "sales", "write"},
         annotations=_modify,
         meta=UI_META,
-        direct=True,
     )
     register_preview_tool(
         mcp,
@@ -2314,5 +2312,4 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"orders", "sales", "write", "destructive"},
         annotations=_destructive,
         meta=UI_META,
-        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -1045,7 +1045,6 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"inventory", "stock_transfer", "write"},
         annotations=_modify,
         meta=UI_META,
-        direct=True,
     )
     register_preview_tool(
         mcp,
@@ -1053,5 +1052,4 @@ def register_tools(mcp: FastMCP) -> None:
         tags={"inventory", "stock_transfer", "write", "destructive"},
         annotations=_destructive,
         meta=UI_META,
-        direct=True,
     )

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -72,7 +72,7 @@ from typing import Any, Literal
 
 from babel.numbers import format_currency
 from prefab_ui.actions import Action, SetState, ShowToast
-from prefab_ui.actions.mcp import CallTool, SendMessage, UpdateContext
+from prefab_ui.actions.mcp import CallTool, UpdateContext
 from prefab_ui.actions.navigation import OpenLink
 from prefab_ui.app import PrefabApp
 from prefab_ui.components import (
@@ -321,9 +321,17 @@ def _build_apply_action(
     # the modification card binding ``state.plan_actions`` for live-tick row
     # updates) sees its row data land before the iframe morphs to its
     # ``applied=True`` rendering.
+    #
+    # ``SetState("error", None)`` on success is the retry-cleanup: every
+    # preview card renders an ``If("error")`` destructive Alert whenever
+    # ``state.error`` is truthy, so a successful Retry click after an
+    # earlier failure would leave the "Apply failed" Alert stuck on the
+    # otherwise-applied card. Clearing the slot keeps the rendered state
+    # internally consistent.
     on_success: list[Action] = [
         *(extra_on_success or []),
         SetState("pending", False),
+        SetState("error", None),
         # ``result`` MUST land before ``applied`` flips — the applied-state
         # tree binds Buttons to ``{{ result.id }}`` / ``{{ result.katana_url }}``
         # templates (see ``_render_preview_footer``). Setting ``applied=True``
@@ -338,6 +346,12 @@ def _build_apply_action(
         # in the iframe can't fire two applies (which would create
         # duplicate POs etc.). Cleared in on_success/on_error.
         SetState("pending", True),
+        # Clear any prior error before re-firing the apply (this same
+        # action chain backs the Retry button after an apply failure —
+        # see ``_render_apply_button_row``). Without this the destructive
+        # Alert from the failed previous attempt would stay visible
+        # while the retry is in flight, contradicting the Pending pill.
+        SetState("error", None),
         CallTool(
             tool=confirm_tool,
             arguments=args,

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -4408,8 +4408,9 @@ def build_modification_preview_ui(
     Confirm fires ``tools/call`` directly; the on_success chain pushes
     ``RESULT.actions`` into ``state.plan_actions`` so each row's status
     cell ticks PLANNED → APPLIED/FAILED in place without re-rendering
-    the iframe (ADR-0016 direct-apply rail). The iframe also pushes the
-    structured result to the agent via ``ui/update-model-context``.
+    the iframe (ADR-0021 unified direct-apply rail). The iframe also
+    pushes the structured result to the agent via
+    ``ui/update-model-context``.
     """
     actions = response.get("actions") or []
     if not actions:

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -2869,12 +2869,7 @@ def _init_create_card_state(response: dict[str, Any]) -> dict[str, Any]:
     ``SetState("result", RESULT)`` before flipping ``applied=True``.
     """
     applied = not response.get("is_preview", True)
-    state: dict[str, Any] = {
-        "applied": applied,
-        "pending": False,
-        "cancelled": False,
-        "error": None,
-    }
+    state: dict[str, Any] = {**_APPLY_RAIL_STATE_INIT, "applied": applied}
     if applied:
         state["result"] = response
     return state
@@ -3881,11 +3876,13 @@ def build_fulfill_preview_ui(
     fulfilled_rows = response.get("fulfilled_rows") or []
     fulfilled_rows_display = [_build_fulfill_row_display(r) for r in fulfilled_rows]
 
-    state = {
+    # Seed the full apply-rail state shape so the unified
+    # ``_render_apply_button_row`` Rx bindings (``applied`` / ``error``)
+    # resolve against present slots — see ADR-0021.
+    state: dict[str, Any] = {
+        **_APPLY_RAIL_STATE_INIT,
         "response": response,
         "fulfilled_rows": fulfilled_rows_display,
-        "pending": False,
-        "cancelled": False,
     }
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
@@ -4440,10 +4437,7 @@ def build_modification_preview_ui(
     n_actions = len(actions)
 
     state: dict[str, Any] = {
-        "pending": False,
-        "cancelled": False,
-        "applied": False,
-        "error": None,
+        **_APPLY_RAIL_STATE_INIT,
         _PLAN_ACTIONS_KEY: _actions_to_rows(actions),
     }
 
@@ -4709,11 +4703,13 @@ def build_receipt_ui(
     received_items = response.get("received_items") or []
     received_items_display = [_build_receipt_row_display(it) for it in received_items]
 
+    # Seed the full apply-rail state shape so the unified
+    # ``_render_apply_button_row`` Rx bindings (``applied`` / ``error``)
+    # resolve against present slots — see ADR-0021.
     state: dict[str, Any] = {
+        **_APPLY_RAIL_STATE_INIT,
         "response": response,
         "received_items": received_items_display,
-        "pending": False,
-        "cancelled": False,
     }
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
@@ -5109,7 +5105,11 @@ def build_batch_recipe_update_ui(
         "secondary" if is_preview else ("destructive" if failed > 0 else "default")
     )
 
+    # Seed the full apply-rail state shape so the unified
+    # ``_render_apply_button_row`` Rx bindings (``applied`` / ``error``)
+    # resolve against present slots — see ADR-0021.
     state: dict[str, Any] = {
+        **_APPLY_RAIL_STATE_INIT,
         "rows": flat_rows,
         "summary": {
             "total": total,
@@ -5120,8 +5120,6 @@ def build_batch_recipe_update_ui(
         "is_preview": is_preview,
         "warnings": warnings,
         "groups": list(groups.keys()),
-        "pending": False,
-        "cancelled": False,
     }
     apply_action = _build_apply_action(confirm_tool, confirm_request)
     cancel_action = _build_cancel_action(

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -360,9 +360,13 @@ def _build_cancel_action(operation_label: str) -> list[Action]:
     knows the user opted out. The agent's tool description coaches it to
     acknowledge briefly and move on without re-issuing.
 
-    ``operation_label`` is a human-readable phrase like ``"the fulfillment"``
-    or ``"that preview"`` — embedded in the UpdateContext payload so the
-    agent has enough context to acknowledge specifically.
+    ``operation_label`` is a human-readable phrase that already carries
+    its own determiner — ``"the fulfillment"`` / ``"that purchase order"``
+    / ``"the receipt for PO-123"`` / ``"those purchase order changes"`` —
+    so the template embeds it verbatim. The previous template hard-coded
+    a leading "the" which doubled up on every existing call site
+    (``"User cancelled the the stock adjustment preview."``); fixed
+    inline by letting the call site own the determiner.
 
     See ``docs/adr/0021-unified-direct-apply-rail.md`` for the
     architectural rationale (supersedes ADR-0015's ``SendMessage`` cancel
@@ -370,7 +374,7 @@ def _build_cancel_action(operation_label: str) -> list[Action]:
     """
     return [
         SetState("cancelled", True),
-        UpdateContext(content=f"User cancelled the {operation_label} preview."),
+        UpdateContext(content=f"User cancelled {operation_label} preview."),
     ]
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -37,30 +37,33 @@ shape. If a field corresponds to a Katana entity not yet in
 ``EntityKind``, add the path template in ``web_urls.py`` and wire
 the link.
 
-**Button action selection.** Each card button picks one of three
-primitives based on what its click needs to do:
+**Action primitive selection.** Card actions choose between four
+host primitives based on intent:
 
-- ``CallTool(tool, arguments={...})`` — re-invoke an MCP tool
-  deterministically. Use when every arg is resolvable at card-build
-  time from the response dict the builder receives, or from a
-  ``{{ result.<field> }}`` template that resolves against the
-  apply-response state. ``Check Inventory`` (with a known SKU) and
+- ``CallTool(tool, arguments={...})`` — deterministic tool re-invocation
+  when every required argument is resolvable at card-build time, either
+  from the response dict the builder receives or from a
+  ``{{ result.<field> }}`` template that resolves against the apply-
+  response state. ``Check Inventory`` (with a known SKU) and
   ``View Variant Details`` (with a known sku/variant_id) are the
-  canonical shape.
-- ``OpenLink(url=...)`` — host opens the URL directly. Used for every
-  ``View in Katana`` button across the cards.
-- ``UpdateContext(content="...")`` — push a chat-context update so
-  the agent composes the next call itself. Right primitive when the
-  next-step tool needs args the card can't produce (PO needs supplier
-  + location + items; "MOs using this material" has no ingredient
-  filter today — #758; receive needs per-row items; open-ended
-  modifies).
-
-The preview→apply rail still uses ``SendMessage`` because of the spec
-finding behind ADR-0015: iframe-initiated ``tools/call`` returns to
-the iframe, not the agent, so the agent has to re-issue the apply
-itself. ``_build_apply_action`` / ``_build_cancel_action`` are the
-only two ``SendMessage`` callsites remaining in this module.
+  canonical follow-up shape. This is also the preview→apply rail:
+  the Confirm button fires ``tools/call`` with the original args +
+  ``preview=False`` and pushes the structured result back to the
+  agent's model context via ``ui/update-model-context``. See ADR-0021
+  for the rationale.
+- ``OpenLink(url=...)`` — URL navigation; the host opens the link
+  directly with no agent round-trip. Used for every ``View in Katana``
+  button across the cards.
+- ``UpdateContext(content="...")`` — push a chat-context update so the
+  agent composes the next call itself. Right primitive when the next-
+  step tool needs args the card can't produce (PO needs supplier +
+  location + items; "MOs using this material" has no ingredient filter
+  today — #758; receive needs per-row items; open-ended modifies). Also
+  used on the Cancel button to signal the user opted out without
+  polluting the chat history.
+- ``SendMessage(...)`` — legacy chat-prompt primitive. Reserved for
+  fallback uses where the agent needs to *speak* (rare; usually prefer
+  ``UpdateContext``).
 """
 
 from __future__ import annotations
@@ -194,39 +197,9 @@ def status_badge_variant(entity: str, status: str | None) -> str:
 # follows the iframe-happy-path coaching ends its turn waiting for clicks
 # that never come (see #648). Mention the iframe path second.
 #
-# The rationale for the chat-message rail lives in ADR-0015; the
-# Confirm-then-iframe-handles-everything UX in ADR-0016.
+# The unified Confirm-fires-CallTool / Cancel-fires-UpdateContext rail
+# rationale lives in ADR-0021 (supersedes ADR-0015's SendMessage rail).
 PREVIEW_APPLY_COACHING = (
-    "Preview→apply pattern: when ``preview=True`` (default) the tool returns "
-    "a Prefab card describing the planned change. The ``content`` channel of "
-    "the tool result carries the response JSON, so you always have the data "
-    "even if the card itself doesn't render. Handle both host scenarios:\n\n"
-    "1. If the host does NOT render MCP Apps iframes (Claude Code, plain CLI "
-    "clients, etc.) — common signal: the user says they can't see the card, "
-    "or you have no other evidence the card was rendered — the Prefab card "
-    "is invisible. Summarize the planned change in chat from the ``content`` "
-    "JSON (what's changing, key field values), ask the user to confirm, then "
-    "re-issue the call with ``preview=False`` yourself. Do NOT end your turn "
-    "waiting for a button click — there is none.\n\n"
-    "2. If the host DOES render iframes (Claude Desktop, Claude.ai, Cowork, "
-    "etc.), the card has Confirm/Cancel buttons the user clicks. Do NOT "
-    "re-narrate the card or ask for confirmation in chat — the buttons "
-    "handle that. End your turn after the preview response. If you later "
-    "receive a chat message starting with ``Apply: call <tool>(...)`` or "
-    "``Cancel: do not apply ...``, that is a button click from a previous "
-    "preview: for Apply re-issue the tool call exactly as written; for "
-    "Cancel acknowledge briefly without re-issuing."
-)
-
-
-# Coaching text for tools using the direct-apply rail (Confirm button fires
-# ``tools/call`` directly + iframe pushes the structured result back via
-# ``ui/update-model-context``). The agent does not re-issue the call — it
-# receives the apply result automatically on its next turn. See
-# ``docs/adr/0016-direct-apply-confirm-button-rail.md`` (forthcoming).
-#
-# Same no-iframe-first lead as PREVIEW_APPLY_COACHING (see #648).
-PREVIEW_APPLY_DIRECT_COACHING = (
     "Preview→apply pattern: when ``preview=True`` (default) the tool returns "
     "a Prefab card describing the planned change. The ``content`` channel of "
     "the tool result carries the response JSON, so you always have the data "
@@ -247,30 +220,25 @@ PREVIEW_APPLY_DIRECT_COACHING = (
     "result — acknowledge completion, suggest next steps. Do NOT re-narrate "
     "the preview card, do NOT ask for confirmation in chat (the buttons "
     "handle that), and Do NOT re-issue the call after the iframe already "
-    "applied. End your turn after the preview response. If you receive a "
-    "chat message starting with ``Cancel: do not apply ...``, the user "
-    "opted out — acknowledge briefly without re-issuing."
+    "applied. End your turn after the preview response. If you receive an "
+    "``UpdateContext`` notification that the user cancelled the preview, "
+    "acknowledge briefly without re-issuing."
 )
 
 
-def with_preview_coaching(fn: Any, *, direct: bool = False) -> str:
+def with_preview_coaching(fn: Any) -> str:
     """Build a FastMCP tool description by appending preview→apply coaching
     to the function's docstring.
 
-    Two coaching variants:
-
-    - ``direct=False`` (default): tools using the SendMessage rail. Confirm
-      fires a ``Apply: call <tool>(...)`` chat message; agent re-issues.
-    - ``direct=True``: tools using the direct-apply rail. Confirm fires
-      ``tools/call`` directly and pushes the result via
-      ``ui/update-model-context``; agent does not re-issue.
+    All preview-mode write tools share a single coaching variant: Confirm
+    fires the apply ``tools/call`` directly and pushes the result via
+    ``ui/update-model-context``; the agent does not re-issue.
 
     Most callers should use :func:`register_preview_tool` rather than
     calling this directly.
     """
-    coaching = PREVIEW_APPLY_DIRECT_COACHING if direct else PREVIEW_APPLY_COACHING
     base = (fn.__doc__ or "").strip()
-    return f"{base}\n\n{coaching}" if base else coaching
+    return f"{base}\n\n{PREVIEW_APPLY_COACHING}" if base else PREVIEW_APPLY_COACHING
 
 
 def register_preview_tool(
@@ -280,103 +248,30 @@ def register_preview_tool(
     tags: set[str],
     annotations: Any,
     meta: Any = None,
-    direct: bool = False,
 ) -> None:
     """Register a preview-mode write tool with standard coaching applied.
 
-    Set ``direct=True`` for tools whose preview UI uses the direct-apply
-    rail (Confirm button fires ``tools/call`` directly and pushes the
-    structured result back via ``ui/update-model-context``). Default
-    ``direct=False`` uses the SendMessage rail (Confirm fires a chat
-    ``Apply: call ...`` for the agent to re-issue).
+    All preview tools use the unified direct-apply rail (Confirm fires
+    ``tools/call`` directly and pushes the structured result back via
+    ``ui/update-model-context``); see ADR-0021 for the architectural
+    rationale.
     """
     mcp.tool(
-        description=with_preview_coaching(fn, direct=direct),
+        description=with_preview_coaching(fn),
         tags=tags,
         annotations=annotations,
         meta=meta,
     )(fn)
 
 
-def _build_apply_message(tool_name: str, args: dict[str, Any]) -> str:
-    """Format the SendMessage text the Confirm button emits to prompt the
-    agent to re-issue the apply tool call.
-
-    Shape (uniform across all preview-mode write tools)::
-
-        Apply: call <tool_name>(<key>=<value>, ..., preview=False)
-
-    The message is human-readable and machine-parseable: the agent's tool
-    description coaches it to recognize the ``Apply:`` prefix and re-invoke
-    ``<tool_name>`` with the inlined args verbatim. ``preview=False`` is
-    placed last regardless of where ``preview`` appears in ``args.items()``
-    iteration order — for ``ConfirmableRequest`` subclasses the base-class
-    ``preview`` field can appear in the middle, but the agent should read
-    a stable trailing ``, preview=False)``.
-
-    ``args`` comes from ``request.model_dump(mode="json")``, so values are
-    already JSON primitives (str, None, bool, int/float, list, dict) — we
-    can use built-in ``repr`` for byte-identical Python-source rendering.
-    """
-    body = ", ".join(
-        f"{key}={value!r}" for key, value in args.items() if key != "preview"
-    )
-    suffix = "preview=False"
-    inner = f"{body}, {suffix}" if body else suffix
-    return f"Apply: call {tool_name}({inner})"
-
-
 def _build_apply_action(
-    confirm_tool: str | None,
-    confirm_request: BaseModel | None,
-) -> list[Action] | None:
-    """Construct the Confirm-button click action, or ``None`` when both
-    inputs are ``None``.
-
-    The action does **not** call the apply tool directly. By MCP spec, an
-    iframe-initiated ``tools/call`` returns its result to the iframe, not to
-    the agent's context — so the agent would never see the structured apply
-    response. Instead, the click marks the preview card as ``pending`` and
-    sends a ``SendMessage`` instructing the agent to re-issue the call. The
-    agent then makes the real tool call through its own tool-calling loop
-    and gets the full structured response back.
-
-    See ``docs/adr/0015-confirmation-pattern-for-write-tools.md`` for the
-    architectural rationale.
-
-    ``confirm_tool`` and ``confirm_request`` must be both set or both
-    ``None`` (the latter for builders that render their non-preview
-    branch — no Confirm button to wire).
-    """
-    if confirm_tool is None and confirm_request is None:
-        return None
-    if confirm_tool is None or confirm_request is None:
-        raise ValueError(
-            "confirm_tool and confirm_request must be set together (or both None)"
-        )
-    args = confirm_request.model_dump(mode="json")
-    if "preview" not in args:
-        raise ValueError(
-            f"_build_apply_action requires a request model with a "
-            f"`preview` field; {type(confirm_request).__name__} has none. "
-            f"Without that field the SendMessage would tell the agent to "
-            f"re-issue {confirm_tool} with an unrecognized preview=False "
-            f"argument, failing validation downstream."
-        )
-    args["preview"] = False
-    return [
-        SetState("pending", True),
-        SendMessage(_build_apply_message(confirm_tool, args)),
-    ]
-
-
-def _build_apply_action_direct(
     confirm_tool: str | None,
     confirm_request: BaseModel | None,
     *,
     extra_on_success: list[Action] | None = None,
 ) -> list[Action] | None:
-    """Construct the direct-apply Confirm-button click action chain.
+    """Construct the Confirm-button click action chain, or ``None`` when
+    both inputs are ``None``.
 
     The chain is ``[SetState(pending, True), CallTool(...)]``. Setting
     ``pending=True`` synchronously before the call fires is the spam guard:
@@ -398,12 +293,12 @@ def _build_apply_action_direct(
     reaches the model; ``structuredContent`` is for UI rendering and is
     not guaranteed in model context.
 
-    See ``docs/adr/0016-direct-apply-confirm-button-rail.md`` (forthcoming)
-    for the architectural rationale; supersedes ADR-0015 for tools that
-    opt into this rail.
+    See ``docs/adr/0021-unified-direct-apply-rail.md`` for the
+    architectural rationale (supersedes ADR-0015's SendMessage rail).
 
     ``confirm_tool`` and ``confirm_request`` must be both set or both
-    ``None`` (the latter for builders that render their non-preview branch).
+    ``None`` (the latter for builders that render their non-preview
+    branch — no Confirm button to wire).
     """
     if confirm_tool is None and confirm_request is None:
         return None
@@ -414,8 +309,11 @@ def _build_apply_action_direct(
     args = confirm_request.model_dump(mode="json")
     if "preview" not in args:
         raise ValueError(
-            f"_build_apply_action_direct requires a request model with a "
-            f"`preview` field; {type(confirm_request).__name__} has none."
+            f"_build_apply_action requires a request model with a "
+            f"`preview` field; {type(confirm_request).__name__} has none. "
+            f"Without that field the CallTool would re-issue {confirm_tool} "
+            f"with an unrecognized preview=False argument, failing "
+            f"validation downstream."
         )
     args["preview"] = False
     # The on_success chain runs the caller's extras BEFORE the generic
@@ -458,17 +356,21 @@ def _build_cancel_action(operation_label: str) -> list[Action]:
     """Construct the Cancel-button click action.
 
     Marks the preview card as ``cancelled`` (so the buttons gray out + a
-    "Cancelled" pill appears) and sends a ``SendMessage`` so the agent
+    "Cancelled" pill appears) and pushes a context update so the agent
     knows the user opted out. The agent's tool description coaches it to
     acknowledge briefly and move on without re-issuing.
 
     ``operation_label`` is a human-readable phrase like ``"the fulfillment"``
-    or ``"that preview"`` — embedded in the SendMessage text so the agent
-    has enough context to acknowledge specifically.
+    or ``"that preview"`` — embedded in the UpdateContext payload so the
+    agent has enough context to acknowledge specifically.
+
+    See ``docs/adr/0021-unified-direct-apply-rail.md`` for the
+    architectural rationale (supersedes ADR-0015's ``SendMessage`` cancel
+    indirection).
     """
     return [
         SetState("cancelled", True),
-        SendMessage(f"Cancel: do not apply {operation_label}."),
+        UpdateContext(content=f"User cancelled the {operation_label} preview."),
     ]
 
 
@@ -478,26 +380,23 @@ def _render_apply_button_row(
     apply_action: list[Action] | None,
     cancel_action: list[Action],
     disabled: bool = False,
-    direct_apply: bool = False,
 ) -> None:
     """Render the preview-card button row with state-aware visuals.
 
-    States driven by iframe state:
+    States driven by iframe state (post-ADR-0021 unified rail):
 
     - **Default** — Confirm + Cancel buttons enabled.
-    - **Pending…** — pill rendered, both buttons disabled. Set on click for
-      both rails: SendMessage rail uses it as the re-issue handoff signal;
-      direct-apply rail uses it as the in-flight click guard so a
-      double-click cannot fire two applies. Cleared in on_success /
-      on_error for direct rail; persists for SendMessage rail (the agent
-      re-issue replaces the card).
-    - **Applied** — pill rendered, both buttons disabled. Direct-apply rail
-      only (``direct_apply=True``); apply succeeded and the iframe morphed.
-    - **Error** — pill rendered, both buttons disabled. Direct-apply rail
-      only; apply failed. The error reason is in iframe state and was
-      pushed to the agent via ``ui/update-model-context``.
+    - **Pending…** — pill rendered, both buttons disabled. Set on click as
+      the in-flight click guard so a double-click cannot fire two applies.
+      Cleared in on_success / on_error.
+    - **Applied** — pill rendered, both buttons disabled. Apply succeeded
+      and the iframe morphed in place.
+    - **Error** — pill rendered, both buttons disabled. Apply failed; the
+      error reason is in iframe state and was pushed to the agent via
+      ``ui/update-model-context``.
     - **Cancelled** — pill rendered, both buttons disabled, after Cancel
-      click.
+      click. The cancel action pushes an ``UpdateContext`` notification so
+      the agent knows the user opted out.
 
     ``disabled=True`` is the block-warning fallback: only the Cancel button
     is offered (no Confirm). The Cancel button still binds
@@ -523,10 +422,8 @@ def _render_apply_button_row(
     # state (PREVIEW / APPLIED / FAILED) separately; the button is
     # specifically about "what action ran or can run next."
     #
-    # State machine (direct-apply rail):
-    # - Preview:           ``Confirm Changes`` (default, + loader icon
-    #                      ``loader`` on the pending replacement) →
-    #                      fires apply
+    # State machine (unified direct-apply rail, ADR-0021):
+    # - Preview:           ``Confirm Changes`` (default) → fires apply
     # - Pending:           ``Applying…`` (default + ``loader`` icon,
     #                      disabled)
     # - Applied + url:     ``View in Katana`` (success + ``external-link``
@@ -541,97 +438,72 @@ def _render_apply_button_row(
     #                      delete data" which is semantically wrong
     #                      for a retry affordance
     # - Cancelled:         ``Cancelled`` (outline, disabled)
-    #
-    # The SendMessage-rail (``direct_apply=False``) variant only
-    # transitions Preview → Pending; the agent re-issue replaces the
-    # card so applied/error/cancelled are out-of-process.
     with Row(gap=2):
-        if direct_apply:
-            with If("pending"):
-                # Loader icon + spinner-style label conveys in-flight
-                # state more clearly than the bare "Applying…" text.
+        with If("pending"):
+            # Loader icon + spinner-style label conveys in-flight
+            # state more clearly than the bare "Applying…" text.
+            Button(
+                label="Applying…",
+                variant="default",
+                icon="loader",
+                disabled=True,
+            )
+        with Elif("applied"):
+            with If("result.katana_url"):
+                # Success variant (green) + external-link icon —
+                # primary affordance on a successful apply is to
+                # see the result in Katana.
                 Button(
-                    label="Applying…",
-                    variant="default",
-                    icon="loader",
+                    label="View in Katana",
+                    variant="success",
+                    icon="external-link",
+                    on_click=OpenLink(url="{{ result.katana_url }}"),
+                )
+            with Else():
+                # No URL (typically a successful delete) — keep
+                # the success variant + check icon so the user
+                # gets unambiguous confirmation the action ran.
+                Button(
+                    label="Applied",
+                    variant="success",
+                    icon="check",
                     disabled=True,
                 )
-            with Elif("applied"):
-                with If("result.katana_url"):
-                    # Success variant (green) + external-link icon —
-                    # primary affordance on a successful apply is to
-                    # see the result in Katana.
-                    Button(
-                        label="View in Katana",
-                        variant="success",
-                        icon="external-link",
-                        on_click=OpenLink(url="{{ result.katana_url }}"),
-                    )
-                with Else():
-                    # No URL (typically a successful delete) — keep
-                    # the success variant + check icon so the user
-                    # gets unambiguous confirmation the action ran.
-                    Button(
-                        label="Applied",
-                        variant="success",
-                        icon="check",
-                        disabled=True,
-                    )
-            with Elif("error"):
-                # Warning variant (amber) + rotate icon signals "the
-                # previous attempt failed, click to redo." Destructive
-                # variant (red) would imply "this will delete data" —
-                # semantically wrong for a retry affordance (per the
-                # /ui-review audit). The action re-fires apply_action,
-                # which resets the rail via SetState("error", None) and
-                # restarts the apply chain.
-                Button(
-                    label="Retry",
-                    variant="warning",
-                    icon="rotate-cw",
-                    on_click=apply_action,
-                )
-            with Elif("cancelled"):
-                Button(label="Cancelled", variant="outline", disabled=True)
-            with Else():
-                # Preview state — explicit ``disabled=Rx("pending")`` is
-                # the belt-and-suspenders double-click guard: the
-                # SetState("pending", True) at the start of the on_click
-                # chain disables the button before If/Elif has a chance
-                # to swap it. Both layers protect against rapid
-                # double-click firing two CallTools.
-                Button(
-                    label=confirm_label,
-                    variant="default",
-                    on_click=apply_action,
-                    disabled=Rx("pending"),
-                )
-        else:
-            # SendMessage rail — simpler state machine, only
-            # Preview ↔ Pending ↔ Cancelled visible (agent re-issue
-            # replaces the card for terminal apply outcomes).
-            with If("pending"):
-                Button(
-                    label="Pending…",
-                    variant="default",
-                    icon="loader",
-                    disabled=True,
-                )
-            with Elif("cancelled"):
-                Button(label="Cancelled", variant="outline", disabled=True)
-            with Else():
-                Button(
-                    label=confirm_label,
-                    variant="default",
-                    on_click=apply_action,
-                    disabled=Rx("pending") | Rx("cancelled"),
-                )
+        with Elif("error"):
+            # Warning variant (amber) + rotate icon signals "the
+            # previous attempt failed, click to redo." Destructive
+            # variant (red) would imply "this will delete data" —
+            # semantically wrong for a retry affordance (per the
+            # /ui-review audit). The action re-fires apply_action,
+            # which resets the rail via SetState("error", None) and
+            # restarts the apply chain.
+            Button(
+                label="Retry",
+                variant="warning",
+                icon="rotate-cw",
+                on_click=apply_action,
+            )
+        with Elif("cancelled"):
+            Button(label="Cancelled", variant="outline", disabled=True)
+        with Else():
+            # Preview state — explicit ``disabled=Rx("pending")`` is
+            # the belt-and-suspenders double-click guard: the
+            # SetState("pending", True) at the start of the on_click
+            # chain disables the button before If/Elif has a chance
+            # to swap it. Both layers protect against rapid
+            # double-click firing two CallTools.
+            Button(
+                label=confirm_label,
+                variant="default",
+                on_click=apply_action,
+                disabled=Rx("pending"),
+            )
         # Cancel button — disabled in all terminal states so the row
         # width stays constant (two buttons always visible). Cancel
         # only does anything in Preview.
-        cancel_locked: Any = Rx("pending") | Rx("cancelled")
-        if direct_apply:
-            cancel_locked = cancel_locked | Rx("applied") | Rx("error")
+        cancel_locked: Any = (
+            Rx("pending") | Rx("cancelled") | Rx("applied") | Rx("error")
+        )
         Button(
             label="Cancel",
             variant="outline",
@@ -2514,12 +2386,12 @@ def _render_field_diff_line(
     # reflow when an apply fails.
 
 
-# Initial state slots written by the direct-apply rail's Confirm/Cancel
-# action chains. Builders that opt into the rail seed these to ``False`` /
+# Initial state slots written by the unified apply rail's Confirm/Cancel
+# action chains (ADR-0021). Every preview card seeds these to ``False`` /
 # ``None`` so the iframe's If/Elif blocks have something to bind to before
 # the first click. ``SetState`` mutations from
-# ``_build_apply_action_direct`` / ``_build_cancel_action`` flip them.
-_DIRECT_APPLY_STATE_INIT: dict[str, Any] = {
+# ``_build_apply_action`` / ``_build_cancel_action`` flip them.
+_APPLY_RAIL_STATE_INIT: dict[str, Any] = {
     "pending": False,
     "cancelled": False,
     "applied": False,
@@ -2567,8 +2439,8 @@ def build_stock_adjustment_create_ui(
     apply_action: list[Action] | None = None
     cancel_action: list[Action] | None = None
     if is_preview:
-        state.update(_DIRECT_APPLY_STATE_INIT)
-        apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+        state.update(_APPLY_RAIL_STATE_INIT)
+        apply_action = _build_apply_action(confirm_tool, confirm_request)
         cancel_action = _build_cancel_action("the stock adjustment")
 
     location_id = response.get("location_id")
@@ -2620,7 +2492,6 @@ def build_stock_adjustment_create_ui(
                     confirm_label="Confirm & Create",
                     apply_action=apply_action,
                     cancel_action=cancel_action,
-                    direct_apply=True,
                 )
             elif response.get("katana_url"):
                 Button(
@@ -2659,8 +2530,8 @@ def build_stock_adjustment_update_ui(
     apply_action: list[Action] | None = None
     cancel_action: list[Action] | None = None
     if is_preview:
-        state.update(_DIRECT_APPLY_STATE_INIT)
-        apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+        state.update(_APPLY_RAIL_STATE_INIT)
+        apply_action = _build_apply_action(confirm_tool, confirm_request)
         cancel_action = _build_cancel_action("the stock-adjustment update")
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
@@ -2705,7 +2576,6 @@ def build_stock_adjustment_update_ui(
                     confirm_label="Confirm & Update",
                     apply_action=apply_action,
                     cancel_action=cancel_action,
-                    direct_apply=True,
                 )
             elif response.get("katana_url"):
                 Button(
@@ -2734,8 +2604,8 @@ def build_stock_adjustment_delete_ui(
     apply_action: list[Action] | None = None
     cancel_action: list[Action] | None = None
     if is_preview:
-        state = dict(_DIRECT_APPLY_STATE_INIT)
-        apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+        state = dict(_APPLY_RAIL_STATE_INIT)
+        apply_action = _build_apply_action(confirm_tool, confirm_request)
         cancel_action = _build_cancel_action("the stock-adjustment deletion")
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
@@ -2793,7 +2663,6 @@ def build_stock_adjustment_delete_ui(
                     confirm_label="Confirm & Delete",
                     apply_action=apply_action,
                     cancel_action=cancel_action,
-                    direct_apply=True,
                 )
     return app
 
@@ -2949,7 +2818,6 @@ def _render_preview_footer(
                 apply_action=None,
                 cancel_action=cancel_action,
                 disabled=True,
-                direct_apply=True,
             )
             return
         with If("applied"):
@@ -2977,7 +2845,6 @@ def _render_preview_footer(
                 confirm_label=confirm_label,
                 apply_action=apply_action,
                 cancel_action=cancel_action,
-                direct_apply=True,
             )
 
 
@@ -2998,7 +2865,7 @@ def _init_create_card_state(response: dict[str, Any]) -> dict[str, Any]:
     applied-state Buttons (``{{ result.katana_url }}`` etc.). On the
     standalone-applied path we seed it from the response here; on the
     in-place morph path the on_success chain in
-    :func:`_build_apply_action_direct` populates it via
+    :func:`_build_apply_action` populates it via
     ``SetState("result", RESULT)`` before flipping ``applied=True``.
     """
     applied = not response.get("is_preview", True)
@@ -3362,7 +3229,7 @@ def build_po_create_ui(
     status = response.get("status")
     entity_type = response.get("entity_type")
 
-    apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    apply_action = _build_apply_action(confirm_tool, confirm_request)
     cancel_action = _build_cancel_action("that purchase order")
     extra_badges: tuple[tuple[str, str], ...] = (
         ((entity_type, "outline"),) if entity_type and entity_type != "regular" else ()
@@ -3540,7 +3407,7 @@ def build_po_modify_ui(
     # at #760 — see issue for design options.
     changes_by_field = _index_changes_by_field(actions)
 
-    apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    apply_action = _build_apply_action(confirm_tool, confirm_request)
     # ``_build_cancel_action`` interpolates its arg into "Cancel: do not
     # apply X.", so the noun phrase has to read naturally there. Verb
     # forms like ``"that purchase order modify"`` (the previous shape)
@@ -3667,7 +3534,7 @@ def build_so_create_ui(
     item_count = response.get("item_count")
     delivery_date = response.get("delivery_date")
 
-    apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    apply_action = _build_apply_action(confirm_tool, confirm_request)
     cancel_action = _build_cancel_action("that sales order")
 
     with (
@@ -3758,7 +3625,7 @@ def build_mo_create_ui(
     production_deadline_date = response.get("production_deadline_date")
     additional_info = response.get("additional_info")
 
-    apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    apply_action = _build_apply_action(confirm_tool, confirm_request)
     cancel_action = _build_cancel_action("that manufacturing order")
 
     with (
@@ -4550,7 +4417,7 @@ def build_modification_preview_ui(
         if legacy is not None:
             actions = [legacy]
 
-    apply_action = _build_apply_action_direct(confirm_tool, confirm_request)
+    apply_action = _build_apply_action(confirm_tool, confirm_request)
     # NOTE: A live-tick design (rows ticking PLANNED -> APPLIED in place via
     # ``SetState("plan_actions", RESULT.actions)``) was attempted in #634 but
     # turned out to be broken: ``$result`` in the on_success Rx context
@@ -4633,7 +4500,6 @@ def build_modification_preview_ui(
                 apply_action=apply_action,
                 cancel_action=cancel_action,
                 disabled=bool(block_warnings),
-                direct_apply=True,
             )
     return app
 

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -5196,6 +5196,85 @@ class TestConfirmButtonDirectApplyRail:
             f"morph so the apply rail can retry on failure. Got buttons={labels!r}"
         )
 
+    def test_apply_action_clears_error_state_on_click_and_on_success(self):
+        """Per PR #808 review: the Retry button reuses ``apply_action`` and
+        every preview card renders an ``If("error")`` destructive Alert
+        whenever ``state.error`` is truthy. Without explicit clears, a
+        successful Retry leaves the failed-attempt Alert stuck on the
+        otherwise-applied card.
+
+        The apply action chain must clear ``state.error`` in two places:
+
+        1. **Click-time** — at the start of the on_click list, alongside
+           ``pending=True``. Hides the destructive Alert the moment the
+           retry fires, matching the Pending pill visual state.
+        2. **On success** — inside ``on_success`` alongside the
+           ``applied=True`` morph. Belt-and-suspenders for the successful
+           case so the rendered applied card never carries a stale error.
+        """
+        from katana_mcp.tools.foundation.purchase_orders import (
+            CreatePurchaseOrderRequest,
+            PurchaseOrderItem,
+        )
+
+        request = CreatePurchaseOrderRequest(
+            supplier_id=2,
+            location_id=3,
+            order_number="PO-RETRY",
+            items=[PurchaseOrderItem(variant_id=10, quantity=1.0, price_per_unit=2.0)],
+        )
+        app = build_po_create_ui(
+            {
+                "id": 1,
+                "order_number": "PO-RETRY",
+                "supplier_id": 2,
+                "location_id": 3,
+                "status": "NOT_RECEIVED",
+                "warnings": [],
+            },
+            confirm_request=request,
+            confirm_tool="create_purchase_order",
+        )
+        envelope = app.to_json()
+        on_click = self._confirm_action(envelope, "Confirm & Create Purchase Order")
+
+        # Click-time clear: among the top-level setState actions before
+        # the toolCall, exactly one must set error=None.
+        # ``on_click`` is the CallTool itself; click-chain wrapper lives
+        # one level up — fetch via the Confirm button's on_click array.
+        buttons = _find_buttons_by_label(envelope, "Confirm & Create Purchase Order")
+        click_chain = buttons[0].get("onClick") or buttons[0].get("on_click")
+        assert isinstance(click_chain, list)
+        prefire_error_clears = [
+            a
+            for a in click_chain
+            if a.get("action") == "setState"
+            and a.get("key") == "error"
+            and a.get("value") is None
+        ]
+        assert len(prefire_error_clears) == 1, (
+            "Click chain must set error=None before firing the apply so "
+            "the destructive Alert from any prior failed attempt hides "
+            "immediately on Retry. Got chain="
+            f"{click_chain!r}"
+        )
+
+        # On-success clear: inside the CallTool's onSuccess list.
+        on_success = on_click.get("onSuccess") or []
+        success_error_clears = [
+            a
+            for a in on_success
+            if a.get("action") == "setState"
+            and a.get("key") == "error"
+            and a.get("value") is None
+        ]
+        assert len(success_error_clears) == 1, (
+            "on_success must set error=None alongside the applied morph "
+            "so a successful Retry doesn't leave a stale failure Alert "
+            "rendered on the applied card. Got on_success="
+            f"{on_success!r}"
+        )
+
 
 class TestCancelButtonEmitsUpdateContext:
     """The Cancel button (post-ADR-0021) fires ``setState("cancelled", True)``

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -2390,12 +2390,12 @@ class TestBuildPOModifyUI:
 
     def test_cancel_messages_use_natural_noun_phrases_per_verb(self):
         """``_build_cancel_action`` interpolates its arg into the
-        ``UpdateContext`` payload "User cancelled the X preview." — the
-        noun phrase has to read naturally there. Modify/correct cards
-        interpolate "those purchase order changes" / "those purchase
-        order corrections"; delete cards interpolate "that purchase
-        order deletion". The previous shape (e.g. "that purchase order
-        modify") was grammatically awkward — Copilot flagged on #755."""
+        ``UpdateContext`` payload "User cancelled <noun phrase> preview."
+        — the noun phrase has to read naturally there. Modify/correct
+        cards interpolate "those purchase order changes" / "those purchase
+        order corrections"; delete cards interpolate "that purchase order
+        deletion". The previous shape (e.g. "that purchase order modify")
+        was grammatically awkward — Copilot flagged on #755."""
         for tool, expected_phrase in [
             ("modify_purchase_order", "those purchase order changes"),
             ("correct_purchase_order", "those purchase order corrections"),
@@ -5199,9 +5199,10 @@ class TestConfirmButtonDirectApplyRail:
 
 class TestCancelButtonEmitsUpdateContext:
     """The Cancel button (post-ADR-0021) fires ``setState("cancelled", True)``
-    plus an ``updateContext(content="User cancelled the ... preview.")``
+    plus an ``updateContext(content="User cancelled <noun phrase> preview.")``
     so the agent sees the user's opt-out as a context update — no chat
-    indirection.
+    indirection. The noun phrase carries its own determiner ("the" / "that"
+    / "those") so the template doesn't double-up the article.
     """
 
     def _assert_cancel_actions(self, on_click: list[dict]) -> None:
@@ -5214,13 +5215,28 @@ class TestCancelButtonEmitsUpdateContext:
             u
             for u in update_contexts
             if isinstance(u.get("content"), str)
-            and u["content"].startswith("User cancelled the ")
+            and u["content"].startswith("User cancelled ")
             and u["content"].endswith(" preview.")
         ]
         assert len(cancel_msgs) == 1, (
             f"Expected exactly one Cancel updateContext starting with "
-            f"'User cancelled the ' and ending with ' preview.'; "
+            f"'User cancelled ' and ending with ' preview.'; "
             f"got {[u.get('content') for u in update_contexts]!r}"
+        )
+        # Regression-guard for the article-doubling bug (#808 review): the
+        # previous template hard-coded a leading "the" while call sites
+        # already passed article-prefixed phrases, producing "the the …"
+        # / "the that …". The noun phrase must start with its own
+        # determiner, never with a doubled article.
+        content = cancel_msgs[0]["content"]
+        assert not content.startswith("User cancelled the the "), (
+            f"Cancel content has double 'the the': {content!r}"
+        )
+        assert not content.startswith("User cancelled the that "), (
+            f"Cancel content has 'the that' mix-up: {content!r}"
+        )
+        assert not content.startswith("User cancelled the those "), (
+            f"Cancel content has 'the those' mix-up: {content!r}"
         )
 
     def test_order_preview_cancel(self):

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -14,7 +14,6 @@ from typing import Any, ClassVar
 import pytest
 from katana_mcp.tools.prefab_ui import (
     PREVIEW_APPLY_COACHING,
-    PREVIEW_APPLY_DIRECT_COACHING,
     _format_money,
     build_batch_recipe_update_ui,
     build_fulfill_preview_ui,
@@ -2390,13 +2389,13 @@ class TestBuildPOModifyUI:
         assert "Confirm Delete" in rendered
 
     def test_cancel_messages_use_natural_noun_phrases_per_verb(self):
-        """``_build_cancel_action`` interpolates its arg into "Cancel: do
-        not apply X." — the noun phrase has to read naturally there.
-        Modify/correct cards interpolate "those purchase order changes" /
-        "those purchase order corrections"; delete cards interpolate
-        "that purchase order deletion". The previous shape (e.g. "that
-        purchase order modify") was grammatically awkward — Copilot
-        flagged on #755."""
+        """``_build_cancel_action`` interpolates its arg into the
+        ``UpdateContext`` payload "User cancelled the X preview." — the
+        noun phrase has to read naturally there. Modify/correct cards
+        interpolate "those purchase order changes" / "those purchase
+        order corrections"; delete cards interpolate "that purchase
+        order deletion". The previous shape (e.g. "that purchase order
+        modify") was grammatically awkward — Copilot flagged on #755."""
         for tool, expected_phrase in [
             ("modify_purchase_order", "those purchase order changes"),
             ("correct_purchase_order", "those purchase order corrections"),
@@ -4744,11 +4743,10 @@ class TestBuildBatchRecipeUpdateUI:
 def _confirm_button_on_click(envelope: dict, label: str) -> list[dict]:
     """Return the on_click action list for the Confirm button matching ``label``.
 
-    All Confirm buttons in the new (post-#316) confirmation pattern fire
-    a list of two actions: ``setState("pending", True)`` and
-    ``sendMessage("Apply: call <tool>(<args>, preview=False)")``. The
-    Cancel button mirrors this with ``cancelled`` and a ``"Cancel: ..."``
-    SendMessage.
+    Per ADR-0021 every Confirm button fires a list of two actions:
+    ``setState("pending", True)`` and ``toolCall(<apply_tool>, ...)``.
+    The Cancel button mirrors this with ``setState("cancelled", True)``
+    and an ``updateContext(...)`` notification.
     """
     buttons = _find_buttons_by_label(envelope, label)
     assert len(buttons) == 1, (
@@ -4761,42 +4759,47 @@ def _confirm_button_on_click(envelope: dict, label: str) -> list[dict]:
     return on_click
 
 
-class TestConfirmButtonEmitsApplyMessage:
-    """The Confirm button on every preview card must fire two actions:
+class TestConfirmButtonEmitsCallTool:
+    """The Confirm button on every preview card fires two actions per
+    ADR-0021:
 
     1. ``setState("pending", True)`` — flips the card to a "Pending…"
-       pill and grays out the buttons (no double-fire footgun).
-    2. ``sendMessage("Apply: call <tool>(<inlined args>, preview=False)")``
-       — prompts the agent to re-issue the apply call.
+       pill, grays out the buttons (in-flight click guard).
+    2. ``toolCall(<apply_tool>, arguments={..., preview=False}, ...)``
+       — calls the apply tool directly from the iframe. The
+       ``on_success`` chain pushes the structured result back into the
+       agent's model context via ``updateContext``.
 
-    The button does **not** fire ``CallTool`` directly. Per ADR-0015 and
-    the spec finding behind #316, an iframe-initiated ``tools/call``
-    returns its result to the iframe, not to the agent — so the only way
-    for the agent to see the apply response is to make the call itself.
+    Supersedes the old ADR-0015 ``SendMessage`` re-issue handshake; see
+    the unified rail ADR for the spec finding that motivated the move
+    (``ui/update-model-context`` lets the iframe push the result to the
+    agent's context, removing the need for an agent re-issue).
     """
 
     @staticmethod
     def _assert_apply_actions(on_click: list[dict], tool_name: str) -> dict:
         """Validate that on_click is exactly [SetState(pending, True),
-        SendMessage(Apply: call <tool>(...))] and return the SendMessage."""
+        CallTool(<tool_name>, arguments={..., preview=False}, ...)] and
+        return the CallTool action."""
         set_states = [a for a in on_click if a.get("action") == "setState"]
-        send_messages = [a for a in on_click if a.get("action") == "sendMessage"]
+        tool_calls = [a for a in on_click if a.get("action") == "toolCall"]
         assert any(
             a.get("key") == "pending" and a.get("value") is True for a in set_states
         ), f"Expected setState('pending', True) in on_click; got {on_click!r}"
-        apply_msgs = [
-            m
-            for m in send_messages
-            if isinstance(m.get("content"), str)
-            and m["content"].startswith(f"Apply: call {tool_name}(")
-        ]
-        assert len(apply_msgs) == 1, (
-            f"Expected exactly one SendMessage with 'Apply: call {tool_name}('; "
-            f"got {[m.get('content') for m in send_messages]!r}"
+        matching = [c for c in tool_calls if c.get("tool") == tool_name]
+        assert len(matching) == 1, (
+            f"Expected exactly one toolCall to {tool_name!r}; "
+            f"got {[c.get('tool') for c in tool_calls]!r}"
         )
-        return apply_msgs[0]
+        call = matching[0]
+        args = call.get("arguments") or {}
+        assert args.get("preview") is False, (
+            f"Confirm-button toolCall must bake preview=False into arguments; "
+            f"got {args!r}"
+        )
+        return call
 
-    def test_fulfill_preview_confirm_emits_apply_send_message(self):
+    def test_fulfill_preview_confirm_emits_call_tool(self):
         app = build_fulfill_preview_ui(
             {
                 "order_id": 9999,
@@ -4808,12 +4811,12 @@ class TestConfirmButtonEmitsApplyMessage:
         )
         envelope = app.to_json()
         on_click = _confirm_button_on_click(envelope, "Confirm Fulfillment")
-        msg = self._assert_apply_actions(on_click, "fulfill_order")
-        assert "order_id=9999" in msg["content"]
-        assert "order_type='sales'" in msg["content"]
-        assert "preview=False" in msg["content"]
+        call = self._assert_apply_actions(on_click, "fulfill_order")
+        args = call["arguments"]
+        assert args["order_id"] == 9999
+        assert args["order_type"] == "sales"
 
-    def test_receipt_preview_confirm_emits_apply_send_message(self):
+    def test_receipt_preview_confirm_emits_call_tool(self):
         from katana_mcp.tools.foundation.purchase_orders import (
             ReceiveItemRequest,
             ReceivePurchaseOrderRequest,
@@ -4837,11 +4840,10 @@ class TestConfirmButtonEmitsApplyMessage:
         )
         envelope = app.to_json()
         on_click = _confirm_button_on_click(envelope, "Confirm Receipt")
-        msg = self._assert_apply_actions(on_click, "receive_purchase_order")
-        assert "order_id=1234" in msg["content"]
-        assert "preview=False" in msg["content"]
+        call = self._assert_apply_actions(on_click, "receive_purchase_order")
+        assert call["arguments"]["order_id"] == 1234
 
-    def test_batch_recipe_preview_confirm_emits_apply_send_message(self):
+    def test_batch_recipe_preview_confirm_emits_call_tool(self):
         request = _StubRequest()
         app = build_batch_recipe_update_ui(
             {
@@ -4866,20 +4868,43 @@ class TestConfirmButtonEmitsApplyMessage:
         )
         envelope = app.to_json()
         on_click = _confirm_button_on_click(envelope, "Execute batch")
-        msg = self._assert_apply_actions(on_click, "batch_update_recipes")
-        assert "preview=False" in msg["content"]
+        self._assert_apply_actions(on_click, "batch_update_recipes")
+
+    def test_fulfill_preview_confirm_pushes_result_via_update_context(self):
+        """The unified apply rail's on_success chain must include
+        ``UpdateContext(content=$result)`` so the structured apply
+        response reaches the agent's context on its next turn.
+        """
+        app = build_fulfill_preview_ui(
+            {
+                "order_id": 5,
+                "order_type": "manufacturing",
+                "order_number": "MO-2",
+                "status": "PARTIALLY_DELIVERED",
+                "warnings": [],
+            }
+        )
+        envelope = app.to_json()
+        on_click = _confirm_button_on_click(envelope, "Confirm Fulfillment")
+        call = self._assert_apply_actions(on_click, "fulfill_order")
+        on_success = call.get("onSuccess")
+        assert isinstance(on_success, list), (
+            f"Expected onSuccess to be a list; got {on_success!r}"
+        )
+        update_contexts = [a for a in on_success if a.get("action") == "updateContext"]
+        assert len(update_contexts) == 1, (
+            f"Expected exactly one updateContext in on_success; got {update_contexts!r}"
+        )
+        assert update_contexts[0].get("content") == "{{ $result }}", (
+            f"updateContext.content must carry $result so the agent receives "
+            f"the structured apply response; got {update_contexts[0]!r}"
+        )
 
 
 class TestConfirmButtonDirectApplyRail:
-    """Direct-apply rail (ADR-0016, supersedes ADR-0015 for opted-in tools):
-
-    The Confirm button fires ``tools/call`` directly from the iframe with
-    the original args + ``preview=False``, and on success pushes the
-    structured result back to the agent's model context via
-    ``ui/update-model-context``. The agent does NOT re-issue the call.
-
-    Currently opted into by ``create_purchase_order``; rolling out to other
-    write tools after Cowork verification.
+    """Pre-#807 direct-apply rail tests, retained as the smoke test for the
+    create-PO card's full retry / error / spam-guard contract. Now the
+    unified rail (ADR-0021) every preview tool uses.
     """
 
     @staticmethod
@@ -5172,27 +5197,30 @@ class TestConfirmButtonDirectApplyRail:
         )
 
 
-class TestCancelButtonEmitsCancelMessage:
-    """The Cancel button must fire ``setState("cancelled", True)`` plus a
-    ``sendMessage("Cancel: do not apply ...")`` so the agent recognizes the
-    user's opt-out and moves on. Mirrors the Confirm-button contract above.
+class TestCancelButtonEmitsUpdateContext:
+    """The Cancel button (post-ADR-0021) fires ``setState("cancelled", True)``
+    plus an ``updateContext(content="User cancelled the ... preview.")``
+    so the agent sees the user's opt-out as a context update — no chat
+    indirection.
     """
 
     def _assert_cancel_actions(self, on_click: list[dict]) -> None:
         set_states = [a for a in on_click if a.get("action") == "setState"]
-        send_messages = [a for a in on_click if a.get("action") == "sendMessage"]
+        update_contexts = [a for a in on_click if a.get("action") == "updateContext"]
         assert any(
             a.get("key") == "cancelled" and a.get("value") is True for a in set_states
         ), f"Expected setState('cancelled', True) in on_click; got {on_click!r}"
         cancel_msgs = [
-            m
-            for m in send_messages
-            if isinstance(m.get("content"), str)
-            and m["content"].startswith("Cancel: do not apply ")
+            u
+            for u in update_contexts
+            if isinstance(u.get("content"), str)
+            and u["content"].startswith("User cancelled the ")
+            and u["content"].endswith(" preview.")
         ]
         assert len(cancel_msgs) == 1, (
-            f"Expected exactly one Cancel SendMessage; "
-            f"got {[m.get('content') for m in send_messages]!r}"
+            f"Expected exactly one Cancel updateContext starting with "
+            f"'User cancelled the ' and ending with ' preview.'; "
+            f"got {[u.get('content') for u in update_contexts]!r}"
         )
 
     def test_order_preview_cancel(self):
@@ -5351,10 +5379,11 @@ class TestBuildApplyActionXorInvariant:
 
         assert _build_apply_action(None, None) is None
 
-    def test_apply_message_inlines_args_and_overrides_preview(self):
-        """The ``Apply: call ...`` SendMessage must inline every request
-        field as a literal value and force ``preview=False`` regardless
-        of the request's preview value (the user already saw the preview).
+    def test_apply_inlines_args_and_overrides_preview(self):
+        """The Confirm-button ``CallTool`` must carry every request field
+        as a literal value in ``arguments`` and force ``preview=False``
+        regardless of the request's preview value (the user already saw
+        the preview).
         """
         from katana_mcp.tools.foundation.orders import FulfillOrderRequest
         from katana_mcp.tools.prefab_ui import _build_apply_action
@@ -5362,30 +5391,23 @@ class TestBuildApplyActionXorInvariant:
         request = FulfillOrderRequest(order_id=42, order_type="sales", preview=True)
         actions = _build_apply_action("fulfill_order", request)
         assert actions is not None
-        send_messages = [a for a in actions if hasattr(a, "content")]
-        assert len(send_messages) == 1
-        # ``Action`` is a discriminated union; only some variants expose
-        # ``content``. ``hasattr`` filters at runtime, but the static type
-        # is the bare union — read via ``getattr`` to satisfy the checker.
-        text = getattr(send_messages[0], "content", None)
-        assert isinstance(text, str)
-        assert text.startswith("Apply: call fulfill_order(")
-        assert "order_id=42" in text
-        assert "order_type='sales'" in text
-        # preview is forced to False even though request.preview was True
-        assert "preview=False" in text
-        assert "preview=True" not in text
-        # And ``preview=False`` is the trailing arg regardless of where the
-        # field appears in args.items() iteration order — agents read a
-        # stable suffix.
-        assert text.rstrip(")").endswith(", preview=False"), (
-            f"`preview=False` must be the trailing arg; got: {text!r}"
+        # Find the CallTool action.
+        tool_calls = [a for a in actions if getattr(a, "tool", None) == "fulfill_order"]
+        assert len(tool_calls) == 1, (
+            f"Expected exactly one CallTool to fulfill_order; got {actions!r}"
         )
+        call = tool_calls[0]
+        args = getattr(call, "arguments", None)
+        assert isinstance(args, dict)
+        assert args["order_id"] == 42
+        assert args["order_type"] == "sales"
+        # preview is forced to False even though request.preview was True
+        assert args["preview"] is False
 
     def test_preview_field_required_in_request(self):
         """A request model without a ``preview`` field is a programmer
-        error — the SendMessage would prompt the agent to call the tool
-        with an unrecognized argument that fails validation downstream.
+        error — the CallTool would invoke the tool with an unrecognized
+        ``preview=False`` argument that fails validation downstream.
         Fail loudly at UI-build time instead.
         """
         from katana_mcp.tools.prefab_ui import _build_apply_action
@@ -6356,17 +6378,11 @@ class TestPreviewCoachingLeadsWithNoIframeFallback:
     ended their turns waiting for clicks the user could not make.
     """
 
-    @pytest.mark.parametrize(
-        "coaching",
-        [PREVIEW_APPLY_COACHING, PREVIEW_APPLY_DIRECT_COACHING],
-        ids=["sendmessage-rail", "direct-apply-rail"],
-    )
-    def test_no_iframe_scenario_appears_before_iframe_scenario(
-        self, coaching: str
-    ) -> None:
+    def test_no_iframe_scenario_appears_before_iframe_scenario(self) -> None:
         """The no-iframe path must be discussed BEFORE the iframe path so
         agents whose host doesn't render Prefab cards don't miss the
         fallback instructions."""
+        coaching = PREVIEW_APPLY_COACHING
         # Numbered scenarios — `1.` introduces no-iframe, `2.` iframe.
         no_iframe_idx = coaching.find("does NOT render")
         iframe_idx = coaching.find("DOES render")
@@ -6384,33 +6400,21 @@ class TestPreviewCoachingLeadsWithNoIframeFallback:
             "footgun #648 fixed."
         )
 
-    @pytest.mark.parametrize(
-        "coaching",
-        [PREVIEW_APPLY_COACHING, PREVIEW_APPLY_DIRECT_COACHING],
-        ids=["sendmessage-rail", "direct-apply-rail"],
-    )
-    def test_mentions_content_channel_as_data_source(self, coaching: str) -> None:
+    def test_mentions_content_channel_as_data_source(self) -> None:
         """The no-iframe fallback path tells the agent to summarize from the
         ``content`` channel — make sure the coaching points there explicitly
         so agents don't claim "I don't have enough data" instead of reading
         the JSON they were just handed."""
-        assert "``content``" in coaching, (
+        assert "``content``" in PREVIEW_APPLY_COACHING, (
             "coaching must direct the agent to the ``content`` channel for "
             "the no-iframe summarize-then-confirm path; otherwise agents "
             "may not realize the response data is already in context."
         )
 
-    @pytest.mark.parametrize(
-        "coaching",
-        [PREVIEW_APPLY_COACHING, PREVIEW_APPLY_DIRECT_COACHING],
-        ids=["sendmessage-rail", "direct-apply-rail"],
-    )
-    def test_no_iframe_path_says_re_issue_with_preview_false(
-        self, coaching: str
-    ) -> None:
+    def test_no_iframe_path_says_re_issue_with_preview_false(self) -> None:
         """The no-iframe fallback must spell out the apply mechanic
         (``preview=False``) so the agent isn't left guessing how to apply."""
-        assert "preview=False" in coaching, (
+        assert "preview=False" in PREVIEW_APPLY_COACHING, (
             "the no-iframe fallback must tell the agent to re-issue with "
             "``preview=False``"
         )

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -1748,7 +1748,7 @@ class TestBuildPOCreateUI:
         the response so the applied-state Buttons (which bind to
         ``{{ result.id }}`` and ``{{ result.katana_url }}``) resolve. On
         the in-place morph path, the on_success chain in
-        ``_build_apply_action_direct`` writes the same key."""
+        ``_build_apply_action`` writes the same key."""
         order = dict(self._PO_RESPONSE, **self._PO_APPLIED)
         app = build_po_create_ui(
             order,
@@ -5743,7 +5743,7 @@ class TestBlockWarningSuppressesConfirm:
 class _ModifyStubRequest(BaseModel):
     """Stub for ``ConfirmableRequest`` used by modification-card tests.
 
-    Mirrors the load-bearing fields ``_build_apply_action_direct`` reads
+    Mirrors the load-bearing fields ``_build_apply_action`` reads
     (``id``, ``preview``) without pulling a real entity request shape into
     these unit tests.
     """

--- a/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
+++ b/katana_mcp_server/tests/test_tool_descriptions_and_annotations.py
@@ -1,7 +1,8 @@
 """Regression tests pinning two cross-cutting properties of registered MCP tools:
 
 1. Every tool whose request model has a ``preview`` field includes the
-   preview→apply coaching block in its description (closes #544).
+   preview→apply coaching block in its description (closes #544). After
+   ADR-0021 every preview tool uses the unified direct-apply rail.
 2. ``destructiveHint`` annotations follow the policy fixed in ADR-0015
    (#316 housekeeping).
 
@@ -40,25 +41,21 @@ def registered_tools() -> dict[str, Any]:
 # block (``with_preview_coaching``) in their description so the agent
 # recognizes the iframe round-trip.
 #
-# Two rails:
-#   - SendMessage rail (default) — Confirm fires a ``Apply: call`` chat hint
-#     and the agent re-issues. Coaching: ``PREVIEW_APPLY_COACHING``.
-#   - Direct-apply rail (``register_preview_tool(direct=True)``) — Confirm
-#     fires ``tools/call`` directly and pushes the structured result back via
-#     ``ui/update-model-context``. Coaching: ``PREVIEW_APPLY_DIRECT_COACHING``.
+# Per ADR-0021, all preview-button tools use the unified direct-apply rail:
+# Confirm fires ``tools/call`` directly and pushes the structured result
+# back via ``ui/update-model-context``; Cancel pushes an UpdateContext
+# notification of the user's opt-out.
 #
 # ``rebuild_cache`` has a ``preview`` field but renders markdown text rather
 # than a Prefab card, so it does not need coaching about button-driven
-# Apply: messages.
-
-# Tools currently using the direct-apply rail (per ADR-0016 spike).
-DIRECT_APPLY_TOOLS = [
+# Apply behavior.
+PREVIEW_BUTTON_TOOLS = [
     # Order creates that route through per-entity build_<po|so|mo>_create_ui.
     "create_purchase_order",
     "create_sales_order",
     "create_manufacturing_order",
     # Modification tools — every tool that returns a ModificationResponse
-    # via _modification.to_tool_result is on the direct-apply rail.
+    # via _modification.to_tool_result is on the apply rail.
     "modify_purchase_order",
     "delete_purchase_order",
     "modify_sales_order",
@@ -77,17 +74,12 @@ DIRECT_APPLY_TOOLS = [
     "create_stock_adjustment",
     "update_stock_adjustment",
     "delete_stock_adjustment",
-]
-
-# Tools still using the SendMessage rail (default, per ADR-0015). Tracked
-# for migration in #633.
-SEND_MESSAGE_APPLY_TOOLS = [
+    # Tools migrated from the SendMessage rail to the unified apply rail
+    # by ADR-0021.
     "receive_purchase_order",
     "create_stock_transfer",
     "fulfill_order",
 ]
-
-PREVIEW_BUTTON_TOOLS = DIRECT_APPLY_TOOLS + SEND_MESSAGE_APPLY_TOOLS
 
 
 @pytest.mark.parametrize("tool_name", PREVIEW_BUTTON_TOOLS)
@@ -95,7 +87,8 @@ def test_preview_button_tool_has_no_renarrate_coaching(
     registered_tools: dict[str, Any], tool_name: str
 ) -> None:
     """Every preview-button tool's description must include the
-    "do not re-narrate" coaching (closes #544). Required for both rails.
+    "do not re-narrate" coaching (closes #544). Required for all tools
+    that emit a Prefab preview card.
     """
     tool = registered_tools[tool_name]
     description = tool.description or ""
@@ -106,40 +99,25 @@ def test_preview_button_tool_has_no_renarrate_coaching(
     )
 
 
-@pytest.mark.parametrize("tool_name", SEND_MESSAGE_APPLY_TOOLS)
-def test_send_message_apply_tool_has_apply_call_coaching(
+@pytest.mark.parametrize("tool_name", PREVIEW_BUTTON_TOOLS)
+def test_preview_button_tool_has_update_model_context_coaching(
     registered_tools: dict[str, Any], tool_name: str
 ) -> None:
-    """SendMessage-rail tools must coach the agent to recognize the
-    ``Apply: call <tool>(...)`` chat hint and re-issue.
-    """
-    tool = registered_tools[tool_name]
-    description = tool.description or ""
-    assert "Apply: call" in description, (
-        f"{tool_name}: missing 'Apply: call' coaching — agent will not "
-        f"recognize the Confirm-button SendMessage and re-issue the call. "
-        f"Wire via with_preview_coaching() (direct=False) in register_tools."
-    )
-
-
-@pytest.mark.parametrize("tool_name", DIRECT_APPLY_TOOLS)
-def test_direct_apply_tool_has_update_model_context_coaching(
-    registered_tools: dict[str, Any], tool_name: str
-) -> None:
-    """Direct-apply-rail tools must coach the agent that the apply result
-    arrives via ``ui/update-model-context``, not via re-issue.
+    """Every preview-button tool must coach the agent that the apply
+    result arrives via ``ui/update-model-context`` (post-ADR-0021 unified
+    rail), not via agent re-issue.
     """
     tool = registered_tools[tool_name]
     description = tool.description or ""
     assert "ui/update-model-context" in description, (
         f"{tool_name}: missing 'ui/update-model-context' coaching — agent "
         f"won't know to expect the apply result via the iframe context push. "
-        f"Wire via with_preview_coaching(direct=True) in register_tools."
+        f"Wire via with_preview_coaching() in register_tools."
     )
     assert "Do NOT re-issue" in description, (
         f"{tool_name}: missing 'Do NOT re-issue' coaching — agent may "
         f"incorrectly re-issue after the iframe already applied. "
-        f"Wire via with_preview_coaching(direct=True) in register_tools."
+        f"Wire via with_preview_coaching() in register_tools."
     )
 
 
@@ -174,13 +152,8 @@ def test_read_only_tools_do_not_have_coaching(
         if name not in registered_tools:
             continue
         description = registered_tools[name].description or ""
-        assert "Apply: call" not in description, (
-            f"{name}: read-only tool unexpectedly carries the preview→apply "
-            f"coaching. The coaching should only be on tools that emit a "
-            f"Prefab preview card with Confirm/Cancel buttons."
-        )
         assert "ui/update-model-context" not in description, (
-            f"{name}: read-only tool unexpectedly carries the direct-apply "
+            f"{name}: read-only tool unexpectedly carries the apply-rail "
             f"coaching. The coaching should only be on tools that emit a "
             f"Prefab preview card with Confirm/Cancel buttons."
         )


### PR DESCRIPTION
## Summary

Migrates the preview→apply card's Confirm and Cancel buttons off the `SendMessage` rail (ADR-0015) onto the unified direct-apply rail (ADR-0021):

- **Confirm** now fires `CallTool(<apply_tool>, arguments={...orig_args, preview: False}, on_success=[..., UpdateContext($result)], on_error=[..., UpdateContext("Apply failed: $error")])`. The iframe makes the apply call directly and `ui/update-model-context` (SEP-1865) delivers the structured response into the agent's context for its next turn — no chat round-trip.
- **Cancel** now fires `UpdateContext("User cancelled the <description> preview.")` + `SetState("cancelled", True)`. No more `"Cancel: do not apply ..."` chat line.

This is the architectural follow-up to #807, which migrated drill-in / view-in-Katana / open-ended SendMessage uses across `prefab_ui.py` to the same primitives. After this PR there is no longer a `_build_apply_action_direct` / `_build_apply_action` split — both collapse into a single `_build_apply_action`. `_render_apply_button_row` loses its `direct_apply` flag, `register_preview_tool` / `with_preview_coaching` lose their `direct=` flag, and the dual `PREVIEW_APPLY_DIRECT_COACHING` constant is removed (one coaching variant now).

### Files affected

- `katana_mcp_server/src/katana_mcp/tools/prefab_ui.py` — apply/cancel action builders, button row renderer, coaching constants.
- `katana_mcp_server/src/katana_mcp/resources/help.py` — `katana://help/tools` agent guidance section.
- `katana_mcp_server/src/katana_mcp/tools/foundation/*.py` — drop `direct=True` arg from `register_preview_tool` callers (no longer recognized).
- `katana_mcp_server/tests/test_prefab_ui.py` — `TestConfirmButtonEmitsApplyMessage` → `TestConfirmButtonEmitsCallTool`; `TestCancelButtonEmitsCancelMessage` → `TestCancelButtonEmitsUpdateContext`; xor-invariant test updated to assert `CallTool.arguments` instead of `Apply: call ...` text.
- `katana_mcp_server/tests/test_tool_descriptions_and_annotations.py` — collapsed `SEND_MESSAGE_APPLY_TOOLS` / `DIRECT_APPLY_TOOLS` lists into a single `PREVIEW_BUTTON_TOOLS` list.

### ADRs

- **ADR-0021** (new, `katana_mcp_server/docs/adr/`) documents the unified rail and the SEP-1865 spec change that made it possible.
- **ADR-0015** is marked Superseded with a header pointing at ADR-0021. The body (and its `destructiveHint` policy table) is preserved verbatim — the policy still carries forward.

### UX preservation

The user-visible flow is unchanged: button labels still say "Confirm X" / "Cancel"; pending → applied → error → cancelled state machine identical. Only the underlying action primitive changed.

### #807 conflict watch

PR #807 is open against `main` and also touches `prefab_ui.py`. The apply/cancel rail functions (`_build_apply_action`, `_build_cancel_action`, `_render_apply_button_row`) don't overlap with #807's drill-in changes. No conflicts encountered branching off the same `origin/main` SHA.

## Test plan

- [x] `uv run pyright katana_mcp_server/src/katana_mcp/tools/prefab_ui.py` — 0 errors
- [x] `uv run pytest katana_mcp_server/tests/` — 237 prefab UI tests + 73 tool-description tests pass
- [x] `uv run poe check` — 3531 passed, 2 skipped (browser tests skipped — no browser installed in worktree)
- [ ] CI green