### PR TITLE
fix(mcp): flip customer-card currency badge to secondary variant

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -3833,7 +3833,7 @@ def build_customer_create_ui(
     apply_action = _build_apply_action(confirm_tool, confirm_request)
     cancel_action = _build_cancel_action("that customer")
     extra_badges: tuple[tuple[str, str], ...] = (
-        ((currency, "outline"),) if currency else ()
+        ((currency, "secondary"),) if currency else ()
     )
 
     with (

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.93.0"
+version = "0.93.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- The customer create card's Tier 1 header was rendering currency as a second `outline` Badge alongside the name (also `outline`), producing a visually-merged double-badge look.
- Flip currency to `secondary` so it reads as a distinct chip from the headline.

## Why now (not bundled with #831)

This was originally folded into #831 (`modify_customer` parent), but unlike PO's currency badge — which only surfaces on outsourced POs — the customer card carries currency on *every* render. The duplicate-outline look is visible to every operator on every customer create. Worth a standalone one-liner now rather than waiting for the modify_customer scaffolding.

## Test plan

- [x] `uv run pytest katana_mcp_server/tests/tools/test_customers.py` — 21 passed
- [x] No tests pin the badge variant, so no test updates needed
- [ ] CI green (browser render tests will exercise the new variant)

Refs #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)