### PR TITLE
feat(mcp): user-centric content on prefab UI cards + /card-review skill

### DIFF
--- a/.claude/skills/card-review/SKILL.md
+++ b/.claude/skills/card-review/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: card-review
+description: >-
+  Audit Prefab UI card builders (`build_*_ui` in `katana_mcp_server/src/katana_mcp/tools/prefab_ui.py`)
+  for user-centric content: real names over IDs, no redundant text dumps,
+  named helpers over ad-hoc rendering. Reports findings; does not modify code.
+  Use when reviewing card UX or after touching `prefab_ui.py`.
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(grep *)
+  - Bash(rg *)
+---
+
+# /card-review — Prefab UI Card UX Audit
+
+## PURPOSE
+
+Surface user-centric-content problems in MCP card builders before the operator
+sees them. Cards live in `katana_mcp_server/src/katana_mcp/tools/prefab_ui.py`
+as `build_<entity>_ui(response) -> PrefabApp` functions and render inside Claude
+Code as the iframe payload of a `ToolResult`.
+
+## CRITICAL
+
+- **Read-only review** — propose fixes, don't apply them. Cite `file:line` for every finding.
+- **Anchor on the user's actual decision** — every card answers "what am I confirming?" The audit asks whether the rendered content lets the operator answer that without consulting the raw tool blob or the Katana web UI.
+- **Cross-check with `feedback-user-centric-card-content` memory** — that rule is the foundational principle this skill enforces; new anti-patterns we find belong added to `references/prefab-anti-patterns.md`.
+
+## ASSUMES
+
+- Target is one card (`/card-review build_fulfill_preview_ui`) or all (`/card-review --all`).
+- Findings are reported as `[HIGH|MEDIUM|LOW|NONE] <card_name>` with file:line.
+- The repo already has the right pattern set (`_render_party_line`, `_render_address_block`, `_render_field_diff_line`, `_render_failed_changes_block`, `_render_preview_header`/`_render_preview_footer`). The bar is "does this card use them, or bypass them?"
+
+## STANDARD PATH
+
+### 1. Identify the card(s) to audit
+
+```bash
+grep -n "^def build_.*_ui" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+```
+
+Pick by name or audit all. Each `build_*_ui` consumes a response dict (see the impl
+side in `katana_mcp_server/src/katana_mcp/tools/foundation/*.py`).
+
+### 2. Scan against the seven anti-patterns
+
+Run each grep pattern against the card's function body. Detail + remediation is in
+[references/prefab-anti-patterns.md](references/prefab-anti-patterns.md).
+
+| # | Anti-pattern | Grep target |
+|---|---|---|
+| 1 | Redundant text dump next to a table/widget | `for .* in response\[.*"`, `Muted\(content=` followed by `DataTable` |
+| 2 | Internal IDs surfaced in user-facing text | `f"\w+ ID: \{`, `f"#\{`, `_id}` inside `Text(content=…)` |
+| 3 | Missing party / address reference info on an order card | absence of `_render_party_line\|_render_address_block` in any SO/PO/MO body |
+| 4 | Abstract verbs over content (`Operation`, `Target`, `n action(s)`) | `"Operation"`, `"Target"`, `n_actions`, `f"\{verb_label\}"` |
+| 5 | Wire shape leaking to UI (snake_case headers, raw enum values, `model_dump()` dumps) | `header="\w*_\w+"`, `\.value\b` inside `Text(content=` |
+| 6 | Buried decision context (table below 3+ warnings/metrics) | inspect layout order: identity → metrics → reference → decision-driver → footer |
+| 7 | Helper-fallback masking (`name=None` passed to a party-line helper) | `_render_party_line\(.*name=None`, or a `_render_party_line` call whose source dict has no `*_name` field |
+
+### 3. Cross-reference positive helpers
+
+Each anti-pattern finding pairs with a specific gold-standard helper. See
+[references/positive-helpers.md](references/positive-helpers.md) for the inventory
+and "use when" guide. If the card already uses the right helper but mis-passes args
+(e.g., `entity_id` without `name`), flag the call site, not the helper itself.
+
+### 4. Report
+
+```text
+## Card Review: <card_name>
+
+### Severity
+HIGH | MEDIUM | LOW | NONE
+
+### Findings
+- [Anti-pattern #N] `prefab_ui.py:NNNN-NNNN` — <one-line quote of the offending code>
+  Fix: <which helper + how to call it>
+- ...
+
+### Positive (when severity NONE)
+- Uses `_render_party_line` for Customer (`prefab_ui.py:NNNN`)
+- ...
+```
+
+For `--all`, group cards by severity band (HIGH first), one block per card. Keep
+the total report scannable — under ~50 lines per band.
+
+## EDGE CASES
+
+- **Card already uses a helper but the helper itself emits an ID** — flag the helper, not the card. `_render_party_line` falls back to `f"<Label> ID: {entity_id}"` when name is None; the impl side should resolve the name (typed cache: `resolve_entity_name(catalog, Cached*, id, entity_label="…")` — pattern at `katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py:568`).
+- **Success card vs preview card divergence** — the post-action card often inherits the preview's reference block. Audit both branches; the `is_preview` switch is not an excuse to drop user-facing content.
+- **MO branch on shared card** — manufacturing orders legitimately lack a customer + shipping address. The audit should skip the missing-reference-info check when `order_type == "manufacturing"` and the card has a per-branch guard.
+- **Generic fallback cards** (`build_modification_preview_ui`, `build_modification_result_ui`) — these are the "no per-entity builder yet" fallback. The right fix is usually to *promote* the path to a per-entity builder (model: `build_po_modify_ui`), not to polish the generic one.
+
+## RELATED
+
+- `frontend-design-review` skill (upstream `microsoft/skills@frontend-design-review`, vendored at `.claude/skills/frontend-design-review/`) — provides the three-pillar framework (Frictionless / Quality Craft / Trustworthy). This skill rebinds the pillars to Prefab UI semantics.
+- `code-modernizer` agent — actively rewrites the patterns this skill flags.
+- `/review` skill — broader code review; use after `/card-review` for non-UX issues.
+- `feedback-user-centric-card-content` memory — the foundational principle this skill enforces.

--- a/.claude/skills/card-review/references/positive-helpers.md
+++ b/.claude/skills/card-review/references/positive-helpers.md
@@ -1,0 +1,207 @@
+# Positive Helpers — When to Reach for Each
+
+Project-canonical rendering helpers in `katana_mcp_server/src/katana_mcp/tools/prefab_ui.py`.
+Cards that bypass these helpers and roll their own rendering are the source of every
+anti-pattern in `prefab-anti-patterns.md`.
+
+Pair each finding from a `/card-review` run with the matching helper here so the
+remediation is concrete.
+
+Line numbers are intentionally omitted — `prefab_ui.py` evolves and hard-coded
+positions drift faster than this file is maintained. Use `grep -n "^def
+_render_party_line" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py` (or LSP
+`goToDefinition`) to jump to the current location.
+
+---
+
+## `_render_party_line`
+
+**Signature:**
+
+```python
+def _render_party_line(
+    label: str,
+    *,
+    name: str | None,
+    entity_id: int | None,
+    entity_kind: EntityKind | None = None,
+) -> None
+```
+
+**Use when:** a card refers to a Katana entity (customer / supplier / location / variant) and wants to surface its identity.
+
+**Behavior:**
+
+- `name` + `entity_kind` → renders `<label>: <Link name>` (Katana web URL).
+- `name` only (no `entity_kind`, or `entity_kind` has no web URL) →
+  `<label>: <name>`. The entity_id is dropped from the visible text —
+  it's still on the response for programmatic consumers, but the card
+  doesn't echo it next to its resolved name when there's no
+  click-through to anchor (anti-pattern #2 — don't double-print a raw
+  ID alongside its name).
+- Neither name nor URL → `<label> ID: <entity_id>`. Last-resort
+  fallback when impl-side name resolution couldn't fill `name`; the
+  matching impl path should also append a cache-miss advisory to
+  `warnings` so the operator sees *why* the name is missing.
+- `entity_id is None` → renders nothing (skip).
+
+**Reach for it instead of:**
+
+```python
+Text(content=f"Customer: {name} (ID: {customer_id})")
+Text(content=f"Location ID: {location_id}")
+```
+
+**Call example** (`build_so_create_ui` — grep `_render_party_line\("Customer"`):
+
+```python
+_render_party_line(
+    "Customer",
+    name=response.get("customer_name"),
+    entity_id=response.get("customer_id"),
+    entity_kind="customer",
+)
+```
+
+---
+
+## `_render_party_diff_line`
+
+**Signature:**
+
+```python
+def _render_party_diff_line(
+    label: str,
+    *,
+    id_change: FieldChangeView,
+    name_change: FieldChangeView | None,
+    prior_name: str | None,
+) -> None
+```
+
+**Use when:** a modify card's party (supplier / customer / location) is *changing* — renders `<before-name> (<before-id>) → <after-name> (<after-id>)` with the `✗` failure gutter.
+
+**Reach for it instead of:** custom `f"{old} → {new}"` strings inside `Text(content=…)`.
+
+---
+
+## `_render_address_block`
+
+**Signature:**
+
+```python
+def _render_address_block(label: str, address: dict[str, Any]) -> bool
+```
+
+**Use when:** any card displays a postal address (shipping, billing, supplier address). Returns `False` if every field except `entity_type` was empty (caller decides whether to skip the section).
+
+**Behavior:**
+
+- Reads `first_name`/`last_name`/`company`/`line_1`/`line_2`/`city`/`state`/`zip`/`country`/`phone`.
+- Composes the recipient/company/street/locality/country lines, skipping blank components.
+- Wire-format note: reads `address["zip"]` (the attrs `to_dict()` emits the wire name).
+
+**Companion:** `_addresses_are_equivalent(a, b)` — call before rendering a Billing block to dedup against Shipping. The canonical implementation lives in `katana_mcp/tools/_addresses.py` (shared between impl + UI); `prefab_ui.py` re-exports the legacy private name.
+
+**Reach for it instead of:** manually building a multi-line address string in `Text(content=…)`.
+
+**Call example** (`_render_customer_entity_view` — grep for the function name):
+
+```python
+ship = next((a for a in addresses if a.get("entity_type") == "shipping"), None)
+bill = next((a for a in addresses if a.get("entity_type") == "billing"), None)
+if ship:
+    _render_address_block("Shipping Address", ship)
+if bill and not _addresses_are_equivalent(ship or {}, bill):
+    _render_address_block("Billing Address", bill)
+```
+
+---
+
+## `_render_field_diff_line`
+
+**Use when:** modify card needs a scalar before/after line (status, notes, arrival date, etc.). Handles the `(prior unknown)` case and the 2-character `✗` gutter for failed fields.
+
+**Reach for it instead of:**
+
+```python
+Text(content=f"Status: {old} → {new}")
+```
+
+Or a 3-column DataTable (`Field / Old / New`) when the field count is small — `_render_field_diff_line` is cleaner for scalar diffs.
+
+---
+
+## `_render_failed_changes_block`
+
+**Use when:** modify card needs to surface per-field apply failures *without* destabilizing the unchanged-row layout. Renders a single Alert block at the bottom listing every failed field + its server error.
+
+**Reach for it instead of:** inline error text after each failed field (jitter), or a generic "some changes failed" Alert with no diagnostics (unhelpful).
+
+---
+
+## `_render_preview_header` / `_render_preview_footer`
+
+**Use when:** any preview/applied card that needs the standard four-tier layout (title prefix + entity badge + status badge in header; Confirm + Cancel + optional next-action buttons in footer).
+
+**Reach for them instead of:** hand-rolled `CardHeader` + `CardTitle` + `Badge` triplet (drift risk — every card ends up with subtly different gap/variant choices).
+
+**Call example** (`build_po_create_ui`):
+
+```python
+_render_preview_header(
+    title_prefix="Purchase Order",
+    entity="purchase_order",
+    order_number=order_number,
+    status=status,
+)
+# … body …
+_render_preview_footer(
+    title_prefix="Purchase Order",
+    block_warnings=block_warnings,
+    confirm_label="Confirm & Create Purchase Order",
+    apply_action=apply_action,
+    cancel_action=cancel_action,
+)
+```
+
+---
+
+## Resolving names impl-side
+
+Helpers above all assume the response already carries the user-facing `*_name` field.
+The impl side resolves names via the typed cache:
+
+**`resolve_entity_name`** — in `katana_mcp_server/src/katana_mcp/tools/tool_result_utils.py`
+
+```python
+async def resolve_entity_name(
+    catalog: Any,
+    cached_cls: Any,
+    entity_id: int,
+    *,
+    entity_label: str,
+) -> tuple[str | None, str | None]
+```
+
+Returns `(name, warning)`. If the cache miss / API fallback can't resolve a name, the warning string surfaces on the response so the operator sees a "couldn't resolve <Label> name" note instead of a silent empty field.
+
+**Call sites to pattern-match** (grep `resolve_entity_name` in `foundation/`):
+
+- `sales_orders.py` — customer + location name on SO create.
+- `purchase_orders.py` — supplier name on PO create.
+- `stock_transfers.py` — location names on stock transfer.
+- `orders.py` — customer name on fulfill SO.
+- `inventory.py` — location name on stock-adjustment create/update/delete.
+
+Cache classes (`CachedCustomer`, `CachedSupplier`, `CachedLocation`, etc.) live in
+`katana_public_api_client/models_pydantic/_generated/`.
+
+---
+
+## When to add a new helper
+
+If a `/card-review` pass surfaces the same anti-pattern in 2+ cards and no helper
+above fits, that's the signal to write a new helper. Naming follows the existing
+pattern — `_render_<noun>_<shape>` for render helpers, `_<resolver-target>_section`
+for impl-side composites. Add the new helper to this file when it lands.

--- a/.claude/skills/card-review/references/prefab-anti-patterns.md
+++ b/.claude/skills/card-review/references/prefab-anti-patterns.md
@@ -1,0 +1,225 @@
+# Prefab UI Anti-Patterns
+
+Catalog of patterns that violate the user-centric-content rule. Each entry shows
+the bad shape (with a real `prefab_ui.py` excerpt from current or recently-fixed
+code), the symptom the operator sees, and the fix.
+
+The numbering matches the table in `SKILL.md` "Scan against the seven anti-patterns".
+
+---
+
+## 1. Redundant text dump next to a table/widget
+
+**Symptom.** The card lists every row twice — once as a Muted text block, once as a `DataTable` — so the operator scrolls past 9 lines of "Row 108854645: ship 1 of …" to reach the table that says the same thing.
+
+**Detection grep:**
+
+```text
+grep -n "for .* in response\[" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+grep -n "Muted(content=" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py | head
+```
+
+Cross-check: any `Muted` followed within ~5 lines by `DataTable` over the same response key is suspect.
+
+**Historical bad example** (the fulfill card before phase 2):
+
+```python
+def _render_inventory_updates(response, *, label="Inventory Changes:"):
+    if response.get("inventory_updates"):
+        Muted(content=label)
+        for update in response["inventory_updates"]:
+            Text(content=f"  {update}")
+```
+
+The strings in `inventory_updates` are server-generated `"Row {row_id}: ship {qty} of {label}"` lines that also become rows in the `_render_fulfill_per_row_table` DataTable below.
+
+**Fix.** Pick one rendering. The DataTable carries structured columns (Item / SKU / Qty / Serials / Batch / Line Total) — keep it. Delete the text block. Single-line context (e.g., a `picked_date`) promotes to a Metric, not a re-rendered text line.
+
+---
+
+## 2. Internal IDs surfaced in user-facing text
+
+**Symptom.** Card body shows `Variant ID: 12345`, `Supplier: Acme (ID: 67)`, `Row 108854645: …`. The number means nothing to the operator and crowds out the name.
+
+**Detection grep:**
+
+```text
+grep -nE "f\"\w+ ID:" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+grep -nE "f\"#\{" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+grep -nE "Text\(content=f\".*_id" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+```
+
+**Bad shapes:**
+
+```python
+Text(content=f"Variant ID: {variant_id}")
+Text(content=f"Supplier: {name} (ID: {supplier_id})")
+Text(content=f"Location ID: {location_id}")
+```
+
+**Fix.** `_render_party_line("Supplier", name=..., entity_id=..., entity_kind="supplier")`. The helper:
+
+- Renders the name as a `Link` to the Katana web UI when `entity_kind` resolves.
+- Falls back to plain `"<Label>: <name>"` (no ID parenthetical) when no `entity_kind` is supplied. The structured response still carries the ID for programmatic consumers; the card text doesn't echo it next to its resolved name when there's no click-through to anchor.
+- Falls back to `"<Label> ID: <id>"` only when name is missing — and that's a *signal*, not the target shape: resolve the name impl-side via `resolve_entity_name(catalog, Cached*, id, entity_label="…")`.
+
+If a Variant ID appears in body text, the SKU should usually replace it entirely. SKUs are the human-facing identifier; variant IDs are wire-shape.
+
+---
+
+## 3. Missing party / address reference info on an order card
+
+**Symptom.** An SO / PO / MO confirmation card has no customer / supplier / location name, no shipping address. The operator can confirm the action but can't verify *who* it ships to or *where* it draws from.
+
+**Detection:**
+
+```text
+# List the order-related card builders.
+rg -nE "^def build_(so|po|mo|fulfill|receipt)_.*_ui" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+
+# For any card found above, check that its body uses the party-line /
+# address-block helpers. Run after reading the function with the LSP
+# (``goToDefinition``) or a Read on the spanning line range.
+rg -nE "_render_party_line|_render_address_block" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+```
+
+A card-builder name from the first command whose function body (located
+via LSP / Read) doesn't appear in the second command's hits is a finding.
+
+**Fix.** Tier 3 reference block, before the Tier 3 per-row table:
+
+```python
+_render_party_line(
+    "Customer",  # or "Supplier", "Location"
+    name=response.get("customer_name"),
+    entity_id=response.get("customer_id"),
+    entity_kind="customer",
+)
+if shipping_address:
+    _render_address_block("Shipping Address", shipping_address)
+if billing_address:  # only when not equivalent to shipping
+    _render_address_block("Billing Address", billing_address)
+```
+
+Impl side adds the response fields (`customer_name`, `shipping_address: dict[str, Any] | None`, etc.) and resolves names via the typed cache.
+
+---
+
+## 4. Abstract verbs over content
+
+**Symptom.** Columns labeled `Operation`, `Target`, `Changes`, `# of actions`. The user has to mentally translate "3 field(s) changed" back to "what changed?".
+
+**Detection:**
+
+```text
+grep -nE "\"Operation\"|\"Target\"|n_actions|f\"\{verb_label\}\"" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+```
+
+**Historical bad example** (modification preview card):
+
+```python
+_ACTION_COLUMNS = [
+    DataTableColumn(key="num", header="#"),
+    DataTableColumn(key="operation", header="Operation"),
+    DataTableColumn(key="target", header="Target"),
+    DataTableColumn(key="changes", header="Changes"),
+    DataTableColumn(key="status", header="Status"),
+]
+
+# elsewhere:
+target_label = f"#{target}"  # raw entity_id
+summary = f"{n_changes} field(s) changed"  # count, not content
+```
+
+**Fix.** Promote to a per-entity renderer (`_render_po_entity_view`-style) when the entity type is known. For unknown types, the column set becomes `Field / Before / After / Status` keyed off the entity's `prior_state` vs `changes`. Render each entity as its own sub-card body — never a row in a table-of-actions.
+
+Title drops `"N action(s)"` — single-action shows `"<entity_type> <entity_no>"`; multi-action shows `"<N> <entity_type>s"`.
+
+---
+
+## 5. Wire shape leaking to UI
+
+**Symptom.** Snake_case headers in DataTables (`recipe_row_id`, `inventory_movements_id`), raw enum values (`AddressEntityType.SHIPPING` instead of `Shipping`), `model_dump()` output rendered as a JSON-ish dump.
+
+**Detection:**
+
+```text
+grep -nE "header=\"\w+_\w+\"" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+grep -nE "\.value\b" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py | grep -v "warnings\|metric"
+```
+
+**Bad shapes:**
+
+```python
+DataTableColumn(key="recipe_row_id", header="Row ID")  # wire identifier, no user value
+DataTableColumn(key="mo_id", header="MO")              # raw integer; user wants order_no
+Text(content=f"Type: {address.entity_type.value}")     # enum dump
+```
+
+**Fix.** Resolve wire IDs to user-facing labels impl-side. For columns that exist purely as drill-down anchors (e.g. "click to see the underlying MO"), prefer a per-row Katana URL on a name column over a separate ID column.
+
+---
+
+## 6. Buried decision context
+
+**Symptom.** The thing the operator confirms (per-row table, address block, before/after diff) sits below 3+ warnings, metrics, or status badges. The operator's eye lands on the noise before the signal.
+
+**Detection.** Read the card's `CardContent` block top-to-bottom. The intended order is:
+
+1. **Tier 1 — Identity:** `_render_preview_header` (title + entity badge + status badge).
+2. **Tier 2 — Decision metrics:** `Metric` row (Total / Item count / Picked date).
+3. **Tier 3 — Reference data:** party lines + address blocks + per-row DataTable / per-field diff.
+4. **Tier 4 — Actions:** `_render_preview_footer` with Confirm/Cancel + secondary buttons.
+
+Warnings rail (`BLOCK:`-prefixed) goes *under* Tier 3, immediately above Tier 4. Non-blocking informational warnings go inside Tier 3 next to what they describe — never inside Tier 1.
+
+**Fix.** Reorder. If a card has a `Separator` before the DataTable, the table is buried — move the table up so it's the first body element the eye sees after the Tier 2 metrics.
+
+---
+
+## 7. Helper-fallback masking
+
+**Symptom.** A card calls `_render_party_line(name=None, entity_id=<id>, …)` (or any party helper without a resolved name). The helper *appears* in the diff, the audit grep for "raw ID in Text" misses it, but the rendered output is still `"<Label> ID: <id>"` per the helper's documented fallback. The card looks clean at the call site but the operator still sees a bare numeric ID.
+
+**Detection grep:**
+
+```text
+grep -n "_render_party_line" katana_mcp_server/src/katana_mcp/tools/prefab_ui.py | grep -E "name=None|name=response\.get"
+```
+
+Also: any call where `response.get("<thing>_name")` is referenced but the response model has no `<thing>_name` field — the call always degrades to ID-only.
+
+**Bad shape** (from `build_so_create_ui` before the LOW-band fix):
+
+```python
+_render_party_line(
+    "Location",
+    name=None,  # SalesOrderResponse has no location_name
+    entity_id=response.get("location_id"),
+)
+```
+
+The comment correctly documents *why* it's None — but the user still sees `"Location ID: 17"`. The fix is impl-side, not at the call.
+
+**Fix.** Resolve the name on the impl side via the typed cache:
+
+```python
+location_name, name_warning = await resolve_entity_name(
+    services.typed_cache.catalog,
+    CachedLocation,
+    location_id,
+    entity_label="Location",
+)
+```
+
+Then add `location_name` to the response model and pass it through. Pattern: grep `resolve_entity_name` in `katana_mcp_server/src/katana_mcp/tools/foundation/` for current call sites (sales_orders / purchase_orders / stock_transfers / orders / inventory).
+
+When the cache miss + API fallback can't resolve a name, `resolve_entity_name` returns a non-None `warning` string — surface that on the response's `warnings` list so the operator sees "couldn't resolve Location name" instead of a silent ID-only line.
+
+---
+
+## Process notes
+
+- New anti-patterns spotted during a `/card-review` run should land here, not in the SKILL.md. The skill loads `references/` lazily; the catalog can grow without bloating the skill's main file.
+- Each bad-example excerpt above is a *historical* shape from this repo. When a card is rewritten, the excerpt stays — it's documentation of what the rewrite fixed, not a current bug.
+- Examples should be quoted from real code. Synthetic / made-up bad examples drift faster than real ones.

--- a/.claude/skills/frontend-design-review/SKILL.md
+++ b/.claude/skills/frontend-design-review/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: frontend-design-review
+description: >
+  Review and create distinctive, production-grade frontend interfaces with high design quality and design system compliance.
+  Evaluates using three pillars: frictionless insight-to-action, quality craft, and trustworthy building.
+  USE FOR: PR reviews, design reviews, accessibility audits, design system compliance checks, creative frontend design,
+  UI code review, component reviews, responsive design checks, theme testing, and creating memorable UI.
+  DO NOT USE FOR: Backend API reviews, database schema reviews, infrastructure or DevOps work, pure business logic
+  without UI, or non-frontend code.
+acknowledgments: |
+  Design review principles and quality pillar framework created by @Quirinevwm (https://github.com/Quirinevwm).
+  Creative frontend guidance inspired by Anthropic's frontend-design skill
+  (https://github.com/anthropics/skills/tree/main/skills/frontend-design). Licensed under respective terms.
+---
+
+# Frontend Design Review
+
+Review UI implementations against design quality standards and your design system **OR** create distinctive, production-grade frontend interfaces from scratch.
+
+## Two Modes
+
+### Mode 1: Design Review
+Evaluate existing UI for design system compliance, three quality pillars (Frictionless, Quality Craft, Trustworthy), accessibility, and code quality.
+
+### Mode 2: Creative Frontend Design
+Create distinctive interfaces that avoid generic "AI slop" aesthetics, have clear conceptual direction, and execute with precision.
+
+---
+
+## Creative Frontend Design
+
+Before coding, commit to an aesthetic direction:
+- **Purpose**: What problem does this solve? Who uses it?
+- **Tone**: minimal, maximalist, retro-futuristic, organic, luxury, playful, editorial, brutalist, art deco, soft/pastel, industrial, etc.
+- **Constraints**: Framework, performance, accessibility requirements.
+- **Differentiation**: What makes this distinctive and context-appropriate?
+
+### Aesthetics Guidelines
+
+- **Typography**: Distinctive fonts that elevate aesthetics. Pair a display font with a refined body font. Avoid Inter, Roboto, Arial, Space Grotesk.
+- **Color & Theme**: Cohesive palette with CSS variables. Dominant colors + sharp accents > timid, evenly-distributed palettes.
+- **Motion**: CSS-only preferred. One well-orchestrated page load with staggered reveals > scattered micro-interactions.
+- **Spatial Composition**: Asymmetry, overlap, diagonal flow, grid-breaking elements, generous negative space OR controlled density.
+- **Backgrounds**: Gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, grain overlays.
+
+**AVOID**: Overused fonts, cliched color schemes, predictable layouts, cookie-cutter design without context-specific character.
+
+Match implementation complexity to vision. Maximalist = elaborate code. Minimalist = restraint and precision.
+
+---
+
+## Design Review
+
+### Design System Workflow
+
+**Before implementing:**
+1. Review component in your Storybook / component library for API and usage
+2. Use Figma Dev Mode to get exact specs (spacing, tokens, properties)
+3. Implement using design system components + design tokens
+
+**During review:**
+1. Compare implementation to Figma design
+2. Verify design tokens are used (not hardcoded values)
+3. Check all variants/states are implemented correctly
+4. Flag deviations (needs design approval)
+
+**If component doesn't exist:**
+1. Check if existing component can be adapted
+2. Reach out to design for new component creation
+3. Document exception and rationale in code
+
+### Review Process
+
+1. Identify user task
+2. Check design system for matching patterns
+3. Evaluate aesthetic direction
+4. Identify scope (component, feature, or flow)
+5. Evaluate each pillar
+6. Score and prioritize issues (blocking/major/minor)
+7. Provide recommendations with design system examples
+
+### Core Principles
+
+- **Task completion**: Minimum clicks. Every screen answers "What can I do?" and "What happens next?"
+- **Action hierarchy**: 1-2 primary actions per view. Progressive disclosure for secondary.
+- **Onboarding**: Explain features on introduction. Smart defaults over configuration.
+- **Navigation**: Clear entry/exit points. Back/cancel always available. Breadcrumbs for deep flows.
+
+---
+
+## Quality Pillars
+
+### 1. Frictionless Insight to Action
+
+**Evaluate:** Task completable in ≤3 interactions? Primary action obvious and singular?
+
+**Red flags:** Excessive clicks, multiple competing primary buttons, buried actions, dead ends.
+
+### 2. Quality is Craft
+
+**Evaluate:**
+- Design system compliance: matches Figma specs, uses design tokens
+- Aesthetic direction: distinctive typography, cohesive colors, intentional motion
+- Accessibility: Grade C minimum (WCAG 2.1 A), Grade B ideal (WCAG 2.1 AA)
+
+**Red flags:** Generic AI aesthetics, hardcoded values, implementation doesn't match Figma, broken reflow, missing focus indicators.
+
+### 3. Trustworthy Building
+
+**Evaluate:**
+- AI transparency: disclaimer on AI-generated content
+- Error transparency: actionable error messages
+
+**Red flags:** Missing AI disclaimers, opaque errors without guidance.
+
+---
+
+## Review Output Format
+
+See [references/review-output-format.md](references/review-output-format.md) for the full review template.
+
+## Review Type Modifiers
+
+See [references/review-type-modifiers.md](references/review-type-modifiers.md) for context-specific review focus areas (PR, Creative, Design, Accessibility).
+
+## Quick Checklist
+
+See [references/quick-checklist.md](references/quick-checklist.md) for the pre-approval checklist covering design system compliance, aesthetic quality, frictionless, quality craft, and trustworthy pillars.
+
+## Pattern Examples
+
+See [references/pattern-examples.md](references/pattern-examples.md) for good/bad examples of creative frontend and design system review work.
+
+---
+
+## Acknowledgments
+
+Creative frontend principles inspired by [Anthropic's frontend-design skill](https://github.com/anthropics/skills/tree/main/skills/frontend-design). Design review principles and quality pillar framework created by [@Quirinevwm](https://github.com/Quirinevwm) for systematic UI evaluation.

--- a/.claude/skills/frontend-design-review/references/pattern-examples.md
+++ b/.claude/skills/frontend-design-review/references/pattern-examples.md
@@ -1,0 +1,21 @@
+# Pattern Examples
+
+## Creative Frontend (New Interfaces)
+
+### Good: Clear Aesthetic Direction
+- Landing page with brutalist aesthetic: Raw typography (Neue Haas Grotesk), stark black and white, asymmetric layouts
+- Dashboard with organic theme: Rounded forms, earth tones, flowing animations, textured backgrounds
+
+### Bad: Generic AI Aesthetic
+- Overused fonts, cliched color schemes, centered content, generic card layouts
+
+## Design System Review (Existing Work)
+
+### Good: Frictionless
+- Single primary button, clear task completion path
+
+### Good: Quality Craft
+- Uses design system with tokens, distinctive typography, keyboard accessible, tested in themes
+
+### Bad: Quality Craft
+- Hardcoded values, generic overused fonts, poor contrast in dark mode

--- a/.claude/skills/frontend-design-review/references/quick-checklist.md
+++ b/.claude/skills/frontend-design-review/references/quick-checklist.md
@@ -1,0 +1,38 @@
+# Quick Checklist
+
+Before approving any UI work:
+
+## Design System Compliance
+- [ ] Component verified in your Figma Design System
+- [ ] Component implementation checked in your Component Library
+- [ ] Figma Dev Mode specs followed (spacing, tokens, typography)
+- [ ] Design tokens used (no hardcoded hex colors or pixel values)
+- [ ] Token imports verified in code
+- [ ] All variants/states implemented as designed in Figma
+- [ ] Spacing measurements match Figma Dev Mode exactly
+- [ ] Deviations documented with design approval
+
+## Aesthetic Quality (especially for new designs)
+- [ ] Clear conceptual direction (not generic overused fonts and cliched schemes)
+- [ ] Distinctive typography (avoid overused fonts)
+- [ ] Cohesive color palette with CSS variables
+- [ ] Intentional motion (staggered reveals, hover states)
+- [ ] Visual interest through composition (asymmetry, overlap, grid-breaking)
+- [ ] Atmosphere through backgrounds (gradients, textures, patterns)
+- [ ] Implementation complexity matches vision
+
+## Frictionless
+- [ ] Core task completable efficiently (≤3 interactions)
+- [ ] Single clear primary action per view
+
+## Quality Craft
+- [ ] Uses design system components (verified in Figma)
+- [ ] Design tokens used (no hardcoded values)
+- [ ] Distinctive aesthetic (not generic overused fonts/cliched schemes)
+- [ ] Accessible (Grade C minimum, Grade B ideal)
+- [ ] Keyboard navigation complete
+- [ ] Tested in light/dark/high contrast modes
+
+## Trustworthy
+- [ ] AI-generated content has disclaimer
+- [ ] Error messages are actionable

--- a/.claude/skills/frontend-design-review/references/review-output-format.md
+++ b/.claude/skills/frontend-design-review/references/review-output-format.md
@@ -1,0 +1,68 @@
+# Review Output Format
+
+```
+## Frontend Design Review: [Component/Feature Name]
+
+### Context
+- **Purpose**: What problem does this solve? Who uses it?
+- **Aesthetic Direction**: [If new design: describe the bold conceptual direction]
+- **User Task**: What is the user trying to accomplish?
+
+### Summary
+[Pass/Needs Work/Blocked] - [One-line assessment]
+
+### Design System Compliance (if applicable)
+- [ ] Component exists in [Your Figma Design System]
+- [ ] Component usage verified in [Your Component Library]
+- [ ] Implementation matches Figma specs (spacing, colors, typography)
+- [ ] Uses design tokens (not hardcoded values) - verified in code
+- [ ] All variants match design system options
+- [ ] Spacing verified against Figma Dev Mode
+- [ ] Documented exception if deviating from design system
+
+### Aesthetic Quality (especially for new designs)
+- [ ] Clear conceptual direction (not generic AI aesthetic)
+- [ ] Distinctive typography choices
+- [ ] Cohesive color palette with CSS variables
+- [ ] Intentional motion and micro-interactions
+- [ ] Spatial composition creates visual interest
+- [ ] Backgrounds and visual details add atmosphere
+
+### Pillar Assessment
+
+| Pillar | Status | Notes |
+|--------|--------|-------|
+| Frictionless | 🟢/🟠/⚫ | Task completion efficient, primary action clear |
+| Quality Craft | 🟢/🟠/⚫ | Design system compliant, aesthetic distinctive, accessible |
+| Trustworthy | 🟢/🟠/⚫ | AI disclaimers present, errors actionable |
+
+**Legend:** 🟢 Pass | 🟠 Needs attention | ⚫ Blocking issue
+
+### Design Critique
+**Verdict:** [Pass / Needs work / Reach out to design for more support]
+
+**Rationale:** [Brief explanation based on pillar assessment, design system compliance, and aesthetic direction]
+
+**Criteria:**
+- **Pass**: All pillars 🟢 or minor 🟠 that don't block user tasks, design system compliant, clear aesthetic direction
+- **Needs work**: Multiple 🟠 or any critical workflow issues, design system deviations, or generic aesthetic choices
+- **Reach out to design for more support**: Any ⚫ blocking issues, fundamental pattern problems, major design system violations, or need for aesthetic direction
+
+### Issues
+
+**Blocking (must fix before merge):**
+1. [Pillar/Design System/Aesthetic] Issue description + recommendation with link
+
+**Major (should fix):**
+1. [Pillar/Design System/Aesthetic] Issue description + pattern suggestion with reference
+
+**Minor (consider for refinement):**
+1. [Pillar/Design System/Aesthetic] Issue description + optional improvement
+
+### Recommendations
+- [Design system component to use with link]
+- [Specific code change with design token reference]
+- [Typography recommendation for better aesthetic direction]
+- [Motion/animation suggestion]
+- [Link to design system in Figma]
+```

--- a/.claude/skills/frontend-design-review/references/review-type-modifiers.md
+++ b/.claude/skills/frontend-design-review/references/review-type-modifiers.md
@@ -1,0 +1,31 @@
+# Review Type Modifiers
+
+Adjust focus based on review context:
+
+## PR Review
+- **Focus**: Code implementation, design system component usage, design token usage, accessibility in code
+- **Check**: Proper imports, design tokens used (not hardcoded), ARIA attributes present
+- **Verify**: Component matches Figma specs using Dev Mode
+
+## Creative Frontend Review
+- **Focus**: Aesthetic direction, typography choices, visual distinctiveness, motion design
+- **Check**: Clear conceptual intent, avoiding generic AI patterns, cohesive execution
+- **Verify**: Implementation complexity matches vision (maximalist needs elaborate code, minimalist needs precision)
+
+## Design Review
+- **Focus**: User flows, interaction patterns, visual hierarchy, navigation, design system alignment
+- **Check**: Task completion path, action hierarchy, progressive disclosure
+- **Verify**: All components exist in design system or have documented exceptions
+
+## Accessibility Audit
+- **Focus**: Deep dive Quality Craft pillar
+- **Check**: Keyboard testing, screen reader testing, contrast ratios, ARIA patterns
+- **Test with**: Screen readers (NVDA, JAWS, Narrator), keyboard only, 200% zoom
+- **Verify**: Design system accessibility features are properly implemented
+
+## Design System Compliance Audit
+- **Focus**: Deep dive design system usage
+- **Check**: All components match Figma specs, design tokens used throughout, no hardcoded values
+- **Test**: Compare implementation side-by-side with Figma using Dev Mode
+- **Verify**: Component variants, spacing, colors, typography all match design system
+- **Document**: Any deviations with rationale and plan to align

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1793,7 +1793,7 @@ Complete a manufacturing or sales order.
 **Returns:** Standard fulfillment envelope (`order_id`, `order_type`,
 `order_number`, `status`, `is_preview`, `inventory_updates`, `warnings`,
 `next_actions`, `message`) plus the Tier 2 metrics + Tier 3 per-row
-breakdown introduced in #553:
+breakdown introduced in #553 + the post-#card-ux reference block:
 - `fulfilled_rows`: Per-row breakdown — list of `{row_id, variant_id, sku,
   display_name, quantity, serial_numbers, batch_summary, price_per_unit,
   row_total, currency}`. For manufacturing orders this is always a single
@@ -1808,6 +1808,20 @@ breakdown introduced in #553:
 - `currency`: ISO 4217 currency code (sales orders only; `None` for MOs).
 - `katana_url`: Deep link to the order in the Katana web UI (drives the
   Tier 4 "View in Katana" action on the success card).
+- `customer_id` / `customer_name` *(sales orders only)*: Customer placing
+  the SO. `customer_name` is resolved through the typed cache and drives
+  the Tier-3 `Customer:` party-line on the card. `None` on manufacturing
+  orders (MOs have no customer).
+- `shipping_address` / `billing_address` *(sales orders only)*:
+  `SalesOrderAddress.to_dict()` dicts fetched from
+  `/sales_order_addresses`. `billing_address` is `None` when it duplicates
+  shipping (the card hides the second block in that case).
+- `picked_date`: ISO-8601 timestamp surfaced as the `Picked` (sales) or
+  `Completed` (manufacturing) Metric. On the success path the impl
+  prefers the server-stamped value (`fulfillment.picked_date` for SOs,
+  `MO.done_date` for MOs) over the caller-supplied `completed_at`.
+  `None` when no timestamp is known (preview without `completed_at` and
+  server hasn't stamped yet).
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/tools/_addresses.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_addresses.py
@@ -1,0 +1,40 @@
+"""Shared address-comparison helper used by impl and UI layers.
+
+Lifted out of ``prefab_ui`` so that ``foundation/*`` impl modules can use
+it without pulling the entire Prefab UI module into the tool-execution
+path (which also avoided a latent circular-import risk: ``prefab_ui``
+already imports a handful of foundation modules).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The exact set of fields ``prefab_ui._render_address_block`` surfaces.
+# ``entity_type`` is the label on each block (not part of equivalence);
+# server-side fields (id, customer_id, timestamps) don't enter into the
+# "is this the same physical place?" judgement.
+_USER_VISIBLE_ADDRESS_FIELDS: tuple[str, ...] = (
+    "first_name",
+    "last_name",
+    "company",
+    "phone",
+    "line_1",
+    "line_2",
+    "city",
+    "state",
+    "zip",
+    "country",
+)
+
+
+def addresses_are_equivalent(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    """Two addresses are equivalent if every user-visible field matches.
+
+    Falsy values (``None``, ``""``) collapse to ``None`` before the
+    comparison so a blank string and an unset field don't surface as
+    different addresses on the card.
+    """
+    return all(
+        (a.get(k) or None) == (b.get(k) or None) for k in _USER_VISIBLE_ADDRESS_FIELDS
+    )

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -249,19 +249,69 @@ def _derive_status_label(action: ActionResult) -> str:
     return "FAILED"
 
 
+def _format_change_value(value: Any) -> str:
+    """Render a ``FieldChange.old`` / ``.new`` value for the Changes column.
+
+    Strings render verbatim; everything else through ``str()``. ``None``
+    becomes ``"—"`` for cleared / unset fields, **except** when the field
+    is flagged ``is_unknown_prior`` (handled by the caller) — see
+    :class:`FieldChange` docstring on why the distinction matters.
+    """
+    if value is None:
+        return "—"
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
 def _derive_summary(action: ActionResult) -> str:
-    """One-line description of what an action does, for the Changes column."""
+    """Content-rich one-line description of what an action does.
+
+    Drives the Changes column on the modification card (#card-ux,
+    anti-pattern #4). Three shapes:
+
+    - **delete**: ``"deleted"``.
+    - **add / create**: ``"added: <field>, <field>, ..."`` (+ ``(+N more)``
+      tail when the change list is long).
+    - **update / modify / correct**: a single FieldChange renders inline
+      as ``"<field>: <old> → <new>"``; multi-field changes surface field
+      names + an optional ``(+N more)`` tail.
+
+    The ``is_unknown_prior`` flag is honored: a field whose prior state
+    couldn't be resolved renders as ``"<field>: (prior unknown) → <new>"``
+    rather than ``"— → <new>"`` which would lie about the prior having
+    been blank (per :class:`FieldChange` docstring at line 137).
+
+    Pre-#card-ux this emitted ``"N field(s) changed"`` count-only strings
+    that gave the operator nothing actionable.
+    """
     op = action.operation.lower()
     if op.startswith("delete"):
         return "deleted"
     if op.startswith("add") or op.startswith("create"):
-        n = len(action.changes)
-        return f"{n} field(s) set"
+        if not action.changes:
+            return "added"
+        field_names = [c.field for c in action.changes]
+        head = ", ".join(field_names[:3])
+        tail = f" (+{len(field_names) - 3} more)" if len(field_names) > 3 else ""
+        return f"added: {head}{tail}"
     # update_*, modify_*, correct_*, etc.
-    n = sum(1 for c in action.changes if not c.is_unchanged)
-    if n == 0 and action.changes:
-        return f"{len(action.changes)} field(s) — no change"
-    return f"{n} field(s) changed"
+    changed = [c for c in action.changes if not c.is_unchanged]
+    if not changed and action.changes:
+        return "no change"
+    if not changed:
+        return "—"
+    if len(changed) == 1:
+        c = changed[0]
+        new = _format_change_value(c.new)
+        old = "(prior unknown)" if c.is_unknown_prior else _format_change_value(c.old)
+        return f"{c.field}: {old} → {new}"
+    # Multi-field case: surface field names so the operator knows *what*
+    # changed without reading the underlying tool blob.
+    field_names = [c.field for c in changed]
+    head = ", ".join(field_names[:3])
+    tail = f" (+{len(field_names) - 3} more)" if len(field_names) > 3 else ""
+    return f"{head}{tail}"
 
 
 class ModificationResponse(BaseModel):

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/inventory.py
@@ -32,6 +32,7 @@ from katana_mcp.tools.tool_result_utils import (
     naive_utc,
     parse_iso_datetime,
     parse_request_dates,
+    resolve_entity_name,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
@@ -293,15 +294,19 @@ async def _fetch_stock_for_variant(
         )
 
     # Batch the location-name lookups via the cache's bulk helper —
-    # one query for N IDs instead of N round trips. Cache misses are
-    # non-fatal (location_id alone is still useful to the caller).
-    loc_names: dict[int, str | None] = {}
+    # one query for N IDs instead of N round trips. Cache misses fall
+    # back to ``"Location {id}"`` so the card's Location cell is never
+    # blank — review item #14 (post-#card-ux the cards dropped the
+    # raw-ID fallback column, so the impl owns the fallback now).
+    loc_names: dict[int, str] = {}
     if rows:
         unique_loc_ids = {row.location_id for row in rows}
         loc_lookups = await services.typed_cache.catalog.get_many_by_ids(
             CachedLocation, unique_loc_ids
         )
-        loc_names = {lid: _attr(loc_lookups.get(lid), "name") for lid in unique_loc_ids}
+        for lid in unique_loc_ids:
+            resolved = _attr(loc_lookups.get(lid), "name")
+            loc_names[lid] = resolved if resolved else f"Location {lid}"
 
     by_location = [
         LocationStock(
@@ -1395,14 +1400,18 @@ async def _inventory_at_impl(
                 latest[key] = m
 
         unique_loc_ids = {loc_id for _, loc_id in latest}
-        loc_names: dict[int, str | None] = {}
+        loc_names: dict[int, str] = {}
         if unique_loc_ids:
             loc_lookups = await services.typed_cache.catalog.get_many_by_ids(
                 CachedLocation, unique_loc_ids
             )
-            loc_names = {
-                lid: _attr(loc_lookups.get(lid), "name") for lid in unique_loc_ids
-            }
+            # Cache-miss fallback: ``"Location {id}"`` so the card's
+            # Location cell is never blank (review item #14). The card
+            # dropped the raw-ID column post-#card-ux, so the impl owns
+            # the fallback.
+            for lid in unique_loc_ids:
+                resolved = _attr(loc_lookups.get(lid), "name")
+                loc_names[lid] = resolved if resolved else f"Location {lid}"
 
         result_items: list[InventoryAtItem] = []
         for _input, (vid, sku, display_name) in input_to_variant.items():
@@ -1503,10 +1512,27 @@ async def inventory_at(
     }
     content = json.dumps(payload, indent=2, default=str)
 
+    # Resolve the location's display name so the Tier-1 badge reads
+    # ``"Warehouse A"`` instead of ``"Location 17"`` (anti-pattern #2).
+    # Cache-miss falls back silently to the bare ID (the badge handles
+    # the None case); no advisory warning here because the inventory_at
+    # tool returns a JSON content envelope, not a Pydantic response with
+    # a ``warnings`` field.
+    location_name: str | None = None
+    if request.location_id is not None:
+        services = get_services(context)
+        location_name, _loc_warn = await resolve_entity_name(
+            services.typed_cache.catalog,
+            CachedLocation,
+            request.location_id,
+            entity_label="Location",
+        )
+
     ui = build_inventory_at_ui(
         items=items_dump,
         as_of=response.as_of,
         location_id=request.location_id,
+        location_name=location_name,
         not_found=list(response.not_found),
     )
     return ToolResult(content=content, structured_content=ui)
@@ -1633,10 +1659,22 @@ class StockAdjustmentResponse(BaseModel):
     id: int | None
     is_preview: bool
     location_id: int
+    location_name: str | None = Field(
+        default=None,
+        description=(
+            "Resolved location display name (via ``resolve_entity_name`` on "
+            "``CachedLocation``) for the Tier-1 badge — falls back to "
+            "``'Location <id>'`` when the cache miss can't be filled."
+        ),
+    )
     message: str
     rows: list[StockAdjustmentRowSummary] = Field(default_factory=list)
     rows_summary: str
     reason: str | None = None
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Operator-facing warnings (cache-miss advisories, etc.).",
+    )
     katana_url: str | None = None
 
 
@@ -1708,16 +1746,30 @@ async def _create_stock_adjustment_impl(
 
     rows_summary = "\n".join(rows_summary_parts)
 
+    # Resolve location_name for the Tier-1 badge (anti-pattern #2 fix).
+    # location_id is required on this request so we always have an ID
+    # to resolve against; a cache miss falls back to ``"Location <id>"``
+    # at the card layer.
+    location_name, loc_warn = await resolve_entity_name(
+        services.typed_cache.catalog,
+        CachedLocation,
+        request.location_id,
+        entity_label="Location",
+    )
+    location_warnings: list[str] = [loc_warn] if loc_warn else []
+
     # Preview mode
     if request.preview:
         return StockAdjustmentResponse(
             id=None,
             is_preview=True,
             location_id=request.location_id,
+            location_name=location_name,
             message="Preview — call again with preview=false to create",
             rows=structured_rows,
             rows_summary=rows_summary,
             reason=request.reason,
+            warnings=location_warnings,
         )
 
     # Caller-supplied stock_adjustment_number takes precedence; otherwise
@@ -1770,10 +1822,12 @@ async def _create_stock_adjustment_impl(
         id=adj_id,
         is_preview=False,
         location_id=request.location_id,
+        location_name=location_name,
         message="Stock adjustment created successfully",
         rows=structured_rows,
         rows_summary=rows_summary,
         reason=request.reason,
+        warnings=location_warnings,
         katana_url=katana_web_url("stock_adjustment", adj_id),
     )
 
@@ -2184,11 +2238,36 @@ class UpdateStockAdjustmentResponse(BaseModel):
     is_preview: bool
     stock_adjustment_number: str | None = None
     location_id: int | None = None
+    location_name: str | None = Field(
+        default=None,
+        description=(
+            "Resolved location display name (via ``resolve_entity_name`` on "
+            "``CachedLocation``) for the Tier-3 diff row. ``None`` falls back "
+            "to ``'Location ID: <id>'`` and a non-fatal advisory warning."
+        ),
+    )
     stock_adjustment_date: str | None = None
     reason: str | None = None
     additional_info: str | None = None
     changes_summary: str
+    prior_state: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Snapshot of the SA's pre-update field values keyed by the same "
+            "names the request supplies (``stock_adjustment_number``, "
+            "``stock_adjustment_date``, ``location_id``, ``reason``, "
+            "``additional_info``) plus ``location_name`` resolved through "
+            "the typed cache. Drives the Before column on the Tier-3 diff "
+            "table; ``None`` falls back to ``'(prior unknown)'`` per cell. "
+            "Fetched via /stock_adjustments?ids=[id] on both preview and "
+            "apply paths so the operator sees what they're changing from."
+        ),
+    )
     message: str
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Operator-facing warnings (cache-miss advisories, etc.).",
+    )
     katana_url: str | None = None
 
 
@@ -2244,7 +2323,73 @@ async def _update_stock_adjustment_impl(
             "reason, additional_info)"
         )
 
-    # Preview mode — no API call.
+    # Resolve location_name once (when the caller's update changes
+    # location_id) so the card's Tier-3 diff row shows the new location
+    # by name, not a raw ID (anti-pattern #2). Shared between preview
+    # and apply branches — same impl-side resolution rule fulfill +
+    # receipt cards use.
+    services = get_services(context)
+    location_name: str | None = None
+    location_warnings: list[str] = []
+    if request.location_id is not None:
+        location_name, loc_warn = await resolve_entity_name(
+            services.typed_cache.catalog,
+            CachedLocation,
+            request.location_id,
+            entity_label="Location",
+        )
+        if loc_warn:
+            location_warnings.append(loc_warn)
+
+    # Fetch the existing SA so the card's Tier-3 diff table can show the
+    # operator both sides of every change (Before / After columns). The
+    # apply path also pre-fetches for additional_info echo workarounds
+    # (see ``patch_additional_info``); preview adds the same fetch to
+    # populate prior_state. Best-effort: a transient list-endpoint
+    # failure silently leaves prior_state=None and the card falls back
+    # to "(prior unknown)" per row.
+    prior_state: dict[str, Any] | None = None
+    try:
+        existing_response = await get_all_stock_adjustments.asyncio_detailed(
+            client=services.client, ids=[request.id]
+        )
+        existing_rows = unwrap_data(existing_response, raise_on_error=False, default=[])
+        if existing_rows:
+            existing = existing_rows[0]
+            existing_loc_id = unwrap_unset(existing.location_id, None)
+            # Resolve the prior location's display name so the Before
+            # cell shows the same shape (resolved name) as the After
+            # cell — without this normalization the diff renders
+            # ``"17 → Warehouse B"`` (raw int vs resolved name), the
+            # apples-to-oranges defect from review item #10.
+            prior_location_name: str | None = None
+            if existing_loc_id is not None:
+                prior_location_name, prior_loc_warn = await resolve_entity_name(
+                    services.typed_cache.catalog,
+                    CachedLocation,
+                    existing_loc_id,
+                    entity_label="Location",
+                )
+                if prior_loc_warn:
+                    location_warnings.append(prior_loc_warn)
+            prior_state = {
+                "stock_adjustment_number": existing.stock_adjustment_number,
+                "stock_adjustment_date": iso_or_none(
+                    unwrap_unset(existing.stock_adjustment_date, None)
+                ),
+                "location_id": existing_loc_id,
+                "location_name": prior_location_name,
+                "reason": unwrap_unset(existing.reason, None),
+                "additional_info": unwrap_unset(existing.additional_info, None),
+            }
+    except Exception as exc:
+        logger.warning(
+            "stock_adjustment_update: prior_state fetch failed",
+            id=request.id,
+            error=str(exc),
+        )
+
+    # Preview mode — no further API call.
     if request.preview:
         logger.info(
             "stock_adjustment_update_preview",
@@ -2255,12 +2400,15 @@ async def _update_stock_adjustment_impl(
             is_preview=True,
             stock_adjustment_number=request.stock_adjustment_number,
             location_id=request.location_id,
+            location_name=location_name,
             stock_adjustment_date=request.stock_adjustment_date.isoformat()
             if request.stock_adjustment_date
             else None,
             reason=request.reason,
             additional_info=request.additional_info,
             changes_summary=changes_summary,
+            prior_state=prior_state,
+            warnings=location_warnings,
             message=(
                 f"Preview — call again with preview=false to update stock "
                 f"adjustment {request.id}"
@@ -2268,24 +2416,16 @@ async def _update_stock_adjustment_impl(
             katana_url=katana_web_url("stock_adjustment", request.id),
         )
 
-    services = get_services(context)
-
-    # Pre-fetch only when echo might be needed (caller didn't supply
-    # additional_info) so the common-case PATCH stays a single round trip.
-    # ``raise_on_error=False`` keeps the workaround best-effort: if the
-    # pre-fetch fails (transient 5xx, permission gap, etc.) we treat it
-    # as "no existing snapshot" rather than aborting the user's actual
-    # update. Worst case the wipe still fires; the caller's intended
-    # write still lands. See :func:`patch_additional_info` for the
-    # workaround story.
+    # Echo workaround for additional_info wipe (see
+    # :func:`patch_additional_info`): if the caller didn't supply
+    # additional_info, we need to re-send the existing value so the
+    # PATCH doesn't blank it. We already fetched prior_state above for
+    # the diff card; reuse that here instead of doing a second fetch.
     existing_info_field: str | None | Unset = UNSET
-    if request.additional_info is None:
-        existing_response = await get_all_stock_adjustments.asyncio_detailed(
-            client=services.client, ids=[request.id]
-        )
-        existing_rows = unwrap_data(existing_response, raise_on_error=False, default=[])
-        if existing_rows:
-            existing_info_field = existing_rows[0].additional_info
+    if request.additional_info is None and prior_state is not None:
+        existing_info_field = prior_state.get("additional_info")
+        if existing_info_field is None:
+            existing_info_field = UNSET
 
     api_request = APIUpdateStockAdjustmentRequest(
         stock_adjustment_number=to_unset(request.stock_adjustment_number),
@@ -2319,17 +2459,35 @@ async def _update_stock_adjustment_impl(
         id=updated.id,
     )
 
+    # When the caller didn't change location, the up-front
+    # ``location_name`` resolve was skipped (request.location_id is
+    # None) but ``updated.location_id`` echoes the existing ID — so a
+    # naive ``location_name=location_name`` would leave it None and
+    # the card would fall back to ``"Location ID: <id>"`` for an
+    # unchanged location, undoing the anti-pattern #2 fix on every
+    # SA update that doesn't touch location. Reuse the resolved
+    # prior name (which we already fetched + resolved for the diff
+    # Before column) so the response always carries a name when the
+    # cache had one.
+    if request.location_id is None and prior_state is not None:
+        effective_location_name = prior_state.get("location_name")
+    else:
+        effective_location_name = location_name
+
     return UpdateStockAdjustmentResponse(
         id=updated.id,
         is_preview=False,
         stock_adjustment_number=updated.stock_adjustment_number,
         location_id=updated.location_id,
+        location_name=effective_location_name,
         stock_adjustment_date=iso_or_none(
             unwrap_unset(updated.stock_adjustment_date, None)
         ),
         reason=unwrap_unset(updated.reason, None),
         additional_info=unwrap_unset(updated.additional_info, None),
         changes_summary=changes_summary,
+        prior_state=prior_state,
+        warnings=location_warnings,
         message=f"Stock adjustment {updated.id} updated successfully",
         katana_url=katana_web_url("stock_adjustment", updated.id),
     )
@@ -2385,8 +2543,20 @@ class DeleteStockAdjustmentResponse(BaseModel):
     is_preview: bool
     stock_adjustment_number: str | None
     location_id: int | None
+    location_name: str | None = Field(
+        default=None,
+        description=(
+            "Resolved location display name (via ``resolve_entity_name`` on "
+            "``CachedLocation``). Drives the Tier-3 ``Location:`` party-line "
+            "on the delete card; ``None`` falls back to ``'Location ID: <id>'``."
+        ),
+    )
     row_count: int
     message: str
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Operator-facing warnings (cache-miss advisories, etc.).",
+    )
 
 
 async def _delete_stock_adjustment_impl(
@@ -2426,6 +2596,22 @@ async def _delete_stock_adjustment_impl(
     stock_adjustment_number = existing.stock_adjustment_number
     location_id = existing.location_id
 
+    # Resolve the location's display name so the card's Tier-3 party-line
+    # reads "Location: <name>" instead of "Location ID: <id>" (anti-pattern
+    # #2/#7). Cache-miss surfaces as a non-fatal advisory on warnings —
+    # parallel to fulfill/receipt/update.
+    location_name: str | None = None
+    location_warnings: list[str] = []
+    if location_id is not None:
+        location_name, loc_warn = await resolve_entity_name(
+            services.typed_cache.catalog,
+            CachedLocation,
+            location_id,
+            entity_label="Location",
+        )
+        if loc_warn:
+            location_warnings.append(loc_warn)
+
     if request.preview:
         logger.info(
             "stock_adjustment_delete_preview",
@@ -2437,7 +2623,9 @@ async def _delete_stock_adjustment_impl(
             is_preview=True,
             stock_adjustment_number=stock_adjustment_number,
             location_id=location_id,
+            location_name=location_name,
             row_count=row_count,
+            warnings=location_warnings,
             message=(
                 f"Preview — call again with preview=false to delete stock "
                 f"adjustment {stock_adjustment_number} "
@@ -2464,7 +2652,9 @@ async def _delete_stock_adjustment_impl(
         is_preview=False,
         stock_adjustment_number=stock_adjustment_number,
         location_id=location_id,
+        location_name=location_name,
         row_count=row_count,
+        warnings=location_warnings,
         message=(
             f"Stock adjustment {stock_adjustment_number} (id={request.id}) "
             "deleted; associated inventory movements reversed"

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -70,6 +70,7 @@ from katana_mcp.tools.tool_result_utils import (
     make_tool_result,
     none_coro,
     parse_request_dates,
+    resolve_entity_name,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
@@ -120,6 +121,7 @@ from katana_public_api_client.models import (
     UpdateManufacturingOrderRequest as APIUpdateManufacturingOrderRequest,
 )
 from katana_public_api_client.models_pydantic._generated import (
+    CachedLocation,
     CachedVariant,
     OutsourcedPurchaseOrderIngredientAvailability,
 )
@@ -288,6 +290,15 @@ class ManufacturingOrderResponse(BaseModel):
     sku: str | None = None
     planned_quantity: float | None = None
     location_id: int | None = None
+    location_name: str | None = Field(
+        default=None,
+        description=(
+            "Resolved location display name (typed cache lookup via "
+            "``resolve_entity_name``). Drives the Tier-3 'Location:' line "
+            "on the create card; ``None`` falls back to ``'Location ID: <id>'`` "
+            "and emits a non-fatal warning explaining why."
+        ),
+    )
     status: str | None = None
     order_created_date: datetime | None = None
     production_deadline_date: datetime | None = None
@@ -337,6 +348,15 @@ async def _create_manufacturing_order_impl(
     action = "Previewing" if request.preview else "Starting"
     logger.info(f"{action} manufacturing order ({mode})")
 
+    # Services obtained up front so the impl-side ``resolve_entity_name``
+    # for location_name (anti-pattern #7 fix) is available on every
+    # return path — preview AND apply. Pre-#card-ux the card emitted
+    # ``"Location ID: <id>"`` because ``location_name`` was never resolved;
+    # post-#card-ux the typed cache resolves the human-facing name once,
+    # the card-side ``_render_party_line`` shows it as ``"Location: <name>"``,
+    # and the structured response carries it for non-card consumers.
+    services = get_services(context)
+
     # Make-to-order: fetch the sales_order_row upfront so both preview and
     # apply paths see the same backing data. The duplicate-create guard runs
     # on the apply path too — programmatic callers skipping the preview
@@ -347,7 +367,6 @@ async def _create_manufacturing_order_impl(
     linked_mo: int | None = None
     if is_make_to_order:
         assert request.sales_order_row_id is not None
-        services = get_services(context)
         from katana_public_api_client.api.sales_order_row import (
             get_sales_order_row as api_get_sor,
         )
@@ -366,8 +385,25 @@ async def _create_manufacturing_order_impl(
         # the user to recognize what's being made.
         linked_mo = unwrap_unset(sor.linked_manufacturing_order_id, None)
 
+    # Resolve the location's display name once for every return path
+    # below (preview / apply / refuse). The location_id source depends
+    # on the mode: make-to-order pulls it off the SO row; standalone
+    # reads it from the caller's request.
+    location_id_for_name = sor_location_id if is_make_to_order else request.location_id
+    location_name: str | None = None
+    location_name_warning: str | None = None
+    if location_id_for_name is not None:
+        location_name, location_name_warning = await resolve_entity_name(
+            services.typed_cache.catalog,
+            CachedLocation,
+            location_id_for_name,
+            entity_label="Location",
+        )
+
     if request.preview:
         warnings: list[str] = []
+        if location_name_warning:
+            warnings.append(location_name_warning)
         next_actions = [
             "Review the order details",
             "Set preview=false to create the manufacturing order",
@@ -396,6 +432,7 @@ async def _create_manufacturing_order_impl(
                 variant_id=sor_variant_id,
                 planned_quantity=sor_quantity,
                 location_id=sor_location_id,
+                location_name=location_name,
                 is_preview=True,
                 warnings=warnings,
                 next_actions=next_actions,
@@ -421,6 +458,7 @@ async def _create_manufacturing_order_impl(
             variant_id=request.variant_id,
             planned_quantity=request.planned_quantity,
             location_id=request.location_id,
+            location_name=location_name,
             order_created_date=request.order_created_date,
             production_deadline_date=request.production_deadline_date,
             additional_info=request.additional_info,
@@ -432,16 +470,24 @@ async def _create_manufacturing_order_impl(
 
     # Confirm-path defense-in-depth: refuse if the SO row is already linked.
     if is_make_to_order and linked_mo is not None:
+        # Refusal carries the location-name cache-miss advisory alongside
+        # the BLOCK warning so the operator sees both reasons — review
+        # item #12. Pre-fix this branch hard-coded a single-string list
+        # and silently dropped ``location_name_warning``.
+        refusal_warnings: list[str] = [
+            f"{BLOCK_WARNING_PREFIX} sales_order_row "
+            f"{request.sales_order_row_id} is already linked to "
+            f"manufacturing order {linked_mo}. No new order was created."
+        ]
+        if location_name_warning:
+            refusal_warnings.append(location_name_warning)
         return ManufacturingOrderResponse(
             variant_id=sor_variant_id,
             planned_quantity=sor_quantity,
             location_id=sor_location_id,
+            location_name=location_name,
             is_preview=False,
-            warnings=[
-                f"{BLOCK_WARNING_PREFIX} sales_order_row "
-                f"{request.sales_order_row_id} is already linked to "
-                f"manufacturing order {linked_mo}. No new order was created."
-            ],
+            warnings=refusal_warnings,
             next_actions=[
                 f"Use get_manufacturing_order with order_id={linked_mo} "
                 "to inspect the existing order."
@@ -453,8 +499,6 @@ async def _create_manufacturing_order_impl(
         )
 
     try:
-        services = get_services(context)
-
         if is_make_to_order:
             from katana_public_api_client.api.manufacturing_order import (
                 make_to_order_manufacturing_order as api_mto,
@@ -519,17 +563,24 @@ async def _create_manufacturing_order_impl(
             )
         next_actions.append("Use production tools to track and complete the order")
 
+        # Apply-path warnings include the location-resolution advisory
+        # so a cache miss surfaces even after a successful create.
+        apply_warnings: list[str] = []
+        if location_name_warning:
+            apply_warnings.append(location_name_warning)
         return ManufacturingOrderResponse(
             id=mo.id,
             order_no=order_no,
             variant_id=variant_id,
             planned_quantity=planned_quantity,
             location_id=location_id,
+            location_name=location_name,
             status=status,
             order_created_date=order_created_date,
             production_deadline_date=production_deadline_date,
             additional_info=additional_info,
             is_preview=False,
+            warnings=apply_warnings,
             katana_url=katana_web_url("manufacturing_order", mo.id),
             next_actions=next_actions,
             message=f"Successfully created manufacturing order {order_no or mo.id} (ID: {mo.id})",

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -24,6 +24,7 @@ from katana_mcp.tools.tool_result_utils import (
     BLOCK_WARNING_PREFIX,
     UI_META,
     make_tool_result,
+    resolve_entity_name,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from katana_mcp.web_urls import katana_web_url
@@ -33,7 +34,9 @@ from katana_public_api_client.models import (
     ManufacturingOrderProduction,
     SalesOrder,
 )
+from katana_public_api_client.models.address_entity_type import AddressEntityType
 from katana_public_api_client.models_pydantic._generated import (
+    CachedCustomer,
     CachedMaterial,
     CachedProduct,
     CachedVariant,
@@ -246,6 +249,60 @@ class FulfillOrderResponse(BaseModel):
         ),
     )
 
+    # ---- Tier 3 reference fields surfaced on the fulfill card (sales only) ----
+    customer_id: int | None = Field(
+        default=None,
+        description=(
+            "Customer placing the sales order. Drives the Tier 3 'Customer:' "
+            "party line. ``None`` on manufacturing orders (MOs have no customer)."
+        ),
+    )
+    customer_name: str | None = Field(
+        default=None,
+        description=(
+            "Resolved customer display name (from typed cache via "
+            "``resolve_entity_name``). When ``None`` the card falls back to "
+            "``'Customer ID: <id>'`` — a non-fatal warning is appended to "
+            "``warnings`` so the operator sees why the name is missing."
+        ),
+    )
+    shipping_address: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Shipping ``SalesOrderAddress.to_dict()`` for the SO. Drives the "
+            "Tier 3 'Shipping Address' block. ``None`` when the SO carries no "
+            "shipping address or on manufacturing orders."
+        ),
+    )
+    billing_address: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Billing ``SalesOrderAddress.to_dict()`` for the SO. Only set when "
+            "the billing address differs from shipping (via "
+            "``_addresses_are_equivalent``) — when they match, the card hides "
+            "the billing block to avoid duplication."
+        ),
+    )
+    picked_date: str | None = Field(
+        default=None,
+        description=(
+            "ISO-8601 timestamp surfaced as the 'Picked' (sales) or "
+            "'Completed' (manufacturing) Metric on the card. Population "
+            "rules:\n\n"
+            "- **Preview**: caller's ``completed_at`` if supplied, else "
+            "  ``None`` (Metric is omitted; the server stamps at apply "
+            "  time).\n"
+            "- **SO apply-success**: prefers the server-stamped "
+            "  ``fulfillment.picked_date`` over ``completed_at`` — so a "
+            "  caller that omitted ``completed_at`` still sees the real "
+            "  timestamp Katana recorded.\n"
+            "- **MO apply-success**: prefers ``final_mo.done_date`` over "
+            "  ``completed_at`` for the same reason.\n"
+            "- **Refusal paths**: carries the caller's ``completed_at`` "
+            "  (no server stamp yet)."
+        ),
+    )
+
 
 def _fulfill_response_to_tool_result(
     response: FulfillOrderResponse, *, request: FulfillOrderRequest
@@ -386,6 +443,18 @@ async def _fulfill_manufacturing_order(
             )
         )
 
+    # MO ``picked_date`` carries the caller-supplied ``completed_at`` on
+    # preview so the card surfaces a "Completed" Metric (review item #8).
+    # Pre-fix this field was never set on the MO branch, leaving the
+    # documented "Completed" Metric branch in ``_render_fulfill_metrics``
+    # unreachable. The success path overrides this with the actual
+    # ``done_date`` Katana stamped on the post-completion MO header
+    # (review item #7) so the operator sees the server's authoritative
+    # timestamp even when ``completed_at`` was not supplied.
+    mo_picked_date_iso = (
+        request.completed_at.isoformat() if request.completed_at is not None else None
+    )
+
     if request.preview:
         has_block = any(w.startswith(BLOCK_WARNING_PREFIX) for w in warnings)
         if current_status == "DONE":
@@ -414,6 +483,7 @@ async def _fulfill_manufacturing_order(
             rows_count=rows_count,
             total_quantity=total_qty,
             total_value=total_value,
+            picked_date=mo_picked_date_iso,
             katana_url=katana_url,
         )
 
@@ -432,6 +502,7 @@ async def _fulfill_manufacturing_order(
             warnings=warnings,
             next_actions=["Order is already completed"],
             message=f"Manufacturing order {order_number} is already completed",
+            picked_date=mo_picked_date_iso,
             katana_url=katana_url,
         )
     if has_block:
@@ -451,6 +522,7 @@ async def _fulfill_manufacturing_order(
                 f"{sum(1 for w in warnings if w.startswith(BLOCK_WARNING_PREFIX))} "
                 "issue(s); no status change made."
             ),
+            picked_date=mo_picked_date_iso,
             katana_url=katana_url,
         )
 
@@ -529,6 +601,18 @@ async def _fulfill_manufacturing_order(
         _summarize_fulfilled_rows(success_rows)
     )
 
+    # Prefer the server-stamped ``done_date`` over the caller's
+    # ``completed_at`` so the success card shows what Katana actually
+    # recorded (review item #7, MO-side). Falls back to the caller-
+    # supplied timestamp when ``done_date`` is unset (legacy fixtures /
+    # transient stamp lag). Defensive isinstance() check — same MagicMock
+    # contract trap as the SO branch.
+    server_done_date = unwrap_unset(final_mo.done_date, None)
+    if isinstance(server_done_date, datetime):
+        success_picked_date_iso: str | None = server_done_date.isoformat()
+    else:
+        success_picked_date_iso = mo_picked_date_iso
+
     logger.info(f"Successfully marked manufacturing order {order_number} as DONE")
     return FulfillOrderResponse(
         order_id=request.order_id,
@@ -544,6 +628,7 @@ async def _fulfill_manufacturing_order(
         rows_count=success_rows_count,
         total_quantity=success_total_qty,
         total_value=success_total_value,
+        picked_date=success_picked_date_iso,
         katana_url=katana_url,
     )
 
@@ -789,6 +874,85 @@ def _format_batch_summary(batch_transactions: Any) -> str | None:
             continue
         parts.append(f"batch {batch_id}x{qty:g}")
     return ", ".join(parts) if parts else None
+
+
+async def _fetch_so_addresses(
+    services: Any, sales_order_id: int
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Fetch shipping + billing address dicts via ``/sales_order_addresses``.
+
+    Returns ``(shipping, billing)`` where each is a
+    ``SalesOrderAddress.to_dict()``-shaped dict ready for
+    ``_render_address_block`` (wire-name keys — ``zip``, not ``zip_``).
+
+    GET /sales_orders/{id} does NOT return addresses inline on the
+    response — the field is ``Unset`` on the wire and only populated when
+    the caller explicitly fetches /sales_order_addresses. The high-level
+    ``get_sales_order`` tool does that fetch via
+    :func:`_fetch_sales_order_addresses` (sales_orders.py:1517); the
+    fulfill tool mirrors the pattern so the Tier-3 reference block
+    actually appears in production. Pre-fix this function read
+    ``so.addresses`` directly and quietly returned ``(None, None)`` on
+    every live tenant.
+
+    Billing is returned as ``None`` when it duplicates shipping — the
+    operator only needs one block in that case (mirrors
+    ``build_customer_create_ui``). Equivalence reuses
+    ``addresses_are_equivalent`` from ``katana_mcp.tools._addresses``:
+    same fields the block renders, no entity_type / timestamp noise.
+
+    Returns ``(None, None)`` when the SO has no addresses; the card
+    branch elides the entire Tier-3 address row in that case. Cache /
+    network failures are swallowed (best-effort) so a fulfill preview
+    isn't blocked by a transient address-endpoint hiccup.
+    """
+    from katana_mcp.tools._addresses import addresses_are_equivalent
+    from katana_public_api_client.api.sales_order_address import (
+        get_all_sales_order_addresses,
+    )
+    from katana_public_api_client.utils import unwrap_data
+
+    try:
+        response = await get_all_sales_order_addresses.asyncio_detailed(
+            client=services.client,
+            sales_order_ids=[sales_order_id],
+            limit=250,
+        )
+    except Exception as exc:
+        logger.warning(
+            "fulfill_sales_order: addresses fetch failed",
+            sales_order_id=sales_order_id,
+            error=str(exc),
+        )
+        return None, None
+    rows = unwrap_data(response, raise_on_error=False, default=[])
+    if not rows:
+        return None, None
+
+    shipping_dict: dict[str, Any] | None = None
+    billing_dict: dict[str, Any] | None = None
+    for row in rows:
+        # The /sales_order_addresses endpoint returns rows as attrs
+        # SalesOrderAddress models when parsed; ``to_dict()`` emits the
+        # wire-shape (``zip`` not ``zip_``). Be defensive for the
+        # already-dict path that fixture-side tests use.
+        row_dict = row.to_dict() if hasattr(row, "to_dict") else row
+        entity_type = row_dict.get("entity_type")
+        if isinstance(entity_type, AddressEntityType):
+            entity_type = entity_type.value
+        if entity_type == "shipping" and shipping_dict is None:
+            shipping_dict = row_dict
+        elif entity_type == "billing" and billing_dict is None:
+            billing_dict = row_dict
+
+    if (
+        shipping_dict is not None
+        and billing_dict is not None
+        and addresses_are_equivalent(shipping_dict, billing_dict)
+    ):
+        billing_dict = None
+
+    return shipping_dict, billing_dict
 
 
 def _build_fulfilled_rows_sales(
@@ -1385,30 +1549,43 @@ async def _fulfill_sales_order(
         display_name_by_row,
     ) = await _resolve_row_serial_info(services, so_rows)
 
-    # Inventory-update lines lead with the canonical Katana-UI display
-    # name (parent / value1 / value2) when the typed cache resolved the
-    # variant, falling back through SKU to ``variant {id}`` so each line
-    # always says something more useful than a bare numeric ID. Matches
-    # the resolution order used by the batch recipe update card.
-    inventory_updates: list[str] = []
-    for row in so_rows:
-        rid = row.id
-        vid = row.variant_id
-        qty = row.quantity
-        serials = overrides_by_row.get(rid)
-        suffix = f" with serials {serials}" if serials else ""
-        label = display_name_by_row.get(rid) or sku_by_row.get(rid) or f"variant {vid}"
-        inventory_updates.append(
-            f"Row {rid}: ship {qty} of {label} (full ordered quantity){suffix}"
-        )
-    if not inventory_updates:
-        inventory_updates.append("(no rows on this sales order)")
-    if request.completed_at is not None:
-        inventory_updates.append(
-            f"picked_date will be set to {request.completed_at.isoformat()}"
-        )
-
     warnings: list[str] = []
+
+    # Tier 3 reference data (#card-ux): resolve customer name + extract
+    # shipping/billing addresses so the fulfill card can show the operator
+    # *who* the package goes to and *where*. Pre-#card-ux the card surfaced
+    # only the order number + status; nothing identifying the recipient.
+    # ``inventory_updates`` is intentionally left empty for the SO branch —
+    # the per-row text dump it carried before duplicated ``fulfilled_rows``
+    # one-for-one (the source of the user-cited redundancy). Structured
+    # consumers read ``fulfilled_rows``; the card reads the resolved name +
+    # addresses below.
+    customer_id = unwrap_unset(so.customer_id, None)
+    customer_name: str | None = None
+    if customer_id is not None:
+        customer_name, customer_name_warning = await resolve_entity_name(
+            services.typed_cache.catalog,
+            CachedCustomer,
+            customer_id,
+            entity_label="Customer",
+        )
+        if customer_name_warning:
+            warnings.append(customer_name_warning)
+    # /sales_order_addresses is a sibling endpoint — GET /sales_orders/{id}
+    # does NOT inline addresses on the response (so.addresses is Unset on
+    # the wire). The high-level ``get_sales_order`` tool does this same
+    # fetch via _fetch_sales_order_addresses; mirroring that pattern here
+    # keeps the fulfill card's Tier-3 reference block actually visible in
+    # production. Pre-fix this function read so.addresses directly and
+    # silently returned (None, None) on every live tenant.
+    shipping_address, billing_address = await _fetch_so_addresses(
+        services, request.order_id
+    )
+    picked_date_iso = (
+        request.completed_at.isoformat() if request.completed_at is not None else None
+    )
+
+    inventory_updates: list[str] = []
     if current_status in ("DELIVERED", "PARTIALLY_DELIVERED"):
         warnings.append(
             f"{BLOCK_WARNING_PREFIX} Sales order {order_number} status is "
@@ -1486,6 +1663,19 @@ async def _fulfill_sales_order(
             )
         )
 
+    # Shared Tier-3 reference kwargs threaded through every SO-branch
+    # response constructor — preview, refusal paths, and success. Keeps
+    # the customer / shipping / billing / picked_date payload consistent
+    # whether the operator sees a preview card or an "already delivered"
+    # refusal card.
+    reference_kwargs: dict[str, Any] = {
+        "customer_id": customer_id,
+        "customer_name": customer_name,
+        "shipping_address": shipping_address,
+        "billing_address": billing_address,
+        "picked_date": picked_date_iso,
+    }
+
     if request.preview:
         has_block = any(w.startswith(BLOCK_WARNING_PREFIX) for w in warnings)
         next_actions = (
@@ -1515,6 +1705,7 @@ async def _fulfill_sales_order(
             total_value=total_value,
             currency=currency,
             katana_url=katana_url,
+            **reference_kwargs,
         )
 
     # Refuse on apply if any BLOCK warning is present — the preview would have
@@ -1536,6 +1727,7 @@ async def _fulfill_sales_order(
                 "to create a duplicate fulfillment"
             ),
             katana_url=katana_url,
+            **reference_kwargs,
         )
     if not so_rows:
         return FulfillOrderResponse(
@@ -1552,6 +1744,7 @@ async def _fulfill_sales_order(
                 "no fulfillment created."
             ),
             katana_url=katana_url,
+            **reference_kwargs,
         )
     if has_block:
         return FulfillOrderResponse(
@@ -1571,6 +1764,7 @@ async def _fulfill_sales_order(
                 "issue(s); no fulfillment created."
             ),
             katana_url=katana_url,
+            **reference_kwargs,
         )
 
     from katana_public_api_client.api.sales_order_fulfillment import (
@@ -1602,6 +1796,19 @@ async def _fulfill_sales_order(
     )
     fulfillment = unwrap_as(fulfill_response, SalesOrderFulfillment)
 
+    # Prefer the server-stamped ``picked_date`` over the caller's
+    # ``completed_at`` (review item #7). Pre-fix the success card hid
+    # the Picked Metric whenever the caller didn't pass ``completed_at``
+    # despite Katana stamping a real timestamp on the fulfillment.
+    # Override the ``picked_date`` slot in reference_kwargs so the spread
+    # below picks up the server's value. Defensive: only override when
+    # the server value is a real ``datetime`` — MagicMock fixtures leak
+    # a child mock through ``unwrap_unset`` and pydantic would then
+    # reject the field at construction time.
+    server_picked = unwrap_unset(fulfillment.picked_date, None)
+    if isinstance(server_picked, datetime):
+        reference_kwargs["picked_date"] = server_picked.isoformat()
+
     logger.info(
         f"Created sales order fulfillment {fulfillment.id} for SO {order_number} "
         f"({len(fulfill_rows)} row(s) DELIVERED)"
@@ -1630,6 +1837,7 @@ async def _fulfill_sales_order(
         total_value=total_value,
         currency=currency,
         katana_url=katana_url,
+        **reference_kwargs,
     )
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -588,6 +588,23 @@ class ReceivePurchaseOrderResponse(BaseModel):
     status: str | None = None
     supplier_id: int | None = None
     supplier_name: str | None = None
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "Receiving location — where the received inventory physically "
+            "lands. Pulled off the PO header for the receipt card so the "
+            "operator confirming a receipt sees the destination at a glance "
+            "(post-#card-ux Tier-3 reference data)."
+        ),
+    )
+    location_name: str | None = Field(
+        default=None,
+        description=(
+            "Resolved receiving-location display name (via ``resolve_entity_name`` "
+            "on ``CachedLocation``). ``None`` falls back to ``'Location ID: <id>'`` "
+            "on the card and surfaces a non-fatal warning."
+        ),
+    )
     currency: str | None = None
     total_cost: float | None = None
     items_received: int = 0
@@ -777,29 +794,52 @@ async def _receive_purchase_order_impl(
         order_no = unwrap_unset(po.order_no, f"PO-{request.order_id}")
         po_status = enum_to_str(unwrap_unset(po.status, None))
         supplier_id = unwrap_unset(po.supplier_id, None)
+        location_id = unwrap_unset(po.location_id, None)
         currency = unwrap_unset(po.currency, None)
         total_cost = unwrap_unset(po.total, None)
+
+        # Resolve supplier + location names up front so all return paths
+        # (preview / refusal / success) carry the same Tier-3 reference
+        # block (#card-ux). Pre-#card-ux only the preview path resolved
+        # supplier_name (and never location_name) — the success card
+        # silently dropped both, leaving the operator without the names
+        # they needed to confirm what they'd just committed inventory to.
+        supplier_name: str | None = None
+        location_name: str | None = None
+        resolution_warnings: list[str] = []
+        if supplier_id is not None:
+            from katana_public_api_client.models_pydantic._generated import (
+                CachedSupplier,
+            )
+
+            supplier_name, sup_warn = await resolve_entity_name(
+                services.typed_cache.catalog,
+                CachedSupplier,
+                supplier_id,
+                entity_label="Supplier",
+            )
+            if sup_warn:
+                resolution_warnings.append(sup_warn)
+        if location_id is not None:
+            from katana_public_api_client.models_pydantic._generated import (
+                CachedLocation,
+            )
+
+            location_name, loc_warn = await resolve_entity_name(
+                services.typed_cache.catalog,
+                CachedLocation,
+                location_id,
+                entity_label="Location",
+            )
+            if loc_warn:
+                resolution_warnings.append(loc_warn)
 
         if request.preview:
             logger.info(
                 f"Preview mode: Would receive {len(request.items)} items for PO {order_no}"
             )
 
-            supplier_name: str | None = None
-            warnings: list[str] = []
-            if supplier_id is not None:
-                from katana_public_api_client.models_pydantic._generated import (
-                    CachedSupplier,
-                )
-
-                supplier_name, sup_warn = await resolve_entity_name(
-                    services.typed_cache.catalog,
-                    CachedSupplier,
-                    supplier_id,
-                    entity_label="Supplier",
-                )
-                if sup_warn:
-                    warnings.append(sup_warn)
+            warnings: list[str] = list(resolution_warnings)
 
             next_actions = [
                 "Review the items to receive",
@@ -829,6 +869,8 @@ async def _receive_purchase_order_impl(
                 status=po_status,
                 supplier_id=supplier_id,
                 supplier_name=supplier_name,
+                location_id=location_id,
+                location_name=location_name,
                 currency=currency,
                 total_cost=total_cost,
                 items_received=len(request.items),
@@ -843,18 +885,27 @@ async def _receive_purchase_order_impl(
         # would otherwise be able to receive items against an already-fully-
         # received PO and create duplicate inventory.
         if po_status == "RECEIVED":
+            # Refusal carries the cache-miss advisories alongside the
+            # BLOCK warning so the operator sees both "why we refused"
+            # AND "why these names didn't resolve" — review item #11.
+            # Pre-fix this branch hard-coded a single-string list and
+            # silently dropped ``resolution_warnings``.
             return ReceivePurchaseOrderResponse(
                 order_id=request.order_id,
                 order_number=order_no,
                 status=po_status,
                 supplier_id=supplier_id,
+                supplier_name=supplier_name,
+                location_id=location_id,
+                location_name=location_name,
                 currency=currency,
                 total_cost=total_cost,
                 items_received=0,
                 is_preview=False,
                 warnings=[
                     f"{BLOCK_WARNING_PREFIX} Purchase order {order_no} is already "
-                    "RECEIVED. No items were received."
+                    "RECEIVED. No items were received.",
+                    *resolution_warnings,
                 ],
                 next_actions=["No action needed — order is already fully received."],
                 message=(
@@ -911,11 +962,15 @@ async def _receive_purchase_order_impl(
             order_number=order_no,
             status=po_status,
             supplier_id=supplier_id,
+            supplier_name=supplier_name,
+            location_id=location_id,
+            location_name=location_name,
             currency=currency,
             total_cost=total_cost,
             items_received=len(request.items),
             received_items=received_items_info,
             is_preview=False,
+            warnings=resolution_warnings,
             next_actions=[
                 f"Received {len(request.items)} items",
                 "Inventory has been updated",

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -128,6 +128,7 @@ from katana_public_api_client.models import (
 )
 from katana_public_api_client.models_pydantic._generated import (
     CachedCustomer,
+    CachedLocation,
     CachedVariant,
 )
 from katana_public_api_client.utils import unwrap_as
@@ -417,6 +418,17 @@ class SalesOrderResponse(BaseModel):
     customer_id: int
     customer_name: str | None = None
     location_id: int | None = None
+    location_name: str | None = Field(
+        default=None,
+        description=(
+            "Resolved location display name (via ``resolve_entity_name`` on "
+            "``CachedLocation``). Pre-#card-ux ``build_so_create_ui`` called "
+            "``_render_party_line(name=None, ...)`` and the helper degraded "
+            "to ``'Location ID: <id>'`` (anti-pattern #7). Now the impl side "
+            "resolves the name; the card-side party-line shows ``'Location: "
+            "<name>'`` instead of the bare id."
+        ),
+    )
     status: str | None = None
     total: float | None = None
     currency: str | None = None
@@ -559,19 +571,38 @@ async def _create_sales_order_impl(
 
     requested_fees = request.shipping_fees or []
 
+    # Resolve customer + location names once, up front, so every return
+    # path (preview / refusal / success) carries the resolved Tier-3
+    # reference fields. Pre-fix the apply-path shipping-fee refusal
+    # silently dropped them and the card fell back to ``"Customer ID: <id>"``
+    # — review item #5. The cache-miss advisories thread through
+    # ``resolution_warnings`` so refusal-branch responses can include
+    # them too (mirrors PO RECEIVED / MO duplicate-link refusal fixes).
+    services = get_services(context)
+    customer_name, cust_warn = await resolve_entity_name(
+        services.typed_cache.catalog,
+        CachedCustomer,
+        request.customer_id,
+        entity_label="Customer",
+    )
+    resolution_warnings: list[str] = [cust_warn] if cust_warn else []
+    location_name: str | None = None
+    if request.location_id is not None:
+        location_name, loc_warn = await resolve_entity_name(
+            services.typed_cache.catalog,
+            CachedLocation,
+            request.location_id,
+            entity_label="Location",
+        )
+        if loc_warn:
+            resolution_warnings.append(loc_warn)
+
     if request.preview:
         logger.info(
             f"Preview mode: SO {request.order_number} would have {len(request.items)} items"
         )
 
-        services = get_services(context)
-        customer_name, cust_warn = await resolve_entity_name(
-            services.typed_cache.catalog,
-            CachedCustomer,
-            request.customer_id,
-            entity_label="Customer",
-        )
-        warnings: list[str] = [cust_warn] if cust_warn else []
+        warnings: list[str] = list(resolution_warnings)
         if request.location_id is None:
             warnings.append(
                 "No location_id specified - order will use default location"
@@ -591,6 +622,7 @@ async def _create_sales_order_impl(
             customer_id=request.customer_id,
             customer_name=customer_name,
             location_id=request.location_id,
+            location_name=location_name,
             status="PENDING",
             total=total_estimate if total_estimate > 0 else None,
             currency=request.currency,
@@ -610,7 +642,8 @@ async def _create_sales_order_impl(
         )
 
     try:
-        services = get_services(context)
+        # ``services`` already obtained above for the name-resolution
+        # pass; no second ``get_services`` call needed.
 
         # Apply-path BLOCK validation: amounts must parse to non-negative
         # decimals BEFORE we POST the SO. We don't roll back the SO on a
@@ -633,9 +666,12 @@ async def _create_sales_order_impl(
                 return SalesOrderResponse(
                     order_number=request.order_number,
                     customer_id=request.customer_id,
+                    customer_name=customer_name,
+                    location_id=request.location_id,
+                    location_name=location_name,
                     is_preview=True,
                     shipping_fee_outcomes=_outcomes_from_planned_fees(requested_fees),
-                    warnings=block_warnings,
+                    warnings=block_warnings + resolution_warnings,
                     next_actions=[
                         "Fix the failing shipping_fees amounts and retry",
                     ],
@@ -791,17 +827,53 @@ async def _create_sales_order_impl(
             ok_count = sum(1 for o in fee_outcomes if o.succeeded is True)
             message += f" with {ok_count}/{len(requested_fees)} shipping fee(s) applied"
 
+        # Reuse the customer + location names resolved up front in the
+        # common case where Katana echoed back the IDs we sent — saves a
+        # typed-cache round-trip per name and prevents duplicate
+        # cache-miss advisories in ``resolution_warnings`` (Copilot
+        # finding on PR #861). Only re-resolve when Katana assigned a
+        # different ID (e.g., the caller omitted ``location_id`` and
+        # the server picked a default).
+        apply_customer_name = customer_name
+        apply_resolution_warnings: list[str] = []
+        if so.customer_id != request.customer_id:
+            apply_customer_name, cust_warn = await resolve_entity_name(
+                services.typed_cache.catalog,
+                CachedCustomer,
+                so.customer_id,
+                entity_label="Customer",
+            )
+            if cust_warn:
+                apply_resolution_warnings.append(cust_warn)
+
+        apply_location_id = unwrap_unset(so.location_id, None)
+        if apply_location_id == request.location_id:
+            apply_location_name = location_name
+        elif apply_location_id is not None:
+            apply_location_name, loc_warn = await resolve_entity_name(
+                services.typed_cache.catalog,
+                CachedLocation,
+                apply_location_id,
+                entity_label="Location",
+            )
+            if loc_warn:
+                apply_resolution_warnings.append(loc_warn)
+        else:
+            apply_location_name = None
+
         return SalesOrderResponse(
             id=so.id,
             order_number=so.order_no,
             customer_id=so.customer_id,
+            customer_name=apply_customer_name,
             location_id=so.location_id,
+            location_name=apply_location_name,
             status=so.status.value if so.status else "UNKNOWN",
             total=total,
             currency=currency,
             is_preview=False,
             shipping_fee_outcomes=fee_outcomes,
-            warnings=fee_warnings,
+            warnings=(fee_warnings + resolution_warnings + apply_resolution_warnings),
             katana_url=katana_web_url("sales_order", so.id),
             next_actions=next_actions,
             message=message,

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -110,6 +110,7 @@ from prefab_ui.rx import EVENT, RESULT, Rx
 from pydantic import BaseModel
 
 from katana_mcp.logging import get_logger
+from katana_mcp.tools._addresses import addresses_are_equivalent
 from katana_mcp.tools.foundation.bom_table import (
     _derive_status_label,
     _merge_bom_rows_for_modify_card,
@@ -1224,17 +1225,34 @@ def _item_supplier_line(item: dict[str, Any]) -> None:
     # the flat top-level default_supplier_id. Common for materials
     # where Katana doesn't embed the supplier object even though the
     # FK is set.
+    #
+    # Anti-pattern #7 (helper-fallback masking): when the nested object
+    # is absent the impl should resolve the supplier name via the typed
+    # cache (``resolve_entity_name(catalog, CachedSupplier, id, …)``)
+    # and feed the resolved name through so this fallback never shows a
+    # raw ``#<id>``. ``get_item`` / ``search_items`` / ``modify_item``
+    # all funnel through ``_item_supplier_line``; threading a resolved
+    # name through each is a follow-up — until then the link works (it
+    # navigates to the right supplier) but the visible text is the ID.
     fallback_sid = item.get("default_supplier_id")
     if fallback_sid:
+        # Prefer a sibling-resolved ``default_supplier_name`` when the
+        # caller threaded one through — keeps existing callers (which
+        # pass only the ID) backward-compatible while letting newer
+        # callers fill in the user-facing name.
+        fallback_name = item.get("default_supplier_name")
+        link_text = fallback_name or f"#{fallback_sid}"
         supplier_url = katana_web_url("supplier", fallback_sid)
         if supplier_url:
             with Row(gap=1):
                 Text(content="Default Supplier:")
                 Link(
-                    content=f"#{fallback_sid}",
+                    content=link_text,
                     href=supplier_url,
                     target="_blank",
                 )
+        elif fallback_name:
+            Text(content=f"Default Supplier: {fallback_name}")
         else:
             Text(content=f"Default Supplier ID: {fallback_sid}")
 
@@ -1736,14 +1754,15 @@ def _inventory_reference_section(stock: dict[str, Any]) -> None:
     if len(by_location) > 1:
         Separator()
         Muted(content="By location:")
+        # ``location_name`` is allowed to be ``None`` when the location
+        # cache misses; that's the case where the impl side should be
+        # resolving the name (typed cache lookup), not the card adding
+        # an ID column. Pre-#card-ux this section carried a permanent
+        # ``location_id`` "ID" column "so rows are never unidentifiable"
+        # — that's exactly anti-pattern #2 (raw IDs as a user surface).
         DataTable(
             columns=[
                 DataTableColumn(key="location_name", header="Location"),
-                # ``location_name`` is allowed to be ``None`` when the
-                # location-cache lookup misses; the ID column stays as
-                # an always-present fallback so rows are never
-                # unidentifiable. Same shape the pre-#549 card had.
-                DataTableColumn(key="location_id", header="ID", align="right"),
                 DataTableColumn(key="in_stock", header="In Stock", align="right"),
                 DataTableColumn(key="available", header="Available", align="right"),
                 DataTableColumn(key="committed", header="Committed", align="right"),
@@ -1991,19 +2010,32 @@ def build_inventory_check_batch_ui(
             Metric(label="Committed", value=str(totals["committed"]))
             Metric(label="Expected", value=str(totals["expected"]))
 
-        DataTable(
-            columns=[
-                DataTableColumn(key="sku", header="SKU", sortable=True),
-                # Variant ID is the row's other primary identifier. A
-                # not-found stub from a variant-ID lookup has empty SKU
-                # and empty product_name — without this column the row
-                # has no visible identity at all and the user can't tell
-                # which input was missing. SKU-bearing rows also get to
-                # show their variant_id so downstream tools (which key
-                # on variant_id) can copy it directly off the table.
+        # Variant ID column is reserved for the unidentifiable-row case:
+        # a row that lacks BOTH ``sku`` AND ``product_name`` has no
+        # human-facing identity (e.g., a variant-ID lookup that resolved
+        # no row, or a stub from a deleted variant). A SKU-less variant
+        # that still has a ``product_name`` (legitimate NetSuite import,
+        # per CLAUDE.md "Variants can have null SKUs") is identifiable
+        # via the Product column — the variant_id column would just
+        # surface a raw wire ID (anti-pattern #2). Only fall back when
+        # the row genuinely has nothing else to anchor the operator.
+        needs_variant_id_column = any(
+            not r.get("sku") and not r.get("product_name") for r in summary_items
+        )
+        columns: list[Any] = [
+            DataTableColumn(key="sku", header="SKU", sortable=True),
+        ]
+        if needs_variant_id_column:
+            columns.append(
                 DataTableColumn(
-                    key="variant_id", header="Variant ID", sortable=True, align="right"
-                ),
+                    key="variant_id",
+                    header="Variant ID",
+                    sortable=True,
+                    align="right",
+                )
+            )
+        columns.extend(
+            [
                 DataTableColumn(key="product_name", header="Product", sortable=True),
                 DataTableColumn(key="uom", header="UoM"),
                 DataTableColumn(
@@ -2028,7 +2060,10 @@ def build_inventory_check_batch_ui(
                     align="right",
                 ),
                 DataTableColumn(key="status_label", header="Status", sortable=True),
-            ],
+            ]
+        )
+        DataTable(
+            columns=columns,
             rows="{{ items }}",
             search=True,
             paginated=True,
@@ -2050,7 +2085,6 @@ def build_inventory_check_batch_ui(
             DataTable(
                 columns=[
                     DataTableColumn(key="location_name", header="Location"),
-                    DataTableColumn(key="location_id", header="ID", align="right"),
                     DataTableColumn(key="in_stock", header="In Stock", align="right"),
                     DataTableColumn(key="available", header="Available", align="right"),
                     DataTableColumn(key="committed", header="Committed", align="right"),
@@ -2263,6 +2297,7 @@ def build_inventory_at_ui(
     items: list[dict[str, Any]],
     as_of: str,
     location_id: int | None = None,
+    location_name: str | None = None,
     not_found: list[str | int] | None = None,
     currency: str | None = None,
 ) -> PrefabApp:
@@ -2305,7 +2340,12 @@ def build_inventory_at_ui(
                 variant="secondary",
             )
             if location_id is not None:
-                Badge(label=f"Location {location_id}", variant="outline")
+                # Use the resolved ``location_name`` when supplied —
+                # ``"Warehouse A"`` reads better than ``"Location 17"``
+                # (anti-pattern #2). Fallback to the bare ID only when
+                # the caller couldn't resolve a name.
+                badge_label = location_name or f"Location {location_id}"
+                Badge(label=badge_label, variant="outline")
             if is_single and items:
                 only = items[0]
                 Badge(label=only.get("sku") or "(no SKU)", variant="outline")
@@ -2436,7 +2476,13 @@ _STOCK_ADJUSTMENT_ROW_COLUMNS: list[DataTableColumn] = [
 
 _STOCK_ADJUSTMENT_FIELD_DIFF_COLUMNS: list[DataTableColumn] = [
     DataTableColumn(key="field", header="Field"),
-    DataTableColumn(key="new_value", header="New Value"),
+    # Before column added post-#card-ux (anti-pattern #5: a diff without
+    # the before-side is uninterpretable — the operator can't tell if
+    # they're changing a field or restating its current value). When the
+    # impl can't resolve the prior_state (e.g., the SA was created before
+    # this enrichment landed), the cell shows "(prior unknown)".
+    DataTableColumn(key="old_value", header="Before"),
+    DataTableColumn(key="new_value", header="After"),
 ]
 
 
@@ -2793,6 +2839,7 @@ def build_stock_adjustment_create_ui(
         cancel_action = _build_cancel_action("the stock adjustment")
 
     location_id = response.get("location_id")
+    location_name = response.get("location_name")
     adj_id = response.get("id")
     reason = response.get("reason")
 
@@ -2802,7 +2849,11 @@ def build_stock_adjustment_create_ui(
             if adj_id is not None:
                 Badge(label=f"#{adj_id}", variant="outline")
             if location_id is not None:
-                Badge(label=f"Location {location_id}", variant="outline")
+                # Resolved ``location_name`` when impl-side filled it,
+                # else fall back to ``"Location <id>"`` (anti-pattern #2
+                # fallback acknowledged in the audit catalog).
+                badge_label = location_name or f"Location {location_id}"
+                Badge(label=badge_label, variant="outline")
             Badge(
                 label="PREVIEW" if is_preview else "APPLIED",
                 variant="secondary" if is_preview else "default",
@@ -2819,6 +2870,12 @@ def build_stock_adjustment_create_ui(
                     columns=_STOCK_ADJUSTMENT_ROW_COLUMNS,
                     rows="{{ plan_rows }}",
                 )
+
+            # Surface cache-miss advisories so the operator sees *why*
+            # the Tier-1 badge fell back to ``"Location <id>"`` when
+            # impl-side location name resolution missed. Pre-fix the
+            # warnings were emitted by the impl but never rendered.
+            _render_warnings_block(response.get("warnings"))
 
             if is_preview:
                 with If("error"):
@@ -2851,6 +2908,99 @@ def build_stock_adjustment_create_ui(
     return app
 
 
+_PRIOR_UNSET = object()
+
+
+def _stock_adjustment_diff_cell(
+    field: str,
+    label: str,
+    display_value: Any,
+    *,
+    prior_state: dict[str, Any],
+    prior_override: Any = _PRIOR_UNSET,
+) -> dict[str, str]:
+    """Build one Before/After diff row for the stock-adjustment update card.
+
+    Three Before-side states:
+
+    - ``prior_override`` supplied (anything, including ``None``) wins —
+      the caller did its own resolution. Used by the Location row,
+      which threads in the resolved prior location name. ``None``
+      means the caller tried to resolve but couldn't (cache miss).
+    - ``field`` is a key on ``prior_state`` → that value. A stored
+      ``None`` renders as ``"(blank)"`` (the field WAS resolved, it
+      was just empty — distinct from "we couldn't resolve at all";
+      Copilot finding on PR #861).
+    - ``field`` is NOT a key on ``prior_state`` → ``"(prior unknown)"``.
+      prior_state was either missing entirely or omitted this field
+      (impl-side pre-fetch failure / forward-compat for a new field
+      that lands after this snapshot was taken).
+    """
+    if prior_override is not _PRIOR_UNSET:
+        old_value = "(prior unknown)" if prior_override is None else str(prior_override)
+    elif field in prior_state:
+        prior_value = prior_state[field]
+        old_value = "(blank)" if prior_value is None else str(prior_value)
+    else:
+        old_value = "(prior unknown)"
+    return {
+        "field": label,
+        "old_value": old_value,
+        "new_value": str(display_value),
+    }
+
+
+def _build_stock_adjustment_diff_rows(
+    response: dict[str, Any], prior_state: dict[str, Any]
+) -> list[dict[str, str]]:
+    """Project the response + prior_state into per-field Before/After rows.
+
+    Pre-#card-ux the diff table carried a ``Location ID`` row with the
+    raw integer ID — anti-pattern #2. Post-#card-ux: location surfaces
+    via the ``location_name`` field (resolved impl-side); the row in
+    the diff table reads "Location" with the resolved name.
+    """
+    diff_rows: list[dict[str, str]] = []
+    for field, label in (
+        ("stock_adjustment_number", "Number"),
+        ("stock_adjustment_date", "Date"),
+        ("reason", "Reason"),
+        ("additional_info", "Additional Info"),
+    ):
+        value = response.get(field)
+        if value is not None:
+            diff_rows.append(
+                _stock_adjustment_diff_cell(
+                    field, label, value, prior_state=prior_state
+                )
+            )
+    if response.get("location_id") is not None:
+        # Before-side reads ``prior_state["location_name"]`` so the
+        # Before/After columns compare resolved name against resolved
+        # name (review item #10).
+        new_location = response.get("location_name") or (
+            f"Location ID: {response['location_id']}"
+        )
+        prior_loc_id = prior_state.get("location_id")
+        prior_loc_name = prior_state.get("location_name")
+        if prior_loc_name:
+            prior_location: str | None = prior_loc_name
+        elif prior_loc_id is not None:
+            prior_location = f"Location ID: {prior_loc_id}"
+        else:
+            prior_location = None
+        diff_rows.append(
+            _stock_adjustment_diff_cell(
+                "location_id",
+                "Location",
+                new_location,
+                prior_state=prior_state,
+                prior_override=prior_location,
+            )
+        )
+    return diff_rows
+
+
 def build_stock_adjustment_update_ui(
     response: dict[str, Any],
     *,
@@ -2863,17 +3013,8 @@ def build_stock_adjustment_update_ui(
     the user can sanity-check what's about to be patched.
     """
     is_preview = bool(response.get("is_preview"))
-    diff_rows: list[dict[str, str]] = []
-    for field, label in (
-        ("stock_adjustment_number", "Number"),
-        ("stock_adjustment_date", "Date"),
-        ("location_id", "Location ID"),
-        ("reason", "Reason"),
-        ("additional_info", "Additional Info"),
-    ):
-        value = response.get(field)
-        if value is not None:
-            diff_rows.append({"field": label, "new_value": str(value)})
+    prior_state = response.get("prior_state") or {}
+    diff_rows = _build_stock_adjustment_diff_rows(response, prior_state)
 
     state: dict[str, Any] = {"diff_rows": diff_rows}
     apply_action: list[Action] | None = None
@@ -2903,6 +3044,12 @@ def build_stock_adjustment_update_ui(
                 )
             else:
                 Muted(content="No field changes supplied.")
+
+            # Surface cache-miss advisories so the operator sees *why*
+            # the Location row may render as ``"Location ID: <id>"`` or
+            # the Before column as ``"(prior unknown)"``. Pre-fix the
+            # warnings were emitted by the impl but never rendered.
+            _render_warnings_block(response.get("warnings"))
 
             if is_preview:
                 with If("error"):
@@ -2976,14 +3123,31 @@ def build_stock_adjustment_delete_ui(
                     label="Number",
                     value=str(response.get("stock_adjustment_number") or "—"),
                 )
-                Metric(
-                    label="Location",
-                    value=str(response.get("location_id") or "—"),
-                )
+                # Location is not a number that belongs on a Metric;
+                # pre-#card-ux it rendered the raw ``location_id`` here
+                # which was meaningless to the operator (anti-pattern #2).
+                # The resolved location name now ships as its own
+                # party-line below.
                 Metric(
                     label="Rows",
                     value=str(response.get("row_count", 0)),
                 )
+
+            # Location party-line below the Metric row — same Tier-3
+            # convention as the fulfill and receipt cards. Falls back to
+            # ``"Location ID: <id>"`` only when impl-side resolution couldn't
+            # fill ``location_name``.
+            _render_party_line(
+                "Location",
+                name=response.get("location_name"),
+                entity_id=response.get("location_id"),
+            )
+
+            # Surface cache-miss advisories so the operator sees *why*
+            # the Location party-line may have fallen back to
+            # ``"Location ID: <id>"``. Pre-fix the warnings were emitted
+            # by the impl but never rendered.
+            _render_warnings_block(response.get("warnings"))
 
             if is_preview:
                 Muted(
@@ -3233,12 +3397,26 @@ def _render_party_line(
 ) -> None:
     """Render a 'Supplier:' / 'Customer:' / 'Location:' line.
 
-    When ``entity_kind`` resolves to a Katana web URL and a ``name`` is
-    present, renders ``<label>: <Link name>`` so users can click through
-    to the source-of-truth entity (mirrors the variant card's parent and
-    default-supplier link pattern; matches this module's "Link Katana
-    entities wherever possible" convention). Falls back to plain text
-    otherwise. Skips entirely when ``entity_id`` is None.
+    Three render shapes, in order:
+
+    1. ``name`` + ``entity_kind`` (which yields a web URL) → ``<label>:
+       <Link name>``. The Link is the user's click-through to the
+       source-of-truth Katana page. Used for Customer / Supplier /
+       Product / Material parties that have per-entity web pages.
+    2. ``name`` only (no ``entity_kind``, or ``entity_kind`` has no web
+       URL) → ``<label>: <name>``. Used for Location / Variant — entity
+       types Katana doesn't expose per-page in the web UI. The
+       entity_id is still on the response for programmatic use, but the
+       card text doesn't echo it (anti-pattern #2: don't double-print
+       a raw ID next to its resolved name when there's no click-through
+       to anchor).
+    3. No name → ``<label> ID: <entity_id>``. The fallback when impl-side
+       name resolution couldn't fill ``name``; surfacing the ID is the
+       only way the operator can identify the entity at all. The matching
+       impl path should also append a cache-miss advisory to ``warnings``
+       so the operator sees *why* the name is missing.
+
+    Skips entirely when ``entity_id`` is None.
     """
     if entity_id is None:
         return
@@ -3248,7 +3426,7 @@ def _render_party_line(
             Text(content=f"{label}:")
             Link(content=name, href=url, target="_blank")
     elif name:
-        Text(content=f"{label}: {name} (ID: {entity_id})")
+        Text(content=f"{label}: {name}")
     else:
         Text(content=f"{label} ID: {entity_id}")
 
@@ -3685,27 +3863,12 @@ def _render_address_block(label: str, address: dict[str, Any]) -> bool:
     return True
 
 
-def _addresses_are_equivalent(a: dict[str, Any], b: dict[str, Any]) -> bool:
-    """Two addresses are equivalent if every user-visible field matches.
-
-    Compares the fields ``_render_address_block`` surfaces — entity_type is
-    irrelevant here (that's what's labelling each block), and server-side
-    fields (id, customer_id, timestamps) don't enter into "is the same
-    place" judgement.
-    """
-    keys = (
-        "first_name",
-        "last_name",
-        "company",
-        "phone",
-        "line_1",
-        "line_2",
-        "city",
-        "state",
-        "zip",
-        "country",
-    )
-    return all((a.get(k) or None) == (b.get(k) or None) for k in keys)
+# Re-export so existing call sites in this module keep working. The real
+# helper now lives in ``_addresses`` so impl-side ``foundation/*`` modules
+# can use it without depending on the Prefab UI module (avoids a latent
+# circular import; ``prefab_ui`` already imports several foundation
+# modules).
+_addresses_are_equivalent = addresses_are_equivalent
 
 
 def _render_customer_entity_view(
@@ -4883,7 +5046,7 @@ def build_so_create_ui(
             )
             _render_party_line(
                 "Location",
-                name=None,  # SalesOrderResponse has no location_name
+                name=response.get("location_name"),
                 entity_id=response.get("location_id"),
             )
             _render_so_shipping_fees_section(
@@ -6391,15 +6554,34 @@ def build_mo_create_ui(
                             label="Deadline",
                             value=_iso_date_only(production_deadline_date),
                         )
-            if variant_id is not None or sku:
-                if sku and variant_id is not None:
-                    Text(content=f"Variant: {sku} (ID: {variant_id})")
-                elif sku:
-                    Text(content=f"Variant: {sku}")
-                else:
-                    Text(content=f"Variant ID: {variant_id}")
-            if location_id is not None:
-                Text(content=f"Location ID: {location_id}")
+            # Variant identity: render SKU as the user-facing name when
+            # resolved. Variants have no per-variant page in Katana web
+            # UI (their parent product/material pages own the variant
+            # configuration), so no ``entity_kind`` — the line stays as
+            # plain text. When SKU is missing we still drop a "Variant
+            # ID: <id>" fallback via ``_render_party_line`` so a
+            # SKU-less variant (NetSuite imports — see CLAUDE.md "Variants
+            # can have null SKUs") isn't invisible to the operator.
+            if sku:
+                Text(content=f"Variant: {sku}")
+            else:
+                _render_party_line(
+                    "Variant",
+                    name=None,
+                    entity_id=variant_id,
+                )
+            # Location resolves to ``location_name`` impl-side via
+            # ``resolve_entity_name(catalog, CachedLocation, ...)``;
+            # ``entity_kind`` is omitted because Katana web UI has no
+            # per-location page (the resolved name is the user-facing
+            # identifier). The helper's fallback shows ``"Location ID:
+            # <id>"`` only when the cache miss can't be filled, and the
+            # underlying response carries a warning explaining why.
+            _render_party_line(
+                "Location",
+                name=response.get("location_name"),
+                entity_id=location_id,
+            )
             if order_created_date:
                 Text(content=f"Created: {_iso_date_only(order_created_date)}")
             if additional_info:
@@ -6449,14 +6631,67 @@ def _extract_fulfill_fields(
     )
 
 
-def _render_inventory_updates(
-    response: dict[str, Any], *, label: str = "Inventory Changes:"
-) -> None:
-    """Render inventory update list if present."""
-    if response.get("inventory_updates"):
-        Muted(content=label)
-        for update in response["inventory_updates"]:
-            Text(content=f"  {update}")
+def _render_fulfill_reference_block(response: dict[str, Any]) -> None:
+    """Render Tier-3 reference data on the fulfill card.
+
+    Two branches:
+
+    - **Sales order** (``order_type == "sales"``): Customer party-line +
+      shipping address (+ billing block when it differs from shipping
+      via ``_addresses_are_equivalent``). The operator-anchoring "who
+      does this ship to / where" facts the #card-ux fulfill card is
+      built around.
+    - **Manufacturing order** (``order_type == "manufacturing"``):
+      ``inventory_updates`` rendered as a side-effects list (review
+      item #6). MOs have no customer or shipping address, but they DO
+      have inventory side-effects the operator needs to confirm
+      ("Raw materials will be consumed from inventory based on BOM",
+      finished-good serial attach, etc.). Pre-fix the MO branch
+      silently dropped this content — the SO-branch deletion was
+      correct (the per-row DataTable carried the same data); the
+      MO-branch loss was a regression.
+    """
+    order_type = response.get("order_type")
+    if order_type == "sales":
+        _render_party_line(
+            "Customer",
+            name=response.get("customer_name"),
+            entity_id=response.get("customer_id"),
+            entity_kind="customer",
+        )
+        shipping = response.get("shipping_address")
+        if shipping:
+            _render_address_block("Shipping Address", shipping)
+        billing = response.get("billing_address")
+        # Defense-in-depth dedup: the impl side
+        # (``_fetch_so_addresses`` in ``foundation/orders.py``) already
+        # returns ``billing=None`` when the two addresses are
+        # equivalent, but older/direct UI payloads that bypass that
+        # impl path can still carry both. Hide the duplicate block here
+        # — mirrors the customer-entity-view's card-side dedup.
+        if billing and not (shipping and addresses_are_equivalent(shipping, billing)):
+            _render_address_block("Billing Address", billing)
+        return
+    if order_type == "manufacturing":
+        # Drop the now-redundant "completed_date will be set to ..." line —
+        # ``picked_date`` is its own Metric on the card. Same for the
+        # serial-attach line, which lands as a row in the per-row table.
+        # What remains is genuinely useful BOM-consumption context.
+        updates = response.get("inventory_updates") or []
+        if not updates:
+            return
+        filtered = [
+            u
+            for u in updates
+            if isinstance(u, str)
+            and not u.startswith("completed_date / done_date will be set to")
+            and not u.startswith("Finished-good serials to attach:")
+        ]
+        if not filtered:
+            return
+        Muted(content="Side effects:")
+        for line in filtered:
+            Text(content=f"  {line}")
 
 
 # Max serial IDs to render verbatim in the fulfill card's "Serials" column
@@ -6512,13 +6747,16 @@ def _build_fulfill_row_display(row: dict[str, Any]) -> dict[str, Any]:
 def _render_fulfill_metrics(response: dict[str, Any]) -> None:
     """Render the Tier 2 metric row for the fulfill card (#553).
 
-    Three metrics:
+    Four metrics:
     - **Rows** — count of rows being fulfilled (always present, never zero
       on a real response — the MO branch synthesizes a single-row entry).
     - **Total Qty** — sum of quantities across rows, rendered via ``:g``.
     - **Total Value** — sum of ``row_total`` across rows, formatted via
       babel. Omitted when no row carries a price (MO branch — MOs track
       cost, not price; the cost ledger lives on a separate surface).
+    - **Picked** (or **Completed** on MO) — the backdated timestamp the
+      caller supplied via ``completed_at``. Omitted when the caller didn't
+      supply one (server-stamps at apply time).
 
     Skipped entirely when the response carries no enrichment
     (back-compat with older payloads that pre-dated #553).
@@ -6529,12 +6767,23 @@ def _render_fulfill_metrics(response: dict[str, Any]) -> None:
     total_qty = response.get("total_quantity")
     total_value = response.get("total_value")
     currency = response.get("currency")
+    picked_date = response.get("picked_date")
+    # Pre-#card-ux the picked_date lived in an ``inventory_updates`` text
+    # blob ("picked_date will be set to …") that rendered above the
+    # per-row table. Promoting to a Metric puts the most operator-relevant
+    # field — when does this fulfillment count? — at eye level alongside
+    # row count + qty + value, instead of buried in a side panel.
+    date_label = (
+        "Completed" if response.get("order_type") == "manufacturing" else "Picked"
+    )
     with Row(gap=4):
         Metric(label="Rows", value=str(rows_count))
         if isinstance(total_qty, int | float):
             Metric(label="Total Qty", value=f"{total_qty:g}")
         if total_value is not None:
             Metric(label="Total Value", value=_format_money(total_value, currency))
+        if picked_date:
+            Metric(label=date_label, value=str(picked_date))
 
 
 def _render_fulfill_per_row_table(
@@ -6670,7 +6919,7 @@ def build_fulfill_preview_ui(
 
         with CardContent(), Column(gap=2):
             _render_fulfill_metrics(response)
-            _render_inventory_updates(response)
+            _render_fulfill_reference_block(response)
             _render_fulfill_per_row_table(
                 fulfilled_rows_display,
                 order_type=raw_order_type,
@@ -6733,14 +6982,20 @@ def build_fulfill_success_ui(
             if response.get("message"):
                 Text(content=response["message"])
             _render_fulfill_metrics(response)
-            if response.get("inventory_updates"):
-                Separator()
-            _render_inventory_updates(response, label="Inventory Updates:")
+            _render_fulfill_reference_block(response)
             _render_fulfill_per_row_table(
                 fulfilled_rows_display,
                 order_type=raw_order_type,
                 is_preview=False,
             )
+            # Surface cache-miss advisories so the operator sees *why*
+            # a Customer / Location party-line may have fallen back to
+            # the raw-ID rendering. Both SO and MO impls populate the
+            # advisories on the success response, but pre-fix the
+            # success card never rendered them — a direct ``preview=
+            # false`` caller would see ``"Customer ID: <id>"`` with no
+            # explanation. Mirrors the preview-card warnings block.
+            _render_warnings_block(response.get("warnings"))
 
         # ``check_inventory`` accepts SKUs OR variant_ids in the same arg
         # (``skus_or_variant_ids``), so coalesce on ``sku or variant_id``
@@ -7059,52 +7314,35 @@ _PLAN_ACTIONS_KEY = "plan_actions"
 _PLAN_ACTIONS_REF = f"{{{{ {_PLAN_ACTIONS_KEY} }}}}"
 
 
-def _derive_summary(action: dict[str, Any]) -> str:
-    """Fallback summary derivation when the action lacks a server-supplied one."""
-    op = str(action.get("operation") or "").lower()
-    changes = action.get("changes") or []
-    if op.startswith("delete"):
-        return "deleted"
-    if op.startswith("add") or op.startswith("create"):
-        return f"{len(changes)} field(s) set"
-    n_changed = sum(
-        1 for c in changes if isinstance(c, dict) and not c.get("is_unchanged")
-    )
-    if n_changed == 0 and changes:
-        return f"{len(changes)} field(s) — no change"
-    return f"{n_changed} field(s) changed"
-
-
 def _action_to_row(idx: int, action: dict[str, Any]) -> dict[str, Any]:
     """Project one ActionResult dict into a DataTable row.
 
-    Returns a dict that carries display-only derived fields (``index``,
-    ``operation_label``, ``target_label``) on top of the underlying
-    ActionResult fields. Pre-populating the same shape both at preview-
-    build time and on the apply RESULT means the on_success
-    ``SetState("plan_actions", RESULT.actions)`` swap doesn't need any
-    transformation — the server's ``status_label``/``summary`` already
-    travel on every ActionResult.
-
-    Falls back to local derivation when ``status_label``/``summary`` are
-    absent (legacy single-action shape, older response generators, tests).
+    Production callers pass already-populated dicts (the ActionResult
+    ``@model_validator`` filled ``operation_label`` / ``target_label`` /
+    ``summary`` / ``status_label`` before ``model_dump()``). Tests and the
+    legacy single-action path pass partial dicts; we round-trip them
+    through ``ActionResult.model_validate`` so the same validator fires
+    and we get the same content-rich summary the production path
+    produces (previously a stale duplicate-validator path lived here and
+    masked anti-pattern #4 — see post-PR #card-ux review finding #2).
     """
-    target = action.get("target_id")
+    from katana_mcp.tools._modification import ActionResult
+
+    populated = ActionResult.model_validate(action).model_dump()
+    target = populated.get("target_id")
     return {
-        "index": action.get("index") or idx,
-        "operation_label": action.get("operation_label")
-        or (_humanize_snake_case(str(action.get("operation") or "")) or "Action"),
-        "target_label": action.get("target_label")
-        or (f"#{target}" if target is not None else "—"),
-        "summary": action.get("summary") or _derive_summary(action),
-        "status_label": action.get("status_label") or _derive_status_label(action),
+        "index": populated.get("index") or idx,
+        "operation_label": populated["operation_label"],
+        "target_label": populated["target_label"],
+        "summary": populated["summary"],
+        "status_label": populated["status_label"],
         # Pass through the underlying fields so RESULT.actions replacement
         # preserves shape (the server's ActionResults carry these too).
-        "operation": action.get("operation"),
+        "operation": populated.get("operation"),
         "target_id": target,
-        "succeeded": action.get("succeeded"),
-        "verified": action.get("verified"),
-        "error": action.get("error"),
+        "succeeded": populated.get("succeeded"),
+        "verified": populated.get("verified"),
+        "error": populated.get("error"),
     }
 
 
@@ -7114,13 +7352,17 @@ def _legacy_action(response: dict[str, Any]) -> dict[str, Any] | None:
     The legacy single-action response carries top-level ``operation`` +
     ``changes`` (instead of an ``actions`` list). Wrap it as one synthetic
     action so both card builders flow through the same row builder.
+
+    Returns a partial dict (``summary`` / ``operation_label`` / etc.
+    omitted); ``_action_to_row`` round-trips it through ``ActionResult``
+    so the validator populates the same content-rich derived fields the
+    multi-action path receives from the dispatcher.
     """
     legacy_changes = response.get("changes") or []
     legacy_op = response.get("operation") or ""
     if not legacy_op and not legacy_changes:
         return None
     is_preview = bool(response.get("is_preview"))
-    n = len(legacy_changes)
     return {
         "operation": legacy_op,
         "target_id": response.get("entity_id"),
@@ -7128,8 +7370,6 @@ def _legacy_action(response: dict[str, Any]) -> dict[str, Any] | None:
         "succeeded": None if is_preview else True,
         "verified": None,
         "error": None,
-        "status_label": "PLANNED" if is_preview else "APPLIED",
-        "summary": f"{n} field(s) changed" if n else "—",
     }
 
 
@@ -7199,8 +7439,11 @@ def build_modification_preview_ui(
 
     with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
-            title_suffix = f" — {n_actions} action(s)" if n_actions > 0 else ""
-            CardTitle(content=f"{verb_label} {entity_type_label}{title_suffix}")
+            # Pre-#card-ux the title carried a "— N action(s)" suffix; the
+            # action count is now a column count in the DataTable below,
+            # which is where it belongs (anti-pattern #4: abstract counts in
+            # titles drown the entity identity that anchors the operator).
+            CardTitle(content=f"{verb_label} {entity_type_label}")
             entity_id = response.get("entity_id")
             if entity_id is not None:
                 Badge(label=f"#{entity_id}", variant="outline")
@@ -7243,11 +7486,10 @@ def build_modification_preview_ui(
                 with Else():
                     Muted(content="This is a preview. No changes have been made.")
 
-            confirm_label = (
-                f"Confirm {n_actions} action(s)" if n_actions > 1 else "Confirm Changes"
-            )
+            # ``Confirm Changes`` reads cleanly regardless of action count;
+            # the per-action breakdown is already visible in the table above.
             _render_apply_button_row(
-                confirm_label=confirm_label,
+                confirm_label="Confirm Changes",
                 apply_action=apply_action,
                 cancel_action=cancel_action,
                 disabled=bool(block_warnings),
@@ -7351,7 +7593,11 @@ def build_item_mutation_ui(
                 Badge(label=str(item["type"]), variant="secondary")
 
         with CardContent(), Column(gap=2):
-            Text(content=f"ID: {item.get('id', 'N/A')}")
+            # Pre-#card-ux this card led with ``"ID: <numeric id>"`` —
+            # anti-pattern #2 (raw IDs as the primary surface). The
+            # Name + SKU lines below carry the user-facing identity;
+            # the numeric id is still available in the structured tool
+            # result for programmatic follow-ups.
             Text(content=f"Name: {item.get('name', 'N/A')}")
             if item.get("sku"):
                 Text(content=f"SKU: {item['sku']}")
@@ -7486,13 +7732,26 @@ def build_receipt_ui(
             )
             if response.get("status"):
                 Text(content=f"PO Status: {response['status']}")
-            if response.get("supplier_id"):
-                name = response.get("supplier_name")
-                Text(
-                    content=f"Supplier: {name} (ID: {response['supplier_id']})"
-                    if name
-                    else f"Supplier ID: {response['supplier_id']}"
-                )
+            # Pre-#card-ux the supplier line manually built
+            # ``"Supplier: <name> (ID: <id>)"``, bypassing
+            # ``_render_party_line``. Using the helper picks up the
+            # Katana web Link decoration for free and routes the
+            # name-resolution fallback through the documented path.
+            _render_party_line(
+                "Supplier",
+                name=response.get("supplier_name"),
+                entity_id=response.get("supplier_id"),
+                entity_kind="supplier",
+            )
+            # Receiving location: shows where the goods physically land.
+            # Pre-#card-ux the receipt card surfaced no Location at all —
+            # the operator confirming a receipt couldn't tell which
+            # warehouse they were committing inventory into.
+            _render_party_line(
+                "Location",
+                name=response.get("location_name"),
+                entity_id=response.get("location_id"),
+            )
             if response.get("total_cost") is not None:
                 Metric(
                     label="PO Total",
@@ -7882,11 +8141,20 @@ def build_batch_recipe_update_ui(
         f"the batch recipe update ({total} planned operation(s))"
     )
 
+    # The pre-#card-ux table carried a separate "Row ID" column rendering
+    # the raw ``recipe_row_id`` (or "(new)"). That ID has no user value —
+    # the ``Action`` column already says ADD/UPDATE/DELETE which captures
+    # the new-vs-existing distinction the integer was standing in for —
+    # and the structured response carries the ID for any programmatic
+    # follow-up. The ``MO`` column still surfaces ``manufacturing_order_id``
+    # as a per-row anchor; resolving it to the MO's order_no via the
+    # typed cache is a follow-up (CachedManufacturingOrder lookup at the
+    # response builder, similar to how customer_name is resolved for
+    # the fulfill card).
     columns = [
         DataTableColumn(key="group", header="Group", sortable=True),
         DataTableColumn(key="mo_id", header="MO", sortable=True),
         DataTableColumn(key="action", header="Action"),
-        DataTableColumn(key="row_id", header="Row ID"),
         DataTableColumn(key="item", header="Item"),
         DataTableColumn(key="sku", header="SKU"),
         DataTableColumn(key="qty", header="Qty", align="right"),

--- a/katana_mcp_server/tests/browser/test_modification_render.py
+++ b/katana_mcp_server/tests/browser/test_modification_render.py
@@ -60,8 +60,16 @@ class TestModificationCardRender:
         assert frame.locator("table").count() == 1
         # Header + 12 action rows.
         assert frame.locator("table tr").count() == 13
-        # Every action shows PLANNED (none have been applied yet).
-        assert frame.locator("td").filter(has_text="PLANNED").count() == 12
+        # Every action shows PLANNED (none have been applied yet). Use a
+        # regex anchored to whole-cell content — the post-#card-ux
+        # content-rich summary cell ("added: variant_id,
+        # planned_quantity_per_unit, notes") would otherwise match the
+        # case-insensitive substring "planned" inside the field name.
+        import re
+
+        assert (
+            frame.locator("td").filter(has_text=re.compile(r"^PLANNED$")).count() == 12
+        )
 
     def test_modify_twelve_actions_applied_renders(self, render_scenario):
         """Result card after a successful apply: all 12 rows APPLIED."""
@@ -476,8 +484,14 @@ class TestModificationCardRender:
         frame = render_scenario("modify_mo_12_actions_preview")
 
         # Pre-state: 12 PLANNED actions, Confirm button visible, neither
-        # post-apply primary visible.
-        assert frame.locator("td").filter(has_text="PLANNED").count() == 12
+        # post-apply primary visible. Whole-cell regex to avoid matching
+        # the content-rich summary cell's "planned_quantity_per_unit"
+        # field-name substring (case-insensitive partial would catch it).
+        import re
+
+        assert (
+            frame.locator("td").filter(has_text=re.compile(r"^PLANNED$")).count() == 12
+        )
         assert frame.locator("button").filter(has_text="Confirm").first.is_visible()
         assert frame.locator("button").filter(has_text="View in Katana").count() == 0
         # Use exact-match locator for "Applied" to avoid matching the

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -1379,11 +1379,14 @@ class TestBuildInventoryCheckUI:
         column_keys = [c.get("key") for c in tables[0].get("columns", [])]
         assert "reorder_point" in column_keys
         assert "status_label" in column_keys
-        # ``location_id`` must be present as an always-rendered fallback
-        # for the multi-location case where ``location_name`` may be
-        # ``None`` on a cache miss — without it the row is unidentifiable.
-        assert "location_id" in column_keys, (
-            f"Per-location table must keep location_id as a fallback identifier; "
+        # Post-#card-ux: ``location_id`` is NOT a visible column. The
+        # raw ID had no user value (anti-pattern #2); rows where
+        # ``location_name`` resolves null should be fixed impl-side
+        # (typed cache + ``resolve_entity_name``), not patched with a
+        # fallback ID column. Pre-#card-ux comment: "location_id is an
+        # always-rendered fallback so rows are never unidentifiable."
+        assert "location_id" not in column_keys, (
+            f"Per-location table must drop the raw location_id column; "
             f"got columns {column_keys!r}"
         )
         # Ensure the builder annotated the rows in state with status_label
@@ -2104,11 +2107,29 @@ class TestBuildMOCreateUI:
             confirm_tool="create_manufacturing_order",
         )
         rendered = str(app.to_json())
-        # MO carries the variant in tier 3 as "Variant: WIDGET-42 (ID: 555)"
-        assert "WIDGET-42" in rendered
-        assert "555" in rendered
+        # Post-#card-ux: variant line surfaces SKU only (no "(ID: 555)"
+        # parenthetical) when SKU is resolved — variant_id is a wire
+        # identifier with no user value (anti-pattern #2). The SKU
+        # itself, ``WIDGET-42``, IS the user-facing identifier.
+        assert "Variant: WIDGET-42" in rendered
         # Deadline metric uses the date portion only.
         assert "2026-06-01" in rendered
+
+    def test_variant_id_only_renders_when_sku_missing(self):
+        """SKU-less variants (legacy NetSuite imports — CLAUDE.md
+        ``Variants can have null SKUs``) fall back to ``"Variant ID:
+        <id>"`` so the row stays identifiable. Confirmed by SKU-bearing
+        rows above, which must NOT carry the ID parenthetical."""
+        response = dict(self._MO_RESPONSE)
+        response["sku"] = None
+        app = build_mo_create_ui(
+            response,
+            confirm_request=_StubRequest(),
+            confirm_tool="create_manufacturing_order",
+        )
+        rendered = str(app.to_json())
+        # SKU is None → fall back path emits "Variant ID: 555".
+        assert "Variant ID: 555" in rendered
 
     def test_uses_order_no_field_not_order_number(self):
         """MO response uses ``order_no``; verify the badge reads that
@@ -5653,6 +5674,222 @@ class TestBuildFulfillUI:
         assert state["fulfilled_rows"][0]["batch_summary"] == "batch 42x30, batch 51x20"
 
     # ------------------------------------------------------------------
+    # Tier 3 reference block (#card-ux): customer + addresses + picked
+    # ------------------------------------------------------------------
+
+    def _so_response_with_reference(
+        self,
+        *,
+        billing_address: dict[str, Any] | None = None,
+        picked_date: str | None = "2026-05-08T23:14:00+00:00",
+    ) -> dict[str, Any]:
+        response = self._so_response()
+        response["customer_id"] = 1500
+        response["customer_name"] = "Acme Bikes Inc."
+        response["shipping_address"] = {
+            "entity_type": "shipping",
+            "first_name": "Sarah",
+            "last_name": "Johnson",
+            "company": "Acme Bikes Inc.",
+            "line_1": "123 Main Street",
+            "line_2": "Suite 4B",
+            "city": "Portland",
+            "state": "OR",
+            "zip": "97201",
+            "country": "US",
+            "phone": "+1-503-555-0123",
+        }
+        response["billing_address"] = billing_address
+        response["picked_date"] = picked_date
+        return response
+
+    def test_preview_renders_customer_party_line_with_name(self):
+        """The fulfill card surfaces ``customer_name`` as a Link to the
+        Katana customer page — not a bare ``Customer ID: <id>`` line.
+        Pinned for the #card-ux user-centric content rule: the operator
+        must be able to see *who* the shipment goes to without consulting
+        the raw response or the Katana web UI."""
+        envelope = build_fulfill_preview_ui(
+            self._so_response_with_reference()
+        ).to_json()
+        links = _find_components_by_type(envelope, "Link")
+        link_contents = [link.get("content") for link in links]
+        assert "Acme Bikes Inc." in link_contents, (
+            f"Expected Customer name 'Acme Bikes Inc.' to render as a Link "
+            f"(party-line helper); got Link contents {link_contents!r}"
+        )
+
+    def test_preview_renders_shipping_address_block(self):
+        """``_render_address_block`` composes a multi-line block from the
+        SalesOrderAddress dict — recipient, company, street, locality,
+        country/phone — so the operator confirms shipment destination
+        in human terms, not by clicking through to the Katana UI."""
+        envelope = build_fulfill_preview_ui(
+            self._so_response_with_reference()
+        ).to_json()
+        texts = _find_components_by_type(envelope, "Text")
+        contents = [t.get("content", "") for t in texts]
+        assert any("Shipping Address" in c for c in contents)
+        # Recipient + locality + country should all appear in the rendered
+        # block per ``_render_address_block``'s composition rules.
+        assert any("Sarah Johnson" in c for c in contents)
+        assert any("Portland" in c for c in contents)
+        assert any("OR 97201" in c for c in contents)
+
+    def test_preview_omits_billing_block_when_equal_to_shipping(self):
+        """``_fetch_so_addresses`` returns ``billing=None`` when the two
+        addresses are equivalent — the card must not render a duplicate
+        Billing Address block. Pinned for the dedup rule that mirrors
+        ``_render_customer_entity_view``."""
+        envelope = build_fulfill_preview_ui(
+            self._so_response_with_reference(billing_address=None)
+        ).to_json()
+        contents = [
+            t.get("content", "") for t in _find_components_by_type(envelope, "Text")
+        ]
+        assert not any("Billing Address" in c for c in contents), (
+            "Billing Address block must be hidden when impl-side dedup "
+            "found it equivalent to shipping."
+        )
+
+    def test_preview_card_side_dedup_when_impl_passes_equivalent_addresses(self):
+        """Defense-in-depth: when a caller bypasses ``_fetch_so_addresses``
+        (older payload, direct UI call) and supplies both shipping +
+        billing as equivalent dicts, the card MUST still dedup. Pre-fix
+        the card unconditionally rendered the billing block whenever the
+        field was truthy — Copilot caught this on PR #861."""
+        response = self._so_response_with_reference()
+        # Equivalent dicts that the impl-side dedup would have collapsed
+        # but the response carried through unchanged.
+        equivalent_billing = dict(response["shipping_address"])
+        equivalent_billing["entity_type"] = "billing"
+        response["billing_address"] = equivalent_billing
+        envelope = build_fulfill_preview_ui(response).to_json()
+        contents = [
+            t.get("content", "") for t in _find_components_by_type(envelope, "Text")
+        ]
+        assert not any("Billing Address" in c for c in contents), (
+            "Card must dedup an equivalent billing block even when the "
+            "impl side passed both addresses through unchanged."
+        )
+
+    def test_preview_renders_billing_block_when_different(self):
+        """When billing differs from shipping the card renders both
+        blocks so the operator sees the discrepancy (rare, but it happens
+        for net-30 customers whose AP department is at a different
+        address than the receiving location)."""
+        billing = {
+            "entity_type": "billing",
+            "first_name": "Accounts",
+            "last_name": "Payable",
+            "company": "Acme Bikes Inc.",
+            "line_1": "999 Finance Ave",
+            "city": "Beaverton",
+            "state": "OR",
+            "zip": "97005",
+            "country": "US",
+        }
+        envelope = build_fulfill_preview_ui(
+            self._so_response_with_reference(billing_address=billing)
+        ).to_json()
+        contents = [
+            t.get("content", "") for t in _find_components_by_type(envelope, "Text")
+        ]
+        assert any("Billing Address" in c for c in contents)
+        assert any("Beaverton" in c for c in contents)
+
+    def test_preview_renders_picked_date_metric(self):
+        """Pre-#card-ux the picked_date lived in an ``inventory_updates``
+        text blob; #card-ux promotes it to a Tier-2 Metric so the
+        operator sees *when* this fulfillment counts at eye level."""
+        envelope = build_fulfill_preview_ui(
+            self._so_response_with_reference()
+        ).to_json()
+        metrics = _find_components_by_type(envelope, "Metric")
+        picked = next((m for m in metrics if m.get("label") == "Picked"), None)
+        assert picked is not None, (
+            f"Expected a 'Picked' Metric; got labels "
+            f"{[m.get('label') for m in metrics]!r}"
+        )
+        assert picked.get("value") == "2026-05-08T23:14:00+00:00"
+
+    def test_preview_omits_picked_metric_when_unset(self):
+        """No ``picked_date`` on the response (caller didn't pass
+        ``completed_at``) → server-stamps at apply time → no Picked
+        Metric on the card."""
+        envelope = build_fulfill_preview_ui(
+            self._so_response_with_reference(picked_date=None)
+        ).to_json()
+        labels = [m.get("label") for m in _find_components_by_type(envelope, "Metric")]
+        assert "Picked" not in labels
+
+    def test_mo_card_skips_customer_and_address_block(self):
+        """Manufacturing orders have no customer and no shipping address
+        (the work happens at a single location). The MO branch of the
+        fulfill card must skip the Tier-3 reference block entirely —
+        a Customer party-line would be nonsense, and a missing-shipping
+        warning would create noise. Pinned by ``order_type`` discriminator
+        in ``_render_fulfill_reference_block``."""
+        response = {
+            "order_type": "manufacturing",
+            "order_number": "MO-001",
+            "order_id": 456,
+            "status": "IN_PROGRESS",
+            "is_preview": True,
+            "rows_count": 1,
+            "total_quantity": 1.0,
+            "total_value": None,
+            "customer_id": None,
+            "customer_name": None,
+            "shipping_address": None,
+            "billing_address": None,
+            "fulfilled_rows": [
+                {
+                    "row_id": None,
+                    "variant_id": 555,
+                    "sku": "FG-001",
+                    "display_name": "Finished Good",
+                    "quantity": 1.0,
+                    "serial_numbers": [],
+                    "batch_summary": None,
+                    "price_per_unit": None,
+                    "row_total": None,
+                    "currency": None,
+                }
+            ],
+        }
+        envelope = build_fulfill_preview_ui(response).to_json()
+        contents = [
+            t.get("content", "") for t in _find_components_by_type(envelope, "Text")
+        ]
+        assert not any("Shipping Address" in c for c in contents)
+        assert not any("Customer:" in c for c in contents)
+
+    def test_preview_does_not_dump_inventory_updates(self):
+        """Pre-#card-ux the preview card listed every row twice — once
+        as a Muted text dump (``Row 108854645: ship 1 of …``) and once
+        as a DataTable. The dump is gone; the DataTable carries all the
+        structured columns. Pinned so a future re-introduction of the
+        dump (e.g. accidentally adding ``_render_inventory_updates`` back)
+        breaks the build."""
+        response = self._so_response_with_reference()
+        # Even if the response carries inventory_updates strings (back-compat),
+        # the card must NOT render them above the per-row DataTable.
+        response["inventory_updates"] = [
+            "Row 501: ship 5 of WIDGET-100 (full ordered quantity)",
+            "Row 502: ship 2 of WIDGET-200 (full ordered quantity)",
+        ]
+        envelope = build_fulfill_preview_ui(response).to_json()
+        contents = [
+            t.get("content", "") for t in _find_components_by_type(envelope, "Text")
+        ]
+        for line in response["inventory_updates"]:
+            assert all(line not in c for c in contents), (
+                f"Inventory-updates dump line {line!r} must not appear "
+                f"as Text on the preview card (it duplicates the DataTable)."
+            )
+
+    # ------------------------------------------------------------------
     # Tier 4 success-side actions
     # ------------------------------------------------------------------
 
@@ -8675,11 +8912,145 @@ class TestBuildModificationPreviewUI:
             f"delete_item card title must start with 'Delete'; got {titles!r}"
         )
 
-    def test_title_action_count_suffix_uses_n_actions(self):
-        """The action-count suffix must be present whenever there's at
-        least one planned action, including the legacy single-action
-        shape (where ``actions`` is empty but ``changes`` is populated).
-        Closes Copilot review finding.
+    def test_single_change_summary_renders_old_to_new(self):
+        """Post-#card-ux ``_derive_summary`` projects a single
+        ``FieldChange`` to the inline ``"<field>: <old> → <new>"`` form
+        — content-rich, not a "1 field changed" count. Pinned for
+        anti-pattern #4 absence."""
+        response = _modification_preview_response(
+            actions=[
+                {
+                    "operation": "update_header",
+                    "target_id": 42,
+                    "changes": [
+                        {
+                            "field": "status",
+                            "old": "DRAFT",
+                            "new": "ACTIVE",
+                            "is_added": False,
+                            "is_unchanged": False,
+                            "is_unknown_prior": False,
+                        }
+                    ],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                }
+            ],
+        )
+        app = build_modification_preview_ui(
+            response,
+            confirm_request=_ModifyStubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        envelope = app.to_json()
+        plan_rows = envelope["state"]["plan_actions"]
+        assert len(plan_rows) == 1
+        assert plan_rows[0]["summary"] == "status: DRAFT → ACTIVE", (
+            f"Single-change summary must inline old → new; got "
+            f"{plan_rows[0]['summary']!r}"
+        )
+
+    def test_multi_change_summary_lists_field_names(self):
+        """Multi-field changes surface the field names (truncated +
+        ``(+N more)`` for long lists) instead of an abstract count.
+        Pinned for anti-pattern #4 absence."""
+        response = _modification_preview_response(
+            actions=[
+                {
+                    "operation": "update_header",
+                    "target_id": 42,
+                    "changes": [
+                        {
+                            "field": f"field_{i}",
+                            "old": "a",
+                            "new": "b",
+                            "is_added": False,
+                            "is_unchanged": False,
+                            "is_unknown_prior": False,
+                        }
+                        for i in range(5)
+                    ],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                }
+            ],
+        )
+        app = build_modification_preview_ui(
+            response,
+            confirm_request=_ModifyStubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        envelope = app.to_json()
+        plan_rows = envelope["state"]["plan_actions"]
+        # First three names render inline; the rest collapse to "(+N more)".
+        assert "field_0" in plan_rows[0]["summary"]
+        assert "field_1" in plan_rows[0]["summary"]
+        assert "field_2" in plan_rows[0]["summary"]
+        assert "(+2 more)" in plan_rows[0]["summary"]
+        # The pre-#card-ux "N field(s) changed" form must NOT appear.
+        assert "field(s) changed" not in plan_rows[0]["summary"]
+
+    def test_confirm_label_is_constant_not_action_count(self):
+        """Confirm button reads ``"Confirm Changes"`` for any action
+        count — the count is column-level info, not a button label.
+        Pinned for anti-pattern #4 absence (count abstraction in the
+        primary CTA)."""
+        response = _modification_preview_response(
+            actions=[
+                {
+                    "operation": "update_header",
+                    "target_id": 42,
+                    "changes": [],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                },
+                {
+                    "operation": "update_header",
+                    "target_id": 43,
+                    "changes": [],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                },
+                {
+                    "operation": "update_header",
+                    "target_id": 44,
+                    "changes": [],
+                    "succeeded": None,
+                    "error": None,
+                    "verified": None,
+                    "actual_after": None,
+                },
+            ],
+        )
+        app = build_modification_preview_ui(
+            response,
+            confirm_request=_ModifyStubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        envelope = app.to_json()
+        buttons = _find_components_by_type(envelope, "Button")
+        labels = [b.get("label") for b in buttons]
+        assert "Confirm Changes" in labels, (
+            f"Confirm button must read 'Confirm Changes'; got {labels!r}"
+        )
+        assert not any(
+            isinstance(label, str) and "action(s)" in label for label in labels
+        ), f"No button label may include 'N action(s)'; got {labels!r}"
+
+    def test_title_omits_abstract_action_count(self):
+        """Post-#card-ux the title drops the ``"— N action(s)"`` suffix.
+        Count is column-level information (visible in the DataTable
+        below); putting it in the title was anti-pattern #4 (abstract
+        counts in identity slots). Pinned to break any future regression
+        that reintroduces the verb-count title shape.
         """
         response = _modification_preview_response(
             actions=[],
@@ -8713,8 +9084,16 @@ class TestBuildModificationPreviewUI:
                     collect_titles(v)
 
         collect_titles(envelope)
-        assert any("1 action(s)" in t for t in titles), (
-            f"Legacy single-action title must include the count suffix; got {titles!r}"
+        # Title must read clean — entity type only, no abstract count.
+        # ``_modification_preview_response`` uses entity_type="product";
+        # ``confirm_tool="modify_purchase_order"`` only drives the verb
+        # (``_verb_label`` reads the leading token), so the rendered title
+        # is "Modify Product".
+        assert any("Modify Product" in t for t in titles), (
+            f"Title should carry the verb + entity type; got {titles!r}"
+        )
+        assert not any("action(s)" in t for t in titles), (
+            f"Title must not include 'N action(s)' abstract suffix; got {titles!r}"
         )
 
     def test_twelve_action_mixed_plan_renders_single_state_bound_table(self):
@@ -8800,10 +9179,16 @@ class TestBuildModificationPreviewUI:
         assert [r["index"] for r in plan_rows] == list(range(1, 13))
         assert all(r["status_label"] == "PLANNED" for r in plan_rows)
 
-        # Adds have target_label "—", deletes have "#<id>".
+        # Adds have target_label "—", deletes have "#<id>". Summary text
+        # is the post-#card-ux content-rich form: add operations list
+        # the field names being set (anti-pattern #4 — count alone was
+        # uninformative); deletes use the neutral "deleted" verb.
         for r in plan_rows[:6]:
             assert r["target_label"] == "—"
-            assert "field(s) set" in r["summary"]
+            # The "added: <field>, <field>, ..." shape replaces the old
+            # "N field(s) set" count summary.
+            assert r["summary"].startswith("added: ")
+            assert "variant_id" in r["summary"]
         for r in plan_rows[6:]:
             assert r["target_label"].startswith("#")
             assert r["summary"] == "deleted"

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -2699,7 +2699,9 @@ async def test_update_stock_adjustment_skips_echo_when_existing_is_empty():
 
 @pytest.mark.asyncio
 async def test_update_stock_adjustment_caller_explicit_additional_info_wins():
-    """Caller-supplied additional_info wins; no pre-fetch needed (saves a round trip)."""
+    """Caller-supplied additional_info wins on the PATCH body — even though
+    the impl always pre-fetches the prior SA (now used to populate
+    ``prior_state`` for the card's Before column, review item #4)."""
     context, _ = create_mock_context()
 
     updated = _make_mock_adjustment(id=42, additional_info="new notes")
@@ -2708,8 +2710,14 @@ async def test_update_stock_adjustment_caller_explicit_additional_info_wins():
         id=42, additional_info="new notes", preview=False
     )
 
+    # Pre-fetch returns an SA with the OLD additional_info — the impl
+    # must NOT use it to override the caller's explicit "new notes".
+    prior_mock_response = MagicMock(
+        status_code=200,
+        parsed=MagicMock(data=[_make_mock_adjustment(id=42, additional_info="old")]),
+    )
     update_mock = AsyncMock(return_value=MagicMock())
-    fetch_mock = AsyncMock()
+    fetch_mock = AsyncMock(return_value=prior_mock_response)
     with (
         patch(f"{_SA_GET_ALL}.asyncio_detailed", new=fetch_mock),
         patch(f"{_SA_UPDATE}.asyncio_detailed", new=update_mock),
@@ -2719,7 +2727,6 @@ async def test_update_stock_adjustment_caller_explicit_additional_info_wins():
 
     body = update_mock.call_args.kwargs["body"]
     assert body.additional_info == "new notes"
-    fetch_mock.assert_not_awaited()  # No pre-fetch when caller supplied the field
 
 
 @pytest.mark.asyncio
@@ -2752,6 +2759,53 @@ async def test_update_stock_adjustment_pre_fetch_failure_is_best_effort():
     # The user's update lands even though the pre-fetch failed.
     assert result.is_preview is False
     update_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_stock_adjustment_preview_populates_prior_state():
+    """Preview fetches the existing SA so the card's Before column shows
+    what the operator is changing from. prior_state carries the same
+    field names the diff card reads (review item #4 — pre-fix every
+    Before cell rendered "(prior unknown)" because the impl never fetched).
+    location_name resolution lands on prior_state so the Before/After
+    diff compares resolved name against resolved name (review item #10).
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    from katana_public_api_client.models_pydantic._generated import CachedLocation
+
+    # The cache resolves the prior location to "Warehouse A".
+    cached_loc = CachedLocation(id=99, name="Warehouse A")
+
+    async def _get_by_id(cls, entity_id, **_kw):
+        if cls is CachedLocation and entity_id == 99:
+            return cached_loc
+        return None
+
+    lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(side_effect=_get_by_id)
+
+    prior_sa = _make_mock_adjustment(
+        id=42,
+        stock_adjustment_number="SA-OLD",
+        location_id=99,
+        reason="old reason",
+        additional_info="old notes",
+    )
+    fetch_mock = AsyncMock(
+        return_value=MagicMock(status_code=200, parsed=MagicMock(data=[prior_sa]))
+    )
+
+    request = UpdateStockAdjustmentParams(id=42, reason="new reason", preview=True)
+    with patch(f"{_SA_GET_ALL}.asyncio_detailed", new=fetch_mock):
+        result = await _update_stock_adjustment_impl(request, context)
+
+    assert result.is_preview is True
+    assert result.prior_state is not None
+    assert result.prior_state["stock_adjustment_number"] == "SA-OLD"
+    assert result.prior_state["location_id"] == 99
+    assert result.prior_state["location_name"] == "Warehouse A"
+    assert result.prior_state["reason"] == "old reason"
+    assert result.prior_state["additional_info"] == "old notes"
 
 
 # ============================================================================
@@ -2867,10 +2921,11 @@ async def test_check_inventory_zero_stock_returns_empty_by_location():
 
 
 @pytest.mark.asyncio
-async def test_check_inventory_location_name_falls_back_to_none_on_cache_miss():
+async def test_check_inventory_location_name_falls_back_to_id_on_cache_miss():
     """If the cache doesn't have the location (cold cache, lag, etc.),
-    `location_name` is None — the location_id alone is still useful and
-    cache lag shouldn't block the inventory lookup."""
+    ``location_name`` falls back to ``"Location {id}"`` so the card's
+    Location cell is never blank (review item #14 — the cards dropped
+    the raw-ID fallback column post-#card-ux; impl owns the fallback)."""
     context, lifespan_ctx = create_mock_context()
     lifespan_ctx.typed_cache.catalog.get_by_sku = AsyncMock(
         return_value={"id": 3001, "sku": "WIDGET-001", "display_name": "Test Widget"}
@@ -2894,7 +2949,7 @@ async def test_check_inventory_location_name_falls_back_to_none_on_cache_miss():
 
     assert len(results[0].by_location) == 1
     assert results[0].by_location[0].location_id == 999999
-    assert results[0].by_location[0].location_name is None
+    assert results[0].by_location[0].location_name == "Location 999999"
     assert results[0].by_location[0].in_stock == 5.0
 
 

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -68,7 +68,15 @@ async def test_create_manufacturing_order_preview():
     assert result.id is None
     assert "preview" in result.message.lower()
     assert len(result.next_actions) > 0
-    assert len(result.warnings) == 0  # All optional fields provided
+    # Filter out the location-resolution cache-miss advisory that #card-ux
+    # introduced — the conftest stub cache doesn't carry the location row
+    # so resolve_entity_name surfaces a "Location with id=N was not found"
+    # advisory (non-fatal, no BLOCK prefix). Real warnings come from
+    # missing optional fields; all of those are populated here.
+    non_advisory_warnings = [
+        w for w in result.warnings if not w.startswith("Location with id=")
+    ]
+    assert non_advisory_warnings == []  # All optional fields provided
 
 
 @pytest.mark.asyncio
@@ -294,10 +302,15 @@ async def test_create_manufacturing_order_missing_optional_fields():
     assert result.order_created_date is None
     assert result.production_deadline_date is None
     assert result.additional_info is None
-    # Verify warnings for missing optional fields
-    assert len(result.warnings) == 2
-    assert any("production_deadline_date" in w for w in result.warnings)
-    assert any("additional_info" in w for w in result.warnings)
+    # Verify warnings for missing optional fields. Filter out the
+    # cache-miss advisory for the location name (#card-ux); it surfaces
+    # on every test that doesn't pre-seed CachedLocation.
+    non_advisory_warnings = [
+        w for w in result.warnings if not w.startswith("Location with id=")
+    ]
+    assert len(non_advisory_warnings) == 2
+    assert any("production_deadline_date" in w for w in non_advisory_warnings)
+    assert any("additional_info" in w for w in non_advisory_warnings)
 
 
 @pytest.mark.asyncio

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -407,6 +407,98 @@ def test_render_action_block_status_labels():
         assert expected_label in md, f"missing {expected_label} for {action}"
 
 
+class TestDeriveSummary:
+    """ActionResult ``@model_validator`` populates ``summary`` via
+    :func:`_modification._derive_summary`. The post-#card-ux derivation
+    is content-rich (field names + ``old → new`` inline) — pinned here
+    against the production path (the model validator), not against a
+    duplicate dict-side helper that the prefab UI used to carry.
+    """
+
+    def test_single_change_renders_inline_old_to_new(self):
+        action = ActionResult(
+            operation="update_header",
+            target_id=42,
+            changes=[
+                FieldChange(field="status", old="DRAFT", new="ACTIVE"),
+            ],
+        )
+        assert action.summary == "status: DRAFT → ACTIVE"
+
+    def test_multi_change_surfaces_field_names_with_overflow_tail(self):
+        action = ActionResult(
+            operation="update_header",
+            target_id=42,
+            changes=[FieldChange(field=f"f{i}", old="a", new="b") for i in range(5)],
+        )
+        assert action.summary == "f0, f1, f2 (+2 more)"
+        assert "field(s) changed" not in action.summary
+
+    def test_add_operation_lists_field_names_not_count(self):
+        action = ActionResult(
+            operation="add_recipe_row",
+            target_id=None,
+            changes=[
+                FieldChange(field="variant_id", new=100, is_added=True),
+                FieldChange(field="quantity", new=2, is_added=True),
+            ],
+        )
+        assert action.summary == "added: variant_id, quantity"
+        assert "field(s) set" not in action.summary
+
+    def test_delete_operation_summary(self):
+        action = ActionResult(operation="delete_recipe_row", target_id=5)
+        assert action.summary == "deleted"
+
+    def test_unknown_prior_renders_with_explicit_marker_not_em_dash(self):
+        """`is_unknown_prior` must be visually distinct from a `None`
+        prior value. Otherwise the operator can't tell whether the
+        field was blank or just unresolvable."""
+        action = ActionResult(
+            operation="update_addresses",
+            target_id=42,
+            changes=[
+                FieldChange(
+                    field="line_1",
+                    old=None,
+                    new="123 Main St",
+                    is_unknown_prior=True,
+                ),
+            ],
+        )
+        assert action.summary == "line_1: (prior unknown) → 123 Main St"
+        # The em-dash must NOT appear — it would mean "the field was blank
+        # before" which is a different statement than "we don't know".
+        assert "—" not in action.summary
+
+    def test_no_changes_renders_em_dash(self):
+        action = ActionResult(operation="update_header", target_id=42, changes=[])
+        assert action.summary == "—"
+
+    def test_all_unchanged_renders_no_change(self):
+        action = ActionResult(
+            operation="update_header",
+            target_id=42,
+            changes=[
+                FieldChange(
+                    field="status", old="DRAFT", new="DRAFT", is_unchanged=True
+                ),
+            ],
+        )
+        assert action.summary == "no change"
+
+    def test_validator_does_not_overwrite_explicit_summary(self):
+        """A caller-supplied summary string wins over the derived one —
+        the validator only fills when ``summary`` is empty."""
+        action = ActionResult(
+            operation="update_header",
+            target_id=42,
+            changes=[FieldChange(field="status", old="A", new="B")],
+            summary="custom note",
+        )
+        assert action.summary == "custom note"
+
+
 def test_render_includes_prior_state_block_when_set():
     response = ModificationResponse(
         entity_type="purchase_order",

--- a/katana_mcp_server/tests/tools/test_orders.py
+++ b/katana_mcp_server/tests/tools/test_orders.py
@@ -293,12 +293,15 @@ async def test_fulfill_sales_order_preview():
     assert result.order_number == "SO-001"
     assert result.status == "NOT_SHIPPED"
     assert result.is_preview is True
-    # Preview now lists the rows that will ship — one entry per SO row.
-    # On cold cache (no display_name resolved) the line falls back to the
-    # ``variant {id}`` sentinel, same as the legacy contract.
-    assert len(result.inventory_updates) == 2
-    assert any("variant 100" in u for u in result.inventory_updates)
-    assert any("variant 200" in u for u in result.inventory_updates)
+    # Per-row identity now flows through ``fulfilled_rows`` (the Tier-3
+    # DataTable on the card) — the pre-#card-ux ``inventory_updates``
+    # text dump duplicated the same data row-for-row, was the source of
+    # the user-cited card redundancy, and is now intentionally empty on
+    # the SO branch. Cold-cache rows surface variant_id without a
+    # display_name; the row entry is still emitted.
+    assert result.inventory_updates == []
+    assert len(result.fulfilled_rows) == 2
+    assert {row.variant_id for row in result.fulfilled_rows} == {100, 200}
     # Last next_action should mention preview=false.
     assert any("preview=false" in a for a in result.next_actions)
 
@@ -358,10 +361,15 @@ async def test_fulfill_sales_order_preview_lifts_display_name():
     request = FulfillOrderRequest(order_id=5678, order_type="sales", preview=True)
     result = await _fulfill_order_impl(request, context)
 
-    # Both lines lead with the canonical display name (parent / config1).
-    assert len(result.inventory_updates) == 2
-    assert any("Big Widget / Red" in u for u in result.inventory_updates)
-    assert any("Small Widget / Blue" in u for u in result.inventory_updates)
+    # Per-row display_name now lands on ``fulfilled_rows[i].display_name``
+    # (the structured data feeding the Tier-3 DataTable on the card) —
+    # the legacy ``inventory_updates`` text dump that previously carried
+    # the canonical Katana-UI display name was removed because it
+    # duplicated the table one row at a time and exposed internal row IDs
+    # the operator doesn't care about.
+    display_names = [row.display_name for row in result.fulfilled_rows]
+    assert "Big Widget / Red" in display_names
+    assert "Small Widget / Blue" in display_names
 
 
 @pytest.mark.asyncio
@@ -732,7 +740,222 @@ async def test_fulfill_sales_order_preview_accepts_serial_override():
     result = await _fulfill_order_impl(request, context)
 
     assert not [w for w in result.warnings if w.startswith("BLOCK:")]
-    assert any("serials [501]" in u for u in result.inventory_updates)
+    # Per-row serial overrides now flow through ``fulfilled_rows[i].serial_numbers``
+    # (the structured Tier-3 payload that drives the DataTable's Serials
+    # column). Pre-#card-ux the serial overrides were dumped into
+    # ``inventory_updates`` as ``"with serials [501]"`` text — gone with
+    # the rest of the redundant text dump.
+    serials_by_row = {row.row_id: row.serial_numbers for row in result.fulfilled_rows}
+    assert serials_by_row.get(1) == [501]
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_preview_surfaces_customer_and_addresses():
+    """The fulfill card needs Customer name + Shipping/Billing addresses
+    to answer the operator's question "who is this for and where does
+    it go?" (#card-ux). The impl resolves the customer name via the
+    typed cache and fetches addresses from the ``/sales_order_addresses``
+    sub-resource (raw ``GET /sales_orders/{id}`` does NOT inline them) —
+    with billing deduped against shipping when they're equivalent."""
+    from katana_public_api_client.models import SalesOrderAddress
+    from katana_public_api_client.models.address_entity_type import AddressEntityType
+    from katana_public_api_client.models_pydantic._generated import CachedCustomer
+
+    context, lifespan_ctx = create_mock_context()
+
+    # Address rows come from a SEPARATE /sales_order_addresses fetch
+    # (review item #3) — the raw GET /sales_orders/{id} response does not
+    # inline addresses. Mock the sub-resource endpoint so the production
+    # flow that _fulfill_sales_order actually exercises is covered.
+    ship_addr = MagicMock(spec=SalesOrderAddress)
+    ship_addr.entity_type = AddressEntityType.SHIPPING
+    ship_addr.to_dict = lambda: {
+        "entity_type": "shipping",
+        "first_name": "Sarah",
+        "last_name": "Johnson",
+        "company": "Acme Bikes Inc.",
+        "line_1": "123 Main Street",
+        "city": "Portland",
+        "state": "OR",
+        "zip": "97201",
+        "country": "US",
+    }
+    bill_addr = MagicMock(spec=SalesOrderAddress)
+    bill_addr.entity_type = AddressEntityType.BILLING
+    bill_addr.to_dict = lambda: {
+        "entity_type": "billing",
+        "first_name": "Accounts",
+        "last_name": "Payable",
+        "company": "Acme Bikes Inc.",
+        "line_1": "999 Finance Ave",
+        "city": "Beaverton",
+        "state": "OR",
+        "zip": "97005",
+        "country": "US",
+    }
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-ADDR"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 1.0)]
+    mock_so.customer_id = 1500
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+    from katana_public_api_client.api.sales_order_address import (
+        get_all_sales_order_addresses,
+    )
+
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    # /sales_order_addresses returns a list-response envelope; unwrap_data
+    # expects ``.data`` on the parsed body.
+    mock_addresses_body = MagicMock()
+    mock_addresses_body.data = [ship_addr, bill_addr]
+    mock_addresses_response = MagicMock(status_code=200, parsed=mock_addresses_body)
+    cast(Any, get_all_sales_order_addresses).asyncio_detailed = AsyncMock(
+        return_value=mock_addresses_response
+    )
+
+    cached_customer = CachedCustomer(
+        id=1500,
+        name="Acme Bikes Inc.",
+        email="orders@acmebikes.example",
+    )
+
+    async def _get_many(cls, ids, **_kw):
+        if cls is CachedCustomer and 1500 in set(ids):
+            return {1500: cached_customer}
+        return {}
+
+    async def _get_by_id(cls, entity_id, **_kw):
+        # ``resolve_entity_name`` reads via ``get_by_id`` (not
+        # ``get_many_by_ids``); the rest of the SO fulfill impl uses
+        # ``get_many_by_ids`` for batched variant lookups. Wire both.
+        if cls is CachedCustomer and entity_id == 1500:
+            return cached_customer
+        return None
+
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(side_effect=_get_many)
+    lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(side_effect=_get_by_id)
+
+    request = FulfillOrderRequest(
+        order_id=99,
+        order_type="sales",
+        preview=True,
+        completed_at=datetime(2026, 5, 8, 23, 14, tzinfo=UTC),
+    )
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.customer_id == 1500
+    assert result.customer_name == "Acme Bikes Inc."
+    assert result.shipping_address is not None
+    assert result.shipping_address["city"] == "Portland"
+    # Billing differs from shipping → both blocks carry through.
+    assert result.billing_address is not None
+    assert result.billing_address["city"] == "Beaverton"
+    # picked_date is promoted to its own response field for the Metric.
+    assert result.picked_date == "2026-05-08T23:14:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_preview_dedups_billing_address():
+    """When shipping and billing describe the same place, the impl
+    returns ``billing_address=None`` so the card doesn't render two
+    identical blocks. Pinned with ``_addresses_are_equivalent`` semantics
+    (every user-visible field matches; entity_type / timestamps are
+    excluded from comparison)."""
+    from katana_public_api_client.models import SalesOrderAddress
+    from katana_public_api_client.models.address_entity_type import AddressEntityType
+
+    context, _lifespan_ctx = create_mock_context()
+
+    shared = {
+        "first_name": "Sarah",
+        "last_name": "Johnson",
+        "company": "Acme Bikes Inc.",
+        "line_1": "123 Main Street",
+        "city": "Portland",
+        "state": "OR",
+        "zip": "97201",
+        "country": "US",
+    }
+    ship_addr = MagicMock(spec=SalesOrderAddress)
+    ship_addr.entity_type = AddressEntityType.SHIPPING
+    ship_addr.to_dict = lambda: {"entity_type": "shipping", **shared}
+    bill_addr = MagicMock(spec=SalesOrderAddress)
+    bill_addr.entity_type = AddressEntityType.BILLING
+    bill_addr.to_dict = lambda: {"entity_type": "billing", **shared}
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-DEDUP"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 1.0)]
+    mock_so.customer_id = None
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+    from katana_public_api_client.api.sales_order_address import (
+        get_all_sales_order_addresses,
+    )
+
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
+    # /sales_order_addresses returns ship + bill via the sub-resource.
+    mock_addresses_body = MagicMock()
+    mock_addresses_body.data = [ship_addr, bill_addr]
+    cast(Any, get_all_sales_order_addresses).asyncio_detailed = AsyncMock(
+        return_value=MagicMock(status_code=200, parsed=mock_addresses_body)
+    )
+
+    request = FulfillOrderRequest(order_id=100, order_type="sales", preview=True)
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.shipping_address is not None
+    assert result.billing_address is None, (
+        "Billing matches shipping field-for-field — impl must return "
+        "billing_address=None so the card doesn't render a duplicate block."
+    )
+
+
+@pytest.mark.asyncio
+async def test_fulfill_sales_order_preview_handles_addresses_endpoint_empty():
+    """When /sales_order_addresses returns no rows for the SO (caller
+    skipped the addresses fetch, transient endpoint hiccup, or a real
+    SO without addresses), the impl returns shipping_address=None /
+    billing_address=None without raising. Pinned for review item #3 —
+    the production failure mode the original MagicMock-on-so.addresses
+    test failed to cover."""
+    context, _lifespan_ctx = create_mock_context()
+
+    mock_so = MagicMock(spec=SalesOrder)
+    mock_so.order_no = "SO-NOADDR"
+    mock_so.status = SalesOrderStatus.NOT_SHIPPED
+    mock_so.sales_order_rows = [_make_so_row(1, 100, 1.0)]
+    mock_so.customer_id = None
+
+    mock_response = MagicMock(status_code=200, parsed=mock_so)
+    from katana_public_api_client.api.sales_order import get_sales_order
+    from katana_public_api_client.api.sales_order_address import (
+        get_all_sales_order_addresses,
+    )
+
+    cast(Any, get_sales_order).asyncio_detailed = AsyncMock(return_value=mock_response)
+
+    # /sales_order_addresses returns an empty data list.
+    empty_addresses_body = MagicMock()
+    empty_addresses_body.data = []
+    cast(Any, get_all_sales_order_addresses).asyncio_detailed = AsyncMock(
+        return_value=MagicMock(status_code=200, parsed=empty_addresses_body)
+    )
+
+    request = FulfillOrderRequest(order_id=101, order_type="sales", preview=True)
+    result = await _fulfill_order_impl(request, context)
+
+    assert result.shipping_address is None
+    assert result.billing_address is None
+    # No exception, no BLOCK warning — the card simply elides the Tier-3
+    # address block when no addresses come back.
+    assert not [w for w in result.warnings if w.startswith("BLOCK:")]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two-part PR landing on a single branch:

**Part 1 — `/card-review` skill (commits 1–2).** Vendors `microsoft/skills@frontend-design-review` under `.claude/skills/` and adds a project-local `/card-review` wrapper that codifies seven Prefab UI anti-patterns (redundant text dumps, IDs over names, missing reference info, abstract verbs over content, wire-shape leakage, buried decision context, helper-fallback masking) plus the named gold-standard helpers (`_render_party_line`, `_render_address_block`, `_render_field_diff_line`, etc.). The skill is the durable artifact: run `/card-review --all` after touching `prefab_ui.py` to re-audit without re-deriving the rubric.

**Part 2 — user-centric content rewrites across 10+ cards (commits 3–11).** Driven by the skill's first audit pass:

- **HIGH** — `build_fulfill_preview_ui` + `build_fulfill_success_ui` drop the redundant `_render_inventory_updates` text dump and gain a Tier-3 reference block (Customer party-line + Shipping/Billing address blocks + Picked/Completed Metric). `build_modification_preview_ui` + `build_modification_result_ui` swap the count-only "N field(s) changed" summary for content-rich `"<field>: <old> → <new>"` / `"added: <fields>"` projection that honors `FieldChange.is_unknown_prior`.
- **MEDIUM** — `build_mo_create_ui` routes variant + location through `_render_party_line`; `build_receipt_ui` gains a receiving-location block; `build_batch_recipe_update_ui` drops the raw `Row ID` column; `build_inventory_check_batch_ui` gates the `Variant ID` column on actual need; `build_stock_adjustment_update_ui` adds a `Before` column populated from a new impl-side `prior_state` fetch; `build_stock_adjustment_delete_ui` drops the raw-ID Metric for a party-line.
- **LOW** — `build_item_mutation_ui` drops the leading `ID:` line; `build_so_create_ui` / `build_stock_adjustment_create_ui` / `build_inventory_at_ui` / `_item_supplier_line` route through resolved names; inventory cards fall back to `"Location {id}"` on cache miss (no more blank cells).
- **Refusal-path consistency** — `_create_sales_order_impl` shipping-fee refusal, `_receive_purchase_order_impl` already-RECEIVED refusal, and `_create_manufacturing_order_impl` make-to-order duplicate-link refusal all now carry resolved names + cache-miss advisories alongside the BLOCK warning.

**Impl-side completeness:**
- `_fulfill_sales_order` fetches `/sales_order_addresses` (raw GET doesn't inline them) and reads server-stamped `fulfillment.picked_date`.
- `_fulfill_manufacturing_order` populates `picked_date` (preview from `completed_at`, success from `final_mo.done_date`).
- `_update_stock_adjustment_impl` pre-fetches the SA on preview to populate `prior_state` for the Before column.
- `_derive_summary` moved from `prefab_ui.py` (dead-code via `ActionResult.@model_validator`) to `_modification.py:252` where the validator actually runs.

## Test plan
- [x] `uv run poe agent-check` — green
- [x] `uv run poe test` — 1494 passed, 41 skipped
- [x] `uv run poe test-browser` — 34 passed
- [x] `uv run poe check` — full pipeline including browser-rendered Prefab tests
- [x] Self-review via `/code-review` skill — 15 findings surfaced and addressed in commits 11+
- [ ] Reviewer spot-check the fulfill_order card visually in Claude Code on a live tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)