### PR TITLE
feat(mcp): consistent soft-state defaults across direct-lookup + list tools

### DIFF
--- a/katana_mcp_server/docs/typed_cache/README.md
+++ b/katana_mcp_server/docs/typed_cache/README.md
@@ -57,13 +57,24 @@ by contrast, is *read-side only* — Katana exposes deletion through DELETE endp
 as a writable boolean on update bodies. Items expose `is_archived` on `ItemInfo` and
 `ItemDetailsResponse` as of #526.
 
-Don't add a new opt-in flag without the matching derived bool, and vice versa.
+Don't add a new opt-in flag without the matching derived bool, and vice versa. The
+shared `SoftDeletableResponse` mixin in `katana_mcp/tools/tool_result_utils.py` provides
+the `deleted_at` + `is_deleted` field plumbing and the derivation validator — soft-
+deletable response models inherit from it so the `is_deleted = deleted_at is not None`
+mapping can't drift across files.
 
-**Known gaps** (filed for follow-up):
+### Three categories of soft-state filtering — keep them separate
 
-- `list_stock_transfers` lacks `include_deleted` parity (#484).
-- `check_inventory` lacks `include_archived` and the `is_archived` row field (#539).
-- Transactional response models lack the `is_deleted` derived bool (#540).
+| Category                             | Default                 | Mechanism                      | Why                                                                                                                                                                             |
+| ------------------------------------ | ----------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Direct lookup** (SKU + ID getters) | `include_*=False`       | request flag on the tool       | the matched entity IS the answer; agent opts in to see soft-state rows. SKU lookups also use `get_by_sku`'s ORDER BY tiebreaker so a live row beats a deleted/archived sibling. |
+| **List filtering** (`list_*` tools)  | `include_*=False`       | request flag; `CatalogQueries` | which parents appear in the list                                                                                                                                                |
+| **Enrichment** (batch lookups by ID) | always `include_*=True` | no flag, hard-coded            | a deleted parent referenced from a live child must still render its identity — e.g. a live SO row referencing a deleted variant still needs to surface its display name         |
+
+The distinction matters because SKUs are non-unique in Katana but IDs are. Direct SKU
+lookups need the tiebreaker + the opt-out default (so a deleted-vs-live sibling resolves
+to live). Enrichment by ID always wants the row regardless of soft state, because the
+parent's response references it by ID and the renderer needs the identity.
 
 ______________________________________________________________________
 

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -537,6 +537,12 @@ invocations.
 - `variant_id` (optional): Single variant ID to look up directly
 - `skus` (optional): Batch — list of SKUs to look up
 - `variant_ids` (optional): Batch — list of variant IDs to look up
+- `include_archived` (optional, default `false`): Include variants whose
+  parent product/material is archived. On a duplicate SKU the live row
+  always wins via the `get_by_sku` tiebreaker; set `true` only when
+  inspecting an archived-only variant directly.
+- `include_deleted` (optional, default `false`): Include soft-deleted
+  variants. Same default rationale — `true` is for cleanup workflows.
 
 **Examples:**
 ```json
@@ -544,6 +550,7 @@ invocations.
 {"variant_id": 12345}
 {"skus": ["BOLT-M8", "NUT-M8"]}
 {"variant_ids": [12345, 12346]}
+{"sku": "ARCHIVED-SKU", "include_archived": true}
 ```
 
 **Returns:** Full variant details including pricing, barcodes,
@@ -573,15 +580,24 @@ Check current stock levels for one or more SKUs or variant IDs — pass a list f
 
 **Parameters:**
 - `skus_or_variant_ids` (required, min 1): List of SKUs (strings) or variant IDs (integers) — mix freely. Pass one for a stock card, many for a summary table.
+- `location_id` (optional): Filter to a single warehouse/facility.
+- `include_archived` (optional, default `false`): Include variants whose
+  parent is archived, and surface archived per-location inventory rows
+  (threaded through to `/inventory`). On a duplicate SKU the live row
+  always wins; `true` is for cleanup workflows. Per-row `is_archived`
+  surfaces on each `LocationStock`.
+- `include_deleted` (optional, default `false`): Include soft-deleted
+  variants when resolving the SKU. Same live-wins-on-duplicates default.
 
 **Examples:**
 ```json
 {"skus_or_variant_ids": ["WIDGET-001"]}
 {"skus_or_variant_ids": ["WIDGET-001", "WIDGET-002"]}
 {"skus_or_variant_ids": ["WIDGET-001", 12345]}
+{"skus_or_variant_ids": ["ARCHIVED-SKU"], "include_archived": true}
 ```
 
-**Returns:** Stock levels (in_stock, available_stock, committed, expected) per variant.
+**Returns:** Stock levels (in_stock, available_stock, committed, expected) per variant. Each per-location row carries `is_archived`; the top-level item carries `is_archived` derived from the variant's parent archive state.
 
 ---
 
@@ -591,6 +607,13 @@ Find items that are below their reorder threshold.
 **Parameters:**
 - `threshold` (optional): Stock threshold level (default: 10)
 - `limit` (optional): Maximum items to return (default: 50)
+- `include_archived` (optional, default `false`): Include archived
+  inventory rows. Archived rows are filtered by default so they can't
+  carry phantom signals into reorder planning; pass `true` for cleanup
+  workflows. Each row reports two distinct archive signals:
+  `is_archived` (variant's parent product/material is archived) and
+  `has_archived_inventory` (at least one per-warehouse inventory row
+  contributing to `current_stock` is archived).
 
 **Returns:** List of items needing reorder with current stock vs threshold.
 
@@ -614,6 +637,11 @@ timestamps, and rank) so no follow-up lookups are needed for standard fields.
   on when the movement record was first written
 - `updated_at_min` / `updated_at_max` (optional, ISO-8601): When the record was
   last modified — useful for incremental sync
+- `include_archived` / `include_deleted` (optional, default `false`):
+  See `get_variant_details` for the soft-state defaults. The live row
+  always wins on duplicate SKUs via the `get_by_sku` tiebreaker; flags
+  are for cleanup workflows that need to inspect an archived/deleted
+  variant's movement history directly.
 
 **Returns:** Movement history with `id`, `variant_id`, `location_id`, `resource_type`,
 `resource_id`, `caused_by_order_no`, `caused_by_resource_id`, `movement_date`,
@@ -640,6 +668,9 @@ picks the most recent matching row — reading its `balance_after`,
   point are ignored.
 - `location_id` (optional): Filter to a single warehouse/facility — only movements
   at that location are considered.
+- `include_archived` / `include_deleted` (optional, default `false`):
+  See `get_variant_details` for the soft-state defaults. Live wins on
+  duplicates; flags for cleanup workflows only.
 
 **Returns:** `{as_of, items, not_found}`. Each item carries `variant_id`, `sku`,
 `display_name`, per-location rows (`location_id`, `location_name`, `balance_at`,
@@ -673,6 +704,13 @@ Create a stock adjustment to correct inventory levels.
   occurred. Leave None to stamp the current call time. Supply for
   back-fills (e.g. recording a physical count from yesterday).
 - `preview` (optional, default true): Set true to preview, false to create
+- `include_archived` (optional, default `false`): Include variants whose
+  parent is archived when resolving row SKUs. Default `false` fails fast
+  with "SKU not found" rather than letting Katana reject downstream; set
+  `true` for cleanup workflows that need to adjust stock on an archived
+  item.
+- `include_deleted` (optional, default `false`): Include soft-deleted
+  variants when resolving row SKUs. Live wins on duplicates regardless.
 
 **Returns:** Adjustment ID and summary of changes.
 
@@ -1792,14 +1830,19 @@ SQL against the typed cache.
 - `page` (optional): Page number (1-based); when set, the response includes
   `pagination` metadata (total_records, total_pages) computed via SQL COUNT
   against the same filter predicate
+- `ids` (optional): Filter by explicit list of stock transfer IDs
 - `status` (optional): "DRAFT", "IN_TRANSIT", or "RECEIVED" (mapped to the
   Katana wire values "draft" / "inTransit" / "received" against the cache
   column)
 - `source_location_id` (optional): Filter by source location ID
 - `destination_location_id` (optional): Filter by destination (target) location ID
 - `stock_transfer_number` (optional): Exact match on the transfer number
+- `include_deleted` (optional, default `false`): When `true`, surface
+  soft-deleted transfers. Mirrors the peer list-tool default (#539, #484).
 - `created_after` / `created_before` (optional): ISO-8601 datetime bounds on
   created_at — indexed SQL range filter
+- `updated_after` / `updated_before` (optional): ISO-8601 datetime bounds on
+  updated_at — indexed SQL range filter (peer parity with PO/SO/MO lists)
 - `include_rows` (optional, default false): Populate per-transfer row details
 
 **Returns:** Summary rows (id, number, status, source/destination, row_count,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
@@ -311,10 +311,14 @@ async def _fetch_mo_recipe_rows_raw(
     state snapshot and ``_resolve_recipe_row`` match user-supplied
     ``old_variant_id`` against *live* recipe rows so corrections can PATCH
     them. Surfacing tombstoned rows would let a correction target a
-    soft-deleted row that Katana would reject downstream. The MCP layer's
-    read tool (``foundation.manufacturing_orders._fetch_mo_recipe_rows``)
-    intentionally does pass ``include_deleted=True`` because it renders
-    diff context — different use case, different default.
+    soft-deleted row that Katana would reject downstream. The cache-merge
+    fetcher (``manufacturing_orders._fetch_mo_recipe_row_attrs_for_cache_merge``)
+    is the one that does pass ``include_deleted=True`` — it has to see
+    tombstones so the merged cache row goes away when Katana hard-deletes
+    via the soft-delete flow. The agent-facing read
+    (``manufacturing_orders._fetch_mo_recipe_rows``) is also live-only;
+    different surfaces, different defaults, same "agents never see
+    tombstones" rule.
     """
     from katana_public_api_client.api.manufacturing_order_recipe import (
         get_all_manufacturing_order_recipe_rows,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
@@ -306,6 +306,15 @@ async def _fetch_mo_recipe_rows_raw(
     Distinct from :func:`foundation.manufacturing_orders._fetch_mo_recipe_rows`
     which returns SKU-enriched ``RecipeRowInfo`` for the read tool. Here we
     need the raw entity for diff and ID resolution.
+
+    ``include_deleted`` is intentionally **not** passed (#693): the close-
+    state snapshot and ``_resolve_recipe_row`` match user-supplied
+    ``old_variant_id`` against *live* recipe rows so corrections can PATCH
+    them. Surfacing tombstoned rows would let a correction target a
+    soft-deleted row that Katana would reject downstream. The MCP layer's
+    read tool (``foundation.manufacturing_orders._fetch_mo_recipe_rows``)
+    intentionally does pass ``include_deleted=True`` because it renders
+    diff context — different use case, different default.
     """
     from katana_public_api_client.api.manufacturing_order_recipe import (
         get_all_manufacturing_order_recipe_rows,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/customers.py
@@ -20,6 +20,7 @@ from katana_mcp.services import get_services
 from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
+    SoftDeletableResponse,
     make_json_result,
     make_tool_result,
 )
@@ -136,7 +137,7 @@ class GetCustomerRequest(BaseModel):
     customer_id: int = Field(..., description="Customer ID to look up")
 
 
-class CustomerAddressInfo(BaseModel):
+class CustomerAddressInfo(SoftDeletableResponse):
     """Full customer address — one entry in ``GetCustomerResponse.addresses``.
 
     Mirrors the wire-shape of ``katana_public_api_client.models.CustomerAddress``
@@ -163,10 +164,9 @@ class CustomerAddressInfo(BaseModel):
     country: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
 
-class GetCustomerResponse(BaseModel):
+class GetCustomerResponse(SoftDeletableResponse):
     """Full customer details. Exhaustive — every field Katana exposes on
     ``Customer`` is surfaced (including nested addresses) so callers don't
     need follow-up lookups for standard fields.
@@ -189,7 +189,6 @@ class GetCustomerResponse(BaseModel):
     default_shipping_id: int | None = None
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
     addresses: list[CustomerAddressInfo] = Field(default_factory=list)
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -112,6 +112,27 @@ class CheckInventoryRequest(BaseModel):
             "Look up via `list_locations`."
         ),
     )
+    include_archived: bool = Field(
+        default=False,
+        description=(
+            "Include archived rows across both surfaces of this tool: "
+            "(1) variants whose parent product/material is archived (the "
+            "identifier-resolution side), and (2) per-location inventory "
+            "rows individually archived at a single warehouse (threaded to "
+            "`/inventory` and surfaced via `LocationStock.is_archived`). "
+            "Default `False` returns only active rows; on a duplicate SKU, "
+            "the live row always wins. Set `True` for cleanup workflows."
+        ),
+    )
+    include_deleted: bool = Field(
+        default=False,
+        description=(
+            "Include soft-deleted variants on the identifier-resolution "
+            "side (SKU or variant-ID). Default `False` returns only live "
+            "rows; on a duplicate SKU, the live row always wins. Set "
+            "`True` only when inspecting a deleted variant directly."
+        ),
+    )
 
 
 class LocationStock(BaseModel):
@@ -134,6 +155,11 @@ class LocationStock(BaseModel):
     safety_stock_level: float | None = None
     value_in_stock: float | None = None
     average_cost: float | None = None
+    # Per-row archive state — Katana lets an inventory row at a single
+    # warehouse be archived independent of the variant's parent. Derived
+    # from ``Inventory.archived_at`` (non-null = archived). Surfaces only
+    # when the request opted in via ``include_archived=True`` (#539).
+    is_archived: bool = False
 
 
 class StockInfo(BaseModel):
@@ -170,6 +196,11 @@ class StockInfo(BaseModel):
     default_supplier_name: str | None = None
     parent_type: Literal["product", "material"] | None = None
     katana_url: str | None = None  # deep-link to parent page
+    # Variant-level archive state lifted from ``CachedVariant.parent_archived_at``
+    # — true when the parent product/material is archived. Mirrors the
+    # ``ItemInfo.is_archived`` / ``ItemDetailsResponse.is_archived``
+    # convention from #526 so callers don't have to inspect the timestamp.
+    is_archived: bool = False
 
 
 class _InventoryRow(NamedTuple):
@@ -188,6 +219,7 @@ class _InventoryRow(NamedTuple):
     safety_stock_level: float | None
     value_in_stock: float | None
     average_cost: float | None
+    is_archived: bool
 
 
 async def _fetch_stock_for_variant(
@@ -196,6 +228,8 @@ async def _fetch_stock_for_variant(
     sku: str,
     product_name: str,
     location_id: int | None = None,
+    *,
+    include_archived: bool = False,
 ) -> StockInfo:
     """Query the inventory endpoint and return totals + per-location breakdown.
 
@@ -203,7 +237,13 @@ async def _fetch_stock_for_variant(
     location (so totals and ``by_location`` only cover one warehouse).
     Without the filter, totals are the sum across every location the
     variant has stock at, and ``by_location`` is sorted by ``in_stock``
-    descending so the largest holding shows first."""
+    descending so the largest holding shows first.
+
+    ``include_archived`` threads through to ``get_all_inventory_point`` so
+    archived per-location inventory rows surface only on explicit opt-in
+    (#539). The default keeps the active-only contract used by reorder
+    planning callers.
+    """
     from katana_public_api_client.api.inventory import get_all_inventory_point
     from katana_public_api_client.domain.converters import unwrap_unset
     from katana_public_api_client.utils import unwrap_data
@@ -211,6 +251,8 @@ async def _fetch_stock_for_variant(
     api_kwargs: dict[str, Any] = {"client": services.client, "variant_id": variant_id}
     if location_id is not None:
         api_kwargs["location_id"] = location_id
+    if include_archived:
+        api_kwargs["include_archived"] = True
     response = await get_all_inventory_point.asyncio_detailed(**api_kwargs)
     inventory_items = unwrap_data(response)
 
@@ -244,6 +286,7 @@ async def _fetch_stock_for_variant(
                 ),
                 value_in_stock=_opt_float(unwrap_unset(inv.value_in_stock, None)),
                 average_cost=_opt_float(unwrap_unset(inv.average_cost, None)),
+                is_archived=unwrap_unset(inv.archived_at, None) is not None,
             )
         )
 
@@ -270,6 +313,7 @@ async def _fetch_stock_for_variant(
             safety_stock_level=row.safety_stock_level,
             value_in_stock=row.value_in_stock,
             average_cost=row.average_cost,
+            is_archived=row.is_archived,
         )
         for row in rows
     ]
@@ -343,6 +387,11 @@ async def _enrich_stock_info_with_parent(
         if r.variant_id is None:
             continue
         variant = variants.get(r.variant_id)
+        # ``parent_archived_at`` is lifted onto the variant during sync;
+        # surface it on the response as ``is_archived`` so callers don't
+        # have to inspect the timestamp (mirrors #526's items-side
+        # convention).
+        r.is_archived = _attr(variant, "parent_archived_at") is not None
         # Variants carry exactly one of product_id / material_id; pick whichever
         # is set so the right parent map and URL kind get used.
         kind: Literal["product", "material"] | None
@@ -417,14 +466,15 @@ async def _check_inventory_impl(
             during enrichment without a redundant lookup that would also
             silently drop API-fallback rows on a cold cache."""
             if isinstance(item, str):
-                # ``get_by_sku`` defaults filter archived parents and
-                # soft-deleted variants; pass ``include_*=True`` so
-                # ``check_inventory("ARCHIVED-SKU")`` still returns the
-                # row instead of silently looking like the SKU doesn't
-                # exist (matches the legacy cache's "show everything"
-                # semantics for direct lookups).
+                # Soft-state defaults are off (#539): on a duplicate SKU
+                # the live row always wins via the ``get_by_sku``
+                # tiebreaker. Cleanup workflows opt in via the request
+                # flags so an archived-only or deleted-only SKU can still
+                # be resolved.
                 variant = await services.typed_cache.catalog.get_by_sku(
-                    item, include_archived=True, include_deleted=True
+                    item,
+                    include_archived=request.include_archived,
+                    include_deleted=request.include_deleted,
                 )
                 if not variant:
                     logger.warning("inventory_check_not_found", sku=item)
@@ -446,10 +496,16 @@ async def _check_inventory_impl(
                     item,
                     _attr(variant, "display_name") or _attr(variant, "sku") or "",
                     location_id=request.location_id,
+                    include_archived=request.include_archived,
                 )
                 return stock, variant
 
-            variant = await _fetch_variant_by_id(services, item)
+            variant = await _fetch_variant_by_id(
+                services,
+                item,
+                include_archived=request.include_archived,
+                include_deleted=request.include_deleted,
+            )
             if not variant:
                 logger.warning("inventory_check_not_found", variant_id=item)
                 return (
@@ -475,7 +531,12 @@ async def _check_inventory_impl(
                 _attr(variant, "display_name") or sku or _attr(parent, "name") or ""
             )
             stock = await _fetch_stock_for_variant(
-                services, item, sku, product_name, location_id=request.location_id
+                services,
+                item,
+                sku,
+                product_name,
+                location_id=request.location_id,
+                include_archived=request.include_archived,
             )
             return stock, variant
 
@@ -578,6 +639,19 @@ class LowStockRequest(BaseModel):
 
     threshold: int = Field(default=10, description="Stock threshold level")
     limit: int = Field(default=50, description="Maximum items to return")
+    include_archived: bool = Field(
+        default=False,
+        description=(
+            "Include archived rows across both surfaces: per-location "
+            "inventory records marked archived (threaded to `/inventory`, "
+            "counted into `current_stock` and reported via "
+            "`has_archived_inventory`) AND variants whose parent "
+            "product/material is archived (reported via `is_archived`). "
+            "Default `False` — archived rows shouldn't carry phantom "
+            "stock signals into normal reorder planning. Set `True` "
+            "for cleanup workflows."
+        ),
+    )
 
 
 class LowStockItem(BaseModel):
@@ -601,6 +675,19 @@ class LowStockItem(BaseModel):
     default_supplier_id: int | None = None
     default_supplier_name: str | None = None
     minimum_order_quantity: float | None = None
+    # Variant-level archive state lifted from ``CachedVariant.parent_archived_at``
+    # — true when the parent product/material is archived. Surfaces only
+    # when the request opted in via ``include_archived=True`` (#539).
+    is_archived: bool = False
+    # Per-row inventory archive state — true when at least one of the
+    # ``/inventory`` rows contributing to ``current_stock`` for this
+    # variant is itself archived (``Inventory.archived_at`` non-null).
+    # Distinct from ``is_archived`` (parent-archived); a variant with a
+    # live parent can still have archived inventory rows at individual
+    # warehouses. Only meaningful when the request opted in via
+    # ``include_archived=True`` — otherwise archived rows never enter
+    # the aggregation and the flag stays ``False``.
+    has_archived_inventory: bool = False
 
 
 class LowStockResponse(BaseModel):
@@ -654,15 +741,24 @@ async def _list_low_stock_items_impl(
 
         services = get_services(context)
 
+        # ``include_archived`` threads through so reorder planning stays
+        # active-only by default (#539). Cleanup workflows pass
+        # ``include_archived=True`` to surface archived rows.
+        inventory_api_kwargs: dict[str, Any] = {"client": services.client}
+        if request.include_archived:
+            inventory_api_kwargs["include_archived"] = True
         response = await get_all_inventory_point.asyncio_detailed(
-            client=services.client
+            **inventory_api_kwargs
         )
         inventory_rows = unwrap_data(response)
 
         totals: dict[int, float] = {}
+        has_archived_rows: dict[int, bool] = {}
         for inv in inventory_rows:
             qty = float(unwrap_unset(inv.quantity_in_stock, "0"))
             totals[inv.variant_id] = totals.get(inv.variant_id, 0.0) + qty
+            if unwrap_unset(inv.archived_at, None) is not None:
+                has_archived_rows[inv.variant_id] = True
 
         low_stock = sorted(
             (
@@ -743,6 +839,8 @@ async def _list_low_stock_items_impl(
                     default_supplier_id=default_supplier_id,
                     default_supplier_name=_attr(supplier, "name"),
                     minimum_order_quantity=_attr(variant, "minimum_order_quantity"),
+                    is_archived=_attr(variant, "parent_archived_at") is not None,
+                    has_archived_inventory=has_archived_rows.get(variant_id, False),
                 )
             )
 
@@ -844,6 +942,24 @@ class GetInventoryMovementsRequest(BaseModel):
         default=None,
         description="ISO-8601 upper bound on `updated_at`.",
     )
+    include_archived: bool = Field(
+        default=False,
+        description=(
+            "Include movements for variants whose parent product/material "
+            "is archived. Default `False` returns only active rows; on a "
+            "duplicate SKU, the live row always wins. Set `True` for "
+            "cleanup workflows."
+        ),
+    )
+    include_deleted: bool = Field(
+        default=False,
+        description=(
+            "Include movements for soft-deleted variants. Default `False` "
+            "returns only live rows; on a duplicate SKU, the live row "
+            "always wins. Set `True` only when inspecting a deleted "
+            "variant directly."
+        ),
+    )
 
 
 class MovementInfo(BaseModel):
@@ -918,12 +1034,14 @@ async def _get_inventory_movements_impl(
     try:
         services = get_services(context)
 
-        # Resolve SKU → variant_id via the cached catalog. Surface
-        # archived/deleted variants too so the user sees movements
-        # for items they're cleaning up — direct-lookup parity with
-        # the legacy cache's behavior.
+        # Soft-state defaults are off (#539): on a duplicate SKU the live
+        # row always wins via the ``get_by_sku`` tiebreaker. Cleanup
+        # workflows opt in via the request flags so movements for an
+        # archived-only or deleted-only SKU can still be inspected.
         variant = await services.typed_cache.catalog.get_by_sku(
-            request.sku, include_archived=True, include_deleted=True
+            request.sku,
+            include_archived=request.include_archived,
+            include_deleted=request.include_deleted,
         )
         if variant is None:
             duration_ms = round((time.monotonic() - start_time) * 1000, 2)
@@ -1098,6 +1216,22 @@ class InventoryAtRequest(BaseModel):
             "movements at this location are considered."
         ),
     )
+    include_archived: bool = Field(
+        default=False,
+        description=(
+            "Include variants whose parent product/material is archived. "
+            "Default `False` returns only active rows; on a duplicate SKU, "
+            "the live row always wins. Set `True` for cleanup workflows."
+        ),
+    )
+    include_deleted: bool = Field(
+        default=False,
+        description=(
+            "Include soft-deleted variants. Default `False` returns only "
+            "live rows; on a duplicate SKU, the live row always wins. "
+            "Set `True` only when inspecting a deleted variant directly."
+        ),
+    )
 
 
 class InventoryAtLocation(BaseModel):
@@ -1191,10 +1325,17 @@ async def _inventory_at_impl(
         async def _resolve(item: str | int) -> tuple[str | int, Any | None]:
             if isinstance(item, str):
                 v = await services.typed_cache.catalog.get_by_sku(
-                    item, include_archived=True, include_deleted=True
+                    item,
+                    include_archived=request.include_archived,
+                    include_deleted=request.include_deleted,
                 )
             else:
-                v = await _fetch_variant_by_id(services, item)
+                v = await _fetch_variant_by_id(
+                    services,
+                    item,
+                    include_archived=request.include_archived,
+                    include_deleted=request.include_deleted,
+                )
             return (item, v)
 
         resolved_pairs = list(await asyncio.gather(*(_resolve(i) for i in items)))
@@ -1447,6 +1588,24 @@ class CreateStockAdjustmentRequest(BaseModel):
         default=True,
         description="Set true (default) to preview, false to create",
     )
+    include_archived: bool = Field(
+        default=False,
+        description=(
+            "Include variants whose parent product/material is archived "
+            "when resolving row SKUs. Default `False` errors on archived-"
+            "only SKUs ('SKU not found'); set `True` for cleanup workflows "
+            "that need to adjust stock on an archived item."
+        ),
+    )
+    include_deleted: bool = Field(
+        default=False,
+        description=(
+            "Include soft-deleted variants when resolving row SKUs. Default "
+            "`False` errors on deleted-only SKUs; on a duplicate SKU, the "
+            "live row always wins regardless. Set `True` only for "
+            "exceptional cleanup workflows."
+        ),
+    )
 
 
 class StockAdjustmentRowSummary(BaseModel):
@@ -1504,11 +1663,15 @@ async def _create_stock_adjustment_impl(
     rows_summary_parts = []
     structured_rows: list[StockAdjustmentRowSummary] = []
     for row in request.rows:
-        # Direct-lookup path: include archived/deleted so a CLI user
-        # adjusting an in-progress cleanup workflow can still resolve
-        # the SKU. The live API will reject genuinely bad SKUs.
+        # Soft-state defaults are off (#539): on a duplicate SKU the live
+        # row always wins via the ``get_by_sku`` tiebreaker. A bare
+        # ``create_stock_adjustment`` against an archived-only / deleted-
+        # only SKU fails fast with "SKU not found" rather than letting
+        # Katana reject downstream. Cleanup workflows opt in explicitly.
         variant = await services.typed_cache.catalog.get_by_sku(
-            row.sku, include_archived=True, include_deleted=True
+            row.sku,
+            include_archived=request.include_archived,
+            include_deleted=request.include_deleted,
         )
         if variant is None:
             raise ValueError(f"SKU '{row.sku}' not found")

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -157,8 +157,10 @@ class LocationStock(BaseModel):
     average_cost: float | None = None
     # Per-row archive state — Katana lets an inventory row at a single
     # warehouse be archived independent of the variant's parent. Derived
-    # from ``Inventory.archived_at`` (non-null = archived). Surfaces only
-    # when the request opted in via ``include_archived=True`` (#539).
+    # from ``Inventory.archived_at`` (non-null = archived). Always present
+    # in the response schema; only ever ``True`` when the request opted
+    # in via ``include_archived=True`` (#539), since Katana's default
+    # ``/inventory`` filter omits archived rows entirely.
     is_archived: bool = False
 
 
@@ -676,8 +678,10 @@ class LowStockItem(BaseModel):
     default_supplier_name: str | None = None
     minimum_order_quantity: float | None = None
     # Variant-level archive state lifted from ``CachedVariant.parent_archived_at``
-    # — true when the parent product/material is archived. Surfaces only
-    # when the request opted in via ``include_archived=True`` (#539).
+    # — true when the parent product/material is archived. Always present
+    # in the response schema; only ever ``True`` when the request opted
+    # in via ``include_archived=True`` (#539), since archived-parent
+    # variants are otherwise filtered out before they reach this builder.
     is_archived: bool = False
     # Per-row inventory archive state — true when at least one of the
     # ``/inventory`` rows contributing to ``current_stock`` for this

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -44,6 +44,7 @@ from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.list_coercion import CoercedIntListOpt, CoercedStrListOpt
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
+    SoftDeletableResponse,
     make_tool_result,
     resolve_factory_base_currency,
 )
@@ -616,7 +617,7 @@ class ItemVariantSummary(BaseModel):
     """
 
 
-class ItemDetailsResponse(BaseModel):
+class ItemDetailsResponse(SoftDeletableResponse):
     """Full item details. Exhaustive — every field Katana exposes on
     ``Product`` / ``Material`` / ``Service`` is surfaced per-type (the API is
     polymorphic, so not every field applies to every type; product-only and
@@ -643,7 +644,6 @@ class ItemDetailsResponse(BaseModel):
     created_at: str | None = None
     updated_at: str | None = None
     archived_at: str | None = None
-    deleted_at: str | None = None
 
     # Convenience boolean derived from ``archived_at`` — saves callers from
     # having to know the timestamp/null convention. Pair with
@@ -1609,9 +1609,26 @@ class GetVariantDetailsRequest(BaseModel):
         default=None,
         description="Batch lookup: JSON array of variant IDs, e.g. [12345, 67890].",
     )
+    include_archived: bool = Field(
+        default=False,
+        description=(
+            "Include variants whose parent product/material is archived. "
+            "Default `False` returns only active rows; on a duplicate SKU, "
+            "the live row always wins. Set `True` for cleanup workflows "
+            "where you need to inspect an archived variant directly."
+        ),
+    )
+    include_deleted: bool = Field(
+        default=False,
+        description=(
+            "Include soft-deleted variants. Default `False` returns only "
+            "live rows; on a duplicate SKU, the live row always wins. "
+            "Set `True` only when inspecting a deleted variant directly."
+        ),
+    )
 
 
-class VariantDetailsResponse(BaseModel):
+class VariantDetailsResponse(SoftDeletableResponse):
     """Full variant details. Exhaustive — every field Katana exposes on the
     ``Variant`` attrs model is surfaced, including nested configuration
     attributes and custom fields, so callers don't need follow-up lookups.
@@ -1698,7 +1715,6 @@ class VariantDetailsResponse(BaseModel):
     # Metadata
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
 
 class VariantNotFound(BaseModel):
@@ -1930,7 +1946,13 @@ async def _enrich_variants_with_parent(
     return products, materials, supplier_by_id
 
 
-async def _fetch_variant_by_id(services: Any, variant_id: int) -> Any | None:
+async def _fetch_variant_by_id(
+    services: Any,
+    variant_id: int,
+    *,
+    include_archived: bool = True,
+    include_deleted: bool = True,
+) -> Any | None:
     """Look up a variant by ID — cache first, then API fallback.
 
     Returns either a ``CachedVariant`` (cache hit) or a ``VariantResponse``
@@ -1946,13 +1968,27 @@ async def _fetch_variant_by_id(services: Any, variant_id: int) -> Any | None:
 
     Uses ``raise_on_error=False`` so a 404 (or an ErrorResponse body)
     becomes ``None`` instead of a raw ``APIError``, which is what
-    callers expect as the "not found" sentinel. Passes
-    ``include_archived=True`` / ``include_deleted=True`` to the
-    cache lookup so direct-lookup parity matches the legacy cache
-    (every row regardless of soft-state).
+    callers expect as the "not found" sentinel.
+
+    ``include_archived`` / ``include_deleted`` gate the cache lookup —
+    direct-lookup callers (``check_inventory``, ``inventory_at``,
+    ``get_variant_details``) pass the request flags to keep the
+    front-door rule "default to live-only" consistent across SKU and
+    variant-ID identifiers (#539). Enrichment callers (cold-cache
+    backfill for list tools, PO row hydration) accept the ``True``
+    defaults so soft-state variants still resolve to a displayable
+    row. On the API-fallback path, ``include_deleted=False`` post-
+    filters a soft-deleted ``VariantResponse`` to ``None`` (read off
+    ``variant_obj.deleted_at``); ``include_archived=False`` post-filters
+    a variant whose nested ``product_or_material.archived_at`` is non-
+    null (the ``extend=[PRODUCT_OR_MATERIAL]`` payload already carries
+    that field, so no extra round trip is needed).
     """
     v = await services.typed_cache.catalog.get_by_id(
-        CachedVariant, variant_id, include_archived=True, include_deleted=True
+        CachedVariant,
+        variant_id,
+        include_archived=include_archived,
+        include_deleted=include_deleted,
     )
     if v is not None:
         return v
@@ -1969,6 +2005,19 @@ async def _fetch_variant_by_id(services: Any, variant_id: int) -> Any | None:
     variant_obj = unwrap(response, raise_on_error=False)
     if variant_obj is None or isinstance(variant_obj, ErrorResponse):
         return None
+    if not include_deleted:
+        deleted_at = unwrap_unset(getattr(variant_obj, "deleted_at", UNSET), None)
+        if deleted_at is not None:
+            return None
+    if not include_archived:
+        parent = unwrap_unset(getattr(variant_obj, "product_or_material", UNSET), None)
+        parent_archived_at = (
+            unwrap_unset(getattr(parent, "archived_at", UNSET), None)
+            if parent is not None
+            else None
+        )
+        if parent_archived_at is not None:
+            return None
     return variant_obj
 
 
@@ -2074,17 +2123,32 @@ async def _get_variant_details_impl(
     services = get_services(context)
     catalog = services.typed_cache.catalog
 
-    # Parallelize both groups of lookups. Direct-lookup parity with the
-    # legacy cache: include archived/deleted variants so the user can
-    # still inspect rows they're cleaning up.
+    # Parallelize both groups of lookups. Soft-state defaults are off
+    # (#539): on a duplicate SKU the live row always wins via the
+    # ``get_by_sku`` tiebreaker. Cleanup workflows opt in via the
+    # request flags.
     sku_variants, id_variants = await asyncio.gather(
         asyncio.gather(
             *(
-                catalog.get_by_sku(s, include_archived=True, include_deleted=True)
+                catalog.get_by_sku(
+                    s,
+                    include_archived=request.include_archived,
+                    include_deleted=request.include_deleted,
+                )
                 for s in sku_cleaned
             )
         ),
-        asyncio.gather(*(_fetch_variant_by_id(services, v) for v in variant_ids)),
+        asyncio.gather(
+            *(
+                _fetch_variant_by_id(
+                    services,
+                    v,
+                    include_archived=request.include_archived,
+                    include_deleted=request.include_deleted,
+                )
+                for v in variant_ids
+            )
+        ),
     )
 
     hits, not_found = _partition_variant_lookups(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -57,6 +57,7 @@ from katana_mcp.tools.tool_result_utils import (
     BLOCK_WARNING_PREFIX,
     UI_META,
     PaginationMeta,
+    SoftDeletableResponse,
     apply_date_window_filters,
     coerce_enum,
     enum_to_str,
@@ -593,14 +594,13 @@ class SerialNumberInfo(BaseModel):
     quantity_change: int | None = None
 
 
-class AssignedOperatorInfo(BaseModel):
+class AssignedOperatorInfo(SoftDeletableResponse):
     """One entry in an operation row's ``assigned_operators`` /
     ``completed_by_operators`` list. Mirrors the generated ``AssignedOperator``.
     """
 
     operator_id: int
     name: str
-    deleted_at: str | None = None
 
 
 class RecipeRowBatchTransactionInfo(BaseModel):
@@ -612,7 +612,7 @@ class RecipeRowBatchTransactionInfo(BaseModel):
     quantity: float | None = None
 
 
-class RecipeRowInfo(BaseModel):
+class RecipeRowInfo(SoftDeletableResponse):
     """Full manufacturing-order recipe row. Exhaustive — every field on
     ``ManufacturingOrderRecipeRow`` is surfaced, plus the resolved SKU
     and canonical ``display_name`` for display convenience.
@@ -646,10 +646,9 @@ class RecipeRowInfo(BaseModel):
     cost: float | None = None
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
 
-class OperationRowInfo(BaseModel):
+class OperationRowInfo(SoftDeletableResponse):
     """Full manufacturing-order operation row. Exhaustive — every field on
     ``ManufacturingOrderOperationRow`` is surfaced.
     """
@@ -690,10 +689,9 @@ class OperationRowInfo(BaseModel):
     completed_at: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
 
-class ProductionIngredientInfo(BaseModel):
+class ProductionIngredientInfo(SoftDeletableResponse):
     """One entry in a production's ``ingredients`` list. Mirrors the
     generated ``ManufacturingOrderProductionIngredient``.
     """
@@ -709,10 +707,9 @@ class ProductionIngredientInfo(BaseModel):
     cost: float | None = None
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
 
-class ProductionOperationInfo(BaseModel):
+class ProductionOperationInfo(SoftDeletableResponse):
     """One entry in a production's ``operations`` list. Mirrors the
     generated ``ManufacturingOrderOperationProduction``.
     """
@@ -727,10 +724,9 @@ class ProductionOperationInfo(BaseModel):
     cost: float | None = None
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
 
-class ProductionInfo(BaseModel):
+class ProductionInfo(SoftDeletableResponse):
     """Full manufacturing-order production record. Exhaustive — every field
     on ``ManufacturingOrderProduction`` is surfaced.
     """
@@ -754,10 +750,9 @@ class ProductionInfo(BaseModel):
     )
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
 
-class GetManufacturingOrderResponse(BaseModel):
+class GetManufacturingOrderResponse(SoftDeletableResponse):
     """Full manufacturing order details. Exhaustive — every field Katana
     exposes on ``ManufacturingOrder`` is surfaced (including nested recipe
     rows, operation rows, and production records) so callers don't need
@@ -800,7 +795,6 @@ class GetManufacturingOrderResponse(BaseModel):
     )
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
     recipe_rows: list[RecipeRowInfo] = Field(
         default_factory=list,
         description="Recipe rows (ingredients) on the manufacturing order.",

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -51,6 +51,7 @@ from katana_mcp.tools.tool_result_utils import (
     BLOCK_WARNING_PREFIX,
     UI_META,
     PaginationMeta,
+    SoftDeletableResponse,
     apply_date_window_filters,
     coerce_enum,
     enum_to_str,
@@ -964,7 +965,7 @@ class GetPurchaseOrderRequest(BaseModel):
     order_id: int | None = Field(default=None, description="Purchase order ID")
 
 
-class PurchaseOrderRowInfo(BaseModel):
+class PurchaseOrderRowInfo(SoftDeletableResponse):
     """Full purchase order line item — every field Katana exposes on
     ``PurchaseOrderRow`` is surfaced so callers don't need follow-up lookups
     for standard row fields (UOM conversion, currency, landed_cost, etc.).
@@ -973,7 +974,6 @@ class PurchaseOrderRowInfo(BaseModel):
     id: int
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
     quantity: float | None = None
     variant_id: int | None = None
     sku: str | None = None
@@ -1008,7 +1008,7 @@ class PurchaseOrderRowInfo(BaseModel):
     )
 
 
-class PurchaseOrderAdditionalCostRowInfo(BaseModel):
+class PurchaseOrderAdditionalCostRowInfo(SoftDeletableResponse):
     """Full additional cost row — every field Katana exposes on
     ``PurchaseOrderAdditionalCostRow`` (shipping, duties, handling, etc.).
     """
@@ -1016,7 +1016,6 @@ class PurchaseOrderAdditionalCostRowInfo(BaseModel):
     id: int
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
     additional_cost_id: int | None = None
     group_id: int | None = None
     name: str | None = None
@@ -1043,7 +1042,7 @@ class PurchaseOrderAccountingMetadataInfo(BaseModel):
     created_at: str | None = None
 
 
-class SupplierInfo(BaseModel):
+class SupplierInfo(SoftDeletableResponse):
     """Embedded supplier details — every field Katana exposes on
     ``Supplier`` when the PO payload includes the inline supplier record.
     """
@@ -1061,10 +1060,9 @@ class SupplierInfo(BaseModel):
     )
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
 
-class GetPurchaseOrderResponse(BaseModel):
+class GetPurchaseOrderResponse(SoftDeletableResponse):
     """Full purchase-order details. Exhaustive — every field Katana exposes
     on ``RegularPurchaseOrder`` is surfaced, plus nested inline rows and
     fetched-on-demand additional cost rows and accounting metadata. Callers
@@ -1075,7 +1073,6 @@ class GetPurchaseOrderResponse(BaseModel):
     katana_url: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
     status: str | None = None
     order_no: str | None = None
     entity_type: str | None = None

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
@@ -17,7 +17,10 @@ from sqlmodel import SQLModel
 from katana_mcp.logging import observe_tool
 from katana_mcp.services import get_services
 from katana_mcp.tools.decorators import cache_read
-from katana_mcp.tools.tool_result_utils import make_json_result
+from katana_mcp.tools.tool_result_utils import (
+    SoftDeletableResponse,
+    make_json_result,
+)
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_public_api_client.models_pydantic._generated import (
     CachedAdditionalCost,
@@ -172,7 +175,7 @@ class GetSupplierRequest(BaseModel):
     supplier_id: int = Field(..., description="Supplier ID to look up")
 
 
-class GetSupplierResponse(BaseModel):
+class GetSupplierResponse(SoftDeletableResponse):
     id: int
     name: str
     email: str | None = None
@@ -189,7 +192,6 @@ class GetSupplierResponse(BaseModel):
     country: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
 
 def _iso_or_none(value: Any) -> str | None:

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -52,6 +52,7 @@ from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
     PaginationMeta,
+    SoftDeletableResponse,
     apply_date_window_filters,
     coerce_enum,
     enum_to_str,
@@ -978,7 +979,7 @@ class GetSalesOrderRequest(BaseModel):
     order_id: int | None = Field(default=None, description="Sales order ID")
 
 
-class SalesOrderRowDetail(BaseModel):
+class SalesOrderRowDetail(SoftDeletableResponse):
     """Full sales order row — every field on ``SalesOrderRow`` surfaced.
 
     Used inside ``GetSalesOrderResponse.rows`` where we want the exhaustive
@@ -1019,10 +1020,9 @@ class SalesOrderRowDetail(BaseModel):
     )
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
 
-class SalesOrderAddressInfo(BaseModel):
+class SalesOrderAddressInfo(SoftDeletableResponse):
     """Full sales order address — one entry in ``GetSalesOrderResponse.addresses``.
 
     Mirrors every field on the ``SalesOrderAddress`` attrs model. The attrs
@@ -1045,7 +1045,6 @@ class SalesOrderAddressInfo(BaseModel):
     country: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
 
 class SalesOrderShippingFeeInfo(BaseModel):
@@ -1058,7 +1057,7 @@ class SalesOrderShippingFeeInfo(BaseModel):
     description: str | None = None
 
 
-class GetSalesOrderResponse(BaseModel):
+class GetSalesOrderResponse(SoftDeletableResponse):
     """Full sales order details. Exhaustive — every field Katana exposes on
     ``SalesOrder`` is surfaced (including nested rows, addresses, and
     shipping fee) so callers don't need follow-up lookups for standard fields.
@@ -1121,7 +1120,6 @@ class GetSalesOrderResponse(BaseModel):
     # Timestamps
     created_at: str | None = None
     updated_at: str | None = None
-    deleted_at: str | None = None
 
     # Line items — exhaustive per-row detail
     rows: list[SalesOrderRowDetail] = Field(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -42,6 +42,7 @@ from katana_mcp.tools._modification_dispatch import (
     run_modify_plan,
     unset_dict,
 )
+from katana_mcp.tools.list_coercion import CoercedIntListOpt
 from katana_mcp.tools.tool_result_utils import (
     BLOCK_WARNING_PREFIX,
     UI_META,
@@ -492,6 +493,13 @@ class ListStockTransfersRequest(BaseModel):
     )
 
     # Domain filters
+    ids: CoercedIntListOpt = Field(
+        default=None,
+        description=(
+            "Filter by explicit list of stock transfer IDs. "
+            "JSON array of integers, e.g. [101, 202, 303]."
+        ),
+    )
     status: StatusLiteral | None = Field(
         default=None,
         description="Filter by transfer status (DRAFT, IN_TRANSIT, RECEIVED)",
@@ -510,6 +518,13 @@ class ListStockTransfersRequest(BaseModel):
     stock_transfer_number: str | None = Field(
         default=None, description="Filter by exact stock transfer number"
     )
+    include_deleted: bool = Field(
+        default=False,
+        description=(
+            "When true, include soft-deleted stock transfers. Default "
+            "`False` matches the peer list-tool convention (#539, #484)."
+        ),
+    )
 
     # Time-window filters
     created_after: str | None = Field(
@@ -517,6 +532,12 @@ class ListStockTransfersRequest(BaseModel):
     )
     created_before: str | None = Field(
         default=None, description="ISO-8601 datetime upper bound on created_at."
+    )
+    updated_after: str | None = Field(
+        default=None, description="ISO-8601 datetime lower bound on updated_at."
+    )
+    updated_before: str | None = Field(
+        default=None, description="ISO-8601 datetime upper bound on updated_at."
     )
 
     # Row inclusion
@@ -537,6 +558,8 @@ class ListStockTransfersResponse(BaseModel):
 _STOCK_TRANSFER_DATE_FIELDS = (
     "created_after",
     "created_before",
+    "updated_after",
+    "updated_before",
 )
 
 
@@ -559,6 +582,8 @@ def _apply_stock_transfer_filters(
         CachedStockTransfer,
     )
 
+    if request.ids is not None:
+        stmt = stmt.where(CachedStockTransfer.id.in_(request.ids))
     if request.status is not None:
         api_value = _STATUS_API_VALUE[request.status]
         stmt = stmt.where(CachedStockTransfer.status == api_value.value)
@@ -574,13 +599,20 @@ def _apply_stock_transfer_filters(
         stmt = stmt.where(
             CachedStockTransfer.stock_transfer_number == request.stock_transfer_number
         )
-    stmt = stmt.where(CachedStockTransfer.deleted_at.is_(None))
+    if not request.include_deleted:
+        stmt = stmt.where(CachedStockTransfer.deleted_at.is_(None))
 
     return apply_date_window_filters(
         stmt,
         parsed_dates,
-        ge_pairs={"created_after": CachedStockTransfer.created_at},
-        le_pairs={"created_before": CachedStockTransfer.created_at},
+        ge_pairs={
+            "created_after": CachedStockTransfer.created_at,
+            "updated_after": CachedStockTransfer.updated_at,
+        },
+        le_pairs={
+            "created_before": CachedStockTransfer.created_at,
+            "updated_before": CachedStockTransfer.updated_at,
+        },
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
+++ b/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
@@ -41,8 +41,9 @@ class SoftDeletableResponse(BaseModel):
     that escape hatch must set the field explicitly.
 
     Read-side only — Katana exposes deletion via DELETE endpoints, not
-    via a writable boolean on update bodies. See ``typed_cache/README.md``
-    "Archive / deleted state" for the asymmetry vs. ``is_archived``.
+    via a writable boolean on update bodies. See
+    ``katana_mcp_server/docs/typed_cache/README.md`` "Archive / deleted
+    state" for the asymmetry vs. ``is_archived``.
     """
 
     deleted_at: str | None = None

--- a/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
+++ b/katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py
@@ -15,10 +15,10 @@ import json
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 from fastmcp.tools import ToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from katana_mcp.logging import get_logger
 
@@ -26,6 +26,40 @@ if TYPE_CHECKING:
     from prefab_ui.app import PrefabApp
 
 logger = get_logger(__name__)
+
+
+class SoftDeletableResponse(BaseModel):
+    """Mixin: derives ``is_deleted: bool`` from ``deleted_at`` after validation.
+
+    Mirrors #526's ``is_archived`` convention so callers don't need to
+    parse the timestamp/null shape. Subclasses get the field plumbing
+    for free; the ``mode="after"`` validator fires on any construction
+    path that runs validation — direct ``__init__``, ``model_validate``,
+    ``model_validate_json`` — and sets ``is_deleted=True`` when
+    ``deleted_at`` is non-null. ``model_construct`` bypasses validation
+    in Pydantic v2 and will **not** derive ``is_deleted``; callers using
+    that escape hatch must set the field explicitly.
+
+    Read-side only — Katana exposes deletion via DELETE endpoints, not
+    via a writable boolean on update bodies. See ``typed_cache/README.md``
+    "Archive / deleted state" for the asymmetry vs. ``is_archived``.
+    """
+
+    deleted_at: str | None = None
+    is_deleted: bool = False
+
+    @model_validator(mode="after")
+    def _derive_is_deleted(self) -> Self:
+        # Only derive when ``is_deleted`` wasn't explicitly provided —
+        # ``not self.is_deleted`` can't distinguish the default ``False``
+        # from an explicit ``is_deleted=False`` and would silently override
+        # an explicit ``False`` on a round-tripped payload that also
+        # carries a non-null ``deleted_at``. ``model_fields_set`` is the
+        # pydantic-native signal for "was this field passed by the
+        # caller?" — true only when explicitly provided at construction.
+        if self.deleted_at is not None and "is_deleted" not in self.model_fields_set:
+            self.is_deleted = True
+        return self
 
 
 # Opt-in marker for Prefab UI rendering. Pass as ``meta=UI_META`` in

--- a/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/queries.py
@@ -286,6 +286,16 @@ class CatalogQueries:
             include_archived=include_archived,
             include_deleted=include_deleted,
         )
+        # SKU is non-unique on the wire — duplicate live + soft-state rows
+        # are real. Without an ORDER BY, ``result.first()`` is undefined
+        # and a deleted variant can win over its live sibling (#539). Sort
+        # live before archived before deleted so the live row always
+        # surfaces even when the caller opts in to soft-state rows.
+        stmt = stmt.order_by(
+            CachedVariant.deleted_at.is_(None).desc(),
+            CachedVariant.parent_archived_at.is_(None).desc(),
+            CachedVariant.id.desc(),
+        )
         async with self._engine.session() as session:
             result = await session.exec(stmt)
             return result.first()

--- a/katana_mcp_server/tests/test_mcp_parameter_passing.py
+++ b/katana_mcp_server/tests/test_mcp_parameter_passing.py
@@ -90,13 +90,15 @@ class TestMCPParameterPassing:
         sig = inspect.signature(list_low_stock_items)
         params = list(sig.parameters.keys())
 
-        assert params == ["threshold", "limit", "context"], (
-            "list_low_stock_items has flattened params: threshold, limit, context"
+        assert params == ["threshold", "limit", "include_archived", "context"], (
+            "list_low_stock_items has flattened params: "
+            "threshold, limit, include_archived, context"
         )
         assert sig.parameters["threshold"].annotation is int
         assert sig.parameters["limit"].annotation is int
         assert sig.parameters["threshold"].default == 10
         assert sig.parameters["limit"].default == 50
+        assert sig.parameters["include_archived"].default is False
 
         # Check check_inventory signature
         sig2 = inspect.signature(check_inventory)
@@ -105,10 +107,12 @@ class TestMCPParameterPassing:
         assert params2 == [
             "skus_or_variant_ids",
             "location_id",
+            "include_archived",
+            "include_deleted",
             "context",
         ], (
             "check_inventory has flattened params: "
-            "skus_or_variant_ids, location_id, context"
+            "skus_or_variant_ids, location_id, include_archived, include_deleted, context"
         )
         # skus_or_variant_ids is required (no default) so the MCP schema marks
         # it required; the min_length=1 Pydantic constraint also rejects [].

--- a/katana_mcp_server/tests/test_typed_cache_catalog.py
+++ b/katana_mcp_server/tests/test_typed_cache_catalog.py
@@ -454,6 +454,76 @@ class TestCatalogQueriesGetters:
         assert result_upper.id == result_lower.id == result_mixed.id == 1
 
     @pytest.mark.asyncio
+    async def test_get_by_sku_prefers_live_over_deleted_duplicate(
+        self, typed_cache_engine
+    ):
+        """A live variant outranks a soft-deleted sibling sharing the SKU.
+
+        Regression for #539: SKUs aren't unique in Katana, and without
+        an ORDER BY the cache returned whichever row SQLite happened to
+        scan first — which could be the deleted one.
+        """
+        deleted_dt = datetime(2025, 3, 1, tzinfo=UTC)
+        async with typed_cache_engine.session() as session:
+            session.add(CachedVariant(id=1, sku="DUP-SKU", deleted_at=deleted_dt))
+            session.add(CachedVariant(id=2, sku="DUP-SKU"))
+            await session.commit()
+
+        default = await typed_cache_engine.catalog.get_by_sku("DUP-SKU")
+        opted_in = await typed_cache_engine.catalog.get_by_sku(
+            "DUP-SKU", include_deleted=True
+        )
+
+        assert default is not None
+        assert default.id == 2
+        # Tiebreaker still picks the live row even when the caller opts in.
+        assert opted_in is not None
+        assert opted_in.id == 2
+
+    @pytest.mark.asyncio
+    async def test_get_by_sku_prefers_live_over_archived_parent_duplicate(
+        self, typed_cache_engine
+    ):
+        """A live variant outranks an archived-parent sibling sharing the SKU."""
+        archived_dt = datetime(2025, 3, 1, tzinfo=UTC)
+        async with typed_cache_engine.session() as session:
+            session.add(
+                CachedVariant(id=1, sku="DUP-SKU", parent_archived_at=archived_dt)
+            )
+            session.add(CachedVariant(id=2, sku="DUP-SKU"))
+            await session.commit()
+
+        default = await typed_cache_engine.catalog.get_by_sku("DUP-SKU")
+        opted_in = await typed_cache_engine.catalog.get_by_sku(
+            "DUP-SKU", include_archived=True
+        )
+
+        assert default is not None
+        assert default.id == 2
+        assert opted_in is not None
+        assert opted_in.id == 2
+
+    @pytest.mark.asyncio
+    async def test_get_by_sku_orders_archived_before_deleted_when_no_live(
+        self, typed_cache_engine
+    ):
+        """No live row: archived beats deleted under full opt-in."""
+        deleted_dt = datetime(2025, 3, 1, tzinfo=UTC)
+        archived_dt = datetime(2025, 3, 2, tzinfo=UTC)
+        async with typed_cache_engine.session() as session:
+            session.add(CachedVariant(id=1, sku="DUP-SKU", deleted_at=deleted_dt))
+            session.add(
+                CachedVariant(id=2, sku="DUP-SKU", parent_archived_at=archived_dt)
+            )
+            await session.commit()
+
+        result = await typed_cache_engine.catalog.get_by_sku(
+            "DUP-SKU", include_archived=True, include_deleted=True
+        )
+        assert result is not None
+        assert result.id == 2
+
+    @pytest.mark.asyncio
     async def test_get_many_by_ids_dedupes_and_returns_dict(self, typed_cache_engine):
         """Duplicates collapse; the result is keyed by id for hits only."""
         async with typed_cache_engine.session() as session:

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -183,13 +183,23 @@ async def test_check_inventory_not_found():
     assert result.in_stock == 0
 
 
-def _mock_inventory_row(variant_id: int, quantity_in_stock: str) -> MagicMock:
-    """Build an attrs-shaped Inventory mock for one variant/location row."""
+def _mock_inventory_row(
+    variant_id: int,
+    quantity_in_stock: str,
+    *,
+    archived_at: str | None = None,
+) -> MagicMock:
+    """Build an attrs-shaped Inventory mock for one variant/location row.
+
+    ``archived_at`` defaults to ``None`` so mocks behave as live rows;
+    pass an ISO timestamp to simulate an archived warehouse row.
+    """
     inv = MagicMock()
     inv.variant_id = variant_id
     inv.quantity_in_stock = quantity_in_stock
     inv.quantity_committed = "0"
     inv.quantity_expected = "0"
+    inv.archived_at = archived_at
     return inv
 
 
@@ -329,6 +339,68 @@ async def test_list_low_stock_sums_across_locations():
     assert len(result.items) == 1
     assert result.items[0].sku == "MULTI-LOC"
     assert result.items[0].current_stock == 8
+
+
+@pytest.mark.asyncio
+async def test_list_low_stock_surfaces_distinct_parent_and_inventory_archive_signals():
+    """`is_archived` and `has_archived_inventory` track distinct surfaces.
+
+    ``include_archived=True`` threads through to ``/inventory`` so
+    archived warehouse rows enter the aggregation, AND surfaces a
+    variant's parent archive state. The two are independent: a variant
+    with a live parent can have archived inventory rows at some
+    warehouses, and a variant with an archived parent can have all
+    rows live. Pin both signals so callers (reorder planners,
+    cleanup workflows) can branch on them separately (#539).
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    # Variant 6001: live parent, mixed inventory rows (one archived).
+    # Variant 6002: archived parent, all-live inventory rows.
+    # Variant 6003: live parent, all-live rows (both flags False).
+    inventory_rows = [
+        _mock_inventory_row(6001, "2", archived_at=None),
+        _mock_inventory_row(6001, "1", archived_at="2025-06-01T00:00:00Z"),
+        _mock_inventory_row(6002, "3", archived_at=None),
+        _mock_inventory_row(6003, "4", archived_at=None),
+    ]
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        return_value={
+            6001: {
+                "id": 6001,
+                "sku": "LIVE-PARENT-ARCHIVED-INV",
+                "display_name": "Mixed inv archive",
+                "parent_archived_at": None,
+            },
+            6002: {
+                "id": 6002,
+                "sku": "ARCHIVED-PARENT-LIVE-INV",
+                "display_name": "Archived parent",
+                "parent_archived_at": "2025-01-01T00:00:00Z",
+            },
+            6003: {
+                "id": 6003,
+                "sku": "ALL-LIVE",
+                "display_name": "Fully live",
+                "parent_archived_at": None,
+            },
+        }
+    )
+
+    with (
+        patch(f"{_INVENTORY_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=inventory_rows),
+    ):
+        request = LowStockRequest(threshold=10, include_archived=True)
+        result = await _list_low_stock_items_impl(request, context)
+
+    by_sku = {item.sku: item for item in result.items}
+    assert by_sku["LIVE-PARENT-ARCHIVED-INV"].is_archived is False
+    assert by_sku["LIVE-PARENT-ARCHIVED-INV"].has_archived_inventory is True
+    assert by_sku["ARCHIVED-PARENT-LIVE-INV"].is_archived is True
+    assert by_sku["ARCHIVED-PARENT-LIVE-INV"].has_archived_inventory is False
+    assert by_sku["ALL-LIVE"].is_archived is False
+    assert by_sku["ALL-LIVE"].has_archived_inventory is False
 
 
 @pytest.mark.asyncio
@@ -2252,6 +2324,66 @@ async def test_check_inventory_single_variant_id():
 
 
 @pytest.mark.asyncio
+async def test_check_inventory_variant_id_threads_default_live_only_flags():
+    """Variant-ID branch defaults to live-only (include_archived=False / include_deleted=False).
+
+    Regression: previously ``_fetch_variant_by_id`` hard-coded
+    ``include_archived=True, include_deleted=True`` so the variant-ID
+    direct-lookup path could resolve a soft-deleted variant even when
+    the request defaulted to live-only — diverging from the SKU
+    branch's default behavior. Now keyed off the request flags so
+    both identifiers honor the same front-door rule (#539).
+    """
+    context, _ = create_mock_context()
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.items._fetch_variant_by_id",
+            new_callable=AsyncMock,
+            return_value={"id": 42, "sku": "WIDGET-42", "display_name": "Widget 42"},
+        ) as mock_fetch,
+        patch(f"{_INVENTORY_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        request = CheckInventoryRequest(skus_or_variant_ids=[42])
+        await _check_inventory_impl(request, context)
+
+    mock_fetch.assert_awaited_once()
+    call = mock_fetch.await_args
+    assert call is not None
+    assert call.kwargs.get("include_archived") is False
+    assert call.kwargs.get("include_deleted") is False
+
+
+@pytest.mark.asyncio
+async def test_check_inventory_variant_id_threads_explicit_opt_in_flags():
+    """Variant-ID branch threads explicit include_archived=True / include_deleted=True."""
+    context, _ = create_mock_context()
+
+    with (
+        patch(
+            "katana_mcp.tools.foundation.items._fetch_variant_by_id",
+            new_callable=AsyncMock,
+            return_value={"id": 42, "sku": "WIDGET-42", "display_name": "Widget 42"},
+        ) as mock_fetch,
+        patch(f"{_INVENTORY_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        request = CheckInventoryRequest(
+            skus_or_variant_ids=[42],
+            include_archived=True,
+            include_deleted=True,
+        )
+        await _check_inventory_impl(request, context)
+
+    mock_fetch.assert_awaited_once()
+    call = mock_fetch.await_args
+    assert call is not None
+    assert call.kwargs.get("include_archived") is True
+    assert call.kwargs.get("include_deleted") is True
+
+
+@pytest.mark.asyncio
 async def test_check_inventory_mixed_sku_and_variant_id():
     """Mixed string + integer input exercises both the cache-by-sku and fetch-by-id routes.
 
@@ -2287,7 +2419,13 @@ async def test_check_inventory_mixed_sku_and_variant_id():
     }
 
     async def _fake_fetch_stock(
-        _services, variant_id, _sku, _product_name, location_id=None
+        _services,
+        variant_id,
+        _sku,
+        _product_name,
+        location_id=None,
+        *,
+        include_archived=False,
     ):
         return stock_by_id[variant_id]
 
@@ -4051,3 +4189,200 @@ async def test_inventory_at_rejects_bad_as_of():
     request = InventoryAtRequest(skus_or_variant_ids=["W-1"], as_of="not-a-datetime")
     with pytest.raises(ValueError, match="as_of"):
         await _inventory_at_impl(request, context)
+
+
+# ============================================================================
+# Soft-state defaults (#539) — request flags thread through to get_by_sku
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_check_inventory_defaults_to_active_only():
+    """Default request → ``get_by_sku`` called with both flags False (#539).
+
+    Regression: previously hard-coded ``include_*=True``, so a deleted
+    variant could win a SKU lookup over its live sibling.
+    """
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=None)
+
+    request = CheckInventoryRequest(skus_or_variant_ids=["DELETED-SKU"])
+    await _check_inventory_impl(request, context)
+
+    lifespan_ctx.typed_cache.catalog.get_by_sku.assert_called_with(
+        "DELETED-SKU", include_archived=False, include_deleted=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_inventory_opt_in_threads_flags_to_get_by_sku():
+    """Request flags thread through verbatim for cleanup workflows."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "DELETED-SKU", "display_name": "X"}
+    )
+
+    with (
+        patch(f"{_INVENTORY_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        request = CheckInventoryRequest(
+            skus_or_variant_ids=["DELETED-SKU"],
+            include_archived=True,
+            include_deleted=True,
+        )
+        await _check_inventory_impl(request, context)
+
+    lifespan_ctx.typed_cache.catalog.get_by_sku.assert_called_with(
+        "DELETED-SKU", include_archived=True, include_deleted=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_inventory_movements_defaults_to_active_only():
+    """Default request → ``get_by_sku`` called with both flags False (#539)."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=None)
+
+    request = GetInventoryMovementsRequest(sku="DELETED-SKU")
+    await _get_inventory_movements_impl(request, context)
+
+    lifespan_ctx.typed_cache.catalog.get_by_sku.assert_called_with(
+        "DELETED-SKU", include_archived=False, include_deleted=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_inventory_at_defaults_to_active_only():
+    """Default request → ``get_by_sku`` called with both flags False (#539)."""
+    from katana_mcp.tools.foundation.inventory import (
+        InventoryAtRequest,
+        _inventory_at_impl,
+    )
+
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=None)
+
+    request = InventoryAtRequest(
+        skus_or_variant_ids=["DELETED-SKU"], as_of="2026-01-01T00:00:00+00:00"
+    )
+    await _inventory_at_impl(request, context)
+
+    lifespan_ctx.typed_cache.catalog.get_by_sku.assert_called_with(
+        "DELETED-SKU", include_archived=False, include_deleted=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_inventory_threads_include_archived_to_inventory_api():
+    """include_archived=True on the request reaches get_all_inventory_point (#539)."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "WIDGET-001", "display_name": "X"}
+    )
+
+    with (
+        patch(f"{_INVENTORY_API}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        request = CheckInventoryRequest(
+            skus_or_variant_ids=["WIDGET-001"], include_archived=True
+        )
+        await _check_inventory_impl(request, context)
+
+    # The kwargs passed to get_all_inventory_point must carry the flag.
+    assert mock_api.await_args is not None
+    assert mock_api.await_args.kwargs.get("include_archived") is True
+
+
+@pytest.mark.asyncio
+async def test_check_inventory_default_omits_include_archived_kwarg():
+    """Default request → ``include_archived`` not sent so Katana applies its
+    default (active-only). Avoids changing wire behavior for legacy callers."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "WIDGET-001", "display_name": "X"}
+    )
+
+    with (
+        patch(f"{_INVENTORY_API}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        request = CheckInventoryRequest(skus_or_variant_ids=["WIDGET-001"])
+        await _check_inventory_impl(request, context)
+
+    assert mock_api.await_args is not None
+    assert "include_archived" not in mock_api.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_check_inventory_surfaces_is_archived_on_location_row():
+    """Per-location ``LocationStock.is_archived`` reflects the inventory
+    row's own ``archived_at`` so callers can identify archived warehouse
+    rows when they opt in via ``include_archived=True`` (#539)."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
+        return_value={"id": 3001, "sku": "WIDGET-001", "display_name": "X"}
+    )
+
+    archived_row = MagicMock()
+    archived_row.variant_id = 3001
+    archived_row.location_id = 100
+    archived_row.quantity_in_stock = "5.0"
+    archived_row.quantity_committed = "0"
+    archived_row.quantity_expected = "0"
+    archived_row.reorder_point = None
+    archived_row.safety_stock_level = None
+    archived_row.value_in_stock = None
+    archived_row.average_cost = None
+    archived_row.archived_at = "2025-09-01T00:00:00+00:00"
+
+    with (
+        patch(f"{_INVENTORY_API}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_UNWRAP_DATA, return_value=[archived_row]),
+    ):
+        request = CheckInventoryRequest(
+            skus_or_variant_ids=["WIDGET-001"], include_archived=True
+        )
+        results = await _check_inventory_impl(request, context)
+
+    assert results[0].by_location[0].is_archived is True
+
+
+@pytest.mark.asyncio
+async def test_list_low_stock_items_threads_include_archived_to_inventory_api():
+    """include_archived=True on the request reaches get_all_inventory_point (#539)."""
+    context, _ = create_mock_context()
+
+    with (
+        patch(f"{_INVENTORY_API}.asyncio_detailed", new_callable=AsyncMock) as mock_api,
+        patch(_UNWRAP_DATA, return_value=[]),
+    ):
+        request = LowStockRequest(threshold=10, include_archived=True)
+        await _list_low_stock_items_impl(request, context)
+
+    assert mock_api.await_args is not None
+    assert mock_api.await_args.kwargs.get("include_archived") is True
+
+
+@pytest.mark.asyncio
+async def test_create_stock_adjustment_defaults_to_active_only():
+    """Default request → ``get_by_sku`` called with both flags False (#539).
+
+    The write path defaults to ``False`` so an archived-only / deleted-only
+    SKU fails fast with "SKU not found" rather than letting Katana reject
+    downstream.
+    """
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=None)
+
+    request = CreateStockAdjustmentRequest(
+        location_id=1,
+        rows=[StockAdjustmentRow(sku="DELETED-SKU", quantity=1)],
+    )
+    with pytest.raises(ValueError, match="DELETED-SKU"):
+        await _create_stock_adjustment_impl(request, context)
+
+    lifespan_ctx.typed_cache.catalog.get_by_sku.assert_called_with(
+        "DELETED-SKU", include_archived=False, include_deleted=False
+    )

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -8,6 +8,7 @@ headers that LLM consumers misread (the SW7083 supplier_item_codes bug).
 
 from __future__ import annotations
 
+import datetime
 import json
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -777,7 +778,7 @@ async def test_get_variant_details_mixed_skus_and_variant_ids_partial():
         2: {"id": 2, "sku": "VAR-OK", "display_name": "Variant OK"},
     }
 
-    async def _fetch(_services, vid):
+    async def _fetch(_services, vid, **_kwargs):
         return by_id.get(vid)
 
     with patch(
@@ -835,6 +836,165 @@ async def test_get_variant_details_batch_json_includes_not_found():
     payload = json.loads(_content_text(result))
     assert [v["sku"] for v in payload["variants"]] == ["WIDGET-B"]
     assert payload["not_found"] == [{"sku": "MISSING-A"}]
+
+
+# ============================================================================
+# Soft-state defaults (#539) — request flags thread through to get_by_sku
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_defaults_to_active_only():
+    """Default request → ``get_by_sku`` called with both flags False (#539).
+
+    Regression: previously the tool hard-coded ``include_*=True``, so a
+    deleted variant could win a SKU lookup over its live sibling. The
+    typed-cache ``get_by_sku`` tiebreaker is the belt; the default-False
+    flags are the suspenders.
+    """
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=None)
+
+    with pytest.raises(ValueError, match="DELETED-SKU"):
+        await _get_variant_details_impl(
+            GetVariantDetailsRequest(sku="DELETED-SKU"), context
+        )
+
+    lifespan_ctx.typed_cache.catalog.get_by_sku.assert_called_with(
+        "DELETED-SKU", include_archived=False, include_deleted=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_variant_details_opt_in_threads_flags_to_get_by_sku():
+    """Request flags thread through verbatim so cleanup workflows can
+    resolve an archived-only or deleted-only SKU."""
+    context, lifespan_ctx = create_mock_context()
+    variant_dict = dict(_FULL_VARIANT_DICT)
+    variant_dict["deleted_at"] = "2024-09-01T12:00:00+00:00"
+    lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(return_value=variant_dict)
+
+    request = GetVariantDetailsRequest(
+        sku="DELETED-SKU", include_archived=True, include_deleted=True
+    )
+    result = await _get_variant_details_impl(request, context)
+
+    assert len(result.found) == 1
+    lifespan_ctx.typed_cache.catalog.get_by_sku.assert_called_with(
+        "DELETED-SKU", include_archived=True, include_deleted=True
+    )
+
+
+# ============================================================================
+# _fetch_variant_by_id — API-fallback soft-state filtering (#539)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_variant_by_id_api_fallback_filters_archived_parent():
+    """``include_archived=False`` post-filters an API-fallback variant whose
+    extended ``product_or_material.archived_at`` is non-null.
+
+    Regression: previously the API-fallback path only post-filtered on
+    ``variant_obj.deleted_at``, so a cold-cache miss could still return an
+    archived-parent variant even when callers relied on default live-only
+    semantics. The ``extend=[PRODUCT_OR_MATERIAL]`` payload already carries
+    ``archived_at``, so honoring the flag costs no extra round trip.
+    """
+    from katana_mcp.tools.foundation.items import _fetch_variant_by_id
+
+    from katana_public_api_client.models.product import Product
+    from katana_public_api_client.models.product_type import ProductType
+    from katana_public_api_client.models.variant_response import VariantResponse
+    from katana_public_api_client.models.variant_type import VariantType
+
+    _, lifespan_ctx = create_mock_context()
+    services = lifespan_ctx
+    services.client = MagicMock()
+    services.typed_cache.catalog.get_by_id = AsyncMock(return_value=None)
+
+    archived_parent = Product(
+        id=42,
+        name="Archived Knife Set",
+        type_=ProductType.PRODUCT,
+        archived_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC),
+    )
+    api_variant = VariantResponse(
+        id=9001,
+        sku="ARCHIVED-PARENT",
+        product_id=42,
+        material_id=None,
+        type_=VariantType.PRODUCT,
+        product_or_material=archived_parent,
+    )
+
+    api_response = MagicMock()
+    with (
+        patch(
+            "katana_public_api_client.api.variant.get_variant.asyncio_detailed",
+            new_callable=AsyncMock,
+            return_value=api_response,
+        ),
+        patch(
+            "katana_public_api_client.utils.unwrap",
+            return_value=api_variant,
+        ),
+    ):
+        live_only = await _fetch_variant_by_id(
+            services, 9001, include_archived=False, include_deleted=False
+        )
+        with_archived = await _fetch_variant_by_id(
+            services, 9001, include_archived=True, include_deleted=False
+        )
+
+    assert live_only is None
+    assert with_archived is api_variant
+
+
+@pytest.mark.asyncio
+async def test_fetch_variant_by_id_api_fallback_filters_deleted_variant():
+    """``include_deleted=False`` post-filters an API-fallback variant whose
+    ``deleted_at`` is non-null."""
+    from katana_mcp.tools.foundation.items import _fetch_variant_by_id
+
+    from katana_public_api_client.models.variant_response import VariantResponse
+    from katana_public_api_client.models.variant_type import VariantType
+
+    _, lifespan_ctx = create_mock_context()
+    services = lifespan_ctx
+    services.client = MagicMock()
+    services.typed_cache.catalog.get_by_id = AsyncMock(return_value=None)
+
+    api_variant = VariantResponse(
+        id=9002,
+        sku="DELETED-VAR",
+        product_id=43,
+        material_id=None,
+        type_=VariantType.PRODUCT,
+        deleted_at=datetime.datetime(2025, 2, 1, tzinfo=datetime.UTC),
+    )
+
+    api_response = MagicMock()
+    with (
+        patch(
+            "katana_public_api_client.api.variant.get_variant.asyncio_detailed",
+            new_callable=AsyncMock,
+            return_value=api_response,
+        ),
+        patch(
+            "katana_public_api_client.utils.unwrap",
+            return_value=api_variant,
+        ),
+    ):
+        live_only = await _fetch_variant_by_id(
+            services, 9002, include_archived=False, include_deleted=False
+        )
+        with_deleted = await _fetch_variant_by_id(
+            services, 9002, include_archived=False, include_deleted=True
+        )
+
+    assert live_only is None
+    assert with_deleted is api_variant
 
 
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_stock_transfers.py
+++ b/katana_mcp_server/tests/tools/test_stock_transfers.py
@@ -562,6 +562,77 @@ async def test_list_stock_transfers_date_filters(context_with_typed_cache, no_sy
 
 
 @pytest.mark.asyncio
+async def test_list_stock_transfers_filters_by_ids(context_with_typed_cache, no_sync):
+    """`ids=[...]` filters to the explicit ID set (#484)."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_transfer(id=1),
+            make_stock_transfer(id=2),
+            make_stock_transfer(id=3),
+        ],
+    )
+
+    result = await _list_stock_transfers_impl(
+        ListStockTransfersRequest(ids=[1, 3]), context
+    )
+
+    assert {t.id for t in result.transfers} == {1, 3}
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_updated_date_filters(
+    context_with_typed_cache, no_sync
+):
+    """`updated_after` / `updated_before` apply as indexed range filters (#484)."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_transfer(id=1, updated_at=datetime(2025, 12, 15)),  # before
+            make_stock_transfer(id=2, updated_at=datetime(2026, 2, 15)),  # inside
+            make_stock_transfer(id=3, updated_at=datetime(2026, 5, 1)),  # after
+        ],
+    )
+
+    result = await _list_stock_transfers_impl(
+        ListStockTransfersRequest(
+            updated_after="2026-01-01T00:00:00+00:00",
+            updated_before="2026-04-01T00:00:00+00:00",
+        ),
+        context,
+    )
+
+    assert {t.id for t in result.transfers} == {2}
+
+
+@pytest.mark.asyncio
+async def test_list_stock_transfers_include_deleted_default_excludes(
+    context_with_typed_cache, no_sync
+):
+    """`include_deleted` defaults to False — tombstoned rows stay hidden (#484, #539)."""
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_stock_transfer(id=1),
+            make_stock_transfer(id=2, deleted_at=datetime(2026, 3, 1)),
+        ],
+    )
+
+    default_result = await _list_stock_transfers_impl(
+        ListStockTransfersRequest(), context
+    )
+    assert {t.id for t in default_result.transfers} == {1}
+
+    opt_in_result = await _list_stock_transfers_impl(
+        ListStockTransfersRequest(include_deleted=True), context
+    )
+    assert {t.id for t in opt_in_result.transfers} == {1, 2}
+
+
+@pytest.mark.asyncio
 async def test_list_stock_transfers_caps_to_limit(context_with_typed_cache, no_sync):
     """`limit` caps the result size even when more rows match."""
     context, _, typed_cache = context_with_typed_cache

--- a/katana_mcp_server/tests/tools/test_tool_result_utils.py
+++ b/katana_mcp_server/tests/tools/test_tool_result_utils.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock
 import pytest
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
+    SoftDeletableResponse,
     make_tool_result,
     resolve_entity_name,
     resolve_factory_base_currency,
@@ -223,3 +224,54 @@ async def test_resolve_factory_base_currency_returns_none_for_empty_code():
     code = await resolve_factory_base_currency(cache)
 
     assert code is None
+
+
+# ============================================================================
+# SoftDeletableResponse — derives is_deleted from deleted_at (#540)
+# ============================================================================
+
+
+class _SoftStub(SoftDeletableResponse):
+    """Minimal subclass to exercise the mixin's validator behavior."""
+
+    id: int
+
+
+def test_soft_deletable_response_derives_is_deleted_when_timestamp_set():
+    """`deleted_at` non-null → `is_deleted` set to True by the validator."""
+    stub = _SoftStub(id=1, deleted_at="2025-01-01T00:00:00+00:00")
+    assert stub.is_deleted is True
+
+
+def test_soft_deletable_response_keeps_is_deleted_false_when_timestamp_null():
+    """`deleted_at` None → `is_deleted` stays at the field default (False)."""
+    stub = _SoftStub(id=2)
+    assert stub.is_deleted is False
+    assert stub.deleted_at is None
+
+
+def test_soft_deletable_response_honors_explicit_is_deleted():
+    """An explicit `is_deleted=True` survives even when `deleted_at` is None.
+
+    Pin the precedence: the validator only fires when `deleted_at` is set
+    AND `is_deleted` was not explicitly provided. That keeps round-tripping
+    serialized payloads (where both fields may be present) lossless.
+    """
+    stub = _SoftStub(id=3, is_deleted=True)
+    assert stub.is_deleted is True
+    assert stub.deleted_at is None
+
+
+def test_soft_deletable_response_preserves_explicit_false_with_deleted_at():
+    """Explicit `is_deleted=False` survives even when `deleted_at` is set.
+
+    Regression: previously the validator used `not self.is_deleted` and
+    couldn't distinguish the field default (False) from an explicit
+    False, so a round-tripped payload like
+    `{"deleted_at": "...", "is_deleted": false}` would silently
+    flip `is_deleted` to True. Now keyed off `model_fields_set` so
+    explicit values are preserved.
+    """
+    stub = _SoftStub(id=4, deleted_at="2025-01-01T00:00:00+00:00", is_deleted=False)
+    assert stub.is_deleted is False
+    assert stub.deleted_at == "2025-01-01T00:00:00+00:00"

--- a/uv.lock
+++ b/uv.lock
@@ -1329,7 +1329,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.93.3"
+version = "0.94.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Three-category rollout fixing a real bug — `get_variant_details` / `check_inventory` resolved to a deleted variant when a live row shared the SKU — and consolidating the soft-state consistency work that #539, #484, #540, and #693 were tracking separately.

Closes #539
Closes #484
Closes #540
Closes #693

## The bug

SKUs are non-unique in Katana but the typed cache's `get_by_sku` returned `result.first()` with no `ORDER BY`, so a deleted variant could win the lookup over its live sibling. Compounded by 5 SKU-direct-lookup tools that hard-coded `include_archived=True` / `include_deleted=True` against the cache for "show everything" legacy behavior.

## The three-category rule (now documented)

| Category                          | Default                  | Why                                                                         |
| --------------------------------- | ------------------------ | --------------------------------------------------------------------------- |
| Direct lookup (SKU + ID getters)  | `include_*=False`        | the matched entity IS the answer; agent opts in for cleanup                 |
| List filtering (`list_*` tools)   | `include_*=False`        | which parents appear in the list                                            |
| Enrichment (batch by ID)          | always `include_*=True`  | a deleted parent on a live child must still render its identity             |

## Layers

- **L1 `get_by_sku` tiebreaker** (`typed_cache/queries.py`): `ORDER BY deleted_at IS NULL DESC, parent_archived_at IS NULL DESC, id DESC` so live wins regardless of caller flags.
- **L2 front-door tools default to live-only**: 5 tools (`get_variant_details`, `check_inventory`, `get_inventory_movements`, `inventory_at`, `create_stock_adjustment`) accept `include_archived` / `include_deleted` request flags defaulting to `False`.
- **L3 `include_archived` to `/inventory`** (#539 original): threaded through `check_inventory` and `list_low_stock_items` so archived per-location inventory rows surface only on opt-in. Added `is_archived` to `StockInfo`, `LocationStock`, `LowStockItem`.
- **L4 `list_stock_transfers` parity** (#484): added `ids`, `updated_after` / `updated_before`, `include_deleted` filters.
- **L5 `is_deleted` derived bool** (#540): `SoftDeletableResponse` mixin in `tool_result_utils.py`; 19 transactional response classes inherit from it and auto-derive `is_deleted` from `deleted_at` via `model_validator(mode="after")`.
- **L6 `corrections.py` audit** (#693): documented why `_fetch_mo_recipe_rows_raw` intentionally excludes tombstones — close-state snapshot matches against live rows only.
- **Docs**: `typed_cache/README.md` now spells out the three-category rule. Help-resource entries updated for all 6 touched tools.

## Enrichment sites stay unchanged (~25 sites)

Back-door enrichment lookups across `orders.py`, `purchase_orders.py`, `sales_orders.py`, `manufacturing_orders.py`, `bom.py`, `tool_result_utils.py` keep their hard-coded `include_*=True` — a deleted variant referenced from a live SO row must still render its identity.

## Test plan

- [x] 3 tiebreaker tests pin live-wins-on-SKU-duplicate (`test_typed_cache_catalog.py`)
- [x] 7 default-active-only tests pin flag-threading per front-door tool
- [x] 4 inventory-archived tests pin the `/inventory` thread-through + per-row `is_archived` field
- [x] 3 `list_stock_transfers` filter tests
- [x] 3 `SoftDeletableResponse` derivation tests
- [x] `test_mcp_parameter_passing.py` signature pins updated for new flags
- [x] `uv run poe check` clean (format, mdformat, ruff, ty, 3575 tests pass)

20 files changed, +783/-81 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
