### PR TITLE
feat(mcp): add sub-step timing to _modify_manufacturing_order_impl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,6 +420,7 @@ Configured in `.claude/settings.local.json` (gitignored):
 | Client guide           | [katana_public_api_client/docs/guide.md](katana_public_api_client/docs/guide.md)                                 |
 | OpenAPI spec authoring | [katana_public_api_client/docs/spec-authoring.md](katana_public_api_client/docs/spec-authoring.md)               |
 | MCP docs               | [katana_mcp_server/docs/README.md](katana_mcp_server/docs/README.md)                                             |
+| Modify-pipeline timing | [katana_mcp_server/docs/LOGGING.md](katana_mcp_server/docs/LOGGING.md) — "Modify-pipeline sub-step timing"       |
 | Prefab UI pitfalls     | [katana_mcp_server/docs/prefab/README.md](katana_mcp_server/docs/prefab/README.md)                               |
 | Typed cache patterns   | [katana_mcp_server/docs/typed_cache/README.md](katana_mcp_server/docs/typed_cache/README.md)                     |
 | TypeScript client      | [packages/katana-client/README.md](packages/katana-client/README.md)                                             |

--- a/katana_mcp_server/docs/LOGGING.md
+++ b/katana_mcp_server/docs/LOGGING.md
@@ -231,6 +231,34 @@ Example with metrics:
 }
 ```
 
+### Modify-pipeline sub-step timing (`modify_manufacturing_order`)
+
+`_modify_manufacturing_order_impl`
+(`katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py`) emits
+three sub-step `duration_ms` events on the `preview=false` path so the next 30s+ slow
+call leaves a diagnostic breadcrumb (#853, refs #786). Grep your structlog output for:
+
+| Event                                | Step                                        | Wraps                                                      |
+| ------------------------------------ | ------------------------------------------- | ---------------------------------------------------------- |
+| `mo_modify_patch_completed`          | The Katana PATCH apply (header update)      | `api_update_manufacturing_order.asyncio_detailed`          |
+| `mo_modify_verify_refetch_completed` | Sibling recipe-row re-fetch for cache merge | `_fetch_mo_recipe_row_attrs_for_cache_merge`               |
+| `mo_modify_cache_merge_completed`    | Parent MO GET re-fetch inside cache merge   | `_fetch_manufacturing_order_attrs` via `refetch_for_merge` |
+
+Each event carries `step`, `duration_ms`, `success`, and `manufacturing_order_id` (the
+`success` field name matches the sibling `tool_completed` /
+`service_operation_completed` events in `katana_mcp/logging.py`, so any log-aggregation
+query that joins on the `success` boolean will see all of these events too). Note that
+not every `preview=false` call emits all three: `mo_modify_patch_completed` only fires
+when the plan includes a header PATCH (`request.update_header is not None`), and the
+cache-merge / verify-refetch events only fire when at least one action runs (the
+cache-merge pass is gated on `actions` inside `run_modify_plan`). The pre-existing
+`tool_completed` event (from `@observe_tool`) gives end-to-end `duration_ms`; subtract
+whichever sub-step events were emitted to see how much fell to local work (plan build,
+action dispatch, cache write-through).
+
+Pattern is MO-only today — once #786 picks a fix path, the equivalent timing can be
+extracted into a shared dispatcher helper.
+
 ## Observability Decorators
 
 The Katana MCP Server provides convenience decorators to automatically instrument tools

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -13,6 +13,9 @@ Tools:
 from __future__ import annotations
 
 import asyncio
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -123,6 +126,79 @@ from katana_public_api_client.models_pydantic._generated import (
 from katana_public_api_client.utils import unwrap_as
 
 logger = get_logger(__name__)
+
+
+# ============================================================================
+# Sub-step timing instrumentation (#853, refs #786)
+#
+# ``modify_manufacturing_order`` with a header-only payload occasionally
+# takes 30s+ end-to-end. The three candidate slow steps are:
+#
+#   1. The Katana PATCH call (``api_update_manufacturing_order``).
+#   2. The post-apply verify re-fetch
+#      (``_fetch_mo_recipe_row_attrs_for_cache_merge`` — recipe rows live at
+#      a sibling endpoint, see ``CacheMerge.refetch_related``).
+#   3. The cache-merge parent re-fetch (``refetch_for_merge`` lambda inside
+#      ``_post_apply_cache_merge``).
+#
+# ``@observe_tool`` already emits ``tool_completed`` with the end-to-end
+# ``duration_ms`` per call; what's missing is which sub-step dominates.
+# The :func:`_log_step_duration` helper wraps each lambda with a
+# ``time.perf_counter``-bracketed structlog event so the next 30s+ session
+# leaves a breadcrumb. The wrapper is intentionally inline (not a
+# decorator) because the steps are lambdas the dispatcher invokes, not
+# named coroutines we can decorate. See
+# ``katana_mcp_server/docs/LOGGING.md`` (the "Modify-pipeline sub-step
+# timing" section) for grep patterns to extract these events from logs.
+# ============================================================================
+
+
+@asynccontextmanager
+async def _log_step_duration(step_name: str, **context: Any) -> AsyncIterator[None]:
+    """Log ``duration_ms`` for a sub-step of ``_modify_manufacturing_order_impl``.
+
+    Emits a single structlog ``info`` event named ``mo_modify_<step>_completed``
+    on exit (success or exception) with the elapsed wall-clock time in
+    milliseconds. The event name is fixed by ``step_name`` so downstream
+    log analyzers can grep deterministically.
+
+    Args:
+        step_name: Short tag identifying the sub-step (e.g. ``"patch"``,
+            ``"verify_refetch"``, ``"cache_merge"``). Used to construct the
+            event name ``mo_modify_<step_name>_completed``.
+        **context: Extra fields merged into the log event (e.g.
+            ``manufacturing_order_id``) for correlation.
+    """
+    # Guard the fixed-schema fields up-front: downstream log-aggregation
+    # joins depend on ``step`` / ``duration_ms`` / ``success`` always being
+    # set by this helper. If a caller passes one of those keys in
+    # ``context`` they would silently override the instrumentation contract
+    # (because ``**context`` is expanded after the explicit kwargs in the
+    # ``logger.info`` call, the dict-merge semantics let the caller win).
+    # Fail loudly instead — this is dev-time misuse, not a runtime path.
+    reserved = {"step", "duration_ms", "success"} & context.keys()
+    if reserved:
+        raise TypeError(
+            f"_log_step_duration: caller passed reserved key(s) {sorted(reserved)} "
+            "in context — these fields are set by the helper to keep the "
+            "instrumentation schema stable. Rename the offending kwarg."
+        )
+    start = time.perf_counter()
+    success = True
+    try:
+        yield
+    except Exception:
+        success = False
+        raise
+    finally:
+        duration_ms = (time.perf_counter() - start) * 1000
+        logger.info(
+            f"mo_modify_{step_name}_completed",
+            step=step_name,
+            duration_ms=round(duration_ms, 2),
+            success=success,
+            **context,
+        )
 
 
 # ============================================================================
@@ -2939,17 +3015,30 @@ async def _modify_manufacturing_order_impl(
         diff = compute_field_diff(
             existing_mo, request.update_header, unknown_prior=existing_mo is None
         )
+        # Sub-step timing (#853): wrap the header PATCH apply so we can
+        # tell how much of a slow ``modify_manufacturing_order`` call is
+        # spent waiting on Katana vs. local work. The base ``apply``
+        # is the closure built by ``make_patch_apply`` — it issues the
+        # ``api_update_manufacturing_order.asyncio_detailed(...)`` call.
+        _base_patch_apply = make_patch_apply(
+            api_update_manufacturing_order,
+            services,
+            request.id,
+            _build_update_header_request(request.update_header, existing_mo),
+            return_type=ManufacturingOrder,
+        )
+
+        async def _timed_patch_apply() -> ManufacturingOrder:
+            # Closes over ``request.id`` — captured eagerly at this call
+            # frame, so it's safe even though the closure runs later.
+            async with _log_step_duration("patch", manufacturing_order_id=request.id):
+                return await _base_patch_apply()
+
         header_action = ActionSpec(
             operation=MOOperation.UPDATE_HEADER,
             target_id=request.id,
             diff=diff,
-            apply=make_patch_apply(
-                api_update_manufacturing_order,
-                services,
-                request.id,
-                _build_update_header_request(request.update_header, existing_mo),
-                return_type=ManufacturingOrder,
-            ),
+            apply=_timed_patch_apply,
             verify=make_response_verifier(diff),
         )
         header_phase = _classify_status_transition(
@@ -3079,6 +3168,27 @@ async def _modify_manufacturing_order_impl(
     if header_action is not None and header_phase is _HeaderPhase.LAST:
         plan.append(header_action)
 
+    # Sub-step timing (#853): wrap both cache-merge re-fetchers so we
+    # can see how the post-apply cache merge spends its wall clock.
+    # ``cache_merge`` step = parent MO GET refetch (the ``refetch_for_merge``
+    # lambda — invoked by ``_post_apply_cache_merge`` to drive
+    # ``merge_filtered_fetch``).
+    # ``verify_refetch`` step = the sibling recipe-rows GET
+    # (``_fetch_mo_recipe_row_attrs_for_cache_merge`` — fans out via
+    # ``CacheMerge.refetch_related`` because recipe rows live at the
+    # separate ``/manufacturing_order_recipe_rows`` endpoint).
+    async def _timed_refetch_for_merge(eid: int) -> Any:
+        async with _log_step_duration("cache_merge", manufacturing_order_id=eid):
+            return await _fetch_manufacturing_order_attrs(services, eid)
+
+    async def _timed_refetch_recipe_rows(eid: int) -> list[Any]:
+        # The outer ``_post_apply_cache_merge`` handler wraps this in
+        # ``except Exception: logger.warning(); continue`` — ``success=False``
+        # events still fire from the ``finally`` block, but the raise is
+        # swallowed and the caller never sees it.
+        async with _log_step_duration("verify_refetch", manufacturing_order_id=eid):
+            return await _fetch_mo_recipe_row_attrs_for_cache_merge(services, eid)
+
     return await run_modify_plan(
         request=request,
         naming=EntityNaming(
@@ -3091,9 +3201,7 @@ async def _modify_manufacturing_order_impl(
         plan=plan,
         cache_merge=CacheMerge(
             cache=services.typed_cache,
-            refetch_for_merge=lambda eid: _fetch_manufacturing_order_attrs(
-                services, eid
-            ),
+            refetch_for_merge=_timed_refetch_for_merge,
             # Recipe rows live at the separate
             # ``/manufacturing_order_recipe_rows`` endpoint (per
             # ``MANUFACTURING_ORDER_SPEC.related_specs``), not embedded
@@ -3105,9 +3213,7 @@ async def _modify_manufacturing_order_impl(
             refetch_related=(
                 (
                     "manufacturing_order_recipe_row",
-                    lambda eid: _fetch_mo_recipe_row_attrs_for_cache_merge(
-                        services, eid
-                    ),
+                    _timed_refetch_recipe_rows,
                 ),
             ),
         ),

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -2763,6 +2763,136 @@ async def test_modify_mo_confirm_executes_in_canonical_order():
     assert response.prior_state is not None
 
 
+@pytest.mark.asyncio
+async def test_modify_mo_emits_substep_timing_events(caplog):
+    """#853 / refs #786 — ``_modify_manufacturing_order_impl`` emits three
+    ``mo_modify_*_completed`` events on the apply path so the next 30s+
+    slow call leaves a diagnostic breadcrumb. Pattern mirrors
+    ``test_unknown_operation_is_logged_and_dropped`` in
+    ``tests/test_prefab_ui.py`` (force structlog through stdlib + caplog).
+
+    The three events correspond to the three candidate slow steps:
+
+    - ``mo_modify_patch_completed`` — the Katana PATCH apply
+    - ``mo_modify_verify_refetch_completed`` — the sibling recipe-rows
+      re-fetch (``CacheMerge.refetch_related``)
+    - ``mo_modify_cache_merge_completed`` — the parent MO GET re-fetch
+      (``CacheMerge.refetch_for_merge`` inside ``_post_apply_cache_merge``)
+    """
+    import logging
+
+    import structlog
+    from katana_mcp.logging import setup_logging
+    from katana_mcp.tools.foundation import manufacturing_orders as mo_module
+
+    # Force structlog through stdlib + JSONRenderer so caplog sees the
+    # emitted info events. Without this the test depends on whether some
+    # earlier test in the same xdist worker happened to call
+    # ``setup_logging`` — flaky between sequential and parallel runs.
+    #
+    # ``setup_logging`` uses ``cache_logger_on_first_use=True``, so the
+    # module-level ``logger = get_logger(__name__)`` in
+    # ``manufacturing_orders.py`` was bound *at import time* under
+    # whatever structlog config was active then — possibly a no-op
+    # ``BoundLoggerBase`` from before any earlier test called
+    # ``setup_logging``. Reconfiguring structlog *after* the proxy has
+    # cached its concrete bound logger has no effect on subsequent
+    # ``logger.info()`` calls. (CI 3.13 failure mode: empty
+    # ``caplog.records`` because the cached bound logger drops info-level
+    # events.) Fix: reconfigure structlog, then re-bind the module's
+    # ``logger`` attribute to a freshly-obtained logger under the new
+    # config.
+    setup_logging(log_level="INFO", log_format="json")
+    mo_module.logger = structlog.get_logger(
+        "katana_mcp.tools.foundation.manufacturing_orders"
+    )
+
+    context, _ = create_mock_context()
+    existing = _mock_mo(mo_id=42, order_no="MO-1")
+    updated = _mock_mo(mo_id=42, order_no="MO-1")
+
+    # ``_post_apply_cache_merge`` does its own ``merge_filtered_fetch``
+    # against the (mocked) cache; patching the late import to a no-op
+    # keeps the test focused on the timing events and avoids touching the
+    # typed-cache schema. The parent GET refetch still fires (timed by
+    # ``cache_merge``), and the related recipe-row fetcher still fires
+    # (timed by ``verify_refetch``).
+    with (
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            f"{_MODIFY_MO_UPDATE}.asyncio_detailed",
+            new_callable=AsyncMock,
+            return_value=MagicMock(parsed=updated),
+        ),
+        patch(
+            "katana_mcp.tools.foundation.manufacturing_orders._fetch_mo_recipe_row_attrs_for_cache_merge",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(_MODIFY_MO_UNWRAP_AS, side_effect=[updated]),
+        patch(
+            "katana_mcp.typed_cache.sync.merge_filtered_fetch",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        request = ModifyManufacturingOrderRequest(
+            id=42,
+            update_header=MOHeaderPatch(status="IN_PROGRESS"),
+            preview=False,
+        )
+        with caplog.at_level(
+            logging.INFO,
+            logger="katana_mcp.tools.foundation.manufacturing_orders",
+        ):
+            response = await _modify_manufacturing_order_impl(request, context)
+
+    assert response.is_preview is False
+    assert all(a.succeeded is True for a in response.actions)
+
+    # Verify all three sub-step events fire, each with a ``duration_ms``.
+    # ``setup_logging(json)`` routes structlog through ``JSONRenderer``,
+    # so ``rec.getMessage()`` is a JSON blob carrying the ``event`` field.
+    # Substring-match the event name (same pattern as
+    # ``test_unknown_operation_is_logged_and_dropped`` in
+    # ``tests/test_prefab_ui.py``). Also pin the ``success`` field name
+    # (matches sibling ``tool_completed`` / ``service_operation_completed``
+    # events in ``katana_mcp/logging.py`` — so any log-aggregation query
+    # that joins on the ``success`` boolean will see these events too).
+    expected_events = {
+        "mo_modify_patch_completed",
+        "mo_modify_verify_refetch_completed",
+        "mo_modify_cache_merge_completed",
+    }
+    matched: set[str] = set()
+    for rec in caplog.records:
+        if rec.name != "katana_mcp.tools.foundation.manufacturing_orders":
+            continue
+        if rec.levelname != "INFO":
+            continue
+        msg = rec.getMessage()
+        for event_name in expected_events:
+            if event_name in msg and "duration_ms" in msg:
+                matched.add(event_name)
+                # Pin the field name — convention is ``success`` not
+                # ``succeeded`` (sibling events in
+                # ``katana_mcp/logging.py``). Any future drift away from
+                # the convention should turn this assertion red.
+                assert '"success":' in msg, (
+                    f"Expected ``success`` field in {event_name} event; "
+                    f"got: {msg[:200]}"
+                )
+    assert matched == expected_events, (
+        f"Expected all three sub-step events {expected_events}; "
+        f"saw {sorted(matched)}. Records: "
+        f"{[(r.name, r.levelname, r.getMessage()[:120]) for r in caplog.records]}"
+    )
+
+
 # ============================================================================
 # delete_manufacturing_order
 # ============================================================================


### PR DESCRIPTION
## Summary

- Wraps the three candidate slow steps in `_modify_manufacturing_order_impl` with `time.perf_counter`-bracketed structlog events so the next 30s+ call leaves a diagnostic breadcrumb.
- Emits `mo_modify_patch_completed`, `mo_modify_verify_refetch_completed`, `mo_modify_cache_merge_completed` — each with `step`, `duration_ms`, `succeeded`, `manufacturing_order_id`.
- Documents the events + grep targets in `katana_mcp_server/docs/LOGGING.md`; references from `CLAUDE.md`'s "Detailed Documentation" table.

Diagnostic-only — no behavior change, no fix code. Phase 1 of #786; the actual fix is gated on which sub-step dominates the 30s cliff in production logs.

## Sub-step → event mapping

| Event                                | Wraps                                                      |
| ------------------------------------ | ---------------------------------------------------------- |
| `mo_modify_patch_completed`          | `api_update_manufacturing_order.asyncio_detailed` (header PATCH) |
| `mo_modify_verify_refetch_completed` | `_fetch_mo_recipe_row_attrs_for_cache_merge` (sibling recipe-rows GET via `CacheMerge.refetch_related`) |
| `mo_modify_cache_merge_completed`    | `_fetch_manufacturing_order_attrs` (parent MO GET inside `_post_apply_cache_merge` via `CacheMerge.refetch_for_merge`) |

## Test plan

- [x] New unit test verifies all three events fire on the `preview=false` path
- [x] `uv run poe agent-check` clean
- [x] `uv run poe test` — 3648 passed, 6 skipped
- [x] Existing MO tests unaffected (91 in `test_manufacturing_orders.py`)
- [ ] Next 30s+ session: grep structlog output for `mo_modify_*_completed` and pick the dominant step → feeds the fix path in #786

Closes #853
Refs #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)