### PR TITLE
feat(mcp): denormalize service_id onto CachedVariant; drop search_items O(N) scan

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -344,27 +344,37 @@ async def _search_items_impl(
     # The parent *item* id that modify_item/get_item need differs from the
     # variant ``id`` search returns. Products/materials carry it on the row
     # (``product_id``/``material_id``); a service variant has null
-    # ``product_id`` AND null ``material_id`` and no dedicated parent column,
-    # so resolve the service item id from ``CachedService`` (whose ``id`` is
-    # the service item id, with the variant id in its nested ``variants[].id``).
-    # Only sync + read the service table when a service is actually in the
-    # result set, so product/material-only searches pay nothing — the common
-    # case. Pass ``include_archived`` through so an archived service hit
-    # (surfaced when the caller opts in) still resolves its parent.
-    service_variant_to_item: dict[int, int] = {}
-    if any(item_type == "service" for _, item_type in typed_variants):
+    # ``product_id`` AND null ``material_id``, so it reads from the cache-only
+    # ``service_id`` column denormalized at sync time (see
+    # ``_backfill_service_variant_links`` in ``typed_cache/sync.py``).
+    #
+    # Only do this when a service is actually in the result set, so
+    # product/material-only searches pay nothing (the common case). Two-step,
+    # because ``smart_search`` above returned *detached* rows whose
+    # ``service_id`` was frozen at fetch time — possibly before this sync's
+    # backfill, or stale from a ``/variants`` delta that nulled it: (1) sync
+    # services, which runs the ``post_sync`` backfill onto the variant rows;
+    # (2) re-read just the service variant rows so we see the backfilled
+    # value. ``include_archived/deleted=True`` so a row ``smart_search``
+    # already surfaced isn't dropped by the re-fetch's soft-state filter.
+    service_parent_by_variant: dict[int, int] = {}
+    service_variant_ids = [
+        int(vid)
+        for v, item_type in typed_variants
+        if item_type == "service" and (vid := _attr(v, "id")) is not None
+    ]
+    if service_variant_ids:
         await ensure_cache_synced(services, CachedService)
-        cached_services = await services.typed_cache.catalog.get_all(
-            CachedService, include_archived=request.include_archived
+        fresh = await services.typed_cache.catalog.get_many_by_ids(
+            CachedVariant,
+            service_variant_ids,
+            include_archived=True,
+            include_deleted=True,
         )
-        for svc in cached_services:
-            svc_id = _attr(svc, "id")
-            if svc_id is None:
-                continue
-            for sv in _attr(svc, "variants") or []:
-                sv_id = _attr(sv, "id")
-                if sv_id is not None:
-                    service_variant_to_item[int(sv_id)] = int(svc_id)
+        for vid, row in fresh.items():
+            service_id = _attr(row, "service_id")
+            if service_id is not None:
+                service_parent_by_variant[int(vid)] = int(service_id)
 
     def _parent_id(v: Any, item_type: str) -> int | None:
         if item_type == "product":
@@ -372,13 +382,12 @@ async def _search_items_impl(
         if item_type == "material":
             return _attr(v, "material_id")
         if item_type == "service":
-            # None when CachedService is empty/stale (or the variant id is
-            # missing) — degrade gracefully rather than emitting the (wrong)
-            # variant id as the parent.
+            # None when the service sync hasn't backfilled this row yet —
+            # degrade gracefully rather than emitting the (wrong) variant id.
             variant_id = _attr(v, "id")
             if variant_id is None:
                 return None
-            return service_variant_to_item.get(int(variant_id))
+            return service_parent_by_variant.get(int(variant_id))
         return None
 
     items_info = [

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -22,16 +22,19 @@ need to change.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from itertools import batched
 from typing import TYPE_CHECKING, Any, Protocol
 
-from sqlalchemy import inspect as sqla_inspect
+from sqlalchemy import (
+    inspect as sqla_inspect,
+    update,
+)
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-from sqlmodel import SQLModel, delete
+from sqlmodel import SQLModel, delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from katana_mcp.logging import get_logger
@@ -197,6 +200,15 @@ class EntitySpec:
     - ``single_record`` — when True, the endpoint returns one record
       directly (Factory) rather than a list-wrapped response. Bypasses
       ``unwrap_data`` and constructs a one-element list internally.
+
+    - ``post_sync`` — an awaitable ``(cache) -> None`` run *after* the
+      entity's rows land (inside the entity lock, after the upsert commit).
+      Used for cross-table denormalization the per-row ``attrs_postprocess``
+      can't do because it has no session — e.g. the service spec backfills
+      ``CachedVariant.service_id`` from each ``CachedService``'s nested
+      variant. Lives on the spec (not just the ``ensure_*`` wrapper) so
+      ``force_resync`` inherits it: a ``rebuild_cache`` of services
+      re-establishes the variant links rather than leaving them stale.
     """
 
     entity_key: str
@@ -210,6 +222,7 @@ class EntitySpec:
     related_specs: tuple[EntitySpec, ...] = field(default_factory=tuple)
     depends_on: tuple[str, ...] = ()
     attrs_postprocess: Callable[[Any, Any], None] | None = None
+    post_sync: Callable[[TypedCacheEngine], Awaitable[None]] | None = None
     extra_fetch_kwargs: dict[str, Any] = field(default_factory=dict)
     supports_incremental: bool = True
     supports_include_deleted: bool = True
@@ -597,6 +610,12 @@ async def _sync_one_locked(
         )
         await session.commit()
 
+    # Cross-table denormalization (e.g. service_id onto variant rows) runs
+    # after the upsert commit, in its own session, still under the entity
+    # lock. Reached by both the normal sync and ``force_resync``.
+    if spec.post_sync is not None:
+        await spec.post_sync(cache)
+
 
 async def merge_filtered_fetch(
     cache: TypedCacheEngine,
@@ -841,6 +860,58 @@ def _variant_postprocess(attrs_obj: Any, cache_row: CachedVariant) -> None:
     cache_row.supplier_item_codes_text = " ".join(codes) if codes else None
 
 
+async def _backfill_service_variant_links(cache: TypedCacheEngine) -> None:
+    """Denormalize ``service_id`` onto the service-type ``CachedVariant`` rows.
+
+    Wired as ``_SERVICE_SPEC.post_sync``; runs after every service sync
+    (normal *and* ``force_resync``), under the service lock, in its own
+    session.
+
+    The parent link only exists on the ``/services`` payload
+    (``ServiceVariant.service_id``); ``/variants`` (the endpoint the variant
+    sync uses) returns service variants with ``product_id=null``,
+    ``material_id=null``, and *no* ``service_id`` — so it can't be lifted in
+    ``_variant_postprocess``, and ``attrs_postprocess`` has no session to
+    reach across tables. Writing the link here lets ``search_items`` read a
+    service's parent item id from the variant row (a keyed lookup) instead of
+    scanning every ``CachedService``.
+
+    Services are 1:1 with variants (the API rejects >1), so each is a
+    single-row ``UPDATE`` keyed on the variant PK. The ``IS DISTINCT FROM``
+    guard makes the steady state a true no-op — no row is touched (and the
+    ``variant_au`` FTS trigger doesn't fire) once the column is already
+    correct, so the full pass on every service sync stays cheap.
+
+    The full pass (not a delta-scoped one) is deliberate: ``_bulk_upsert``
+    sets every non-id column from the payload, so a ``/variants`` delta can
+    transiently null a previously-backfilled ``service_id`` *without* the
+    service itself reappearing in the service delta. Re-linking every service
+    each pass self-heals that case; a delta-scoped backfill would not.
+    ``search_items`` re-reads the variant rows after triggering this sync, so
+    it never observes the pre-backfill value.
+    """
+    variant_id_col: Any = CachedVariant.id
+    service_id_col: Any = CachedVariant.service_id
+    async with cache.session() as session:
+        services = (await session.exec(select(CachedService))).all()
+        for service in services:
+            # ``CachedService.variants`` is a ``PydanticJSON`` column; the read
+            # path returns plain dicts (not ``ServiceVariant`` instances), so
+            # index by key rather than attribute.
+            for sv in service.variants or []:
+                variant_id = sv["id"] if isinstance(sv, dict) else sv.id
+                if variant_id is None:
+                    continue
+                stmt = (
+                    update(CachedVariant)
+                    .where(variant_id_col == variant_id)
+                    .where(service_id_col.is_distinct_from(service.id))
+                    .values(service_id=service.id)
+                )
+                await session.exec(stmt)
+        await session.commit()
+
+
 _PRODUCT_SPEC = EntitySpec(
     entity_key="product",
     api_fn=get_all_products,
@@ -892,6 +963,7 @@ _SERVICE_SPEC = EntitySpec(
     cache_cls=CachedService,
     pydantic_cls=PydanticService,
     extra_fetch_kwargs={"include_archived": True},
+    post_sync=_backfill_service_variant_links,
 )
 
 
@@ -1072,7 +1144,13 @@ async def ensure_variants_synced(client: KatanaClient, cache: TypedCacheEngine) 
 
 
 async def ensure_services_synced(client: KatanaClient, cache: TypedCacheEngine) -> None:
-    """Pull updated services from Katana and upsert into the cache."""
+    """Pull updated services from Katana and upsert into the cache.
+
+    The ``_SERVICE_SPEC.post_sync`` hook then backfills
+    ``CachedVariant.service_id`` from each service's nested variant so
+    ``search_items`` can resolve service ``parent_id`` from a variant row
+    (see :func:`_backfill_service_variant_links`).
+    """
     await _ensure_synced(client, cache, _SERVICE_SPEC)
 
 

--- a/katana_mcp_server/tests/test_typed_cache_catalog.py
+++ b/katana_mcp_server/tests/test_typed_cache_catalog.py
@@ -39,6 +39,7 @@ from katana_mcp.typed_cache import (
     ensure_suppliers_synced,
     ensure_tax_rates_synced,
     ensure_variants_synced,
+    force_resync,
 )
 from katana_mcp.typed_cache.sync import _validate_dependency_graph
 
@@ -389,6 +390,267 @@ class TestVariantPostprocess:
         # ``_variant_to_cache_dict``).
         assert cached.display_name == "FALLBACK-SKU"
         assert cached.parent_archived_at is None
+
+
+class TestServiceVariantLinkBackfill:
+    """``ensure_services_synced`` denormalizes ``service_id`` onto the variant row."""
+
+    @pytest.mark.asyncio
+    async def test_service_id_backfilled_onto_variant(self, typed_cache_engine):
+        """The service sync writes the parent link the /variants payload lacks.
+
+        ``/variants`` returns a service variant with null ``product_id`` /
+        ``material_id`` and no ``service_id`` — the link only exists on
+        ``/services`` (``ServiceVariant.service_id``). The backfill writes it
+        onto ``CachedVariant.service_id`` so ``search_items`` resolves service
+        ``parent_id`` as a plain column read. Mirrors
+        ``test_parent_archived_at_lifted`` (cache-only field, sourced at sync).
+        """
+        # 1. Sync the service-type variant first. Off the /variants wire it
+        #    carries no service_id (null product_id/material_id too).
+        variant_attrs = AttrsVariantResponse.from_dict(
+            {
+                "id": 40722022,
+                "sku": "LABOR",
+                "type": "service",
+                "product_id": None,
+                "material_id": None,
+            }
+        )
+        empty = _list_response([])
+        with (
+            _stub_endpoint("get_all_products", empty),
+            _stub_endpoint("get_all_materials", empty),
+            _stub_endpoint("get_all_variants", _list_response([variant_attrs])),
+        ):
+            await ensure_variants_synced(MagicMock(), typed_cache_engine)
+
+        # Precondition: service_id is null straight off the /variants sync.
+        async with typed_cache_engine.session() as session:
+            pre = await session.get(CachedVariant, 40722022)
+        assert pre is not None
+        assert pre.service_id is None
+
+        # 2. Sync the service whose nested variant carries the parent link.
+        service_attrs = AttrsService.from_dict(
+            {
+                "id": 17253805,
+                "name": "Labor",
+                "variants": [{"id": 40722022, "sku": "LABOR", "service_id": 17253805}],
+            }
+        )
+        with _stub_endpoint("get_all_services", _list_response([service_attrs])):
+            await ensure_services_synced(MagicMock(), typed_cache_engine)
+
+        # 3. The backfill linked the variant row to its parent service item.
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedVariant, 40722022)
+        assert cached is not None
+        assert cached.service_id == 17253805
+
+    @pytest.mark.asyncio
+    async def test_backfill_noop_when_variant_row_absent(self, typed_cache_engine):
+        """A service whose variant row isn't cached yet backfills nothing (no crash).
+
+        The variant sync materializes the row; if it hasn't run, the single-row
+        ``UPDATE ... WHERE id = :variant_id`` matches zero rows and the service
+        sync still completes.
+        """
+        service_attrs = AttrsService.from_dict(
+            {
+                "id": 17253805,
+                "name": "Labor",
+                "variants": [{"id": 99999999, "sku": "LABOR", "service_id": 17253805}],
+            }
+        )
+        with _stub_endpoint("get_all_services", _list_response([service_attrs])):
+            await ensure_services_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedVariant, 99999999)
+        assert cached is None
+
+    @pytest.mark.asyncio
+    async def test_force_resync_service_reestablishes_variant_link(
+        self, typed_cache_engine
+    ):
+        """``force_resync("service")`` runs the backfill, not just a raw re-fetch.
+
+        ``rebuild_cache`` routes through ``force_resync`` → ``_sync_one_locked``,
+        which bypasses ``ensure_services_synced``. The backfill is wired as
+        ``_SERVICE_SPEC.post_sync`` (not just in the ``ensure_*`` wrapper) so it
+        still fires here. Without that, a service rebuild would leave every
+        ``CachedVariant.service_id`` stale and ``search_items`` would return
+        ``parent_id=None`` after a fresh rebuild.
+        """
+        # Sync the variant row only — service_id is null and never backfilled
+        # (no ensure_services_synced call yet).
+        variant_attrs = AttrsVariantResponse.from_dict(
+            {"id": 40722022, "sku": "LABOR", "type": "service"}
+        )
+        empty = _list_response([])
+        with (
+            _stub_endpoint("get_all_products", empty),
+            _stub_endpoint("get_all_materials", empty),
+            _stub_endpoint("get_all_variants", _list_response([variant_attrs])),
+        ):
+            await ensure_variants_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            pre = await session.get(CachedVariant, 40722022)
+        assert pre is not None
+        assert pre.service_id is None
+
+        # Rebuild the service entity via force_resync (the rebuild_cache path).
+        service_attrs = AttrsService.from_dict(
+            {
+                "id": 17253805,
+                "name": "Labor",
+                "variants": [{"id": 40722022, "sku": "LABOR", "service_id": 17253805}],
+            }
+        )
+        with _stub_endpoint("get_all_services", _list_response([service_attrs])):
+            await force_resync(MagicMock(), typed_cache_engine, "service")
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedVariant, 40722022)
+        assert cached is not None
+        assert cached.service_id == 17253805
+
+    @pytest.mark.asyncio
+    async def test_backfill_idempotent_when_already_linked(self, typed_cache_engine):
+        """Re-running the service sync over already-linked rows is a stable no-op.
+
+        Validates the ``IS DISTINCT FROM`` guard: a second sync with the same
+        link leaves ``service_id`` intact (and doesn't error). The guard also
+        suppresses the ``variant_au`` FTS trigger, but the observable contract
+        here is value-stability across repeated syncs.
+        """
+        variant_attrs = AttrsVariantResponse.from_dict(
+            {"id": 40722022, "sku": "LABOR", "type": "service"}
+        )
+        service_attrs = AttrsService.from_dict(
+            {
+                "id": 17253805,
+                "name": "Labor",
+                "variants": [{"id": 40722022, "sku": "LABOR", "service_id": 17253805}],
+            }
+        )
+        empty = _list_response([])
+        with (
+            _stub_endpoint("get_all_products", empty),
+            _stub_endpoint("get_all_materials", empty),
+            _stub_endpoint("get_all_variants", _list_response([variant_attrs])),
+        ):
+            await ensure_variants_synced(MagicMock(), typed_cache_engine)
+
+        with _stub_endpoint("get_all_services", _list_response([service_attrs])):
+            await ensure_services_synced(MagicMock(), typed_cache_engine)
+            await ensure_services_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedVariant, 40722022)
+        assert cached is not None
+        assert cached.service_id == 17253805
+
+    @pytest.mark.asyncio
+    async def test_backfill_links_archived_service_variant(self, typed_cache_engine):
+        """An archived service still backfills — the pass intentionally has no archive filter.
+
+        ``search_items`` with ``include_archived=true`` surfaces archived service
+        hits; their ``parent_id`` must still resolve, so the backfill's
+        ``SELECT`` over ``CachedService`` is unfiltered by archive state.
+        """
+        variant_attrs = AttrsVariantResponse.from_dict(
+            {"id": 40722022, "sku": "LABOR", "type": "service"}
+        )
+        service_attrs = AttrsService.from_dict(
+            {
+                "id": 17253805,
+                "name": "Labor",
+                "archived_at": "2025-02-01T00:00:00Z",
+                "variants": [{"id": 40722022, "sku": "LABOR", "service_id": 17253805}],
+            }
+        )
+        empty = _list_response([])
+        with (
+            _stub_endpoint("get_all_products", empty),
+            _stub_endpoint("get_all_materials", empty),
+            _stub_endpoint("get_all_variants", _list_response([variant_attrs])),
+        ):
+            await ensure_variants_synced(MagicMock(), typed_cache_engine)
+
+        with _stub_endpoint("get_all_services", _list_response([service_attrs])):
+            await ensure_services_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached = await session.get(CachedVariant, 40722022)
+        assert cached is not None
+        assert cached.service_id == 17253805
+
+    @pytest.mark.asyncio
+    async def test_search_items_resolves_service_parent_end_to_end(
+        self, typed_cache_engine
+    ):
+        """Integration: real ``_search_items_impl`` resolves service ``parent_id``.
+
+        Reproduces the original ordering bug end-to-end against a real engine:
+        the variant row is synced with ``service_id=None`` and the service is
+        NOT yet synced, so ``smart_search`` returns a detached row whose
+        ``service_id`` is null. ``_search_items_impl`` then syncs services
+        (firing the ``post_sync`` backfill) and re-reads the variant rows —
+        resolving ``parent_id`` from the fresh value. Reading the stale
+        ``smart_search`` row directly (the pre-fix behavior) returned
+        ``parent_id=None`` here.
+        """
+        from katana_mcp.tools.foundation.items import (
+            SearchItemsRequest,
+            _search_items_impl,
+        )
+        from katana_mcp_server.tests.conftest import create_mock_context
+
+        # Seed only the service-type variant row (service_id null in DB).
+        variant_attrs = AttrsVariantResponse.from_dict(
+            {"id": 40722022, "sku": "LABOR", "type": "service"}
+        )
+        empty = _list_response([])
+        with (
+            _stub_endpoint("get_all_products", empty),
+            _stub_endpoint("get_all_materials", empty),
+            _stub_endpoint("get_all_variants", _list_response([variant_attrs])),
+        ):
+            await ensure_variants_synced(MagicMock(), typed_cache_engine)
+
+        context, lifespan_ctx = create_mock_context()
+        lifespan_ctx.typed_cache = typed_cache_engine
+
+        # The service sync that _search_items_impl triggers internally returns
+        # the parent link; the post_sync backfill writes it onto the variant row.
+        service_attrs = AttrsService.from_dict(
+            {
+                "id": 17253805,
+                "name": "Labor",
+                "variants": [{"id": 40722022, "sku": "LABOR", "service_id": 17253805}],
+            }
+        )
+        # ``_search_items_impl`` carries ``@cache_read(CachedVariant)``, which
+        # re-syncs variants (and its product/material parents) before running;
+        # stub those endpoints empty so the in-cache variant row persists. The
+        # service stub feeds the conditional service sync triggered for the hit.
+        with (
+            _stub_endpoint("get_all_products", empty),
+            _stub_endpoint("get_all_materials", empty),
+            _stub_endpoint("get_all_variants", empty),
+            _stub_endpoint("get_all_services", _list_response([service_attrs])),
+        ):
+            result = await _search_items_impl(
+                SearchItemsRequest(query="LABOR"), context
+            )
+
+        service_rows = [item for item in result.items if item.item_type == "service"]
+        assert len(service_rows) == 1
+        assert service_rows[0].id == 40722022  # variant id
+        assert service_rows[0].parent_id == 17253805  # resolved service item id
 
 
 class TestCatalogQueriesGetters:

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -763,14 +763,18 @@ async def test_search_items_parent_id_for_product_and_material():
 
 
 @pytest.mark.asyncio
-async def test_search_items_parent_id_for_service_resolves_via_cached_service():
-    """Service rows resolve parent_id (service item id) from CachedService.
+async def test_search_items_parent_id_for_service_reads_refetched_service_id():
+    """Service rows resolve parent_id from a FRESH re-read after the backfill.
 
-    A service variant carries null product_id/material_id and no parent
-    column; the parent service item id lives on CachedService (its ``id``,
-    with the variant id in its nested ``variants``). This is the bug case:
-    the variant id (what search returns as ``id``) differs from the service
-    item id (``parent_id``) that modify_item/get_item require.
+    ``smart_search`` returns *detached* rows whose ``service_id`` is frozen at
+    fetch time — possibly null (cold cache, or a /variants delta that nulled
+    it). search_items syncs services (running the backfill that writes
+    ``service_id`` onto the variant rows), then re-reads those rows via
+    ``get_many_by_ids`` and resolves parent_id from the fresh value. Pin that
+    the resolved parent_id comes from the re-fetch, NOT the stale search row:
+    the search row carries ``service_id=None`` here, yet parent_id resolves.
+    This is the bug case — the variant id (search ``id``) differs from the
+    service item id (``parent_id``) that modify_item/get_item require.
     """
     context, lifespan_ctx = create_mock_context()
 
@@ -780,40 +784,43 @@ async def test_search_items_parent_id_for_service_resolves_via_cached_service():
                 "id": 40722022,  # service VARIANT id
                 "product_id": None,
                 "material_id": None,
+                "service_id": None,  # STALE: detached row, pre-backfill
                 "sku": "LABOR",
                 "type": "service",
                 "display_name": "LABOR",
             }
         ]
     )
-    lifespan_ctx.typed_cache.catalog.get_all = AsyncMock(
-        return_value=[
-            {
-                "id": 17253805,  # service ITEM id (parent)
-                "variants": [{"id": 40722022, "service_id": 17253805, "sku": "LABOR"}],
-            }
-        ]
+    # The re-fetch (after the backfill) returns the linked row.
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        return_value={
+            40722022: {"id": 40722022, "service_id": 17253805, "type": "service"}
+        }
     )
 
     result = await _search_items_impl(SearchItemsRequest(query="labor"), context)
 
-    assert result.items[0].id == 40722022
-    assert result.items[0].parent_id == 17253805
-    assert result.items[0].parent_id != result.items[0].id
-    # CachedService is queried to build the variant->service map.
-    from katana_public_api_client.models_pydantic._generated import CachedService
+    from katana_public_api_client.models_pydantic._generated import CachedVariant
 
-    lifespan_ctx.typed_cache.catalog.get_all.assert_awaited_once_with(
-        CachedService, include_archived=False
-    )
+    assert result.items[0].id == 40722022
+    assert result.items[0].parent_id == 17253805  # from re-fetch, not search row
+    assert result.items[0].parent_id != result.items[0].id
+    # Re-read is keyed by the service variant ids — no full CachedService scan.
+    lifespan_ctx.typed_cache.catalog.get_all.assert_not_awaited()
+    refetch = lifespan_ctx.typed_cache.catalog.get_many_by_ids
+    refetch.assert_awaited_once()
+    assert refetch.await_args is not None
+    assert refetch.await_args.args[0] is CachedVariant
+    assert list(refetch.await_args.args[1]) == [40722022]
 
 
 @pytest.mark.asyncio
-async def test_search_items_service_parent_id_resolves_archived_service():
-    """include_archived=true must reach get_all so archived service hits resolve.
+async def test_search_items_service_in_results_triggers_service_sync():
+    """A service hit triggers the incremental service sync before the row read.
 
-    Without threading the flag through, get_all defaults to excluding archived
-    services and an archived service hit would lose its parent_id.
+    The sync runs the backfill (``post_sync``) that links ``service_id`` onto
+    freshly created/edited service variant rows; search re-reads them after.
+    The sync is conditional — only fired when a service is in the result set.
     """
     context, lifespan_ctx = create_mock_context()
 
@@ -823,36 +830,40 @@ async def test_search_items_service_parent_id_resolves_archived_service():
                 "id": 40722022,
                 "product_id": None,
                 "material_id": None,
+                "service_id": None,
                 "sku": "LABOR",
                 "type": "service",
                 "display_name": "LABOR",
             }
         ]
     )
-    lifespan_ctx.typed_cache.catalog.get_all = AsyncMock(
-        return_value=[
-            {"id": 17253805, "variants": [{"id": 40722022, "service_id": 17253805}]}
-        ]
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        return_value={40722022: {"id": 40722022, "service_id": 17253805}}
     )
 
-    result = await _search_items_impl(
-        SearchItemsRequest(query="labor", include_archived=True), context
-    )
+    with patch(
+        "katana_mcp.tools.foundation.items.ensure_cache_synced",
+        new=AsyncMock(),
+    ) as mock_sync:
+        result = await _search_items_impl(SearchItemsRequest(query="labor"), context)
 
     assert result.items[0].parent_id == 17253805
+    # The conditional service sync ran (a service was in the results).
     from katana_public_api_client.models_pydantic._generated import CachedService
 
-    lifespan_ctx.typed_cache.catalog.get_all.assert_awaited_once_with(
-        CachedService, include_archived=True
-    )
+    mock_sync.assert_awaited_once()
+    await_args = mock_sync.await_args
+    assert await_args is not None
+    assert await_args.args[1:] == (CachedService,)
 
 
 @pytest.mark.asyncio
-async def test_search_items_service_parent_id_none_when_services_empty():
-    """A service row degrades to parent_id=None when CachedService is empty.
+async def test_search_items_service_parent_id_none_when_refetch_unlinked():
+    """A service row degrades to parent_id=None when the re-fetch has no link.
 
     Better to return None (the caller learns the parent isn't resolvable)
-    than to emit the wrong-id-space variant id as the parent.
+    than to emit the wrong-id-space variant id as the parent. Covers both the
+    re-fetch missing the row and the row carrying a null ``service_id``.
     """
     context, lifespan_ctx = create_mock_context()
 
@@ -862,30 +873,27 @@ async def test_search_items_service_parent_id_none_when_services_empty():
                 "id": 40722022,
                 "product_id": None,
                 "material_id": None,
+                "service_id": None,
                 "sku": "LABOR",
                 "type": "service",
                 "display_name": "LABOR",
             }
         ]
     )
-    # get_all returns [] by default in create_mock_context — no service rows.
+    # Re-fetch returns the row but it still isn't linked (service_id null).
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        return_value={40722022: {"id": 40722022, "service_id": None}}
+    )
 
     result = await _search_items_impl(SearchItemsRequest(query="labor"), context)
 
     assert result.items[0].id == 40722022
     assert result.items[0].parent_id is None
-    # The join WAS attempted (service in results) but found nothing — pins that
-    # parent_id=None is the empty-cache degrade path, not a skipped lookup.
-    from katana_public_api_client.models_pydantic._generated import CachedService
-
-    lifespan_ctx.typed_cache.catalog.get_all.assert_awaited_once_with(
-        CachedService, include_archived=False
-    )
 
 
 @pytest.mark.asyncio
-async def test_search_items_skips_service_join_when_no_service_rows():
-    """The CachedService read is skipped entirely for product/material-only hits."""
+async def test_search_items_skips_service_sync_when_no_service_rows():
+    """The service sync + re-fetch are skipped entirely for product/material hits."""
     context, lifespan_ctx = create_mock_context()
 
     lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
@@ -894,9 +902,14 @@ async def test_search_items_skips_service_join_when_no_service_rows():
         ]
     )
 
-    await _search_items_impl(SearchItemsRequest(query="p"), context)
+    with patch(
+        "katana_mcp.tools.foundation.items.ensure_cache_synced",
+        new=AsyncMock(),
+    ) as mock_sync:
+        await _search_items_impl(SearchItemsRequest(query="p"), context)
 
-    lifespan_ctx.typed_cache.catalog.get_all.assert_not_awaited()
+    mock_sync.assert_not_awaited()
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids.assert_not_awaited()
 
 
 # ============================================================================

--- a/katana_public_api_client/models_pydantic/_generated/inventory.py
+++ b/katana_public_api_client/models_pydantic/_generated/inventory.py
@@ -1585,6 +1585,12 @@ class CachedVariant(UpdatableEntity, DeletableEntity, table=True):
             description="(cache-only) Space-joined ``supplier_item_codes`` so the FTS5 tokenizer can index multi-token supplier codes without parsing JSON at query time."
         ),
     ] = None
+    service_id: Annotated[
+        Mapped[int | None],
+        Field(
+            description="(cache-only) Parent service item id for service-type variants. Sourced from the /services payload (ServiceVariant.service_id) at sync time — /variants does not carry it. Lets search_items return parent_id for services as a plain row read, like product_id/material_id."
+        ),
+    ] = None
 
 
 class CachedService(ArchivableDeletableEntity, table=True):

--- a/scripts/generate_pydantic_models.py
+++ b/scripts/generate_pydantic_models.py
@@ -360,6 +360,17 @@ CACHE_TABLES: dict[str, CacheTableSpec] = {
                     "without parsing JSON at query time."
                 ),
             ),
+            CacheExtraField(
+                name="service_id",
+                python_type="int | None",
+                description=(
+                    "(cache-only) Parent service item id for service-type "
+                    "variants. Sourced from the /services payload "
+                    "(ServiceVariant.service_id) at sync time — /variants does "
+                    "not carry it. Lets search_items return parent_id for "
+                    "services as a plain row read, like product_id/material_id."
+                ),
+            ),
         ),
         # ``custom_fields`` and ``config_attributes`` are lists of nested
         # objects SQLAlchemy can't auto-map. ``supplier_item_codes`` is a
@@ -842,6 +853,10 @@ def parse_generated_file(
     # Add extra="ignore" to BaseEntity for API response tolerance (#295)
     classes = add_base_entity_extra_ignore(classes)
 
+    # Re-type ``<timestamp>: Any`` phantom fields (datamodel-codegen 0.58.0
+    # regression on allOf+required inherited timestamps) back to AwareDatetime.
+    classes = restore_phantom_any_timestamps(classes)
+
     # #342 cache-table transforms — emit a ``Cached<Name>`` sibling for
     # each CACHE_TABLES entry. The original API class stays pure pydantic;
     # the cache class carries SQLModel ``table=True``, primary keys, FKs,
@@ -1139,6 +1154,51 @@ def add_base_entity_extra_ignore(classes: list[ClassInfo]) -> list[ClassInfo]:
             )
         else:
             fixed_classes.append(cls)
+    return fixed_classes
+
+
+# Inherited entity timestamps that ``datamodel-codegen`` 0.58.0 emits as a
+# bare ``<field>: Any`` when a schema re-lists them in its own ``required``
+# array through an ``allOf`` ``$ref`` merge (it can't resolve the type across
+# the merge). Earlier codegen versions merged the type correctly. The base
+# entity classes (``UpdatableEntity`` etc.) declare these as
+# ``AwareDatetime | None``; when ``required`` they're non-optional. Map each to
+# its canonical description so the restored field matches the base-class
+# semantics and we don't silently regress type safety. See ``InventoryMovement``.
+_REQUIRED_TIMESTAMP_DESCRIPTIONS = {
+    "created_at": "Timestamp when the entity was first created",
+    "updated_at": "Timestamp when the entity was last updated",
+}
+
+
+def restore_phantom_any_timestamps(classes: list[ClassInfo]) -> list[ClassInfo]:
+    """Re-type ``<timestamp>: Any`` phantom fields back to ``AwareDatetime``.
+
+    ``datamodel-codegen`` 0.58.0 emits a bare, required ``created_at: Any`` /
+    ``updated_at: Any`` for an inherited entity timestamp that a schema promotes
+    to ``required`` via an ``allOf`` ``$ref`` (it loses the type through the
+    merge). Rewrite that bare ``Any`` to the concrete required ``AwareDatetime``
+    form the base entity declares, so consumers keep date-aware typing. Only the
+    exact bare-``Any`` shape is touched — legitimately typed fields are left
+    alone, and the trailing ``Any`` import is dropped by the ruff pass if it
+    becomes unused.
+    """
+    fixed_classes = []
+    for cls in classes:
+        new_source = cls.source
+        for field_name, description in _REQUIRED_TIMESTAMP_DESCRIPTIONS.items():
+            replacement = (
+                f"    {field_name}: Annotated[\n"
+                f'        AwareDatetime, Field(description="{description}")\n'
+                f"    ]"
+            )
+            new_source = re.sub(
+                rf"^    {field_name}: Any$",
+                replacement,
+                new_source,
+                flags=re.MULTILINE,
+            )
+        fixed_classes.append(cls.with_source(new_source))
     return fixed_classes
 
 

--- a/tests/test_generate_pydantic_postprocess.py
+++ b/tests/test_generate_pydantic_postprocess.py
@@ -516,3 +516,80 @@ def test_rewrite_preserves_whitespace_and_layout(gen: ModuleType) -> None:
     source = "class Foo:\n    x: int = 1\n    y: str = 'hello'\n"
     rewritten = gen._rewrite_identifiers_outside_strings(source, {"NotPresent": "X"})
     assert rewritten == source
+
+
+# ─── restore_phantom_any_timestamps ─────────────────────────────────────
+
+
+def test_restore_phantom_any_created_updated(gen: ModuleType) -> None:
+    """Bare ``created_at: Any`` / ``updated_at: Any`` → required ``AwareDatetime``.
+
+    datamodel-codegen 0.58.0 emits these phantom ``Any`` fields when a schema
+    promotes an inherited timestamp to ``required`` via allOf (e.g.
+    ``InventoryMovement``). The pass restores the concrete type.
+    """
+    cls = gen.ClassInfo(
+        name="InventoryMovement",
+        source=(
+            "class InventoryMovement(UpdatableEntity):\n"
+            "    rank: Annotated[int | None, Field(description='x')] = None\n"
+            "    created_at: Any\n"
+            "    updated_at: Any\n"
+        ),
+        bases=["UpdatableEntity"],
+        line_start=1,
+        line_end=4,
+    )
+    [out] = gen.restore_phantom_any_timestamps([cls])
+    assert "created_at: Any" not in out.source
+    assert "updated_at: Any" not in out.source
+    assert (
+        "    created_at: Annotated[\n"
+        '        AwareDatetime, Field(description="Timestamp when the entity '
+        'was first created")\n'
+        "    ]"
+    ) in out.source
+    assert (
+        "    updated_at: Annotated[\n"
+        '        AwareDatetime, Field(description="Timestamp when the entity '
+        'was last updated")\n'
+        "    ]"
+    ) in out.source
+
+
+def test_restore_phantom_leaves_typed_timestamps_untouched(gen: ModuleType) -> None:
+    """A correctly-typed ``created_at`` is not rewritten (only bare ``Any`` is)."""
+    typed = (
+        "class Foo(UpdatableEntity):\n"
+        "    created_at: Annotated[\n"
+        '        AwareDatetime | None, Field(description="x")\n'
+        "    ] = None\n"
+    )
+    cls = gen.ClassInfo(
+        name="Foo", source=typed, bases=["UpdatableEntity"], line_start=1, line_end=4
+    )
+    [out] = gen.restore_phantom_any_timestamps([cls])
+    assert out.source == typed
+
+
+def test_restore_phantom_ignores_unrelated_any_fields(gen: ModuleType) -> None:
+    """A non-timestamp ``: Any`` field is left alone — only the mapped names match."""
+    src = "class Foo:\n    metadata: Any\n    created_at: Any\n"
+    cls = gen.ClassInfo(name="Foo", source=src, bases=[], line_start=1, line_end=3)
+    [out] = gen.restore_phantom_any_timestamps([cls])
+    assert "    metadata: Any" in out.source  # untouched
+    assert "created_at: Any" not in out.source  # restored
+
+
+def test_generated_inventory_movement_timestamps_typed() -> None:
+    """End-to-end: the generated InventoryMovement keeps AwareDatetime timestamps."""
+    from katana_public_api_client.models_pydantic._generated.inventory import (
+        InventoryMovement,
+    )
+
+    for field_name in ("created_at", "updated_at"):
+        annotation = InventoryMovement.model_fields[field_name].annotation
+        assert annotation is not Any, (
+            f"{field_name} regressed to Any — restore_phantom_any_timestamps "
+            "should keep it AwareDatetime"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1329,7 +1329,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.100.1"
+version = "0.101.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

`search_items` resolved a service row's `parent_id` (the service **item** id) by loading **every** `CachedService` row and building a `{variant_id → service_id}` map per service-containing search. This replaces that O(N) scan with a denormalized, cache-only **`service_id` column on `CachedVariant`** — sourced from the `/services` payload, where the parent link actually lives.

- **generator**: add a cache-only `service_id` `CacheExtraField` to `CACHE_TABLES["Variant"]` (regenerated `_generated/inventory.py`; **no** `regenerate-client` — the OpenAPI wire spec is untouched).
- **sync**: backfill `CachedVariant.service_id` from each service's nested variant. Wired as a new `EntitySpec.post_sync` hook on `_SERVICE_SPEC`, run inside `_sync_one_locked` — so **`force_resync` (`rebuild_cache`) re-establishes the links too**, not just `ensure_services_synced`. Services are 1:1 with variants → single-row PK `UPDATE`; an `IS DISTINCT FROM` guard makes the steady state a no-op (no write, no FTS-trigger churn). The full pass (not delta-scoped) is deliberate — it self-heals a `/variants` delta that transiently nulls `service_id` without the service reappearing in the service delta.
- **search_items**: sync services for service hits, then **re-read** those variant rows via `get_many_by_ids` and resolve `parent_id` from the fresh value. `smart_search` returns detached rows whose `service_id` is frozen at fetch time (pre-backfill), so reading it directly returned a stale `None` — the re-read closes that gap. Keyed by service-hit ids, so still no full `CachedService` scan.

### Incidental generator-drift fix

Regenerating surfaced pre-existing drift: `datamodel-codegen` 0.58.0 emits a bare `created_at: Any` / `updated_at: Any` for an inherited entity timestamp a schema promotes to `required` via `allOf` (`InventoryMovement`). Main's committed file predated this and there's no CI regen-freshness guard. Added a `restore_phantom_any_timestamps` generator pass that re-types those phantom fields back to the concrete required `AwareDatetime` — so this regen ships no type-safety regression and `inventory.py`'s diff is **only** the `service_id` field.

## Review history

Opened after a full six-dimension self-review. Fixed three reviewer-flagged blockers before opening: the stale detached-row read in `search_items`, the `force_resync` bypass, and the `Any` drift. Added the suggested test coverage (stale-row + re-fetch unit test, real-engine end-to-end test reproducing the original bug, backfill / force_resync / idempotency / archived-service sync tests, generator-pass tests).

## Test plan

- [x] `uv run poe check` green (3758 + 42 browser tests, lint/type/format clean)
- [x] New unit + integration tests cover: re-read resolution, the conditional-sync trigger/skip, degrade-to-None, the sync backfill, `force_resync` re-link, idempotency, archived-service coverage, and the generator pass
- [ ] Live test-tenant e2e (not run — no credentials in this worktree): create a throwaway service, run real `search_items`, confirm `parent_id` resolves and `modify_item(type=service, id=parent_id)` succeeds

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)