### PR TITLE
feat(client): add make_test_client() helper for live-tenant integration testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,14 @@ KATANA_BASE_URL=https://api.katanamrp.com/v1
 DEBUG=false
 LOG_LEVEL=INFO
 
-# Test configuration (for integration tests)
-# Set these if you want to run integration tests
-# KATANA_TEST_API_KEY=your_test_api_key_here
-# KATANA_TEST_BASE_URL=https://api.katanamrp.com/v1
+# Test configuration (for any live-tenant code path: integration tests,
+# probe scripts, smoke tests).
+# Consumed by katana_public_api_client.testing.make_test_client(), which
+# binds a KatanaClient to a non-production tenant. There is NO fallback to
+# KATANA_API_KEY — if KATANA_TEST_API_KEY is unset, the helper raises so
+# test code can't accidentally hit prod.
+KATANA_TEST_API_KEY=your_test_api_key_here
+KATANA_TEST_BASE_URL=https://api.katanamrp.com/v1
 
 # Alternative: Use ~/.netrc for centralized credential management
 # Add to ~/.netrc:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,6 +407,26 @@ Configured in `.claude/settings.local.json` (gitignored):
   `/harness retro` to capture learnings. (When the harness-kit plugin is installed, also
   consider `/session-retro` — see harness-kit#30 — for project-side learnings.)
 
+## Test environment
+
+Anything that talks to a *live* Katana tenant from test code, probes, or CI smoke tests
+goes through **`make_test_client()`** in
+[`katana_public_api_client/testing.py`](katana_public_api_client/testing.py) — not
+`KatanaClient()` directly. The helper reads `KATANA_TEST_API_KEY` (required) and
+`KATANA_TEST_BASE_URL` (optional, defaults to the prod base URL — same Katana
+deployment, different tenant).
+
+**Safety rule: no silent fallback to `KATANA_API_KEY`.** If `KATANA_TEST_API_KEY` is
+unset, the helper raises `RuntimeError`. Falling back to the prod key would let a
+misconfigured CI run mutate production state — exactly the failure mode the helper
+exists to prevent. Tests that want graceful skipping wire the skip in the fixture, not
+in the helper.
+
+Set the env vars in `.env` (uncommented in `.env.example`). Phase 1 landed the helper,
+`.env` updates, and probe-script refactors. Later phases add pytest fixtures, GitHub
+Actions wiring, and the actual live smoke tests — track progress on the
+[project board](https://github.com/users/dougborg/projects/5).
+
 ## Detailed Documentation
 
 **Discover on-demand** - read these when working on specific areas:
@@ -419,6 +439,7 @@ Configured in `.claude/settings.local.json` (gitignored):
 | Architecture           | [.github/agents/guides/shared/ARCHITECTURE_QUICK_REF.md](.github/agents/guides/shared/ARCHITECTURE_QUICK_REF.md) |
 | Client guide           | [katana_public_api_client/docs/guide.md](katana_public_api_client/docs/guide.md)                                 |
 | OpenAPI spec authoring | [katana_public_api_client/docs/spec-authoring.md](katana_public_api_client/docs/spec-authoring.md)               |
+| Test environment       | [katana_public_api_client/testing.py](katana_public_api_client/testing.py) (`make_test_client()`)                |
 | MCP docs               | [katana_mcp_server/docs/README.md](katana_mcp_server/docs/README.md)                                             |
 | Prefab UI pitfalls     | [katana_mcp_server/docs/prefab/README.md](katana_mcp_server/docs/prefab/README.md)                               |
 | Typed cache patterns   | [katana_mcp_server/docs/typed_cache/README.md](katana_mcp_server/docs/typed_cache/README.md)                     |

--- a/katana_public_api_client/testing.py
+++ b/katana_public_api_client/testing.py
@@ -1,0 +1,81 @@
+"""Helpers for building a :class:`KatanaClient` against a non-production tenant.
+
+Phase 1 of the live test environment epic (issue #837). The helper exposed
+here is the only sanctioned way for test code, probe scripts, and CI smoke
+tests to talk to a Katana tenant that *isn't* prod. It deliberately does
+**not** fall back to ``KATANA_API_KEY`` — silently picking up the prod key
+when the test key is unset is the exact failure mode this helper exists to
+prevent.
+
+See ``CLAUDE.md`` ("Test environment") for the rule + reasoning.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from dotenv import dotenv_values
+
+from .katana_client import KatanaClient
+
+__all__ = ["make_test_client"]
+
+_DEFAULT_TEST_BASE_URL = "https://api.katanamrp.com/v1"
+
+
+def _read_test_env(name: str, env_values: Mapping[str, str | None]) -> str | None:
+    """Look up ``name`` from the real environment, then ``env_values``.
+
+    ``env_values`` is the pre-read mapping from :func:`dotenv_values` —
+    passed in by the caller so the ``.env`` file is parsed once per
+    :func:`make_test_client` call rather than once per lookup. Using
+    :func:`dotenv_values` (read-only) rather than :func:`load_dotenv`
+    keeps this helper from mutating ``os.environ``;
+    ``KatanaClient.__init__`` calls ``load_dotenv()`` itself when it
+    constructs the client.
+    """
+    value = os.environ.get(name)
+    if value:
+        return value
+    return env_values.get(name)
+
+
+def make_test_client(**kwargs: Any) -> KatanaClient:
+    """Build a :class:`KatanaClient` bound to the test tenant.
+
+    Reads ``KATANA_TEST_API_KEY`` (required) and ``KATANA_TEST_BASE_URL``
+    (optional, defaults to the production base URL — same Katana
+    deployment, different tenant). Extra keyword arguments pass through
+    to :class:`KatanaClient` unchanged so callers can tune timeouts, the
+    rate limiter, etc.
+
+    Raises:
+        RuntimeError: when ``KATANA_TEST_API_KEY`` is unset. There is
+            **no** fallback to ``KATANA_API_KEY`` — test code must not
+            be able to accidentally hit prod when the env is
+            misconfigured.
+
+    Example:
+        >>> from katana_public_api_client.testing import make_test_client
+        >>> async with make_test_client() as client:
+        ...     # All calls go to the test tenant.
+        ...     ...
+    """
+    env_values = dotenv_values()
+    api_key = _read_test_env("KATANA_TEST_API_KEY", env_values)
+    if not api_key:
+        raise RuntimeError(
+            "KATANA_TEST_API_KEY is not set. make_test_client() will NOT "
+            "fall back to KATANA_API_KEY — that fallback would let test "
+            "code accidentally hit the production tenant. Set "
+            "KATANA_TEST_API_KEY in your environment (see .env.example) "
+            "or skip the test/probe."
+        )
+
+    base_url = (
+        _read_test_env("KATANA_TEST_BASE_URL", env_values) or _DEFAULT_TEST_BASE_URL
+    )
+
+    return KatanaClient(api_key=api_key, base_url=base_url, **kwargs)

--- a/scripts/probe_client_error_handling.py
+++ b/scripts/probe_client_error_handling.py
@@ -21,12 +21,11 @@ angles on the result.
 from __future__ import annotations
 
 import asyncio
-import os
 import sys
 from pathlib import Path
 
-from katana_public_api_client import KatanaClient
 from katana_public_api_client.models import DetailedErrorResponse
+from katana_public_api_client.testing import make_test_client
 from katana_public_api_client.utils import (
     APIError,
     ValidationError,
@@ -110,11 +109,15 @@ async def _post_and_inspect(client_httpx, url: str, payload: dict, label: str) -
 
 
 async def main() -> int:
-    if not os.environ.get("KATANA_API_KEY"):
-        print("KATANA_API_KEY not set — source .env first.", file=sys.stderr)
+    # make_test_client() raises RuntimeError when KATANA_TEST_API_KEY is unset —
+    # no silent fallback to KATANA_API_KEY so this probe can't hit prod.
+    try:
+        client = make_test_client()
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
         return 2
 
-    async with KatanaClient() as client:
+    async with client:
         httpx_client = client.get_async_httpx_client()
 
         # Labels are SDT-tagged so any accidentally-created definition

--- a/scripts/test_mcp_resources.py
+++ b/scripts/test_mcp_resources.py
@@ -11,15 +11,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from dotenv import load_dotenv
 from fastmcp import Context
 
-from katana_public_api_client import KatanaClient
+from katana_public_api_client.testing import make_test_client
 
 # Add project root to path for local MCP server imports
 _project_root = Path(__file__).parent.parent
@@ -121,34 +119,20 @@ async def run_resource_test(resource_name: str, resource_func, context: Context)
 
 async def main():
     """Main test function."""
-    # Load environment variables
-    load_dotenv()
-
-    # Get API key
-    api_key = os.getenv("KATANA_API_KEY")
-    if not api_key:
-        print("ERROR: KATANA_API_KEY environment variable is required")
-        print("Set it in your .env file or export it:")
-        print("  export KATANA_API_KEY=your-api-key-here")
+    # make_test_client() reads KATANA_TEST_API_KEY (no silent fallback to
+    # KATANA_API_KEY) so this script can't accidentally exercise prod.
+    try:
+        client = make_test_client(timeout=30.0, max_retries=3, max_pages=10)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}")
         sys.exit(1)
-
-    assert api_key is not None  # Type narrowing for type checker
-    base_url = os.getenv("KATANA_BASE_URL", "https://api.katanamrp.com/v1")
 
     print("=" * 60)
     print("MCP Resources Test")
     print("=" * 60)
-    print(f"API Base URL: {base_url}")
     print("API Key: [configured]")
 
-    # Initialize KatanaClient and open catalog cache
-    async with KatanaClient(
-        api_key=api_key,
-        base_url=base_url,
-        timeout=30.0,
-        max_retries=3,
-        max_pages=10,
-    ) as client:
+    async with client:
         cache = CatalogCache()
         await cache.open()
         try:

--- a/tests/test_testing_helper.py
+++ b/tests/test_testing_helper.py
@@ -1,0 +1,104 @@
+"""Tests for :mod:`katana_public_api_client.testing`.
+
+The helper is the only sanctioned way for test code, probes, and CI smoke
+tests to talk to a non-production Katana tenant. The contract these tests
+pin down is the no-prod-fallback safety guarantee: when
+``KATANA_TEST_API_KEY`` is unset, ``make_test_client()`` MUST raise rather
+than silently picking up ``KATANA_API_KEY``.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from katana_public_api_client import KatanaClient
+from katana_public_api_client.testing import make_test_client
+
+
+@pytest.mark.unit
+class TestMakeTestClient:
+    """Unit tests for ``make_test_client()`` — no live API calls."""
+
+    def test_returns_configured_katana_client_with_test_env_set(self):
+        """Happy path: helper reads KATANA_TEST_API_KEY and returns a client."""
+        with patch.dict(
+            os.environ,
+            {
+                "KATANA_TEST_API_KEY": "test-tenant-key",
+                "KATANA_TEST_BASE_URL": "https://api.example-test.com/v1",
+            },
+            clear=True,
+        ):
+            client = make_test_client()
+
+        assert isinstance(client, KatanaClient)
+        assert client._base_url == "https://api.example-test.com/v1"
+        assert client.token == "test-tenant-key"
+
+    def test_defaults_base_url_to_production_when_test_base_unset(self):
+        """KATANA_TEST_BASE_URL is optional; defaults to the prod URL.
+
+        Same Katana deployment, different tenant — the API key scopes
+        the credential to a sandbox tenant within the prod cluster.
+        """
+        with (
+            patch(
+                "katana_public_api_client.testing.dotenv_values",
+                lambda *_a, **_kw: {},
+            ),
+            patch.dict(
+                os.environ,
+                {"KATANA_TEST_API_KEY": "test-tenant-key"},
+                clear=True,
+            ),
+        ):
+            client = make_test_client()
+
+        assert client._base_url == "https://api.katanamrp.com/v1"
+
+    def test_raises_runtime_error_when_test_key_missing(self):
+        """Safety guarantee: no silent fallback to KATANA_API_KEY."""
+        # Even with a prod key present in the environment, the helper
+        # must refuse — this is the entire point of the no-fallback rule.
+        with (
+            patch(
+                "katana_public_api_client.testing.dotenv_values",
+                lambda *_a, **_kw: {},
+            ),
+            patch.dict(os.environ, {"KATANA_API_KEY": "prod-key"}, clear=True),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            make_test_client()
+
+        msg = str(exc_info.value)
+        assert "KATANA_TEST_API_KEY" in msg
+        assert "KATANA_API_KEY" in msg, (
+            "Error message should explicitly mention why we don't fall back"
+        )
+        assert "production" in msg.lower() or "prod" in msg.lower()
+
+    def test_raises_runtime_error_when_test_key_empty_string(self):
+        """Empty-string env var counts as unset — same as missing entirely."""
+        with (
+            patch(
+                "katana_public_api_client.testing.dotenv_values",
+                lambda *_a, **_kw: {},
+            ),
+            patch.dict(os.environ, {"KATANA_TEST_API_KEY": ""}, clear=True),
+            pytest.raises(RuntimeError, match="KATANA_TEST_API_KEY"),
+        ):
+            make_test_client()
+
+    def test_kwargs_pass_through_to_katana_client(self):
+        """Extra kwargs forward to KatanaClient so callers can tune timeouts etc."""
+        with patch.dict(
+            os.environ,
+            {"KATANA_TEST_API_KEY": "test-key"},
+            clear=True,
+        ):
+            client = make_test_client(timeout=5.0, max_retries=1, max_pages=3)
+
+        assert client.max_pages == 3


### PR DESCRIPTION
## Summary

Phase 1 of the live test environment epic (#837). Lands the foundation that future phases (pytest fixtures, CI workflow, smoke tests) will build on:

- **New `katana_public_api_client/testing.py`** with `make_test_client()` — reads `KATANA_TEST_API_KEY` (required) + `KATANA_TEST_BASE_URL` (optional, defaults to prod URL — same Katana, different tenant). **No silent fallback to `KATANA_API_KEY`**; missing test key raises `RuntimeError` with a message that explains why the fallback would be dangerous.
- **`.env.example`** — uncommented `KATANA_TEST_API_KEY` / `KATANA_TEST_BASE_URL` lines and added a pointer to the helper.
- **CLAUDE.md** — new "Test environment" section under Detailed Documentation pointing at the helper + the no-prod-fallback rule.
- **Probe-script refactor** — `scripts/probe_client_error_handling.py` and `scripts/test_mcp_resources.py` previously built a `KatanaClient` directly off the prod env; both now route through `make_test_client()` so a misconfigured run can't hit prod.

The other probe scripts (`probe_bom_row_response_shape.py`, `probe_shape_only.py`, `probe_remaining_issues.py`, `probe_issue_737.py`) already use a separate ledger-guarded `SafeClient` httpx wrapper in `spec_drift_verify.py` — touching those would lose their tenant-fingerprint safeguards, so they're deliberately left alone.

Out of scope (future phases of #837): pytest fixtures, GitHub Actions workflow, real smoke tests, optional ADR.

## Test plan

- [x] `uv run poe agent-check` clean
- [x] `uv run poe test` — all 3,652 tests pass
- [x] 5 new unit tests in `tests/test_testing_helper.py` cover happy path, default base URL, missing-key raise, empty-key raise, kwargs passthrough
- [x] Error message verified by hand — clearly explains both *what* is missing and *why* the helper refuses to fall back to `KATANA_API_KEY`

Closes #854
Refs #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)