### PR TITLE
fix(client): POST /outsourced_purchase_order_recipe_rows returns 200, not 201

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -21973,7 +21973,7 @@ paths:
             schema:
               $ref: "#/components/schemas/CreateOutsourcedPurchaseOrderRecipeRowRequest"
       responses:
-        "201":
+        "200":
           description: Outsourced purchase order recipe row created successfully
           headers:
             X-Ratelimit-Limit:

--- a/katana_public_api_client/api/purchase_orders/create_outsourced_purchase_order_recipe_row.py
+++ b/katana_public_api_client/api/purchase_orders/create_outsourced_purchase_order_recipe_row.py
@@ -38,10 +38,10 @@ def _get_kwargs(
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> DetailedErrorResponse | ErrorResponse | OutsourcedPurchaseOrderRecipeRow | None:
-    if response.status_code == 201:
-        response_201 = OutsourcedPurchaseOrderRecipeRow.from_dict(response.json())
+    if response.status_code == 200:
+        response_200 = OutsourcedPurchaseOrderRecipeRow.from_dict(response.json())
 
-        return response_201
+        return response_200
 
     if response.status_code == 400:
         response_400 = ErrorResponse.from_dict(response.json())

--- a/katana_public_api_client/docs/spec-authoring.md
+++ b/katana_public_api_client/docs/spec-authoring.md
@@ -122,19 +122,20 @@ documented status code, so when Katana actually returns 200 the parser falls thr
 `UnexpectedResponse` — *even though the mutation landed server-side*. The bug looks like
 a failure to the caller and invites a destructive retry.
 
-Verified live (`make_test_client()` probe, 2026-05-27):
+Verified live (`make_test_client()` probe, 2026-05-27 and 2026-05-28):
 
 - `POST /sales_order_fulfillments` → 200
 - `POST /stock_transfers` → 200
 - `POST /sales_return_rows` → 200
 - `POST /inventory_reorder_points` → 200
+- `POST /outsourced_purchase_order_recipe_rows` → 200
 
 Pinned by
-`tests/test_openapi_specification.py::test_create_endpoint_success_status_codes`.
+`tests/test_openapi_specification.py::test_create_endpoint_success_status_codes` and
+exercised end-to-end by `tests/test_create_endpoint_regression.py`.
 
-Not yet live-verified (test tenant has no fixtures to probe against; fix when verified):
-`POST /outsourced_purchase_order_recipe_rows` still declares 201 and is almost certainly
-the same drift.
+The full sweep is complete — every `POST` create endpoint in the spec now declares 200.
+A baseline survey at the time of the sweep found these five outliers and no others.
 
 If you genuinely encounter a Katana create endpoint that returns 201 (none confirmed to
 date), accept *both* by declaring `"200"` and `"201"` in the same `responses:` map

--- a/tests/test_create_endpoint_regression.py
+++ b/tests/test_create_endpoint_regression.py
@@ -25,6 +25,9 @@ import pytest
 
 from katana_public_api_client import KatanaClient
 from katana_public_api_client.api.inventory import create_inventory_reorder_point
+from katana_public_api_client.api.purchase_orders import (
+    create_outsourced_purchase_order_recipe_row,
+)
 from katana_public_api_client.api.sales_order_fulfillment import (
     create_sales_order_fulfillment,
 )
@@ -32,10 +35,12 @@ from katana_public_api_client.api.sales_return_row import create_sales_return_ro
 from katana_public_api_client.api.stock_transfer import create_stock_transfer
 from katana_public_api_client.models import (
     CreateInventoryReorderPointRequest,
+    CreateOutsourcedPurchaseOrderRecipeRowRequest,
     CreateSalesOrderFulfillmentRequest,
     CreateSalesReturnRowRequest,
     CreateStockTransferRequest,
     InventoryReorderPoint,
+    OutsourcedPurchaseOrderRecipeRow,
     SalesOrderFulfillment,
     SalesOrderFulfillmentRowRequest,
     SalesOrderFulfillmentStatus,
@@ -201,3 +206,45 @@ async def test_create_inventory_reorder_point_parses_200_body() -> None:
     assert isinstance(reorder, InventoryReorderPoint)
     assert reorder.location_id == 184871
     assert reorder.variant_id == 40699264
+
+
+@pytest.mark.asyncio
+async def test_create_outsourced_purchase_order_recipe_row_parses_200_body() -> None:
+    """Successful POST /outsourced_purchase_order_recipe_rows returns a parsed model.
+
+    Fifth and final spec-drift outlier from the 201→200 sweep. Live-verified
+    2026-05-28 against the test tenant after creating an outsourced PO fixture.
+    """
+    recipe_row_payload = {
+        "id": 719973,
+        "purchase_order_id": 2751274,
+        "purchase_order_row_id": 7949057,
+        "ingredient_variant_id": 40699264,
+        "planned_quantity_per_unit": "2.00000000000000000000",
+        "notes": None,
+        "batch_transactions": [],
+        "cost": None,
+        "created_at": "2026-05-28T19:07:45.541Z",
+        "updated_at": "2026-05-28T19:07:45.541Z",
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/outsourced_purchase_order_recipe_rows"
+        return httpx.Response(200, json=recipe_row_payload)
+
+    async with _client_with_mock_transport(handler) as client:
+        response = await create_outsourced_purchase_order_recipe_row.asyncio_detailed(
+            client=client,
+            body=CreateOutsourcedPurchaseOrderRecipeRowRequest(
+                purchase_order_row_id=7949057,
+                ingredient_variant_id=40699264,
+                planned_quantity_per_unit=2.0,
+            ),
+        )
+
+    row = unwrap_as(response, OutsourcedPurchaseOrderRecipeRow)
+    assert isinstance(row, OutsourcedPurchaseOrderRecipeRow)
+    assert row.id == 719973
+    assert row.purchase_order_row_id == 7949057
+    assert row.ingredient_variant_id == 40699264

--- a/tests/test_openapi_specification.py
+++ b/tests/test_openapi_specification.py
@@ -198,22 +198,18 @@ class TestOpenAPISpecification:
         """Pin live-verified POST create endpoints to status 200.
 
         Katana's actual API returns ``200`` from create endpoints, not ``201``.
-        The spec previously misdeclared four endpoints as ``201``, which caused
+        The spec previously misdeclared five endpoints as ``201``, which caused
         the generated parser to return ``parsed=None`` for what was actually a
         successful response — leading to ``UnexpectedResponse`` errors in
         ``unwrap_as`` even though the mutation had landed server-side.
 
-        All four have been verified live via ``make_test_client()``:
+        All five have been verified live via ``make_test_client()``:
 
         - ``POST /sales_order_fulfillments`` → 200
         - ``POST /stock_transfers`` → 200
         - ``POST /sales_return_rows`` → 200
         - ``POST /inventory_reorder_points`` → 200
-
-        One additional outlier — ``POST /outsourced_purchase_order_recipe_rows`` —
-        also currently declares 201 but has not been live-verified (test tenant
-        has no outsourced POs to probe against). It is intentionally absent from
-        this list; fix when verified.
+        - ``POST /outsourced_purchase_order_recipe_rows`` → 200
         """
         paths = spec.get("paths", {})
         live_verified_endpoints = [
@@ -221,6 +217,7 @@ class TestOpenAPISpecification:
             "/stock_transfers",
             "/sales_return_rows",
             "/inventory_reorder_points",
+            "/outsourced_purchase_order_recipe_rows",
         ]
         for endpoint in live_verified_endpoints:
             post_spec = paths.get(endpoint, {}).get("post", {})


### PR DESCRIPTION
## Summary

Final outlier in the spec-drift status-code sweep started in #863. That PR landed four verified endpoints + flagged this fifth one as deferred because the test tenant had no outsourced POs to probe against. This PR closes the loop.

Live-verified 2026-05-28 by creating an outsourced PO fixture on the test tenant (outsourced POs require `tracking_location_id` — Katana 422s without it), then POSTing a recipe row against the auto-assigned `purchase_order_row_id`:

```
POST /outsourced_purchase_order_recipe_rows → HTTP 200
```

Wire shape captured from the live probe:

```json
{
  "id": 719973,
  "purchase_order_id": 2751274,
  "purchase_order_row_id": 7949057,
  "ingredient_variant_id": 40699264,
  "planned_quantity_per_unit": "2.00000000000000000000",
  "notes": null,
  "batch_transactions": [],
  "cost": null,
  "created_at": "2026-05-28T19:07:45.541Z",
  "updated_at": "2026-05-28T19:07:45.541Z"
}
```

Same drift class as the four endpoints fixed in #863: the generated `_parse_response` only handled the documented 201, so on the real 200 it left `response.parsed = None` and `unwrap_as` raised `UnexpectedResponse` even though the mutation had landed server-side.

## Changes

- **Spec**: `201` → `200` for `POST /outsourced_purchase_order_recipe_rows` in `docs/katana-openapi.yaml`
- **Regenerated parser**: `api/purchase_orders/create_outsourced_purchase_order_recipe_row.py`
- **Parser-level regression test**: added `test_create_outsourced_purchase_order_recipe_row_parses_200_body` to `tests/test_create_endpoint_regression.py` (MockTransport, real-shape body)
- **YAML pin**: added `/outsourced_purchase_order_recipe_rows` to `live_verified_endpoints` in `tests/test_openapi_specification.py`
- **Docs** (`katana_public_api_client/docs/spec-authoring.md`): dropped the "not yet live-verified" caveat; noted the sweep is now complete

## Sweep complete

Every `POST` create endpoint in the spec now declares 200. The baseline survey at the start of the sweep found these five outliers and no others:

| Endpoint | Fixed in |
| --- | --- |
| `POST /sales_order_fulfillments` | #863 |
| `POST /stock_transfers` | #863 |
| `POST /sales_return_rows` | #863 |
| `POST /inventory_reorder_points` | #863 |
| `POST /outsourced_purchase_order_recipe_rows` | this PR |

## Fixture cleanup

The probe PO (`id=2751274`) was deleted via `DELETE /purchase_orders/{id}` immediately after the probe (status 204).

## Test plan

- [x] `uv run poe check` — exit 0 (format, lint, ruff, ty, pyright, yamllint, full test suite incl. browser)
- [x] Live probe via `make_test_client()` confirms `unwrap_as` returns a typed `OutsourcedPurchaseOrderRecipeRow` after the regen
- [x] New MockTransport regression test passes
- [x] YAML-level test now pins all 5 endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)