### PR TITLE
fix(client)!: ServiceVariant.custom_fields nullable to fix create_item(type=service)

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -2816,8 +2816,15 @@ components:
             type:
               $ref: "#/components/schemas/VariantType"
             custom_fields:
-              type: array
-              description: Custom field values specific to this service variant
+              type:
+                - array
+                - "null"
+              description: |
+                Custom field values specific to this service variant. The
+                API returns ``null`` (not ``[]``) when the variant has no
+                custom-field assignments — non-nullable here causes the
+                generated parser to fail with "NoneType is not iterable"
+                on every create_service / get_service response.
               items:
                 type: object
                 properties:

--- a/katana_public_api_client/models/__init__.py
+++ b/katana_public_api_client/models/__init__.py
@@ -443,7 +443,9 @@ from .service import Service
 from .service_list_response import ServiceListResponse
 from .service_type import ServiceType
 from .service_variant import ServiceVariant
-from .service_variant_custom_fields_item import ServiceVariantCustomFieldsItem
+from .service_variant_custom_fields_type_0_item import (
+    ServiceVariantCustomFieldsType0Item,
+)
 from .stock_adjustment import StockAdjustment
 from .stock_adjustment_batch_transaction import StockAdjustmentBatchTransaction
 from .stock_adjustment_list_response import StockAdjustmentListResponse
@@ -917,7 +919,7 @@ __all__ = (
     "ServiceListResponse",
     "ServiceType",
     "ServiceVariant",
-    "ServiceVariantCustomFieldsItem",
+    "ServiceVariantCustomFieldsType0Item",
     "StockAdjustment",
     "StockAdjustmentBatchTransaction",
     "StockAdjustmentListResponse",

--- a/katana_public_api_client/models/service_variant.py
+++ b/katana_public_api_client/models/service_variant.py
@@ -14,8 +14,8 @@ from ..client_types import UNSET, Unset
 from ..models.variant_type import VariantType
 
 if TYPE_CHECKING:
-    from ..models.service_variant_custom_fields_item import (
-        ServiceVariantCustomFieldsItem,
+    from ..models.service_variant_custom_fields_type_0_item import (
+        ServiceVariantCustomFieldsType0Item,
     )
 
 
@@ -42,7 +42,7 @@ class ServiceVariant:
     sales_price: float | None | Unset = UNSET
     default_cost: float | None | Unset = UNSET
     type_: VariantType | Unset = UNSET
-    custom_fields: list[ServiceVariantCustomFieldsItem] | Unset = UNSET
+    custom_fields: list[ServiceVariantCustomFieldsType0Item] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -84,12 +84,17 @@ class ServiceVariant:
         if not isinstance(self.type_, Unset):
             type_ = self.type_.value
 
-        custom_fields: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.custom_fields, Unset):
+        custom_fields: list[dict[str, Any]] | None | Unset
+        if isinstance(self.custom_fields, Unset):
+            custom_fields = UNSET
+        elif isinstance(self.custom_fields, list):
             custom_fields = []
-            for custom_fields_item_data in self.custom_fields:
-                custom_fields_item = custom_fields_item_data.to_dict()
-                custom_fields.append(custom_fields_item)
+            for custom_fields_type_0_item_data in self.custom_fields:
+                custom_fields_type_0_item = custom_fields_type_0_item_data.to_dict()
+                custom_fields.append(custom_fields_type_0_item)
+
+        else:
+            custom_fields = self.custom_fields
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -119,8 +124,8 @@ class ServiceVariant:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.service_variant_custom_fields_item import (
-            ServiceVariantCustomFieldsItem,
+        from ..models.service_variant_custom_fields_type_0_item import (
+            ServiceVariantCustomFieldsType0Item,
         )
 
         d = dict(src_dict)
@@ -186,16 +191,36 @@ class ServiceVariant:
         else:
             type_ = VariantType(_type_)
 
-        _custom_fields = d.pop("custom_fields", UNSET)
-        custom_fields: list[ServiceVariantCustomFieldsItem] | Unset = UNSET
-        if _custom_fields is not UNSET:
-            custom_fields = []
-            for custom_fields_item_data in _custom_fields:
-                custom_fields_item = ServiceVariantCustomFieldsItem.from_dict(
-                    cast(Mapping[str, Any], custom_fields_item_data)
-                )
+        def _parse_custom_fields(
+            data: object,
+        ) -> list[ServiceVariantCustomFieldsType0Item] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            # Empty dict -> None (Katana wire quirk; see #509).
+            if isinstance(data, dict) and not data:
+                return None
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                custom_fields_type_0 = []
+                _custom_fields_type_0 = data
+                for custom_fields_type_0_item_data in _custom_fields_type_0:
+                    custom_fields_type_0_item = (
+                        ServiceVariantCustomFieldsType0Item.from_dict(
+                            cast(Mapping[str, Any], custom_fields_type_0_item_data)
+                        )
+                    )
 
-                custom_fields.append(custom_fields_item)
+                    custom_fields_type_0.append(custom_fields_type_0_item)
+
+                return custom_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[ServiceVariantCustomFieldsType0Item] | None | Unset, data)
+
+        custom_fields = _parse_custom_fields(d.pop("custom_fields", UNSET))
 
         service_variant = cls(
             id=id,

--- a/katana_public_api_client/models/service_variant_custom_fields_type_0_item.py
+++ b/katana_public_api_client/models/service_variant_custom_fields_type_0_item.py
@@ -10,11 +10,11 @@ from attrs import (
 
 from ..client_types import UNSET, Unset
 
-T = TypeVar("T", bound="ServiceVariantCustomFieldsItem")
+T = TypeVar("T", bound="ServiceVariantCustomFieldsType0Item")
 
 
 @_attrs_define
-class ServiceVariantCustomFieldsItem:
+class ServiceVariantCustomFieldsType0Item:
     field_name: str | Unset = UNSET
     field_value: str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -41,13 +41,13 @@ class ServiceVariantCustomFieldsItem:
 
         field_value = d.pop("field_value", UNSET)
 
-        service_variant_custom_fields_item = cls(
+        service_variant_custom_fields_type_0_item = cls(
             field_name=field_name,
             field_value=field_value,
         )
 
-        service_variant_custom_fields_item.additional_properties = d
-        return service_variant_custom_fields_item
+        service_variant_custom_fields_type_0_item.additional_properties = d
+        return service_variant_custom_fields_type_0_item
 
     @property
     def additional_keys(self) -> list[str]:

--- a/katana_public_api_client/models_pydantic/_generated/inventory.py
+++ b/katana_public_api_client/models_pydantic/_generated/inventory.py
@@ -244,7 +244,9 @@ class ServiceVariant(UpdatableEntity, DeletableEntity):
     type: VariantType | None = None
     custom_fields: Annotated[
         list[CustomField1] | None,
-        Field(description="Custom field values specific to this service variant"),
+        Field(
+            description='Custom field values specific to this service variant. The\nAPI returns ``null`` (not ``[]``) when the variant has no\ncustom-field assignments — non-nullable here causes the\ngenerated parser to fail with "NoneType is not iterable"\non every create_service / get_service response.\n'
+        ),
     ] = None
 
 

--- a/katana_public_api_client/models_pydantic/_generated/stock.py
+++ b/katana_public_api_client/models_pydantic/_generated/stock.py
@@ -202,7 +202,7 @@ class SerialNumber(KatanaPydanticBase):
     transaction_id: Annotated[
         str | None,
         Field(
-            description='Identifier of the transaction that affected this serial number.\nMay be the literal string ``"undefined"`` on a transfer\nresponse; expect ``null`` in some edge cases.\n'
+            description="Identifier of the transaction that affected this serial number.\nMay be the literal string ``undefined`` on a transfer\nresponse; expect ``null`` in some edge cases.\n"
         ),
     ] = None
     serial_number: Annotated[

--- a/tests/test_models_pydantic.py
+++ b/tests/test_models_pydantic.py
@@ -491,6 +491,29 @@ class TestWireNullTolerance:
         )
         assert attrs_variant.id == 1
 
+    def test_service_variant_from_dict_with_null_custom_fields(self) -> None:
+        """``ServiceVariant.custom_fields = null`` (observed on every create_service).
+
+        Pre-fix this broke ``create_item(type="service")`` end-to-end:
+        the API returns ``custom_fields: null`` on the nested variant and
+        the parser tried to iterate it. Live-API shape captured 2026-05-26
+        via ``scripts/probe_create_service_response.py``.
+        """
+        from katana_public_api_client.models import (
+            ServiceVariant as AttrsServiceVariant,
+        )
+
+        attrs_variant = AttrsServiceVariant.from_dict(
+            {
+                "id": 1,
+                "sku": "SVC-TEST",
+                "service_id": 100,
+                "custom_fields": None,
+            }
+        )
+        assert attrs_variant.id == 1
+        assert attrs_variant.custom_fields is None
+
     def test_variant_response_from_dict_with_null_custom_fields(self) -> None:
         """``VariantResponse.custom_fields = null`` (single-variant endpoint)."""
         from katana_public_api_client.models import VariantResponse as AttrsVR

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.93.2"
+version = "0.93.3"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

MCP `create_item(type="service")` was failing with `'NoneType' object is not iterable` on every call, regardless of which optional params the user supplied.

**Root cause:** the live Katana API returns `"custom_fields": null` on every service-variant payload (verified 2026-05-26 via `scripts/probe_create_service_response.py`). The OpenAPI spec declared `ServiceVariant.custom_fields` as a non-nullable `type: array`, so the generated `from_dict` parser hit `for custom_fields_item_data in _custom_fields:` with `_custom_fields = None` and raised.

The fix is exactly the same pattern already in place for the regular `Variant.custom_fields` (lines 2728-2731 of the spec) — mark the field nullable and let the generator emit a proper None-handling branch.

## Changes

- **Spec** — `ServiceVariant.custom_fields` now `type: [array, "null"]` with a docstring pinning the rationale.
- **Regenerated client** — `service_variant.py` now has a `_parse_custom_fields` helper that handles `None`, `Unset`, and the empty-dict wire quirk from #509. The pydantic mirror picks up `list[CustomField1] | None`.
- **Test** — `test_service_variant_from_dict_with_null_custom_fields` in `TestWireNullTolerance` pins the live-API shape so a future spec edit can't re-tighten this back to non-nullable without a CI failure.
- **Probe** — `scripts/probe_create_service_response.py` (untracked artifact) captures the live response shape that motivated this fix.

## Breaking change

The generated type `ServiceVariantCustomFieldsItem` was renamed to `ServiceVariantCustomFieldsType0Item` — `openapi-python-client` appends `Type0` to member names of `X | None` unions. **No callers inside this repo referenced the old name** (confirmed via grep). External callers importing the symbol must update their import; the wire format and field name are unchanged.

## How verified

End-to-end against the live Katana tenant:

```
$ uv run python scripts/probe_create_service_response.py
>>> Status: 200
>>> Raw response JSON:
{
  ...
  "variants": [
    {
      ...
      "custom_fields": null,
      ...
    }
  ]
}
```

Post-fix:
```
$ uv run python -c "Service.from_dict(<live response>)"
OK: 17239746 Test
variants[0].custom_fields: None
```

Pre-fix this raised `TypeError: 'NoneType' object is not iterable`.

## Test plan

- [x] `tests/test_models_pydantic.py::TestWireNullTolerance` — 9 passed (incl new test)
- [x] `katana_mcp_server/tests/tools/test_items.py` — 63 passed
- [x] `uv run poe lint` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)