### PR TITLE
fix(tests): type extractable[] via TypedDict for stricter ty

### DIFF
--- a/tests/test_api_quality_analysis.py
+++ b/tests/test_api_quality_analysis.py
@@ -5,9 +5,18 @@ consistency across endpoints, extractable parameters worth promoting to
 shared definitions, etc. Direct yaml inspection — no external scripts.
 """
 
-from typing import Any
+from typing import Any, TypedDict
 
 import pytest
+
+
+class ExtractableParameter(TypedDict):
+    """Heuristic candidate for promotion to a reusable component parameter."""
+
+    name: str | None
+    signature: str
+    usage_count: int
+    endpoints: list[str]
 
 
 class TestAPIQualityAnalysis:
@@ -209,7 +218,7 @@ class TestAPIQualityAnalysis:
                     )
 
         # Find parameters that appear 3+ times (good extraction candidates)
-        extractable = []
+        extractable: list[ExtractableParameter] = []
         for signature, usages in parameter_signatures.items():
             if len(usages) >= 3:
                 # Check if all usages are consistent

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.93.1"
+version = "0.93.2"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- The python-minor-patch dep bump in #836 pulls in a stricter `ty` that flags `tests/test_api_quality_analysis.py:238-240` — `param["endpoints"]` is widened to `Any | str | int | list[str]` because the dict literal is untyped, so `len()` and slicing fail.
- Introduce an `ExtractableParameter` TypedDict and annotate `extractable: list[ExtractableParameter] = []`. Pure typing fix; no runtime change.
- Side effect: re-syncs `uv.lock`'s `katana-mcp-server` line to `0.93.2` (the release commit on main bumped `pyproject.toml` but didn't update `uv.lock`).

## Why fix this on main rather than in #836

PR #836 only edits `uv.lock`. The typing weakness is pre-existing on main and just happens to be surfaced by the newer `ty`. Fixing it on main means:
- The fix lands as its own focused PR (clean blame)
- #836 can rebase onto this and CI will go green
- Future dep bumps don't re-encounter the same trip-wire

## Test plan

- [x] `uv run ruff check tests/test_api_quality_analysis.py` — clean
- [x] `uv run ty check tests/test_api_quality_analysis.py` — clean
- [x] pre-commit (full test + lint suite, on staged files) — passed
- [ ] CI green
- [ ] Rebase #836 onto main after merge → confirm its CI goes green

Refs #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)