### PR TITLE
fix(mcp): manage_product_bom commits every row in batch — close #809

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/bom.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/bom.py
@@ -404,11 +404,20 @@ def _build_update_bom_row_request(patch: BomRowUpdate) -> APIUpdateBomRowRequest
 
 
 def _make_create_bom_row_apply(services: Any, body: APICreateBomRowRequest):
-    async def apply() -> BomRow:
+    async def apply() -> None:
+        # ``POST /bom_rows`` returns 204 No Content per Katana's spec — no
+        # response body to parse. The previous ``unwrap_as(response, BomRow)``
+        # call raised ``APIError`` on every successful create because
+        # ``unwrap`` treated ``parsed is None`` as an error regardless of
+        # status, fail-fast halted the plan, and a multi-row batch silently
+        # became a 1-row commit (#809). Mirror ``_make_delete_bom_row_apply``:
+        # confirm 2xx, otherwise let ``unwrap`` raise the typed error.
         response = await api_create_bom_row.asyncio_detailed(
             client=services.client, body=body
         )
-        return unwrap_as(response, BomRow)
+        if not is_success(response):
+            unwrap(response)
+        return None
 
     return apply
 

--- a/katana_mcp_server/tests/tools/test_bom.py
+++ b/katana_mcp_server/tests/tools/test_bom.py
@@ -313,7 +313,13 @@ async def test_manage_bom_apply_populates_prior_state_from_snapshot():
 
 @pytest.mark.asyncio
 async def test_manage_bom_apply_calls_create_for_each_add():
-    """Confirm mode executes per-action POST /bom_rows for each add."""
+    """Confirm mode executes per-action POST /bom_rows for each add.
+
+    Katana's ``POST /bom_rows`` returns 204 No Content — no body. The
+    apply closure (post-#809) confirms 2xx via ``is_success`` and does
+    not try to parse a row. The mock response carries ``status_code=204``
+    so ``is_success`` returns True without touching ``response.parsed``.
+    """
     context, lifespan = create_mock_context()
     lifespan.typed_cache.catalog.get_many_by_ids = AsyncMock(
         return_value={
@@ -321,14 +327,13 @@ async def test_manage_bom_apply_calls_create_for_each_add():
         }
     )
 
-    new_row = _bom_row()
-
     captured_bodies: list = []
 
     async def fake_create(*, client, body):
         captured_bodies.append(body)
         resp = MagicMock()
-        resp.parsed = new_row
+        resp.status_code = 204
+        resp.parsed = None
         return resp
 
     with (
@@ -340,10 +345,6 @@ async def test_manage_bom_apply_calls_create_for_each_add():
         patch(
             "katana_mcp.tools.foundation.bom.api_create_bom_row.asyncio_detailed",
             side_effect=fake_create,
-        ),
-        patch(
-            "katana_mcp.tools.foundation.bom.unwrap_as",
-            return_value=new_row,
         ),
     ):
         request = ManageProductBomRequest(
@@ -364,6 +365,70 @@ async def test_manage_bom_apply_calls_create_for_each_add():
     assert captured_bodies[0].product_variant_id == 200
     assert captured_bodies[0].ingredient_variant_id == 301
     assert captured_bodies[1].ingredient_variant_id == 302
+
+
+@pytest.mark.asyncio
+async def test_manage_bom_apply_commits_all_rows_against_204_transport():
+    """Regression for #809: ``POST /bom_rows`` returns 204 No Content per the
+    Katana spec. The generated ``_parse_response`` matches the 204 branch,
+    sets ``response.parsed = None``, and the previous ``unwrap_as(response,
+    BomRow)`` then raised ``APIError`` because ``unwrap`` treated
+    ``parsed is None`` as an error regardless of status. Fail-fast halted
+    the plan after the first row, so a 30-row batch silently became a
+    1-row commit in Katana.
+
+    This test drives a real :class:`KatanaClient` against an ``httpx.MockTransport``
+    that returns 204 on every POST — exactly mirroring production — and
+    asserts all rows in the batch run.
+    """
+    import httpx
+
+    from katana_public_api_client import KatanaClient
+
+    posts_served: list[bytes] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith("/bom_rows") and req.method == "POST":
+            posts_served.append(req.content)
+            return httpx.Response(204)
+        return httpx.Response(404, json={"error": "unexpected route"})
+
+    async with KatanaClient(
+        api_key="test-key",
+        base_url="https://api.example.com",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        context, lifespan = create_mock_context()
+        lifespan.client = client
+        lifespan.typed_cache.catalog.get_many_by_ids = AsyncMock(
+            return_value={
+                200: _mock_variant(id=200, sku="SP0502", product_id=17092695),
+            }
+        )
+
+        with patch(
+            "katana_mcp.tools.foundation.bom._fetch_bom_row_infos",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            request = ManageProductBomRequest(
+                id=200,
+                add_bom_rows=[
+                    BomRowAdd(ingredient_variant_id=300 + i, quantity=1.0)
+                    for i in range(5)
+                ],
+                preview=False,
+            )
+            response = await _modify_product_bom_impl(request, context)
+
+    assert len(posts_served) == 5, (
+        f"Only {len(posts_served)} of 5 POSTs reached Katana — "
+        "apply loop halted after the first row (regression of #809)."
+    )
+    assert len(response.actions) == 5
+    assert all(a.succeeded is True for a in response.actions), (
+        f"Some actions failed: {[(a.operation, a.error) for a in response.actions]}"
+    )
 
 
 @pytest.mark.asyncio

--- a/katana_public_api_client/utils.py
+++ b/katana_public_api_client/utils.py
@@ -267,6 +267,20 @@ def unwrap[T](
         ```
     """
     if response.parsed is None:
+        # 2xx + empty body is a legitimate no-content success (Katana
+        # uses 204 for ``POST /bom_rows`` and most DELETEs). The previous
+        # behavior raised ``APIError`` here, which broke every per-row
+        # apply against a no-body endpoint (#809). Callers that need a
+        # body should keep using ``unwrap_as`` (raises on None).
+        #
+        # 2xx + *non-empty* body falls through to the error path on
+        # purpose: ``parsed`` is None there because ``_parse_response``
+        # didn't recognize the status (e.g. the server starts returning
+        # 201 after an API change but the spec still declares 204). The
+        # body is present and unparsed — raising surfaces the schema
+        # drift instead of silently dropping the response.
+        if is_success(response) and not response.content:
+            return None
         if not raise_on_error:
             return None
         name, message, parsed_error = _try_parse_error_body(response.content)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,13 +35,70 @@ class TestUnwrap:
         assert result == webhook_data
         assert isinstance(result, WebhookListResponse)
 
-    def test_unwrap_with_none_parsed_raises_error(self):
-        """Test that unwrap raises APIError when parsed is None.
-
-        Empty body falls back to the "<empty response body>" placeholder.
+    def test_unwrap_returns_none_for_2xx_with_no_body(self):
+        """A 2xx success with ``parsed=None`` is a legitimate 204 No Content
+        response (most Katana POST/PATCH endpoints use this shape), not an
+        error. Regression for #809: the previous behavior incorrectly raised
+        ``APIError`` here, which broke every per-row apply on no-body
+        endpoints — a 30-row BOM batch silently became a 1-row commit
+        because the first 204 raised and fail-fast halted the rest.
         """
         response: Response[Any] = Response(
-            status_code=HTTPStatus.OK,
+            status_code=HTTPStatus.NO_CONTENT,
+            content=b"",
+            headers={},
+            parsed=None,
+        )
+
+        result = utils.unwrap(response)
+
+        assert result is None
+
+    def test_unwrap_returns_none_on_204_even_with_raise_on_error_false(self):
+        """``raise_on_error=False`` is the legacy path; 2xx + parsed=None
+        still returns None cleanly without consulting the error parser.
+        """
+        response: Response[Any] = Response(
+            status_code=HTTPStatus.NO_CONTENT,
+            content=b"",
+            headers={},
+            parsed=None,
+        )
+
+        result = utils.unwrap(response, raise_on_error=False)
+
+        assert result is None
+
+    def test_unwrap_raises_on_2xx_with_non_empty_body_and_parsed_none(self):
+        """A 2xx with a non-empty body but ``parsed=None`` is the schema-drift
+        signal: ``_parse_response`` didn't recognize the status (e.g. the
+        server starts returning 201 with a body after an API change, but
+        the spec still declares 204). Returning None there would silently
+        drop the response and let downstream callers crash on ``.id``
+        access; raising surfaces the drift instead.
+        """
+        body = b'{"id": 42, "name": "unexpected response shape"}'
+        response: Response[Any] = Response(
+            status_code=HTTPStatus(200),
+            content=body,
+            headers={},
+            parsed=None,
+        )
+
+        with pytest.raises(utils.APIError) as exc_info:
+            utils.unwrap(response)
+
+        assert exc_info.value.status_code == 200
+
+    def test_unwrap_raises_on_non_2xx_with_parsed_none(self):
+        """When the status is an error code and ``parsed`` is None
+        (undocumented status, malformed body, etc.), the routing helper
+        still raises ``APIError`` — this is the path the previous
+        ``test_unwrap_with_none_parsed_raises_error`` was actually
+        exercising for 4xx/5xx errors. Pin the behavior explicitly.
+        """
+        response: Response[Any] = Response(
+            status_code=HTTPStatus(418),
             content=b"",
             headers={},
             parsed=None,
@@ -52,21 +109,7 @@ class TestUnwrap:
 
         error = exc_info.value
         assert isinstance(error, utils.APIError)
-        assert "<empty response body>" in str(error)
-        assert error.status_code == 200
-
-    def test_unwrap_with_none_parsed_returns_none_when_not_raising(self):
-        """Test that unwrap returns None when parsed is None and raise_on_error=False."""
-        response: Response[Any] = Response(
-            status_code=HTTPStatus.OK,
-            content=b"{}",
-            headers={},
-            parsed=None,
-        )
-
-        result = utils.unwrap(response, raise_on_error=False)
-
-        assert result is None
+        assert error.status_code == 418
 
     def test_unwrap_undocumented_status_surfaces_body(self):
         """Undocumented status codes (e.g. 412) parse the raw body and surface


### PR DESCRIPTION
## Summary

Closes #809 — `manage_product_bom` was silently committing only the first row of a multi-row `add_bom_rows` plan. Surfaced during the Mayhem 140 pilot session: 30+29+3+2 row batches all became 1+1+1+1 actual commits in Katana, with no FAILED action surfaced to the user.

### Root cause (two layers)

`POST /bom_rows` returns **204 No Content** per Katana's spec — no response body. Two bugs conspired:

1. **`katana_public_api_client.utils.unwrap`** raised `APIError` whenever `response.parsed is None`, regardless of status. 2xx with no body is legitimate 204 success — the error router fell through to the catch-all `APIError` branch because 204 doesn't match any of 401 / 422 / 429 / 5xx.
2. **`_make_create_bom_row_apply`** wrapped the call as `unwrap_as(response, BomRow)` — expected a row body the spec says doesn't exist.

Result: every successful POST raised `APIError` → `execute_plan`'s fail-fast halted the loop → rows 2..N never reached Katana.

### Fixes

- **`unwrap`** now returns `None` cleanly on any 2xx + `parsed=None`, regardless of `raise_on_error`. Non-2xx unparsed responses still route through `_raise_for_status`. Both branches pinned by tests.
- **`_make_create_bom_row_apply`** mirrors `_make_delete_bom_row_apply`: confirm 2xx via `is_success`, otherwise propagate the typed error via `unwrap`. Returns `None` since there's no row body.
- **New regression test** drives a real `KatanaClient` against an `httpx.MockTransport` returning 204 — production-fidelity. Without the fix the assertion catches "only 1 of 5 POSTs reached Katana"; with the fix all 5 land.

### Audit (the "are other entity updates affected?" follow-up)

Of the 47 generated endpoints with 204-only success branches, only **2** are wrapped by MCP write paths:
- `create_bom_row` (this fix)
- `receive_purchase_order` (already uses the correct `is_success` + `unwrap` pattern in both callsites — `purchase_orders.py:886` and `corrections.py:1471`)

All 10 generic `make_post_apply` callsites target endpoints that return 200/201 with body — unaffected.

### Commit scope note

The user-facing bug is MCP-side (#809), so this commit uses `fix(mcp):`. But the underlying SDK fix in `katana_public_api_client/utils.py` is the broader correctness change — any future caller hitting a 204 endpoint benefits. If a separate `fix(client):` release is desired, the commit splits cleanly along package lines (utils.py + tests/test_utils.py for the SDK; bom.py + test_bom.py for the MCP).

## Test plan

- [x] `uv run poe agent-check` — lint + type-check + fast tests pass
- [x] `uv run poe test` — all 3535 tests pass
- [x] `uv run poe check` — full suite (browser tests skip in this env, expected)
- [x] New `test_manage_bom_apply_commits_all_rows_against_204_transport` exercises the production code path end-to-end via real `KatanaClient` + `httpx.MockTransport`
- [ ] Real-world: re-run a multi-row `manage_product_bom` apply in the Mayhem 140 pilot and confirm all rows commit (validates the dev MCP redeploys this code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)