### PR TITLE
fix(mcp): return parent_id from search_items so item CRUD gets the right id

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -501,8 +501,12 @@ Include archived rows:
 {"query": "old style", "include_archived": true}
 ```
 
-**Returns:** List of matching items with ID, SKU, name, sellable status,
-and archived state.
+**Returns:** List of matching items, each with two ids — `id` (the **variant
+id**, for `get_variant_details` / `check_inventory` / order / PO / MO line
+items) and `parent_id` (the **item id**, for `get_item` / `modify_item` /
+`delete_item`) — plus SKU, name, sellable status, and archived state. The two
+differ (a service/product/material item id is not its variant id); pass
+`parent_id`, not `id`, to the item CRUD tools or they 404.
 
 **Archive workflow:** Katana doesn't expose dedicated archive/unarchive
 endpoints. Instead, archive state is a writable boolean on the item header
@@ -925,11 +929,12 @@ polymorphic Product / Material / Service record, plus nested `variants`
 (`is_producible` on products, etc.) stay `null` for the other types.
 
 **Parameters:**
-- `id` (required): Item ID
+- `id` (required): Item id — `search_items`' `parent_id`, NOT the variant
+  `id`. They differ; the variant id 404s here.
 - `type` (required): "product" | "material" | "service"
 
 For per-variant detail (barcodes, supplier codes, custom fields), follow
-up with `get_variant_details`.
+up with `get_variant_details` (which takes the variant `id`).
 
 ---
 
@@ -967,7 +972,10 @@ endpoint; variant sub-payloads route to the shared `/variant` family.
   for SERVICE.
 
 **Parameters:**
-- `id` (required): Item ID
+- `id` (required): Item id — `search_items`' `parent_id`, NOT the variant
+  `id`. They differ; passing the variant id routes to
+  `/products|materials|services/{id}` and 404s (most visibly for services,
+  whose only modify path is `update_header`).
 - `type` (required): "product" | "material" | "service"
 - Any subset of the sub-payloads above
 - `preview` (optional, default true): true=preview, false=execute
@@ -998,7 +1006,7 @@ To find an archived item before unarchiving it, call `search_items` with
 Delete an item. Destructive — Katana cascades child variants server-side.
 
 **Parameters:**
-- `id` (required): Item ID
+- `id` (required): Item id — `search_items`' `parent_id`, NOT the variant `id`.
 - `type` (required): "product" | "material" | "service"
 - `preview` (optional, default true): true=preview, false=delete
 

--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -23,7 +23,7 @@ operating on the same response model.
 from __future__ import annotations
 
 import json
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from enum import Enum
@@ -455,7 +455,10 @@ def compute_field_diff(
 
 
 def make_response_verifier(
-    diff: list[FieldChange], *, field_map: dict[str, str] | None = None
+    diff: list[FieldChange],
+    *,
+    field_map: dict[str, str] | None = None,
+    value_source: Mapping[str, Callable[[Any], Any]] | None = None,
 ) -> Callable[[Any], Awaitable[tuple[bool, dict[str, Any] | None]]]:
     """Build a verify closure that checks the API response body against ``diff``.
 
@@ -466,8 +469,18 @@ def make_response_verifier(
     :func:`compute_field_diff` parameter for fields with names that
     differ between request and response. Used by every
     ``modify_<entity>`` update action's ``ActionSpec.verify``.
+
+    ``value_source`` overrides *where* a field's actual value is read from:
+    a ``{field_name: callable(outcome) -> value}`` map for fields that don't
+    live on the top-level response object. The service update endpoint, for
+    example, echoes a ``Service`` whose pricing (``sales_price`` /
+    ``default_cost`` / ``sku``) lives on the nested first variant, not the
+    header — without an override those fields read as ``None`` and verify
+    spuriously as ``False`` on a successful update. Fields not in the map fall
+    back to ``getattr(outcome, attr)`` as before.
     """
     name_map = field_map or {}
+    source_map = value_source or {}
 
     async def verify(outcome: Any) -> tuple[bool, dict[str, Any] | None]:
         if outcome is None:
@@ -475,8 +488,12 @@ def make_response_verifier(
         actual: dict[str, Any] = {}
         verified = True
         for change in diff:
-            attr = name_map.get(change.field, change.field)
-            raw = getattr(outcome, attr, None)
+            source = source_map.get(change.field)
+            if source is not None:
+                raw = source(outcome)
+            else:
+                attr = name_map.get(change.field, change.field)
+                raw = getattr(outcome, attr, None)
             actual_val = _normalize(unwrap_unset(raw, None))
             actual[change.field] = actual_val
             if change.new is not None and actual_val != change.new:

--- a/katana_mcp_server/src/katana_mcp/tools/decorators.py
+++ b/katana_mcp_server/src/katana_mcp/tools/decorators.py
@@ -104,6 +104,33 @@ async def _run_sync(
     await sync_fn(services.client, services.typed_cache)
 
 
+async def ensure_cache_synced(
+    services: Services, *cached_classes: type[SQLModel]
+) -> None:
+    """Imperatively sync ``Cached*`` classes — the runtime twin of ``@cache_read``.
+
+    For syncs a decorator can't express because the need is *conditional* on
+    the tool's own results: ``search_items`` only needs the service table when
+    a service actually appears in the result set, which it can't know until
+    after the variant search runs. Routed through the same ``_get_sync_fns()``
+    registry as the decorator, so tests that patch ``_sync_fns`` (e.g. the
+    ``_patch_cache_sync`` fixture) neutralize it for free.
+
+    Unlike ``@cache_read`` — which validates eagerly and raises ``ValueError``
+    at decoration time for an unregistered ``Cached*`` class — this runtime
+    helper silently skips classes absent from the registry. That difference is
+    deliberate: the decorator's classes are import-time literals (a typo should
+    fail loudly at import), whereas here a class can be legitimately absent at
+    call time (the ``_patch_cache_sync`` fixture swaps in a registry that omits
+    ``CachedService``), and skipping is exactly how that no-ops in tests.
+    """
+    sync_fns = _get_sync_fns()
+    for cached_cls in cached_classes:
+        sync_fn = sync_fns.get(cached_cls)
+        if sync_fn is not None:
+            await _run_sync(services, sync_fn)
+
+
 def cache_read(*cached_classes: type[SQLModel]) -> Callable:
     """Sync the typed cache for given ``Cached*`` classes before the tool runs.
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -7,6 +7,7 @@ Items are things with SKUs - they appear in the "Items" tab of the Katana UI.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from enum import StrEnum
 from typing import Annotated, Any
 
@@ -40,7 +41,7 @@ from katana_mcp.tools._modification_dispatch import (
     safe_fetch_for_diff,
     unset_dict,
 )
-from katana_mcp.tools.decorators import cache_read
+from katana_mcp.tools.decorators import cache_read, ensure_cache_synced
 from katana_mcp.tools.list_coercion import CoercedIntListOpt, CoercedStrListOpt
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
@@ -97,6 +98,7 @@ from katana_public_api_client.models_pydantic._generated import (
     CachedFactory,
     CachedMaterial,
     CachedProduct,
+    CachedService,
     CachedSupplier,
     CachedVariant,
 )
@@ -163,6 +165,16 @@ class ItemInfo(BaseModel):
     """Item information."""
 
     id: int
+    parent_id: int | None = Field(
+        default=None,
+        description=(
+            "Parent item id — pass this to modify_item / get_item / delete_item "
+            "(type-routed to /products|materials|services/{id}). Distinct from "
+            "``id``, which is the variant id used by get_variant_details and "
+            "order / PO / MO rows. None only when the parent can't be resolved "
+            "(e.g. a service whose parent isn't in the cache yet)."
+        ),
+    )
     sku: str
     name: str
     item_type: str = "unknown"
@@ -235,17 +247,62 @@ async def _search_items_impl(
             return "unknown"
         return type_val.value if hasattr(type_val, "value") else str(type_val)
 
+    # Resolve each row's type once and reuse it below (the parent-id join, the
+    # service guard, and the ItemInfo build all need it).
+    typed_variants = [(v, _item_type(v)) for v in variants]
+
+    # The parent *item* id that modify_item/get_item need differs from the
+    # variant ``id`` search returns. Products/materials carry it on the row
+    # (``product_id``/``material_id``); a service variant has null
+    # ``product_id`` AND null ``material_id`` and no dedicated parent column,
+    # so resolve the service item id from ``CachedService`` (whose ``id`` is
+    # the service item id, with the variant id in its nested ``variants[].id``).
+    # Only sync + read the service table when a service is actually in the
+    # result set, so product/material-only searches pay nothing — the common
+    # case. Pass ``include_archived`` through so an archived service hit
+    # (surfaced when the caller opts in) still resolves its parent.
+    service_variant_to_item: dict[int, int] = {}
+    if any(item_type == "service" for _, item_type in typed_variants):
+        await ensure_cache_synced(services, CachedService)
+        cached_services = await services.typed_cache.catalog.get_all(
+            CachedService, include_archived=request.include_archived
+        )
+        for svc in cached_services:
+            svc_id = _attr(svc, "id")
+            if svc_id is None:
+                continue
+            for sv in _attr(svc, "variants") or []:
+                sv_id = _attr(sv, "id")
+                if sv_id is not None:
+                    service_variant_to_item[int(sv_id)] = int(svc_id)
+
+    def _parent_id(v: Any, item_type: str) -> int | None:
+        if item_type == "product":
+            return _attr(v, "product_id")
+        if item_type == "material":
+            return _attr(v, "material_id")
+        if item_type == "service":
+            # None when CachedService is empty/stale (or the variant id is
+            # missing) — degrade gracefully rather than emitting the (wrong)
+            # variant id as the parent.
+            variant_id = _attr(v, "id")
+            if variant_id is None:
+                return None
+            return service_variant_to_item.get(int(variant_id))
+        return None
+
     items_info = [
         ItemInfo(
             id=_attr(v, "id"),
+            parent_id=_parent_id(v, item_type),
             sku=_attr(v, "sku") or "",
             name=_attr(v, "display_name") or _attr(v, "sku") or "",
-            item_type=_item_type(v),
-            is_sellable=_item_type(v) == "product",
+            item_type=item_type,
+            is_sellable=item_type == "product",
             stock_level=None,
             is_archived=_attr(v, "parent_archived_at") is not None,
         )
-        for v in variants
+        for v, item_type in typed_variants
     ]
 
     return SearchItemsResponse(items=items_info, total_count=len(items_info))
@@ -258,9 +315,13 @@ async def search_items(
 ) -> ToolResult:
     """Search for items (products, materials, services) by name or SKU — returns multiple matching items.
 
-    Use this as the starting point when you need to find items. Returns item IDs
-    and SKUs needed by other tools like create_purchase_order or check_inventory.
-    For full details on a specific item, follow up with get_variant_details.
+    Use this as the starting point when you need to find items. Each result
+    carries two ids: ``id`` is the **variant id** (pass to get_variant_details,
+    check_inventory, and order / PO / MO line items), and ``parent_id`` is the
+    **item id** (pass to modify_item, get_item, delete_item — they route by
+    ``type`` to /products|materials|services/{id} and require the item id, not
+    the variant id). For full details on a specific item, follow up with
+    get_variant_details.
 
     By default, archived items are excluded. Pass ``include_archived=true`` to
     surface them (each row carries an ``is_archived`` flag). To unarchive an
@@ -926,8 +987,11 @@ async def get_item(
     set, and type-specific fields (``is_producible`` on products, etc.)
     stay ``None`` for the other types.
 
-    Use after search_items. For variant-level detail (barcodes, supplier
-    codes, custom fields), follow up with ``get_variant_details``.
+    Use after search_items: pass the item's ``parent_id`` (the item id), NOT
+    the ``id`` (variant id). A service/product/material item id differs from
+    its variant id; passing the variant id here 404s. For variant-level detail
+    (barcodes, supplier codes, custom fields), follow up with
+    ``get_variant_details`` (which takes the variant ``id``).
     """
     response = await _get_item_impl(request, context)
     return _item_details_to_tool_result(response)
@@ -1263,6 +1327,33 @@ def coerce_variant_config_attributes(
     ]
 
 
+# Service header fields that Katana echoes on the nested first variant of the
+# updated ``Service`` rather than on the Service object itself — the response
+# verifier must read them from ``outcome.variants[0]`` or they read as ``None``
+# and verify spuriously as False on a successful update. Only these three need
+# the override: the other ``ItemHeaderPatch`` fields valid for services
+# (``name``, ``uom``, ``category_name``, ``is_sellable``, ``additional_info``,
+# ``is_archived``) echo correctly on the top-level ``Service`` and verify via
+# the default ``getattr(outcome, ...)`` path.
+_SERVICE_VARIANT_VERIFY_FIELDS = ("sales_price", "default_cost", "sku")
+
+
+def _service_variant_value(field: str) -> Callable[[Any], Any]:
+    """Build a ``value_source`` reader for a service field on the first variant.
+
+    Returns ``None`` when the echoed ``Service`` carries no variants (so the
+    verifier records a mismatch rather than crashing).
+    """
+
+    def read(outcome: Any) -> Any:
+        variants = unwrap_unset(getattr(outcome, "variants", None), None) or []
+        if not variants:
+            return None
+        return getattr(variants[0], field, None)
+
+    return read
+
+
 def _build_update_header_request(
     patch: ItemHeaderPatch, item_type: ItemType, existing_item: Any | None = None
 ) -> Any:
@@ -1409,6 +1500,13 @@ async def _modify_item_impl(
         diff = compute_field_diff(
             existing_item, request.update_header, unknown_prior=existing_item is None
         )
+        # Services echo pricing/SKU on the nested first variant, not the
+        # Service header — point the verifier at the variant for those fields.
+        header_value_source = (
+            {f: _service_variant_value(f) for f in _SERVICE_VARIANT_VERIFY_FIELDS}
+            if request.type == ItemType.SERVICE
+            else None
+        )
         plan.append(
             ActionSpec(
                 operation=ItemOperation.UPDATE_HEADER,
@@ -1423,7 +1521,7 @@ async def _modify_item_impl(
                     ),
                     return_type=cfg["return_type"],
                 ),
-                verify=make_response_verifier(diff),
+                verify=make_response_verifier(diff, value_source=header_value_source),
             )
         )
 
@@ -1497,12 +1595,16 @@ async def modify_item(
 ) -> ToolResult:
     """Modify an item — unified surface across header + variant CRUD.
 
-    The required ``type`` discriminator (PRODUCT / MATERIAL / SERVICE)
-    routes header updates to the matching API endpoint family. Variant
-    sub-payloads (``add_variants`` / ``update_variants`` /
-    ``delete_variant_ids``) route to the shared ``/variant`` family —
-    available for PRODUCT and MATERIAL only; services carry pricing on
-    the header itself (``sales_price``, ``default_cost``, ``sku``).
+    ``id`` is the **item id** (search_items' ``parent_id``), NOT the variant
+    ``id``: the item id differs from its variant id, and passing the variant
+    id routes to /products|materials|services/{id} and 404s — most visibly for
+    services, whose only modify path is ``update_header``. The required
+    ``type`` discriminator (PRODUCT / MATERIAL / SERVICE) routes header updates
+    to the matching API endpoint family. Variant sub-payloads
+    (``add_variants`` / ``update_variants`` / ``delete_variant_ids``) route to
+    the shared ``/variant`` family — available for PRODUCT and MATERIAL only;
+    services carry pricing on the header itself (``sales_price``,
+    ``default_cost``, ``sku``).
 
     Sub-payloads (any subset, all optional):
 

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -727,6 +727,178 @@ async def test_search_items_multiple_results():
     assert result.items[1].is_sellable is False
 
 
+@pytest.mark.asyncio
+async def test_search_items_parent_id_for_product_and_material():
+    """parent_id is the product/material item id (not the variant id)."""
+    context, lifespan_ctx = create_mock_context()
+
+    cached_variants = [
+        {
+            "id": 111,
+            "product_id": 222,
+            "sku": "PROD-1",
+            "type": "product",
+            "display_name": "Product One",
+        },
+        {
+            "id": 333,
+            "material_id": 444,
+            "sku": "MAT-1",
+            "type": "material",
+            "display_name": "Material One",
+        },
+    ]
+    lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
+        return_value=cached_variants
+    )
+
+    result = await _search_items_impl(SearchItemsRequest(query="one"), context)
+
+    by_sku = {item.sku: item for item in result.items}
+    # id stays the variant id; parent_id carries the item id for modify_item.
+    assert by_sku["PROD-1"].id == 111
+    assert by_sku["PROD-1"].parent_id == 222
+    assert by_sku["MAT-1"].id == 333
+    assert by_sku["MAT-1"].parent_id == 444
+
+
+@pytest.mark.asyncio
+async def test_search_items_parent_id_for_service_resolves_via_cached_service():
+    """Service rows resolve parent_id (service item id) from CachedService.
+
+    A service variant carries null product_id/material_id and no parent
+    column; the parent service item id lives on CachedService (its ``id``,
+    with the variant id in its nested ``variants``). This is the bug case:
+    the variant id (what search returns as ``id``) differs from the service
+    item id (``parent_id``) that modify_item/get_item require.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
+        return_value=[
+            {
+                "id": 40722022,  # service VARIANT id
+                "product_id": None,
+                "material_id": None,
+                "sku": "LABOR",
+                "type": "service",
+                "display_name": "LABOR",
+            }
+        ]
+    )
+    lifespan_ctx.typed_cache.catalog.get_all = AsyncMock(
+        return_value=[
+            {
+                "id": 17253805,  # service ITEM id (parent)
+                "variants": [{"id": 40722022, "service_id": 17253805, "sku": "LABOR"}],
+            }
+        ]
+    )
+
+    result = await _search_items_impl(SearchItemsRequest(query="labor"), context)
+
+    assert result.items[0].id == 40722022
+    assert result.items[0].parent_id == 17253805
+    assert result.items[0].parent_id != result.items[0].id
+    # CachedService is queried to build the variant->service map.
+    from katana_public_api_client.models_pydantic._generated import CachedService
+
+    lifespan_ctx.typed_cache.catalog.get_all.assert_awaited_once_with(
+        CachedService, include_archived=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_items_service_parent_id_resolves_archived_service():
+    """include_archived=true must reach get_all so archived service hits resolve.
+
+    Without threading the flag through, get_all defaults to excluding archived
+    services and an archived service hit would lose its parent_id.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
+        return_value=[
+            {
+                "id": 40722022,
+                "product_id": None,
+                "material_id": None,
+                "sku": "LABOR",
+                "type": "service",
+                "display_name": "LABOR",
+            }
+        ]
+    )
+    lifespan_ctx.typed_cache.catalog.get_all = AsyncMock(
+        return_value=[
+            {"id": 17253805, "variants": [{"id": 40722022, "service_id": 17253805}]}
+        ]
+    )
+
+    result = await _search_items_impl(
+        SearchItemsRequest(query="labor", include_archived=True), context
+    )
+
+    assert result.items[0].parent_id == 17253805
+    from katana_public_api_client.models_pydantic._generated import CachedService
+
+    lifespan_ctx.typed_cache.catalog.get_all.assert_awaited_once_with(
+        CachedService, include_archived=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_items_service_parent_id_none_when_services_empty():
+    """A service row degrades to parent_id=None when CachedService is empty.
+
+    Better to return None (the caller learns the parent isn't resolvable)
+    than to emit the wrong-id-space variant id as the parent.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
+        return_value=[
+            {
+                "id": 40722022,
+                "product_id": None,
+                "material_id": None,
+                "sku": "LABOR",
+                "type": "service",
+                "display_name": "LABOR",
+            }
+        ]
+    )
+    # get_all returns [] by default in create_mock_context — no service rows.
+
+    result = await _search_items_impl(SearchItemsRequest(query="labor"), context)
+
+    assert result.items[0].id == 40722022
+    assert result.items[0].parent_id is None
+    # The join WAS attempted (service in results) but found nothing — pins that
+    # parent_id=None is the empty-cache degrade path, not a skipped lookup.
+    from katana_public_api_client.models_pydantic._generated import CachedService
+
+    lifespan_ctx.typed_cache.catalog.get_all.assert_awaited_once_with(
+        CachedService, include_archived=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_items_skips_service_join_when_no_service_rows():
+    """The CachedService read is skipped entirely for product/material-only hits."""
+    context, lifespan_ctx = create_mock_context()
+
+    lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
+        return_value=[
+            {"id": 1, "product_id": 2, "sku": "P", "type": "product"},
+        ]
+    )
+
+    await _search_items_impl(SearchItemsRequest(query="p"), context)
+
+    lifespan_ctx.typed_cache.catalog.get_all.assert_not_awaited()
+
+
 # ============================================================================
 # get_inventory_movements Tests
 # ============================================================================

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -2040,6 +2040,72 @@ async def test_modify_item_service_header_dispatches_to_services_endpoint():
 
 
 @pytest.mark.asyncio
+async def test_modify_item_service_header_verifies_pricing_from_variant():
+    """Service update_header verifies sales_price/sku off the echoed variant.
+
+    Katana echoes service pricing on the nested first variant, not the
+    Service header. The service-aware verifier must read those fields from
+    ``outcome.variants[0]`` — otherwise a successful price update reports
+    ``verified=False`` (the bug). ``name`` still verifies off the header.
+    """
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        ModifyItemRequest,
+        _modify_item_impl,
+    )
+
+    context, _ = create_mock_context()
+
+    # Prior state for the diff fetch. ``compute_field_diff`` reads old values
+    # off ``existing`` (the Service header) for each patched field — here
+    # ``name`` and ``sales_price``. On a real ``Service`` the header has no
+    # ``sales_price`` (it lives on the variant), so we set it to None
+    # explicitly: a bare MagicMock would otherwise auto-vivify it to a mock and
+    # the diff's ``old`` would be that mock rather than a real prior value.
+    existing = MagicMock()
+    existing.id = 7
+    existing.name = "Old Name"
+    existing.sales_price = None
+    existing.additional_info = None
+    existing.variants = []
+
+    # Apply outcome — new name on the header, new price/sku on the variant.
+    outcome = MagicMock()
+    outcome.id = 7
+    outcome.name = "Wheel Build Labor"
+    outcome_variant = MagicMock()
+    outcome_variant.sales_price = 120.0
+    outcome_variant.sku = "LABOR-WHEELBUILD"
+    outcome.variants = [outcome_variant]
+
+    with (
+        patch(
+            "katana_public_api_client.api.services.update_service.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "katana_public_api_client.api.services.get_service.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        # diff-fetch unwrap_as -> existing; apply unwrap_as -> outcome.
+        patch(_MODIFY_ITEM_UNWRAP_AS, side_effect=[existing, outcome]),
+    ):
+        request = ModifyItemRequest(
+            id=7,
+            type=ItemType.SERVICE,
+            update_header=ItemHeaderPatch(name="Wheel Build Labor", sales_price=120.0),
+            preview=False,
+        )
+        response = await _modify_item_impl(request, context)
+
+    action = response.actions[0]
+    assert action.succeeded is True
+    # name verifies off the header, sales_price off the nested variant — both
+    # match, so the action verifies end-to-end (was False before the fix).
+    assert action.verified is True
+
+
+@pytest.mark.asyncio
 async def test_modify_item_add_variant_injects_parent_id_for_product():
     from katana_mcp.tools.foundation.items import (
         ModifyItemRequest,

--- a/uv.lock
+++ b/uv.lock
@@ -1329,7 +1329,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.99.0"
+version = "0.100.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

`search_items` returns `CachedVariant.id` (the **variant id**), but `modify_item` / `get_item` / `delete_item` route to `/products|materials|services/{id}` and need the **parent item id**. The two differ, so passing a search result straight into those tools 404s and the operation silently does nothing. Services were uniquely fully-broken — their only modify path is `update_header`, which is exactly the broken id-space.

This adds a **`parent_id`** field to `search_items`' output so callers pass the right id, keeping `id` as the variant id for `get_variant_details` / orders / PO / MO rows.

- **product / material** → `parent_id` lifts from the existing `product_id` / `material_id` cache columns.
- **service** → resolved at query time by joining `CachedService` (its `id` is the service item id, with the variant id in its nested `variants[]`). Guarded behind a service-present check; degrades to `parent_id=None` when `CachedService` is empty/stale rather than emitting the wrong id. `search_items` now also syncs `CachedService`.
- **Bundled verifier fix**: service `update_header` reported `verified=False` on success because pricing (`sales_price` / `default_cost` / `sku`) is echoed on the nested `Service.variants[0]`, not the Service header. `make_response_verifier` gains an optional `value_source` override; the service branch points those fields at the first variant.
- Docstrings + the `katana://help` resource updated to steer callers to `parent_id`.

The silent-no-op and the old `create_item(type='service')` `NoneType` crash from the original report were already fixed; this addresses the still-live root cause (re-scoped, not service-specific).

Closes #868

## Test plan

- [x] `uv run poe check` — 3733 unit + 42 browser/Prefab render tests green
- [x] New unit tests: 4 `search_items` `parent_id` cases (product / material / service-resolves-via-CachedService / empty-cache degrade / join-skipped) + 1 service-verifier test
- [x] **Live end-to-end on the test tenant** (`make_test_client()`): created a throwaway service (item id ≠ variant id), confirmed `search_items` returns `id`=variant + `parent_id`=service item id, `modify_item(type=service, id=parent_id)` **succeeded AND verified=True**, and `get_item` confirmed the change landed
- [x] Card-class sweep of `prefab_ui.py`: no other id-space mismatches (variant ids only flow to `get_variant_details`/`check_inventory`; mutations delegate via `UpdateContext`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)