### PR TITLE
feat(mcp): add create_customer tool with per-entity Prefab card

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -84,6 +84,11 @@ Manufacturing ERP tools for inventory, orders, and production management.
 - **list_serial_numbers** - List serial numbers, optionally scoped by `resource_type` and/or `resource_id`. Diagnostic / lookup tool — use to verify which strings are attached to an MO before fulfillment.
 - **delete_serial_numbers** - Detach serial numbers from a resource. Idempotent (Katana returns 204 even for invalid ids). (preview/apply, destructive)
 
+### Customers
+- **search_customers** - Fuzzy-search customers by name / email. Use for `customer_id` lookups on sales orders.
+- **get_customer** - Full-detail customer record by id (contact fields, currency, default discount, addresses).
+- **create_customer** - Create a new customer (preview/apply). Use for non-Shopify channels (eBay, Amazon, etc.) where buyers don't pre-exist. Cache write-through on apply — `search_customers` sees the new record immediately.
+
 ### Reference Data
 - **list_locations** - List or fuzzy-search warehouses and facilities (id, name, address, primary flag). Use for `location_id` lookups on orders and inventory queries. Supports `query`, `limit`
 - **list_suppliers** - List or fuzzy-search suppliers by name/code (id, name, email, phone, currency, code). Use for `supplier_id` / `default_supplier_id` on POs and materials. Supports `query`, `limit`
@@ -1279,6 +1284,36 @@ Get full details for a customer by ID.
 - `customer_id` (required): Customer ID
 
 **Returns:** Full customer details (name, email, phone, currency, category, comment).
+
+---
+
+### create_customer
+Create a new customer record. Two-step preview/apply flow with a card-rendered
+preview. Use for non-Shopify channels (eBay, Amazon, Etsy, direct-website)
+where buyers don't pre-exist in Katana — Shopify-synced workflows usually see
+the customer arrive on their own.
+
+**Parameters:**
+- `name` (required): Display name shown in Katana and on documents
+- `first_name`, `last_name` (optional): For individual contacts
+- `company` (optional): Company name for business accounts
+- `email`, `phone` (optional): Contact details
+- `currency` (optional): ISO 4217 code (USD, EUR, GBP, ...)
+- `comment` (optional): Internal notes (not shown to the customer)
+- `reference_id` (optional): External reference (e.g., the customer's ID in
+  another system)
+- `category` (optional): Free-form segmentation label
+- `discount_rate` (optional): Default percentage discount on orders (0-100)
+- `addresses` (optional): List of `{entity_type: "billing"|"shipping",
+  first_name, last_name, company, phone, line_1, line_2, city, state, zip,
+  country}` items
+- `preview` (default `true`): If true, returns a preview card; if false,
+  creates the customer
+
+**Returns:** Created customer summary (id, name, contact fields, currency,
+addresses snapshot, katana_url) plus next-action coaching. On apply, the
+new record writes through to the typed cache so a follow-up
+`search_customers` returns it immediately — no `rebuild_cache` needed.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
@@ -1,25 +1,33 @@
 """Customer management tools for Katana MCP Server.
 
-Foundation tools for searching and looking up customer records. Customers
-can grow to thousands and contain PII, so they are served via search tools
-rather than exposed as a resource.
+Foundation tools for searching, looking up, and creating customer records.
+Customers can grow to thousands and contain PII, so reads go through search
+tools rather than a resource; writes follow the standard preview/apply
+pattern with cache write-through so the new record surfaces in
+``search_customers`` immediately.
 """
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
 from pydantic import BaseModel, ConfigDict, Field
 
-from katana_mcp.logging import observe_tool
+from katana_mcp.logging import get_logger, observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.decorators import cache_read
-from katana_mcp.tools.tool_result_utils import make_json_result
+from katana_mcp.tools.tool_result_utils import (
+    UI_META,
+    make_json_result,
+    make_tool_result,
+)
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
 from katana_public_api_client.models_pydantic._generated import CachedCustomer
+
+logger = get_logger(__name__)
 
 # ============================================================================
 # Tool 1: search_customers
@@ -325,9 +333,452 @@ async def get_customer(
     return make_json_result(response)
 
 
+# ============================================================================
+# Tool 3: create_customer
+# ============================================================================
+
+
+AddressEntityType = Literal["billing", "shipping"]
+
+
+class CreateCustomerAddressRequest(BaseModel):
+    """One address (billing or shipping) to attach to the new customer.
+
+    Mirrors the shape of ``CreateCustomerRequest.addresses[*]`` in the
+    Katana OpenAPI spec — fields are optional individually so a caller
+    can supply just the parts they know (e.g., a country-only address for
+    a record they'll flesh out later). ``entity_type`` is the only field
+    that's effectively required for the address to be useful, since the
+    card and Katana both differentiate billing from shipping.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    entity_type: AddressEntityType = Field(
+        ...,
+        description="'billing' or 'shipping'. Drives both card layout and Katana's address routing.",
+    )
+    first_name: str | None = Field(default=None)
+    last_name: str | None = Field(default=None)
+    company: str | None = Field(default=None)
+    phone: str | None = Field(default=None)
+    line_1: str | None = Field(default=None, description="Street address line 1")
+    line_2: str | None = Field(default=None, description="Street address line 2")
+    city: str | None = Field(default=None)
+    state: str | None = Field(default=None, description="State / province / region")
+    zip: str | None = Field(default=None, description="Postal code")
+    country: str | None = Field(default=None)
+
+
+class CreateCustomerRequest(BaseModel):
+    """Request to create a new customer.
+
+    Mirrors ``CreateCustomerRequest`` in ``docs/katana-openapi.yaml`` — ``name``
+    is the only required field; everything else is optional. Use individual
+    ``first_name`` / ``last_name`` for personal contacts; use ``company`` for
+    business accounts (and typically populate ``name`` to mirror the company
+    name).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(
+        ...,
+        description=(
+            "Display name shown in the Katana UI and on documents. For an "
+            "individual contact, use the person's full name; for a business "
+            "account, mirror the company name."
+        ),
+    )
+    first_name: str | None = Field(default=None)
+    last_name: str | None = Field(default=None)
+    company: str | None = Field(default=None)
+    email: str | None = Field(default=None)
+    phone: str | None = Field(default=None)
+    comment: str | None = Field(
+        default=None,
+        description="Internal notes about the customer (not shown to them).",
+    )
+    currency: str | None = Field(
+        default=None,
+        description="ISO 4217 currency code (e.g., USD, EUR, GBP).",
+    )
+    reference_id: str | None = Field(
+        default=None,
+        description="External reference (e.g., the customer's ID in another system).",
+    )
+    category: str | None = Field(
+        default=None,
+        description="Free-form category label for segmentation/reporting.",
+    )
+    discount_rate: float | None = Field(
+        default=None,
+        ge=0,
+        le=100,
+        description="Default percentage discount on this customer's orders (0-100).",
+    )
+    addresses: list[CreateCustomerAddressRequest] = Field(
+        default_factory=list,
+        description=(
+            "Billing and/or shipping addresses. Optional — addresses can be "
+            "added or edited later via Katana's UI."
+        ),
+    )
+    preview: bool = Field(
+        default=True,
+        description="If true (default), returns a preview. If false, creates the customer.",
+    )
+
+
+class CreateCustomerAddressSnapshot(BaseModel):
+    """Address fields surfaced in the create-customer response card.
+
+    Mirrors :class:`CreateCustomerAddressRequest`'s shape on the response
+    side. ``id``/``default`` are populated on the apply branch when Katana
+    returns them — useful for callers that want to identify the
+    server-assigned default address on a multi-address create.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    entity_type: AddressEntityType | None = None
+    id: int | None = None
+    default: bool | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+    company: str | None = None
+    phone: str | None = None
+    line_1: str | None = None
+    line_2: str | None = None
+    city: str | None = None
+    state: str | None = None
+    zip: str | None = None
+    country: str | None = None
+
+
+class CreateCustomerResponse(BaseModel):
+    """Response from creating (or previewing the creation of) a customer.
+
+    Field set is tuned for what the create card needs to render plus the
+    identity / timestamp fields Katana returns on the apply branch.
+    Server-generated fields (``id``, ``katana_url``, ``default_*_id``,
+    timestamps) populate only on the apply branch.
+    """
+
+    id: int | None = None
+    katana_url: str | None = None
+    name: str
+    first_name: str | None = None
+    last_name: str | None = None
+    company: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    comment: str | None = None
+    currency: str | None = None
+    reference_id: str | None = None
+    category: str | None = None
+    discount_rate: float | None = None
+    default_billing_id: int | None = None
+    default_shipping_id: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    addresses: list[CreateCustomerAddressSnapshot] = Field(default_factory=list)
+    is_preview: bool
+    warnings: list[str] = Field(default_factory=list)
+    next_actions: list[str] = Field(default_factory=list)
+    message: str
+
+
+def _customer_response_to_tool_result(
+    response: CreateCustomerResponse,
+    *,
+    request: CreateCustomerRequest,
+) -> ToolResult:
+    """Convert a ``CreateCustomerResponse`` to a ``ToolResult`` with a Prefab UI.
+
+    The preview branch wires the direct-apply rail (Confirm fires
+    ``tools/call`` directly and pushes the structured result back to the
+    agent via ``ui/update-model-context``). Same shape as
+    ``_po_response_to_tool_result`` in ``purchase_orders.py``.
+    """
+    from katana_mcp.tools.prefab_ui import build_customer_create_ui
+
+    ui = build_customer_create_ui(
+        response.model_dump(mode="json"),
+        confirm_request=request,
+        confirm_tool="create_customer",
+    )
+    return make_tool_result(response, ui=ui)
+
+
+def _addresses_snapshot(
+    addresses: list[CreateCustomerAddressRequest],
+) -> list[CreateCustomerAddressSnapshot]:
+    """Project request-side addresses onto the response-side snapshot.
+
+    Used by the preview branch (no API call yet) and as the apply-branch
+    fallback when the server doesn't echo addresses on the response.
+    """
+    return [CreateCustomerAddressSnapshot(**addr.model_dump()) for addr in addresses]
+
+
+def _addresses_from_attrs(server_addresses: Any) -> list[CreateCustomerAddressSnapshot]:
+    """Project the API ``Customer.addresses`` list (attrs) onto the snapshot.
+
+    Used on the apply branch when the server echoes addresses on the
+    response — preferred over :func:`_addresses_snapshot` because the
+    server-side values reflect Katana's normalization (uppercased country
+    codes, trimmed whitespace) and carry the server-assigned ``id`` /
+    ``default`` flag the operator may want to reference next.
+
+    The attrs ``CustomerAddress.entity_type`` is an enum
+    (:class:`AddressEntityType`); ``.value`` extracts the wire string.
+    The attrs ``zip_`` field maps to the wire / snapshot name ``zip``.
+    """
+    from katana_public_api_client.domain.converters import unwrap_unset
+
+    snapshots: list[CreateCustomerAddressSnapshot] = []
+    for addr in server_addresses:
+        entity_type_attr = unwrap_unset(addr.entity_type, None)
+        entity_type_value: AddressEntityType | None = None
+        if entity_type_attr is not None:
+            value = getattr(entity_type_attr, "value", entity_type_attr)
+            if value in ("billing", "shipping"):
+                entity_type_value = value
+        snapshots.append(
+            CreateCustomerAddressSnapshot(
+                entity_type=entity_type_value,
+                id=unwrap_unset(addr.id, None),
+                default=unwrap_unset(addr.default, None),
+                first_name=unwrap_unset(addr.first_name, None),
+                last_name=unwrap_unset(addr.last_name, None),
+                company=unwrap_unset(addr.company, None),
+                phone=unwrap_unset(addr.phone, None),
+                line_1=unwrap_unset(addr.line_1, None),
+                line_2=unwrap_unset(addr.line_2, None),
+                city=unwrap_unset(addr.city, None),
+                state=unwrap_unset(addr.state, None),
+                zip=unwrap_unset(addr.zip_, None),
+                country=unwrap_unset(addr.country, None),
+            )
+        )
+    return snapshots
+
+
+async def _create_customer_impl(
+    request: CreateCustomerRequest, context: Context
+) -> CreateCustomerResponse:
+    """Implementation of the ``create_customer`` tool.
+
+    Preview branch: no API call — echoes the request fields into a
+    response shape the card can render verbatim. Apply branch: POSTs to
+    ``/customers``, unwraps the response into the typed ``Customer``
+    attrs model, then merges the freshly-created row into the typed cache
+    via :func:`merge_filtered_fetch` so a follow-up ``search_customers``
+    call returns it without a ``rebuild_cache`` round-trip.
+    """
+    from katana_public_api_client.client_types import UNSET
+    from katana_public_api_client.domain.converters import to_unset, unwrap_unset
+    from katana_public_api_client.models import (
+        AddressEntityType as APIAddressEntityType,
+        CreateCustomerRequest as APICreateCustomerRequest,
+        CreateCustomerRequestAddressesItem as APIAddressItem,
+        Customer as APICustomer,
+    )
+    from katana_public_api_client.utils import unwrap_as
+
+    # Validate before logging — a whitespace-only name shouldn't surface
+    # as a noisy `Previewing customer '   '` line followed by the raise.
+    if not request.name.strip():
+        raise ValueError("Customer name cannot be empty")
+
+    logger.info(
+        "customer_create_started",
+        preview=request.preview,
+        name=request.name,
+    )
+
+    if request.preview:
+        return CreateCustomerResponse(
+            name=request.name,
+            first_name=request.first_name,
+            last_name=request.last_name,
+            company=request.company,
+            email=request.email,
+            phone=request.phone,
+            comment=request.comment,
+            currency=request.currency,
+            reference_id=request.reference_id,
+            category=request.category,
+            discount_rate=request.discount_rate,
+            addresses=_addresses_snapshot(request.addresses),
+            is_preview=True,
+            warnings=[],
+            next_actions=[
+                "Review the customer details",
+                "Set preview=false to create the customer",
+            ],
+            message=(
+                f"Preview: customer {request.name} ready to create"
+                + (
+                    f" with {len(request.addresses)} address(es)"
+                    if request.addresses
+                    else ""
+                )
+            ),
+        )
+
+    services = get_services(context)
+
+    # Build the API attrs request. ``to_unset`` maps ``None`` → ``UNSET`` for
+    # every optional field so unset values don't ship as explicit nulls
+    # (which Katana treats as "clear this field" on update, but on create
+    # the server is forgiving; we still send the minimal payload for
+    # parity with the rest of the codebase).
+    address_items: list[APIAddressItem] | Any = UNSET
+    if request.addresses:
+        address_items = [
+            APIAddressItem(
+                entity_type=APIAddressEntityType(addr.entity_type),
+                first_name=to_unset(addr.first_name),
+                last_name=to_unset(addr.last_name),
+                company=to_unset(addr.company),
+                phone=to_unset(addr.phone),
+                line_1=to_unset(addr.line_1),
+                line_2=to_unset(addr.line_2),
+                city=to_unset(addr.city),
+                state=to_unset(addr.state),
+                zip_=to_unset(addr.zip),
+                country=to_unset(addr.country),
+            )
+            for addr in request.addresses
+        ]
+
+    api_request = APICreateCustomerRequest(
+        name=request.name,
+        first_name=to_unset(request.first_name),
+        last_name=to_unset(request.last_name),
+        company=to_unset(request.company),
+        email=to_unset(request.email),
+        phone=to_unset(request.phone),
+        comment=to_unset(request.comment),
+        currency=to_unset(request.currency),
+        reference_id=to_unset(request.reference_id),
+        category=to_unset(request.category),
+        discount_rate=to_unset(request.discount_rate),
+        addresses=address_items,
+    )
+
+    from katana_public_api_client.api.customer import (
+        create_customer as api_create_customer,
+    )
+
+    response = await api_create_customer.asyncio_detailed(
+        client=services.client, body=api_request
+    )
+    customer = unwrap_as(response, APICustomer)
+    logger.info("customer_create_succeeded", customer_id=customer.id)
+
+    # Prefer the API's echoed addresses (Katana's normalized values +
+    # server-assigned ``id`` / ``default`` flag) over the request snapshot;
+    # fall back to the request snapshot only when the field is UNSET
+    # (``unwrap_unset`` → None). An echoed ``addresses: []`` is the
+    # server's authoritative "no addresses persisted" — render it as
+    # such, don't override with the request snapshot.
+    server_addresses = unwrap_unset(customer.addresses, None)
+    if server_addresses is not None:
+        addresses_snapshot = _addresses_from_attrs(server_addresses)
+    else:
+        addresses_snapshot = _addresses_snapshot(request.addresses)
+
+    warnings: list[str] = []
+    # Write the freshly-created customer through to the typed cache so a
+    # follow-up ``search_customers`` returns it without ``rebuild_cache``.
+    # ``merge_filtered_fetch`` does not advance the sync watermark — exactly
+    # right here: the next incremental sync will pull this same row plus
+    # anything else that's changed.
+    #
+    # Cache-merge failure must NOT raise: the customer already exists in
+    # Katana, so re-raising would push the operator into retrying and
+    # creating a duplicate (Katana doesn't enforce name uniqueness).
+    # Degrade to a warning; the next incremental sync recovers the row.
+    from katana_mcp.typed_cache.sync import ENTITY_SPECS, merge_filtered_fetch
+
+    try:
+        await merge_filtered_fetch(
+            services.typed_cache, ENTITY_SPECS["customer"], [customer]
+        )
+    except Exception as merge_err:
+        logger.warning(
+            "create_customer.cache_merge_failed",
+            customer_id=customer.id,
+            error=str(merge_err),
+        )
+        warnings.append(
+            f"Customer created in Katana (ID {customer.id}), but the local cache "
+            f"write-through failed ({merge_err}). The customer will appear in "
+            "search_customers after the next incremental sync; do not retry the "
+            "create call or you will create a duplicate."
+        )
+
+    return CreateCustomerResponse(
+        id=customer.id,
+        katana_url=katana_web_url("customer", customer.id),
+        name=unwrap_unset(customer.name, request.name),
+        first_name=unwrap_unset(customer.first_name, request.first_name),
+        last_name=unwrap_unset(customer.last_name, request.last_name),
+        company=unwrap_unset(customer.company, request.company),
+        email=unwrap_unset(customer.email, request.email),
+        phone=unwrap_unset(customer.phone, request.phone),
+        comment=unwrap_unset(customer.comment, request.comment),
+        currency=unwrap_unset(customer.currency, request.currency),
+        reference_id=unwrap_unset(customer.reference_id, request.reference_id),
+        category=unwrap_unset(customer.category, request.category),
+        discount_rate=unwrap_unset(customer.discount_rate, request.discount_rate),
+        default_billing_id=unwrap_unset(customer.default_billing_id, None),
+        default_shipping_id=unwrap_unset(customer.default_shipping_id, None),
+        created_at=_iso_or_none(unwrap_unset(customer.created_at, None)),
+        updated_at=_iso_or_none(unwrap_unset(customer.updated_at, None)),
+        addresses=addresses_snapshot,
+        is_preview=False,
+        warnings=warnings,
+        next_actions=[
+            f"Customer created with ID {customer.id}",
+            "Use create_sales_order to draft an order for this customer",
+        ],
+        message=f"Successfully created customer {request.name} (ID: {customer.id})",
+    )
+
+
+@observe_tool
+@unpack_pydantic_params
+async def create_customer(
+    request: Annotated[CreateCustomerRequest, Unpack()], context: Context
+) -> ToolResult:
+    """Create a new customer in Katana.
+
+    Two-step flow: ``preview=true`` (default) returns a preview card showing
+    the customer about to be created; ``preview=false`` actually creates it.
+    Use for non-Shopify channels (eBay, Amazon, Etsy, direct-website) where
+    buyers don't pre-exist in Katana — Shopify-synced workflows usually see
+    the customer arrive on their own.
+
+    Required: ``name`` (display name). Everything else is optional; pass
+    ``addresses=[{entity_type: "billing", line_1: "...", ...}]`` to attach
+    one or more billing / shipping addresses on the same call. ``currency``
+    should be an ISO 4217 code (USD, EUR, GBP, etc.). On apply, the new
+    record writes through to the typed cache so a follow-up
+    ``search_customers`` returns it immediately.
+    """
+    response = await _create_customer_impl(request, context)
+    return _customer_response_to_tool_result(response, request=request)
+
+
 def register_tools(mcp: FastMCP) -> None:
     """Register all customer tools with the FastMCP instance."""
     from mcp.types import ToolAnnotations
+
+    from katana_mcp.tools.prefab_ui import register_preview_tool
 
     _read = ToolAnnotations(
         readOnlyHint=True,
@@ -335,9 +786,19 @@ def register_tools(mcp: FastMCP) -> None:
         idempotentHint=True,
         openWorldHint=True,
     )
+    _create = ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, openWorldHint=True
+    )
 
     mcp.tool(tags={"customers", "read"}, annotations=_read)(search_customers)
     mcp.tool(tags={"customers", "read"}, annotations=_read)(get_customer)
+    register_preview_tool(
+        mcp,
+        create_customer,
+        tags={"customers", "write"},
+        annotations=_create,
+        meta=UI_META,
+    )
 
 
 __all__ = ["register_tools"]

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -3301,6 +3301,302 @@ def build_po_create_ui(
     return app
 
 
+def _render_address_block(label: str, address: dict[str, Any]) -> bool:
+    """Render one labeled multi-line address block (billing or shipping).
+
+    Surfaces the fields a user actually verifies before committing: who the
+    package is for (recipient name + company), the street lines, the city /
+    state / zip, the country, and the contact phone. Skips blank components
+    silently so a partial address (e.g. country-only) renders as one tight
+    block rather than five empty lines.
+
+    Returns ``True`` if the block rendered; ``False`` if every field
+    except ``entity_type`` was empty (caller can decide whether to skip
+    the whole address section).
+
+    Must be called inside a ``CardContent`` column block.
+    """
+    name_parts = [p for p in (address.get("first_name"), address.get("last_name")) if p]
+    recipient = " ".join(name_parts) if name_parts else None
+    company = address.get("company")
+    line_1 = address.get("line_1")
+    line_2 = address.get("line_2")
+    city = address.get("city")
+    state = address.get("state")
+    # Wire name is ``zip``; the attrs model exposes it as ``zip_`` but
+    # ``model_dump()`` emits the wire name, so we read ``zip`` here.
+    postal = address.get("zip")
+    country = address.get("country")
+    phone = address.get("phone")
+
+    street = ", ".join(p for p in (line_1, line_2) if p)
+    locality_parts: list[str] = []
+    if city:
+        locality_parts.append(city)
+    state_zip = " ".join(p for p in (state, postal) if p)
+    if state_zip:
+        locality_parts.append(state_zip)
+    locality = ", ".join(locality_parts)
+    country_phone = " • ".join(p for p in (country, phone) if p)
+
+    body_lines = [
+        line for line in (recipient, company, street, locality, country_phone) if line
+    ]
+    # Skip rendering entirely when every meaningful field is empty —
+    # otherwise the card surfaces a dangling "Billing Address:" label
+    # with no content underneath, which reads as broken.
+    if not body_lines:
+        return False
+    with Column(gap=0):
+        Text(content=f"{label}:")
+        for line in body_lines:
+            Text(content=f"  {line}")
+    return True
+
+
+def _addresses_are_equivalent(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    """Two addresses are equivalent if every user-visible field matches.
+
+    Compares the fields ``_render_address_block`` surfaces — entity_type is
+    irrelevant here (that's what's labelling each block), and server-side
+    fields (id, customer_id, timestamps) don't enter into "is the same
+    place" judgement.
+    """
+    keys = (
+        "first_name",
+        "last_name",
+        "company",
+        "phone",
+        "line_1",
+        "line_2",
+        "city",
+        "state",
+        "zip",
+        "country",
+    )
+    return all((a.get(k) or None) == (b.get(k) or None) for k in keys)
+
+
+def _render_customer_entity_view(
+    entity: dict[str, Any],
+    *,
+    changes: dict[str, Any] | None = None,
+) -> list[str]:
+    """Render the customer entity view (Tier 3 reference fields + addresses).
+
+    Shared shape with :func:`_render_po_entity_view`: a future
+    ``build_customer_modify_ui`` will pass ``changes`` to decorate each
+    scalar field with ``before → after``. ``changes`` is typed loosely as
+    ``dict[str, Any]`` for now because the modify-card framework's
+    ``FieldChangeView`` will land with #721's customer card; the
+    create-card path always passes ``changes=None``.
+
+    Customer cards skip Tier 2 metrics entirely — there's no money or count
+    aggregate worth promoting to a metric. The decision the operator makes
+    is "this person/company exists in our system," reviewed via the Tier 3
+    fields directly.
+
+    Returns the block-warning list (always empty for now; reserved for
+    future business-rule blocks such as duplicate-email warnings).
+
+    Must be called inside ``with PrefabApp(...) as app, Card(): with
+    CardContent(), Column(gap=3):``.
+    """
+    changes = changes or {}
+    rendered_any = False
+
+    contact_lines = (
+        ("Email", entity.get("email")),
+        ("Phone", entity.get("phone")),
+        ("Company", entity.get("company")),
+        ("Currency", entity.get("currency")),
+        ("Category", entity.get("category")),
+        ("Reference ID", entity.get("reference_id")),
+    )
+    for label, value in contact_lines:
+        change = changes.get(_customer_change_key(label))
+        if change is not None or value:
+            _render_field_diff_line(label, value=value, change=change)
+            rendered_any = True
+
+    discount_rate = entity.get("discount_rate")
+    discount_change = changes.get("discount_rate")
+    if discount_change is not None or discount_rate is not None:
+        # ``:g`` switches to scientific notation outside ~1e-5..1e+6;
+        # an operator fat-finger like ``discount_rate=1000000`` would
+        # then render as "1e+06%" — a deliberate-looking technical
+        # value rather than the obvious red flag the operator needs.
+        # ``:.4f`` with trailing-zero strip keeps fixed-point in all
+        # realistic discount ranges.
+        if isinstance(discount_rate, bool) or not isinstance(
+            discount_rate, (int, float)
+        ):
+            display: Any = discount_rate
+        else:
+            display = f"{discount_rate:.4f}".rstrip("0").rstrip(".") + "%"
+        _render_field_diff_line("Discount Rate", value=display, change=discount_change)
+        rendered_any = True
+
+    comment = entity.get("comment")
+    comment_change = changes.get("comment")
+    if comment_change is not None or comment:
+        _render_field_diff_line("Notes", value=comment, change=comment_change)
+        rendered_any = True
+
+    addresses = entity.get("addresses") or []
+    if addresses:
+        # Sort billing before shipping so the visual order matches operator
+        # expectation. Unknown entity_types sort last in stable insert order.
+        order = {"billing": 0, "shipping": 1}
+        sorted_addresses = sorted(
+            addresses, key=lambda a: order.get(a.get("entity_type") or "", 2)
+        )
+        # Collect ALL billing addresses for dedup, not just the last —
+        # a customer with multiple billings shouldn't fail dedup when
+        # shipping matches the first billing but not the most recently
+        # rendered one. Loop matches each shipping against any prior billing.
+        rendered_billings: list[dict[str, Any]] = []
+        for addr in sorted_addresses:
+            entity_type = (addr.get("entity_type") or "").lower()
+            label = (
+                "Billing Address"
+                if entity_type == "billing"
+                else "Shipping Address"
+                if entity_type == "shipping"
+                else "Address"
+            )
+            if entity_type == "shipping" and any(
+                _addresses_are_equivalent(b, addr) for b in rendered_billings
+            ):
+                Text(content="Shipping Address: (same as billing)")
+                rendered_any = True
+                continue
+            if _render_address_block(label, addr):
+                rendered_any = True
+                if entity_type == "billing":
+                    rendered_billings.append(addr)
+
+    # Empty-card defense: a minimal create_customer(name='X') has no
+    # Tier 3 content to surface. Without this fallback the CardContent
+    # column would be empty and the card would read as broken (header
+    # + blank body + footer).
+    if not rendered_any:
+        Muted(content="No additional contact details provided.")
+
+    return _render_warnings_block(entity.get("warnings"))
+
+
+_CUSTOMER_FIELD_TO_WIRE = {
+    "Email": "email",
+    "Phone": "phone",
+    "Company": "company",
+    "Currency": "currency",
+    "Category": "category",
+    "Reference ID": "reference_id",
+    "Discount Rate": "discount_rate",
+    # "Notes" surfaces the wire field ``comment`` (see
+    # ``_render_customer_entity_view`` — the label is operator-friendly,
+    # the diff key still has to match the wire-shape).
+    "Notes": "comment",
+}
+
+
+def _customer_change_key(label: str) -> str:
+    """Map a user-facing label to the wire field name a future modify card
+    would key its diff lookup off. Kept inline to keep the create-card
+    helper self-contained; the eventual modify card will read the same map.
+
+    Fallback normalizes spaces → underscores so any label not explicitly
+    mapped still produces a wire-shaped key (``"Two Word"`` → ``"two_word"``)
+    rather than a literal lowercase with embedded space.
+    """
+    return _CUSTOMER_FIELD_TO_WIRE.get(label, label.lower().replace(" ", "_"))
+
+
+def build_customer_create_ui(
+    response: dict[str, Any],
+    *,
+    confirm_request: BaseModel,
+    confirm_tool: str,
+) -> PrefabApp:
+    """Build the create-customer card. Handles both preview
+    (``is_preview=True`` → PREVIEW Badge + Confirm/Cancel + direct-apply
+    morph) and applied (``is_preview=False`` → CREATED Badge + View in
+    Katana + next-action buttons) states. Reads
+    ``CreateCustomerResponse.model_dump()`` directly.
+
+    Four-tier framework (#537), pioneer per-entity card for #817:
+
+    - Tier 1 — Identity: title, **customer name** as the headline Badge
+      (the ``_render_preview_header(order_number=...)`` slot — the helper
+      param name is historical from PO/SO/MO; for customer the name itself
+      is the headline), PREVIEW/CREATED state badge, currency badge when
+      set.
+    - Tier 2 — *omitted* — customer creates have no money/count aggregate
+      worth promoting to a Metric.
+    - Tier 3 — content from :func:`_render_customer_entity_view` (shared
+      with the future ``build_customer_modify_ui`` per the #721 design;
+      create cards pass ``changes=None`` so no diff overlay).
+    - Tier 4 — Actions: Confirm & Create + Cancel via the direct-apply
+      rail; applied state surfaces View in Katana + "Create Sales Order"
+      next-action button.
+    """
+    name = response.get("name") or "Customer"
+    # Truncate the headline Badge to keep Tier 1 layout stable. Katana
+    # accepts free-text ``name`` of arbitrary length; PO/SO/MO never
+    # exercised this slot with anything longer than ~20 chars, so the
+    # helper assumed short headlines. 48 chars fits a typical company
+    # name; longer ones surface in the Tier 3 Notes / contact body
+    # where the operator can read them in full.
+    badge_name = name if len(name) <= 48 else name[:45] + "…"
+    currency = response.get("currency")
+    apply_action = _build_apply_action(confirm_tool, confirm_request)
+    cancel_action = _build_cancel_action("that customer")
+    extra_badges: tuple[tuple[str, str], ...] = (
+        ((currency, "outline"),) if currency else ()
+    )
+
+    with (
+        PrefabApp(state=_init_create_card_state(response), css_class="p-4") as app,
+        Card(),
+    ):
+        _render_preview_header(
+            title_prefix="Customer",
+            entity="customer",
+            order_number=badge_name,
+            status=None,
+            extra_badges=extra_badges,
+        )
+        with CardContent(), Column(gap=3):
+            block_warnings = _render_customer_entity_view(response)
+        _render_preview_footer(
+            title_prefix="Customer",
+            block_warnings=block_warnings,
+            confirm_label="Confirm & Create Customer",
+            apply_action=apply_action,
+            cancel_action=cancel_action,
+            next_action_buttons=(
+                # ``create_sales_order`` needs items + quantities that the
+                # customer-create response can't supply. Per ADR-0021,
+                # that's an ``UpdateContext`` (agent composes the call)
+                # rather than a deterministic ``CallTool``. Matches the
+                # PO card's "Receive Items" follow-up shape.
+                (
+                    "Create Sales Order",
+                    UpdateContext(
+                        content=(
+                            "User wants to create a sales order for "
+                            "customer {{ result.id }} ({{ result.name }}). "
+                            "Ask which items and quantities, then call "
+                            "create_sales_order with preview=True."
+                        ),
+                    ),
+                ),
+            ),
+        )
+    return app
+
+
 def _summarize_apply_outcome(
     actions: list[dict[str, Any]],
 ) -> tuple[str, str]:

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -27,6 +27,7 @@ from katana_mcp.tools._modification import (
 )
 from katana_mcp.tools.prefab_ui import (
     build_batch_recipe_update_ui,
+    build_customer_create_ui,
     build_inventory_at_ui,
     build_inventory_check_ui,
     build_item_detail_ui,
@@ -521,6 +522,62 @@ def _batch_recipe_update_app() -> PrefabApp:
 # ---------------------------------------------------------------------------
 
 
+def _customer_create_response(*, is_preview: bool, with_addresses: bool) -> dict:
+    """Build a canned CreateCustomerResponse dict for the customer card.
+
+    ``with_addresses`` toggles billing+shipping snapshots to exercise the
+    address-block rendering and the "same as billing" de-dup path.
+    """
+    base: dict = {
+        "id": None if is_preview else 8001,
+        "katana_url": (
+            None
+            if is_preview
+            else "https://factory.katanamrp.com/contacts/customers/8001"
+        ),
+        "name": "Gourmet Bistro Group",
+        "first_name": "Elena",
+        "last_name": "Rodriguez",
+        "company": "Gourmet Bistro Group Inc",
+        "email": "procurement@gourmetbistro.com",
+        "phone": "+1-555-0125",
+        "comment": "Premium restaurant chain — priority orders",
+        "currency": "USD",
+        "reference_id": "GBG-2024-003",
+        "category": "Fine Dining",
+        "discount_rate": 7.5,
+        "addresses": [],
+        "is_preview": is_preview,
+        "warnings": [],
+        "next_actions": [],
+        "message": (
+            "Preview: customer ready to create"
+            if is_preview
+            else "Successfully created customer (ID: 8001)"
+        ),
+    }
+    if with_addresses:
+        billing = {
+            "entity_type": "billing",
+            "first_name": "Elena",
+            "last_name": "Rodriguez",
+            "company": "Gourmet Bistro Group Inc",
+            "phone": "+1-555-0125",
+            "line_1": "123 Market St",
+            "line_2": "Suite 4",
+            "city": "Springfield",
+            "state": "IL",
+            "zip": "62701",
+            "country": "US",
+        }
+        # Shipping byte-equal to billing exercises the "same as billing"
+        # de-dup branch in ``_render_customer_entity_view``.
+        shipping = dict(billing)
+        shipping["entity_type"] = "shipping"
+        base["addresses"] = [billing, shipping]
+    return base
+
+
 def _stock_adjustment_response(*, is_preview: bool, n_rows: int = 3) -> dict:
     """Build a canned StockAdjustmentResponse dict with N rows."""
     rows = [
@@ -651,6 +708,52 @@ SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
         _stock_adjustment_delete_response(is_preview=False),
         confirm_request=_StubRequest(),
         confirm_tool="delete_stock_adjustment",
+    ),
+    # Customer create card (#817) — preview + applied + addresses variants.
+    "customer_create_preview": lambda: build_customer_create_ui(
+        _customer_create_response(is_preview=True, with_addresses=False),
+        confirm_request=_StubRequest(),
+        confirm_tool="create_customer",
+    ),
+    "customer_create_preview_with_addresses": lambda: build_customer_create_ui(
+        _customer_create_response(is_preview=True, with_addresses=True),
+        confirm_request=_StubRequest(),
+        confirm_tool="create_customer",
+    ),
+    "customer_create_applied": lambda: build_customer_create_ui(
+        _customer_create_response(is_preview=False, with_addresses=True),
+        confirm_request=_StubRequest(),
+        confirm_tool="create_customer",
+    ),
+    # Block-warning gate: the Confirm button must hide and the warnings
+    # badge must surface when ``warnings`` carries a ``BLOCK:`` prefix.
+    # Pins the gate against future regressions (no business-rule warning
+    # populates this on the customer create path today; locked in now).
+    "customer_create_block_warning": lambda: build_customer_create_ui(
+        {
+            **_customer_create_response(is_preview=True, with_addresses=False),
+            "warnings": [
+                "BLOCK: a customer named 'Gourmet Bistro Group' already exists"
+            ],
+        },
+        confirm_request=_StubRequest(),
+        confirm_tool="create_customer",
+    ),
+    # Minimal customer (only ``name``) — pins the empty-Tier-3-body
+    # fallback ("No additional contact details provided.").
+    "customer_create_minimal": lambda: build_customer_create_ui(
+        {
+            "id": None,
+            "katana_url": None,
+            "name": "Minimal Co",
+            "is_preview": True,
+            "addresses": [],
+            "warnings": [],
+            "next_actions": [],
+            "message": "Preview: customer Minimal Co ready to create",
+        },
+        confirm_request=_StubRequest(),
+        confirm_tool="create_customer",
     ),
     "modify_item_single_preview": lambda: build_modification_preview_ui(
         {

--- a/katana_mcp_server/tests/browser/test_other_cards_render.py
+++ b/katana_mcp_server/tests/browser/test_other_cards_render.py
@@ -155,6 +155,76 @@ class TestOtherCardsRender:
         assert frame.locator("text=batch 42x30").count() >= 1
         assert frame.locator("text=SN-001").count() >= 1
 
+    def test_customer_create_preview_renders(self, render_scenario):
+        """``build_customer_create_ui`` preview state (#817).
+
+        Mounts the four-tier customer create card and asserts the
+        user-facing fields surface as values — not API plumbing.
+        """
+        frame = render_scenario("customer_create_preview")
+        # Tier 1 — title + customer name in the headline badge + PREVIEW state.
+        assert frame.locator("text=Customer Preview").count() >= 1
+        assert frame.locator("text=Gourmet Bistro Group").count() >= 1
+        assert frame.locator("text=PREVIEW").count() >= 1
+        # Tier 3 — contact fields rendered with their values, not abstractions.
+        assert frame.locator("text=procurement@gourmetbistro.com").count() >= 1
+        assert frame.locator("text=+1-555-0125").count() >= 1
+        assert frame.locator("text=USD").count() >= 1
+        assert frame.locator("text=Fine Dining").count() >= 1
+        # Tier 4 — Confirm + Cancel.
+        assert frame.locator("text=Confirm & Create Customer").count() >= 1
+        assert frame.locator("text=Cancel").count() >= 1
+        # Anti-regression: no "Operation #" / "Target #" / "field(s) changed"
+        # internal-model leakage in user-visible content.
+        assert frame.locator("text=Operation #").count() == 0
+        assert frame.locator("text=field(s) changed").count() == 0
+
+    def test_customer_create_preview_renders_addresses(self, render_scenario):
+        """Address blocks render with real street/city/state/zip — and the
+        equivalent shipping address de-dupes to '(same as billing)'."""
+        frame = render_scenario("customer_create_preview_with_addresses")
+        # Billing address surfaces the actual lines, not an address ID.
+        assert frame.locator("text=Billing Address:").count() >= 1
+        assert frame.locator("text=123 Market St, Suite 4").count() >= 1
+        assert frame.locator("text=Springfield, IL 62701").count() >= 1
+        # The equivalent shipping address renders the de-dup line, not a
+        # duplicate of the billing block.
+        assert frame.locator("text=Shipping Address: (same as billing)").count() >= 1
+
+    def test_customer_create_applied_renders_view_in_katana(self, render_scenario):
+        """Applied state surfaces the View-in-Katana link + next-action."""
+        frame = render_scenario("customer_create_applied")
+        assert frame.locator("text=Customer Created").count() >= 1
+        assert frame.locator("text=CREATED").count() >= 1
+        assert frame.locator("text=View in Katana").count() >= 1
+        # Direct-apply rail's next-action button.
+        assert frame.locator("text=Create Sales Order").count() >= 1
+
+    def test_customer_create_block_warning_hides_confirm(self, render_scenario):
+        """A BLOCK: warning hides the Confirm button and surfaces the
+        block-warning Badge (gate from _render_warnings_block →
+        _render_preview_footer)."""
+        frame = render_scenario("customer_create_block_warning")
+        # Warning text surfaces, with the BLOCK: prefix stripped.
+        assert (
+            frame.locator(
+                "text=a customer named 'Gourmet Bistro Group' already exists"
+            ).count()
+            >= 1
+        )
+        # Confirm button gone; cannot-proceed coaching shows up.
+        assert frame.locator("text=Confirm & Create Customer").count() == 0
+        assert frame.locator("text=Cannot proceed").count() >= 1
+
+    def test_customer_create_minimal_renders_fallback(self, render_scenario):
+        """A customer with no optional fields renders the empty-Tier-3
+        fallback Muted line instead of a visually-blank card body."""
+        frame = render_scenario("customer_create_minimal")
+        assert frame.locator("text=Minimal Co").count() >= 1
+        assert (
+            frame.locator("text=No additional contact details provided.").count() >= 1
+        )
+
 
 class TestDataTableRowClickBinding:
     """Verify DataTable ``onRowClick`` ``{{ field }}`` per-row bindings

--- a/katana_mcp_server/tests/tools/test_customers.py
+++ b/katana_mcp_server/tests/tools/test_customers.py
@@ -1,13 +1,18 @@
-"""Tests for customer search and lookup tools."""
+"""Tests for customer search, lookup, and create tools."""
 
 import json
 from datetime import datetime
-from unittest.mock import AsyncMock, patch
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from katana_mcp.tools.foundation.customers import (
+    CreateCustomerAddressRequest,
+    CreateCustomerRequest,
     GetCustomerRequest,
     SearchCustomersRequest,
+    _create_customer_impl,
+    _customer_response_to_tool_result,
     _get_customer_impl,
     _search_customers_impl,
     get_customer,
@@ -15,7 +20,9 @@ from katana_mcp.tools.foundation.customers import (
 )
 from katana_mcp_server.tests.conftest import create_mock_context
 
+from katana_public_api_client.models import Customer as APICustomer
 from katana_public_api_client.models_pydantic._generated import CachedCustomer
+from tests.factories import mock_entity_for_modify
 
 
 @pytest.fixture(autouse=True)
@@ -294,3 +301,395 @@ async def test_get_customer_content_is_indented_json():
     data = json.loads(_content_text(result))
     assert data["id"] == 42
     assert data["name"] == "Widgets Inc"
+
+
+# ============================================================================
+# create_customer
+# ============================================================================
+
+
+_MERGE_CACHE_PATH = "katana_mcp.typed_cache.sync.merge_filtered_fetch"
+
+
+@pytest.mark.asyncio
+async def test_create_customer_preview_skips_api_call():
+    """Preview branch must echo request fields without hitting the API or cache."""
+    context, _ = create_mock_context()
+
+    request = CreateCustomerRequest(
+        name="Acme Corp",
+        company="Acme Corp",
+        email="orders@acme.com",
+        phone="+1-555-0100",
+        currency="USD",
+        category="Wholesale",
+        discount_rate=7.5,
+        preview=True,
+    )
+
+    # ``merge_filtered_fetch`` should NOT be called on the preview branch —
+    # patch it so the test fails loudly if the impl regresses.
+    with patch(_MERGE_CACHE_PATH, AsyncMock()) as merge_mock:
+        result = await _create_customer_impl(request, context)
+
+    assert result.is_preview is True
+    assert result.id is None
+    assert result.katana_url is None
+    assert result.name == "Acme Corp"
+    assert result.company == "Acme Corp"
+    assert result.email == "orders@acme.com"
+    assert result.currency == "USD"
+    assert result.discount_rate == 7.5
+    assert result.addresses == []
+    assert "preview=false" in result.message.lower() or result.message.startswith(
+        "Preview"
+    )
+    merge_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_customer_preview_carries_addresses():
+    """Addresses on the request flow through to the preview response snapshot."""
+    context, _ = create_mock_context()
+
+    billing = CreateCustomerAddressRequest(
+        entity_type="billing",
+        first_name="Elena",
+        last_name="Rodriguez",
+        line_1="123 Market St",
+        city="Springfield",
+        state="IL",
+        zip="62701",
+        country="US",
+    )
+    shipping = CreateCustomerAddressRequest(
+        entity_type="shipping",
+        first_name="Elena",
+        last_name="Rodriguez",
+        line_1="500 Warehouse Way",
+        city="Springfield",
+        state="IL",
+        zip="62702",
+        country="US",
+    )
+    request = CreateCustomerRequest(
+        name="Gourmet Bistro Group",
+        addresses=[billing, shipping],
+        preview=True,
+    )
+
+    result = await _create_customer_impl(request, context)
+
+    assert result.is_preview is True
+    assert len(result.addresses) == 2
+    assert result.addresses[0].entity_type == "billing"
+    assert result.addresses[0].line_1 == "123 Market St"
+    assert result.addresses[1].entity_type == "shipping"
+    assert result.addresses[1].line_1 == "500 Warehouse Way"
+
+
+@pytest.mark.asyncio
+async def test_create_customer_empty_name_rejected():
+    """Empty or whitespace-only ``name`` raises before any API call."""
+    context, _ = create_mock_context()
+
+    request = CreateCustomerRequest(name="   ", preview=True)
+    with pytest.raises(ValueError, match="name cannot be empty"):
+        await _create_customer_impl(request, context)
+
+
+def test_create_customer_discount_rate_out_of_range_rejected():
+    """``discount_rate`` outside 0-100 raises at request-parse time —
+    a clean ValidationError rather than an opaque Katana 422 on apply.
+    """
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="less than or equal to 100"):
+        CreateCustomerRequest(name="X", discount_rate=150)
+    with pytest.raises(ValidationError, match="greater than or equal to 0"):
+        CreateCustomerRequest(name="X", discount_rate=-1)
+
+
+@pytest.mark.asyncio
+async def test_create_customer_apply_calls_api_and_merges_cache():
+    """Apply branch must POST to /customers and write through to the cache."""
+    context, _ = create_mock_context()
+
+    api_customer = mock_entity_for_modify(
+        APICustomer,
+        id=8001,
+        name="Acme Corp",
+        email="orders@acme.com",
+        currency="USD",
+        category="Wholesale",
+    )
+    mock_api_response = MagicMock()
+    mock_api_response.status_code = 200
+    mock_api_response.parsed = api_customer
+    mock_api_call = AsyncMock(return_value=mock_api_response)
+
+    import katana_public_api_client.api.customer.create_customer as create_module
+
+    original = create_module.asyncio_detailed
+    cast(Any, create_module).asyncio_detailed = mock_api_call
+
+    try:
+        with patch(_MERGE_CACHE_PATH, AsyncMock()) as merge_mock:
+            request = CreateCustomerRequest(
+                name="Acme Corp",
+                email="orders@acme.com",
+                currency="USD",
+                category="Wholesale",
+                preview=False,
+            )
+            result = await _create_customer_impl(request, context)
+    finally:
+        create_module.asyncio_detailed = original
+
+    assert result.is_preview is False
+    assert result.id == 8001
+    assert result.name == "Acme Corp"
+    assert result.email == "orders@acme.com"
+    assert result.currency == "USD"
+    assert result.katana_url is not None
+    assert "8001" in result.katana_url
+    # Cache write-through must have been invoked with the fresh attrs object.
+    merge_mock.assert_called_once()
+    args, _kwargs = merge_mock.call_args
+    # merge_filtered_fetch(cache, spec, [attrs_obj])
+    assert args[2] == [api_customer]
+    # And the API was called exactly once with the right body shape.
+    mock_api_call.assert_called_once()
+    body = mock_api_call.call_args.kwargs["body"]
+    assert body.name == "Acme Corp"
+    assert body.email == "orders@acme.com"
+    assert body.currency == "USD"
+
+
+@pytest.mark.asyncio
+async def test_create_customer_apply_forwards_addresses_to_api():
+    """Addresses on the request must reach the API attrs body verbatim."""
+    context, _ = create_mock_context()
+
+    api_customer = mock_entity_for_modify(APICustomer, id=8002, name="Bistro Group")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = api_customer
+    mock_api_call = AsyncMock(return_value=mock_response)
+
+    import katana_public_api_client.api.customer.create_customer as create_module
+
+    original = create_module.asyncio_detailed
+    cast(Any, create_module).asyncio_detailed = mock_api_call
+    try:
+        with patch(_MERGE_CACHE_PATH, AsyncMock()):
+            request = CreateCustomerRequest(
+                name="Bistro Group",
+                addresses=[
+                    CreateCustomerAddressRequest(
+                        entity_type="billing",
+                        line_1="123 Market St",
+                        city="Springfield",
+                        zip="62701",
+                        country="US",
+                    )
+                ],
+                preview=False,
+            )
+            await _create_customer_impl(request, context)
+    finally:
+        create_module.asyncio_detailed = original
+
+    body = mock_api_call.call_args.kwargs["body"]
+    assert len(body.addresses) == 1
+    addr = body.addresses[0]
+    # AddressEntityType is an enum on the attrs side; ``.value`` is "billing".
+    assert addr.entity_type.value == "billing"
+    assert addr.line_1 == "123 Market St"
+    # zip → zip_ wire-name workaround on the attrs model.
+    assert addr.zip_ == "62701"
+
+
+@pytest.mark.asyncio
+async def test_create_customer_apply_prefers_server_addresses_over_request_snapshot():
+    """When the API echoes addresses on the create response (with
+    server-assigned ``id`` / ``default`` + normalized values), the tool
+    surfaces those — not the request snapshot — so the card reflects what
+    Katana actually stored.
+    """
+    from katana_public_api_client.client_types import UNSET
+    from katana_public_api_client.models import (
+        AddressEntityType,
+        CustomerAddress,
+    )
+
+    context, _ = create_mock_context()
+
+    # Real attrs CustomerAddress: ``zip_`` (Python keyword workaround) +
+    # AddressEntityType enum for entity_type. Katana normalized country
+    # 'USA' → 'US' and assigned id=3001 / default=True.
+    server_billing = CustomerAddress(
+        id=3001,
+        customer_id=8020,
+        entity_type=AddressEntityType.BILLING,
+        default=True,
+        first_name="Elena",
+        line_1="123 Market St",
+        city="Springfield",
+        state="IL",
+        zip_="62701",
+        country="US",
+        created_at=UNSET,
+        updated_at=UNSET,
+        deleted_at=UNSET,
+    )
+    api_customer = mock_entity_for_modify(
+        APICustomer,
+        id=8020,
+        name="Server Address Echo Co",
+        addresses=[server_billing],
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = api_customer
+
+    import katana_public_api_client.api.customer.create_customer as create_module
+
+    original = create_module.asyncio_detailed
+    cast(Any, create_module).asyncio_detailed = AsyncMock(return_value=mock_response)
+    try:
+        with patch(_MERGE_CACHE_PATH, AsyncMock()):
+            # Request submitted with country='USA' (un-normalized) — should
+            # be replaced by the server's 'US' in the response.
+            request = CreateCustomerRequest(
+                name="Server Address Echo Co",
+                addresses=[
+                    CreateCustomerAddressRequest(
+                        entity_type="billing",
+                        first_name="Elena",
+                        line_1="123 Market St",
+                        city="Springfield",
+                        state="IL",
+                        zip="62701",
+                        country="USA",
+                    )
+                ],
+                preview=False,
+            )
+            result = await _create_customer_impl(request, context)
+    finally:
+        create_module.asyncio_detailed = original
+
+    assert len(result.addresses) == 1
+    addr = result.addresses[0]
+    assert addr.id == 3001  # server-assigned
+    assert addr.default is True  # server-assigned
+    assert addr.country == "US"  # server-normalized (not request 'USA')
+    assert addr.entity_type == "billing"
+
+
+@pytest.mark.asyncio
+async def test_create_customer_apply_surfaces_warning_when_cache_merge_fails():
+    """Cache-merge failure must NOT raise — the customer already exists in
+    Katana, so re-raising would push the operator into retrying and creating
+    a duplicate. The tool returns is_preview=False with a warning instead.
+    """
+    context, _ = create_mock_context()
+
+    api_customer = mock_entity_for_modify(APICustomer, id=8010, name="Cache Failure Co")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = api_customer
+
+    import katana_public_api_client.api.customer.create_customer as create_module
+
+    original = create_module.asyncio_detailed
+    cast(Any, create_module).asyncio_detailed = AsyncMock(return_value=mock_response)
+    try:
+        with patch(
+            _MERGE_CACHE_PATH,
+            AsyncMock(side_effect=RuntimeError("database is locked")),
+        ):
+            request = CreateCustomerRequest(name="Cache Failure Co", preview=False)
+            result = await _create_customer_impl(request, context)
+    finally:
+        create_module.asyncio_detailed = original
+
+    # Customer was created in Katana; we don't lose that fact just because
+    # the cache write-through failed.
+    assert result.is_preview is False
+    assert result.id == 8010
+    # Warning surfaces what happened + explicit "do not retry" coaching.
+    assert any("cache" in w.lower() for w in result.warnings)
+    assert any("duplicate" in w.lower() for w in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_create_customer_apply_writes_through_to_real_cache(typed_cache_engine):
+    """Integration: apply branch writes a row that ``search_customers`` can
+    immediately read back via the real typed cache — no ``rebuild_cache``
+    round-trip needed (the cache-merge contract on #817).
+    """
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache = typed_cache_engine
+
+    # Real APICustomer (not MagicMock) — the cache converter calls
+    # ``Customer.from_attrs(attrs_obj)`` which validates field shapes.
+    api_customer = APICustomer(
+        id=8003,
+        name="Cache Writethrough Test Co",
+        email="qa@example.com",
+        currency="USD",
+    )
+    mock_api_response = MagicMock()
+    mock_api_response.status_code = 200
+    mock_api_response.parsed = api_customer
+
+    import katana_public_api_client.api.customer.create_customer as create_module
+
+    original = create_module.asyncio_detailed
+    cast(Any, create_module).asyncio_detailed = AsyncMock(
+        return_value=mock_api_response
+    )
+    try:
+        request = CreateCustomerRequest(
+            name="Cache Writethrough Test Co",
+            email="qa@example.com",
+            currency="USD",
+            preview=False,
+        )
+        await _create_customer_impl(request, context)
+    finally:
+        create_module.asyncio_detailed = original
+
+    # search_customers reads through the cache via smart_search. Query the
+    # catalog directly — it's the same data path search_customers uses.
+    rows = await typed_cache_engine.catalog.smart_search(
+        CachedCustomer, "Cache Writethrough", limit=10
+    )
+    assert any(r.id == 8003 for r in rows)
+
+
+def test_create_customer_response_to_tool_result_emits_prefab_card():
+    """The ToolResult must carry the Prefab card envelope, not plain JSON."""
+    from katana_mcp.tools.foundation.customers import CreateCustomerResponse
+
+    response = CreateCustomerResponse(
+        name="Acme Corp",
+        is_preview=True,
+        message="Preview",
+    )
+    request = CreateCustomerRequest(name="Acme Corp", preview=True)
+
+    result = _customer_response_to_tool_result(response, request=request)
+
+    # structured_content is the Prefab wire envelope — fastmcp serializes
+    # the PrefabApp into a ``$prefab`` / ``state`` / ``view`` dict at
+    # ToolResult construction time.
+    assert isinstance(result.structured_content, dict)
+    assert "$prefab" in result.structured_content
+    assert "view" in result.structured_content
+    # content channel carries the response JSON for the model context.
+    data = json.loads(_content_text(result))
+    assert data["name"] == "Acme Corp"
+    assert data["is_preview"] is True


### PR DESCRIPTION
Closes #817.

## Summary

Adds `create_customer` to close the create-customer gap for non-Shopify-synced channels (eBay, Amazon, Etsy, direct-website) where buyers don't pre-exist in Katana. Standard preview/apply via the unified direct-apply rail (ADR-0021), plus cache write-through so `search_customers` returns the new row immediately — no `rebuild_cache` round-trip.

Pioneers the per-entity customer card under the #721 modify-card umbrella: `build_customer_create_ui` shares its entity-view renderer with the future `build_customer_modify_ui`. User-centric content per `feedback-user-centric-card-content` — surfaces real name, email, full multi-line addresses, currency, discount rate; no \"Operation #\" / \"Target #\" / \"N field(s) changed\" abstractions.

## What's in scope

- `katana_mcp_server/src/katana_mcp/tools/foundation/customers.py` — new `CreateCustomerRequest` / `CreateCustomerAddressRequest` / `CreateCustomerResponse` / `CreateCustomerAddressSnapshot` pydantic models, `_create_customer_impl` (preview/apply branches), registered via `register_preview_tool` with `UI_META`.
- `katana_mcp_server/src/katana_mcp/tools/prefab_ui.py` — new `_render_address_block`, `_addresses_are_equivalent`, `_render_customer_entity_view`, `_customer_change_key`, `build_customer_create_ui`. Designed so a future `build_customer_modify_ui` reuses the entity-view renderer.
- `katana_mcp_server/src/katana_mcp/resources/help.py` — new Customers section in the overview + full `create_customer` reference entry.

## Out of scope (per #817)

- `modify_customer` / `delete_customer` — file separately if/when needed.

## Hardening from review

Pre-PR multi-angle code review (5 angles × ~8 candidates, 1-vote verifier, sweep) surfaced 15 candidate findings; all 15 addressed in this PR. Notable correctness fixes:

- `discount_rate` validates `ge=0, le=100` — clean `ValidationError` rather than an opaque Katana 422.
- Cache-merge failure is tolerated — Katana already created the customer; re-raising would push the operator into creating a duplicate (Katana doesn't enforce name uniqueness). Surfaces a warning with explicit \"do not retry\" coaching.
- Apply branch prefers server-returned addresses over the request snapshot — picks up Katana's normalization (e.g., `country='USA'` → `'US'`) and assigned `default_*_id` flags.
- Headline Badge truncates names >48 chars (PO/SO/MO never exercised the slot with arbitrary-length strings; customer names can be long).
- Empty Tier 3 body falls back to a `Muted` explainer when only `name` is set.
- Multi-billing address dedup compares each shipping against all prior billings (was: only the last).
- Discount format uses `:.4f`+rstrip — no more scientific notation for extreme values.

## Test plan

- [x] `uv run poe agent-check` — lint, format, ty pass
- [x] `uv run poe test` — 3553 unit tests pass (13 new in `test_customers.py`)
- [x] `uv run poe test-browser` — 26 browser-render tests pass (5 new customer scenarios: preview, preview-with-addresses, applied, block-warning gate, minimal-customer empty-body fallback)
- [x] Manual: `_create_customer_impl(preview=True)` then `preview=False` against a typed-cache fixture → row appears in follow-up `search_customers` without `rebuild_cache` (pinned by `test_create_customer_apply_writes_through_to_real_cache`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)