### PR TITLE
docs(groom): add Custom-fields workstream + schema-mutation guardrail

### DIFF
--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -44,6 +44,18 @@ goes stale immediately. The board is durable; mutate it in place.
 - **Don't grow the heuristics arbitrarily** — keep the rule set tight.
   Each new heuristic must have a concrete observed drift it solves; soft
   signals belong in a richer `/triage` skill (#684), not here.
+- **NEVER mutate the project field schema from inside `/groom`.** Adding,
+  renaming, or reordering options on Priority / Workstream / Status is
+  out of scope. GitHub's `updateProjectV2Field` GraphQL mutation accepts
+  the full option list (no IDs); when invoked, GitHub regenerates every
+  option ID and **all existing item assignments to that field are
+  silently wiped** because items reference options by stale IDs. The
+  `gh project` CLI does not expose a non-destructive "add option" path.
+  If a new bucket is genuinely needed, **stop**, instruct the user to
+  add it through the GitHub UI (Project → "..." → Settings → field →
+  Edit), then re-run the skill. Then update CLAUDE.md "Workstream
+  definitions" in the same change so the doc stays in lockstep with the
+  board schema.
 
 ## ASSUMES
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,8 @@ should I work on?", the answer is the top of Todo. **Do not re-derive the queue 
 - **Fulfillment** — `fulfill_order` / `receive_purchase_order` / order lifecycle.
   Orthogonal to umbrellas.
 - **Spec-drift** — Katana API spec misalignment, codegen issues.
+- **Custom-fields** — Custom-fields vertical: spec alignment, MCP tooling, definition
+  CRUD, search-endpoint coverage. Spans both client and server.
 - **Harness** — `.claude/`, harness-kit integration, skills, agents.
 - **Process** — backlog hygiene, docs, ADRs, retros.
 - **Other** — anything that doesn't fit above; usually means the schema needs a new


### PR DESCRIPTION
## Summary

- Add **Custom-fields** workstream definition to CLAUDE.md "Workstream definitions" — covers the new vertical (spec alignment + MCP tooling) that doesn't fit Cards / Cache / Fulfillment / Spec-drift. Pairs with #805 / #806 which are now classified to it on the [Rolling Backlog](https://github.com/users/dougborg/projects/5).
- Add a CRITICAL guardrail to `.claude/skills/groom/SKILL.md` forbidding project field-schema mutation from inside `/groom`. GitHub's `updateProjectV2Field` GraphQL mutation regenerates every single-select option ID when invoked and silently wipes existing item assignments — `gh project` exposes no non-destructive "add option" path. The skill must stop and route the operator to the GitHub UI instead.

## Why

During a `/groom` session on this branch I added a new "Custom-fields" option to the Workstream field by re-supplying the full option list via `updateProjectV2Field` — and watched all 168 existing Workstream assignments evaporate because GitHub re-issued the option IDs. The session recovered with a heuristic re-classifier (umbrella + label + title + manual overrides), but the structural fix is to refuse to take that action from inside the skill in the first place.

## Test plan

- [x] `uv run poe check` passes (3543 unit/integration tests + 21 browser tests, 0 lint findings)
- [x] CLAUDE.md "Workstream definitions" table renders with Custom-fields between Spec-drift and Harness
- [x] SKILL.md CRITICAL section reads cleanly in raw + rendered markdown (YAML frontmatter intact)
- [ ] Future `/groom` run encountering an "I need a new workstream" situation stops + delegates to the GitHub UI rather than calling `updateProjectV2Field` (manual verification on next groom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)