### PR TITLE
feat(mcp): diff-decorated item modify/delete card (closes #726)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -650,6 +650,7 @@ def to_tool_result(
     """
     from katana_mcp.tools.prefab_ui import (
         build_bom_modify_ui,
+        build_item_modify_ui,
         build_modification_preview_ui,
         build_modification_result_ui,
         build_po_modify_ui,
@@ -658,9 +659,10 @@ def to_tool_result(
 
     response_dict = response.model_dump()
 
-    # Per-entity dispatch — PO migrated in #722, BOM in #811, SO in #723;
-    # remaining entities (MO, stock_transfer, item) fall through to the
-    # legacy builders until their respective child PRs land.
+    # Per-entity dispatch — PO migrated in #722, BOM in #811, SO in #723,
+    # item (product / material / service) in #726; remaining entities
+    # (MO, stock_transfer) fall through to the legacy builders until their
+    # respective child PRs land.
     if response.entity_type == "purchase_order":
         ui = build_po_modify_ui(
             response_dict,
@@ -679,6 +681,14 @@ def to_tool_result(
 
     if response.entity_type == "sales_order":
         ui = build_so_modify_ui(
+            response_dict,
+            confirm_request=confirm_request,
+            confirm_tool=confirm_tool,
+        )
+        return make_tool_result(response, ui=ui)
+
+    if response.entity_type in ("product", "material", "service"):
+        ui = build_item_modify_ui(
             response_dict,
             confirm_request=confirm_request,
             confirm_tool=confirm_tool,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/corrections.py
@@ -211,7 +211,7 @@ def _synthesize_correction_not_run_actions(
     """Build NOT-RUN action dicts for the unattempted phase tail.
 
     Same shape as :func:`_modify_sales_order_impl`'s NOT-RUN synthesis so
-    :func:`build_so_modify_ui` (via :func:`_so_actions_with_not_run_tail`)
+    :func:`build_so_modify_ui` (via :func:`_actions_with_not_run_tail`)
     can merge them into the per-section row morph without distinguishing
     apply-vs-correction provenance. ``succeeded=None`` + ``status_label=
     "NOT RUN"`` sets the "secondary" Badge variant.

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/item_variant_table.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/item_variant_table.py
@@ -1,0 +1,304 @@
+"""Item-variant table-merge domain helpers (non-UI).
+
+Pure-Python projection logic that turns an item modify plan (``prior_state``
+snapshot + variant-CRUD ``ActionResult`` list) into the DataTable row list the
+item modify card renders for its variants collection. Lives outside
+``prefab_ui`` — same split-by-kind-of-work as its sibling :mod:`bom_table`: this
+module shapes plan-action data into row dicts; ``prefab_ui.py`` wraps those rows
+in Prefab components.
+
+The row dicts are deliberately wire-format dicts (no component types, no Prefab
+refs) so they round-trip through ``response.extras`` / iframe ``state`` and JSON
+serialization without loss.
+
+Generalized atop the shared collection-diff skeleton
+(:func:`merge_collection_diff_rows`, #859 / #872) — this module supplies the
+variant-specific cell builders (SKU / sales price / purchase price) as closures;
+the skeleton owns the add/update/delete classification, status stamping, orphan
+handling, and materialization order.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Literal
+
+from katana_mcp.tools.foundation.collection_diff import (
+    STATUS_PREFIX,
+    STATUS_VARIANTS,
+    CollectionDiffSpec,
+    merge_collection_diff_rows,
+)
+
+_VariantRowKind = Literal["existing", "added", "updated", "deleted"]
+
+# Operation vocabulary — the ``ItemOperation`` StrEnum values the item modify
+# plan stamps onto each variant action (foundation/items.py).
+_ADD_OPS = frozenset({"add_variant"})
+_UPDATE_OPS = frozenset({"update_variant"})
+_DELETE_OPS = frozenset({"delete_variant"})
+
+
+def _changes_by_field(
+    changes: list[dict[str, Any]] | None,
+) -> dict[str, dict[str, Any]]:
+    """Index an action's ``changes`` list by field name.
+
+    Each entry is the raw ``FieldChange`` dict (``field`` / ``old`` / ``new``
+    plus the ``is_*`` flags). Mirrors ``bom_table._bom_change_lookup`` — kept
+    local so the two table modules stay independent of each other's internals.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for c in changes or []:
+        if isinstance(c, dict) and isinstance(c.get("field"), str):
+            out[c["field"]] = c
+    return out
+
+
+def _format_price(value: Any) -> str:
+    """Render a variant price for a table cell.
+
+    ``None`` renders as em-dash. Numerics render via ``:g`` to trim trailing
+    zeros (``299.0 → '299'`` while preserving ``2.5``) — matching the plain
+    variant lines in ``_item_single_variant_lines``. Wire shape may serialize a
+    price as a numeric string; coerce so the trailing-zero trim still applies.
+
+    ``Decimal`` is handled explicitly: real modify diffs flow through
+    ``compute_field_diff`` → ``_normalize``, which coerces every numeric /
+    decimal-looking price to :class:`~decimal.Decimal`. Without this branch a
+    ``Decimal("1200.0000000000")`` would fall through to ``str(value)`` and
+    render the full unrounded form instead of the trimmed ``1200``.
+    """
+    if value is None:
+        return "—"
+    if isinstance(value, str):
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return value
+        return f"{numeric:g}"
+    if isinstance(value, (int, float, Decimal)):
+        return f"{float(value):g}"
+    return str(value)
+
+
+def _format_price_diff(old: Any, new: Any, *, unknown_prior: bool) -> str:
+    """Render a price update as ``old → new`` (or ``(prior unknown) → new``)."""
+    after = _format_price(new)
+    if unknown_prior:
+        return f"(prior unknown) → {after}"
+    return f"{_format_price(old)} → {after}"
+
+
+def _existing_row_from_snapshot(variant: dict[str, Any]) -> dict[str, Any]:
+    """Project a prior-state variant dict into the merge-row shape.
+
+    The snapshot variant is the wire shape of ``Variant.to_dict()`` — ``id``
+    (int), ``sku`` (``str | None``), ``sales_price`` / ``purchase_price``
+    (numeric, UNSET-stripped → absent → renders em-dash).
+    """
+    kind: _VariantRowKind = "existing"
+    return {
+        "id": variant.get("id"),
+        "sku": variant.get("sku"),
+        "sales_price_label": _format_price(variant.get("sales_price")),
+        "purchase_price_label": _format_price(variant.get("purchase_price")),
+        "kind": kind,
+        "status_label": "",
+        "status_variant": STATUS_VARIANTS[""],
+        "status_prefix": STATUS_PREFIX["existing"],
+        "error": None,
+    }
+
+
+def _synth_orphan_row(target_id: str) -> dict[str, Any]:
+    """Synthesize a minimal row for an update/delete target absent from the
+    snapshot (rare — partial fetch failure or stale id). Lets the action
+    still surface in the table even without resolved identity context.
+    """
+    kind: _VariantRowKind = "existing"
+    return {
+        "id": target_id,
+        "sku": None,
+        "sales_price_label": "—",
+        "purchase_price_label": "—",
+        "kind": kind,
+        "status_label": "",
+        "status_variant": STATUS_VARIANTS[""],
+        "status_prefix": STATUS_PREFIX["existing"],
+        "error": None,
+    }
+
+
+def _add_action_to_row(
+    action: dict[str, Any],
+    *,
+    status_label: str,
+    status_variant: str,
+    error: str | None,
+) -> dict[str, Any]:
+    """Synthesize an ``added``-kind row from an ``add_variant`` action.
+
+    Reads SKU / sales price / purchase price from the action's ``changes``
+    (every supplied field on the ``VariantAdd`` payload, reported as added).
+    SKU is required on ``VariantAdd`` so it's always present; prices are
+    optional and degrade to em-dash.
+    """
+    changes = _changes_by_field(action.get("changes"))
+    sku_change = changes.get("sku")
+    sales_change = changes.get("sales_price")
+    purchase_change = changes.get("purchase_price")
+    kind: _VariantRowKind = "added"
+    return {
+        "id": "",  # No variant id yet — server assigns on POST.
+        "sku": sku_change.get("new") if sku_change else None,
+        "sales_price_label": _format_price(
+            sales_change.get("new") if sales_change else None
+        ),
+        "purchase_price_label": _format_price(
+            purchase_change.get("new") if purchase_change else None
+        ),
+        "kind": kind,
+        "status_label": status_label,
+        "status_variant": status_variant,
+        "status_prefix": STATUS_PREFIX["added"],
+        "error": error,
+    }
+
+
+def _apply_update_to_row(
+    row: dict[str, Any],
+    action: dict[str, Any],
+    *,
+    status_label: str,
+    status_variant: str,
+    error: str | None,
+) -> None:
+    """Decorate a snapshot row in-place with an ``update_variant`` action's diff.
+
+    Flips ``kind`` to ``updated`` and overlays before→after on SKU / sales
+    price / purchase price when those fields changed. Other variant-field
+    edits (barcodes, supplier_item_codes, lead_time, MOQ, config attributes)
+    still flip the row to ``updated`` with its status pill — they're carried
+    by the action, just not surfaced as dedicated columns in this table.
+    """
+    kind: _VariantRowKind = "updated"
+    row["kind"] = kind
+    row["status_label"] = status_label
+    row["status_variant"] = status_variant
+    row["status_prefix"] = STATUS_PREFIX["updated"]
+    row["error"] = error
+    changes = _changes_by_field(action.get("changes"))
+    sku_change = changes.get("sku")
+    if sku_change is not None:
+        old_sku = sku_change.get("old") or "(no SKU)"
+        new_sku = sku_change.get("new") or "(no SKU)"
+        row["sku"] = f"{old_sku} → {new_sku}"
+    sales_change = changes.get("sales_price")
+    if sales_change is not None:
+        row["sales_price_label"] = _format_price_diff(
+            sales_change.get("old"),
+            sales_change.get("new"),
+            unknown_prior=bool(sales_change.get("is_unknown_prior")),
+        )
+    purchase_change = changes.get("purchase_price")
+    if purchase_change is not None:
+        row["purchase_price_label"] = _format_price_diff(
+            purchase_change.get("old"),
+            purchase_change.get("new"),
+            unknown_prior=bool(purchase_change.get("is_unknown_prior")),
+        )
+
+
+def _apply_delete_to_row(
+    row: dict[str, Any],
+    _action: dict[str, Any],
+    *,
+    status_label: str,
+    status_variant: str,
+    error: str | None,
+) -> None:
+    """Decorate a snapshot row in-place with a ``delete_variant`` action.
+
+    Identity (SKU + prices) is preserved so the user sees *what* is going
+    away; the ``- `` SKU-column gutter + ``deleted`` kind carry the signal.
+    The ``_action`` arg is unused (delete carries no field diff) but the
+    positional slot is required by the ``CollectionDiffSpec.apply_delete``
+    (:class:`_MutateRowFn`) call convention.
+    """
+    kind: _VariantRowKind = "deleted"
+    row["kind"] = kind
+    row["status_label"] = status_label
+    row["status_variant"] = status_variant
+    row["status_prefix"] = STATUS_PREFIX["deleted"]
+    row["error"] = error
+
+
+def merge_variant_rows_for_modify_card(
+    prior_state: dict[str, Any] | None,
+    actions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Project the prior variants + plan actions into a unified row list.
+
+    Existing variants render unchanged; ``add_variant`` actions append as
+    ``added`` rows; ``update_variant`` actions decorate the matched prior
+    variant with before→after on SKU / prices; ``delete_variant`` actions mark
+    the matched row ``deleted``. Header-only modifies (no variant CRUD) yield
+    just the existing variants (or an empty list when prior_state is absent).
+
+    Match key: ``str(variant["id"])`` against ``str(action["target_id"])``.
+    Adds have no target_id and synthesize fresh from their ``changes``.
+    """
+    prior_rows: list[dict[str, Any]] = []
+    if isinstance(prior_state, dict):
+        candidate = prior_state.get("variants")
+        if isinstance(candidate, list):
+            prior_rows = [v for v in candidate if isinstance(v, dict)]
+
+    # Filter to variant-CRUD ops before the merge. The item action list also
+    # carries ``update_header`` / ``delete`` actions (handled outside the
+    # variant table); ``merge_collection_diff_rows`` would otherwise log a
+    # "dropped action — unknown operation" warning for each on every
+    # header-only modify / item delete. Filtering here keeps the merge's
+    # warning meaningful (a genuinely-unknown variant op) and still renders
+    # the existing variant rows for those non-variant plans.
+    variant_ops = _ADD_OPS | _UPDATE_OPS | _DELETE_OPS
+    variant_actions = [
+        a for a in actions if str(a.get("operation") or "").lower() in variant_ops
+    ]
+
+    return merge_collection_diff_rows(
+        prior_rows=prior_rows,
+        actions=variant_actions,
+        spec=CollectionDiffSpec(
+            add_ops=_ADD_OPS,
+            update_ops=_UPDATE_OPS,
+            delete_ops=_DELETE_OPS,
+            key_of=lambda v: str(v["id"]) if v.get("id") is not None else None,
+            existing_row=_existing_row_from_snapshot,
+            synth_orphan=_synth_orphan_row,
+            add_row=_add_action_to_row,
+            apply_update=_apply_update_to_row,
+            apply_delete=_apply_delete_to_row,
+            # Existing variants sort by SKU (None last); adds trail (appended
+            # by the skeleton after the sorted snapshot rows).
+            sort_key=lambda v: (v.get("sku") is None, v.get("sku") or ""),
+        ),
+    )
+
+
+def prepare_variant_table_rows(
+    merged: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Compose the final per-row dicts passed to the DataTable.
+
+    The SKU column shows the kind prefix (``+ ``/``- ``/``~ ``/``  ``) inline
+    so adds vs deletes are visually obvious even without per-row styling —
+    same lexical-gutter trick as the BOM table. SKU-less variants (Katana
+    allows them) render ``(no SKU)`` so the row is never blank.
+    """
+    out: list[dict[str, Any]] = []
+    for r in merged:
+        sku = r.get("sku") or "(no SKU)"
+        out.append({**r, "sku_label": f"{r['status_prefix']}{sku}"})
+    return out

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -1557,6 +1557,48 @@ async def _invalidate_item_cache(_services: Any, _item_type: ItemType) -> None:
     return None
 
 
+async def _resolve_prior_supplier_name(
+    services: Any, response: ModificationResponse
+) -> None:
+    """Stamp the default supplier's display name onto ``response.prior_state``.
+
+    The ``prior_state`` snapshot (raw ``Product`` / ``Material`` ``.to_dict()``)
+    carries only the supplier FK (``default_supplier_id``), so the modify card's
+    supplier line would render a bare ``#<id>`` (anti-pattern #7). Resolve the
+    name from the typed cache here — the card builder is sync and can't — and
+    write it back as ``prior_state["default_supplier_name"]`` for the renderer
+    to pick up. Best-effort: a cache miss leaves the name unset (the link still
+    navigates to the right supplier) and the resolution warning is appended to
+    the response so the gap is visible.
+
+    No-op when the snapshot already carries a name (embedded supplier object)
+    or has no supplier FK (services, or items without a default supplier).
+    """
+    prior_state = response.prior_state
+    if not prior_state:
+        return
+    if prior_state.get("default_supplier_name"):
+        return
+    supplier_id = prior_state.get("default_supplier_id")
+    if supplier_id is None:
+        return
+    # Embedded supplier object (rare for items) wins without a cache hit.
+    embedded = prior_state.get("supplier")
+    if isinstance(embedded, dict) and embedded.get("name"):
+        prior_state["default_supplier_name"] = embedded["name"]
+        return
+    name, warning = await resolve_entity_name(
+        services.typed_cache.catalog,
+        CachedSupplier,
+        supplier_id,
+        entity_label="Default supplier",
+    )
+    if name:
+        prior_state["default_supplier_name"] = name
+    if warning:
+        response.warnings.append(warning)
+
+
 async def _modify_item_impl(
     request: ModifyItemRequest, context: Context
 ) -> ModificationResponse:
@@ -1684,6 +1726,37 @@ async def _modify_item_impl(
     if not request.preview:
         await _invalidate_item_cache(services, request.type)
 
+    # Apply-path: synthesize NOT-RUN entries for the unattempted plan tail.
+    # ``execute_plan`` is fail-fast — ``response.actions`` ends at the first
+    # failed action. Without these the item card's variant-table morph would
+    # silently HIDE every planned variant action past the failure (the morph
+    # replaces the preview rows with the shorter apply list). The card merges
+    # these via ``extras["not_run_actions"]`` (``_actions_with_not_run_tail``),
+    # rendering them with the "NOT RUN" status pill. Mirrors the SO / BOM
+    # fail-fast handling. Caught by Copilot review on #875.
+    if not request.preview:
+        not_run_specs = plan[len(response.actions) :]
+        not_run_actions = [
+            {
+                "operation": spec.operation,
+                "target_id": spec.target_id,
+                "succeeded": None,
+                "error": None,
+                "changes": [
+                    c.model_dump() if hasattr(c, "model_dump") else dict(c)
+                    for c in spec.diff
+                ],
+                "status_label": "NOT RUN",
+            }
+            for spec in not_run_specs
+        ]
+        if not_run_actions:
+            response.extras["not_run_actions"] = not_run_actions
+
+    # Resolve the default supplier's name for the modify card (anti-pattern
+    # #7) — the prior_state snapshot carries only the FK.
+    await _resolve_prior_supplier_name(services, response)
+
     return response
 
 
@@ -1758,6 +1831,10 @@ async def _delete_item_impl(
 
     if not request.preview:
         await _invalidate_item_cache(services, request.type)
+
+    # Resolve the default supplier's name for the delete card (anti-pattern
+    # #7) — the prior_state snapshot carries only the FK.
+    await _resolve_prior_supplier_name(services, response)
 
     return response
 

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -1177,7 +1177,10 @@ def _item_header_section(
 
 
 def _item_metrics_section(
-    item: dict[str, Any], *, collapse_single_variant: bool = False
+    item: dict[str, Any],
+    *,
+    collapse_single_variant: bool = False,
+    changes: dict[str, FieldChangeView] | None = None,
 ) -> None:
     """Render Tier 2 — decision metrics as text rows (not Metric components).
 
@@ -1193,17 +1196,31 @@ def _item_metrics_section(
     ``Variants: 0``, which is *not* hidden even when collapsing: an empty
     variants list on a just-created item is an unexpected/malformed response
     worth surfacing, not noise to suppress.
+
+    ``changes`` (modify card) decorates the editable scalar lines with their
+    before→after diff. The variant *count* is never editable, so it never
+    decorates. When ``changes`` is empty (create / detail cards) every line
+    falls through to its plain ``Text`` form — byte-identical to before.
     """
+    changes = changes or {}
     variants = item.get("variants") or []
     if not (collapse_single_variant and len(variants) == 1):
         Text(content=f"Variants: {len(variants)}")
-    if item.get("lead_time") is not None:
+    lead_time_change = changes.get("lead_time")
+    if lead_time_change is not None and lead_time_change.kind != "unchanged":
+        _render_field_diff_line("Lead Time", change=lead_time_change)
+    elif item.get("lead_time") is not None:
         Text(content=f"Lead Time: {item['lead_time']} days")
-    if item.get("minimum_order_quantity") is not None:
+    moq_change = changes.get("minimum_order_quantity")
+    if moq_change is not None and moq_change.kind != "unchanged":
+        _render_field_diff_line("Min Order Qty", change=moq_change)
+    elif item.get("minimum_order_quantity") is not None:
         Text(content=f"Min Order Qty: {item['minimum_order_quantity']}")
 
 
-def _item_supplier_line(item: dict[str, Any]) -> None:
+def _item_supplier_line(
+    item: dict[str, Any], *, changes: dict[str, FieldChangeView] | None = None
+) -> None:
     """Render the default supplier — preferring the nested ``supplier``
     dict (carries name + id), falling back to the flat
     ``default_supplier_id`` field when the nested record is absent.
@@ -1224,10 +1241,28 @@ def _item_supplier_line(item: dict[str, Any]) -> None:
        authoritative identifier and the link still works).
 
     Supplier appears on Products and Materials (not Services).
+
+    ``changes`` (modify card): when ``default_supplier_id`` is changing,
+    render the before→after party-diff line via :func:`_render_party_diff_line`
+    instead of the Link form (mirrors ``_render_po_entity_view``'s supplier
+    branch). The before-side name comes from the nested supplier / the
+    ``default_supplier_name`` prior; the after name from the
+    ``default_supplier_name`` FieldChange when present.
     """
+    changes = changes or {}
     supplier = item.get("supplier")
     nested_name = supplier.get("name") if isinstance(supplier, dict) else None
     nested_id = supplier.get("id") if isinstance(supplier, dict) else None
+
+    supplier_change = changes.get("default_supplier_id")
+    if supplier_change is not None and supplier_change.kind != "unchanged":
+        _render_party_diff_line(
+            "Default Supplier",
+            id_change=supplier_change,
+            name_change=changes.get("default_supplier_name"),
+            prior_name=nested_name or item.get("default_supplier_name"),
+        )
+        return
 
     if nested_name and nested_id:
         supplier_url = katana_web_url("supplier", nested_id)
@@ -1379,7 +1414,10 @@ def _item_single_variant_lines(
 
 
 def _item_reference_section(
-    item: dict[str, Any], *, collapse_single_variant: bool = False
+    item: dict[str, Any],
+    *,
+    collapse_single_variant: bool = False,
+    changes: dict[str, FieldChangeView] | None = None,
 ) -> None:
     """Render Tier 3 reference data: UoM, category, purchase UoM,
     default supplier (Linked), configs, additional info, and the
@@ -1389,17 +1427,33 @@ def _item_reference_section(
     single variant, render that variant's SKU + prices inline instead of a
     one-row DataTable. Falls back to the item-level ``sku`` when the create
     result didn't echo a variants array so the SKU is never lost.
+
+    ``changes`` (modify card) decorates the editable scalar lines (UoM,
+    Category, Notes) and the supplier line with before→after diffs. Purchase
+    UoM (a composite line) and config axes (a nested collection) keep their
+    plain rendering for now; the variants collection diffs via the separate
+    variant diff-table the modify card renders below this section. Empty
+    ``changes`` → every line falls through to its plain form.
     """
-    if item.get("uom"):
+    changes = changes or {}
+    uom_change = changes.get("uom")
+    if uom_change is not None and uom_change.kind != "unchanged":
+        _render_field_diff_line("UoM", change=uom_change)
+    elif item.get("uom"):
         Text(content=f"UoM: {item['uom']}")
-    if item.get("category_name"):
+    category_change = changes.get("category_name")
+    if category_change is not None and category_change.kind != "unchanged":
+        _render_field_diff_line("Category", change=category_change)
+    elif item.get("category_name"):
         Text(content=f"Category: {item['category_name']}")
     _variant_purchase_uom_line(item)
-    _item_supplier_line(item)
+    _item_supplier_line(item, changes=changes)
     _item_configs_section(item)
-    additional_info = item.get("additional_info")
-    if additional_info:
-        Text(content=f"Notes: {additional_info}")
+    notes_change = changes.get("additional_info")
+    if notes_change is not None and notes_change.kind != "unchanged":
+        _render_field_diff_line("Notes", change=notes_change)
+    elif item.get("additional_info"):
+        Text(content=f"Notes: {item['additional_info']}")
     variants = item.get("variants") or []
     if collapse_single_variant and len(variants) <= 1:
         variant = variants[0] if variants else None
@@ -1503,19 +1557,21 @@ def _render_item_entity_view(
 
     The item analogue of :func:`_render_po_entity_view`: shared between
     ``build_item_detail_ui`` (multi-variant read card, ``collapse_single_variant
-    =False``) and ``build_item_create_ui`` (a freshly-created single-variant
-    item, ``collapse_single_variant=True``). The ``changes`` parameter is the
-    seam for the #726 modify card's before→after diff overlay — accepted now
-    so the create/modify pair shares one renderer, but unused until #726 wires
-    a diff decorator into the metric/reference lines.
+    =False``), ``build_item_create_ui`` (a freshly-created single-variant item,
+    ``collapse_single_variant=True``), and ``build_item_modify_ui`` (which passes
+    ``changes`` to overlay before→after diffs on the editable header/reference
+    lines, #726). Empty ``changes`` → plain rendering, byte-identical to the
+    create/detail cards.
 
     Must be called inside ``with CardContent(), Column(gap=3):``.
     """
-    # ``changes`` reserved for the #726 modify-card diff overlay.
-    _ = changes
-    _item_metrics_section(item, collapse_single_variant=collapse_single_variant)
+    _item_metrics_section(
+        item, collapse_single_variant=collapse_single_variant, changes=changes
+    )
     Separator()
-    _item_reference_section(item, collapse_single_variant=collapse_single_variant)
+    _item_reference_section(
+        item, collapse_single_variant=collapse_single_variant, changes=changes
+    )
     return _render_warnings_block(item.get("warnings"))
 
 

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -118,6 +118,10 @@ from katana_mcp.tools.foundation.bom_table import (
     _summarize_apply_outcome,
 )
 from katana_mcp.tools.foundation.collection_diff import collection_diff_summary
+from katana_mcp.tools.foundation.item_variant_table import (
+    merge_variant_rows_for_modify_card,
+    prepare_variant_table_rows,
+)
 from katana_mcp.tools.tool_result_utils import BLOCK_WARNING_PREFIX
 from katana_mcp.web_urls import EntityKind, katana_web_url
 
@@ -1155,10 +1159,22 @@ def _item_header_section(
         if item.get("is_archived"):
             Badge(label="Archived", variant="secondary")
 
-    # Status pills row. Order chosen to match the agent's typical
-    # decision sequence — sellable first (can this be sold?), then
-    # producible (can this be made?), then tracking flags (will I
-    # need to specify a batch / serial when transacting?).
+    _item_status_pills_row(item)
+
+
+def _item_status_pills_row(item: dict[str, Any]) -> None:
+    """Render the sub-type status-pills row (sellable / producible / batch /
+    serial tracked).
+
+    Order chosen to match the agent's typical decision sequence — sellable
+    first (can this be sold?), then producible (can this be made?), then
+    tracking flags (will I need to specify a batch / serial when
+    transacting?). Shared between :func:`_item_header_section` (create /
+    detail cards) and :func:`build_item_modify_ui`'s header so the modify
+    card carries the same identity signal alongside its reactive state badge.
+
+    Must be called inside a ``CardHeader`` column block.
+    """
     with Row(gap=2):
         if item.get("is_sellable") is not None:
             Badge(
@@ -1198,11 +1214,41 @@ def _item_metrics_section(
     worth surfacing, not noise to suppress.
 
     ``changes`` (modify card) decorates the editable scalar lines with their
-    before→after diff. The variant *count* is never editable, so it never
-    decorates. When ``changes`` is empty (create / detail cards) every line
-    falls through to its plain ``Text`` form — byte-identical to before.
+    before→after diff, plus a leading ``Name`` diff line on a rename (the card
+    title is built from the prior snapshot, so a rename would otherwise surface
+    nowhere) and ``yes → no`` diff lines for changed boolean status flags
+    (``is_sellable`` / ``is_producible`` / tracking flags — the Tier-1 pills
+    render the prior snapshot and aren't diff-aware). The variant *count* is
+    never editable, so it never decorates. When ``changes`` is empty (create /
+    detail cards) every line falls through to its plain ``Text`` form —
+    byte-identical to before.
     """
     changes = changes or {}
+    # Name diff (modify card only) — the card title is built from the prior
+    # snapshot, so a rename would otherwise surface nowhere. Diff-only: on
+    # create/detail ``changes`` is empty and the title carries the name.
+    name_change = changes.get("name")
+    if name_change is not None and name_change.kind != "unchanged":
+        _render_field_diff_line("Name", change=name_change)
+    # Boolean status-flag diffs (modify card only). The Tier-1 status pills
+    # render from the prior snapshot and aren't diff-aware, so a header change
+    # to ``is_sellable`` / ``is_producible`` / tracking flags etc. would show
+    # the stale pill (or nothing). Surface each changed flag as an explicit
+    # ``yes → no`` diff line. Diff-only: empty ``changes`` (create/detail)
+    # renders nothing here — the pills carry the steady-state signal.
+    for flag_field, flag_label in (
+        ("is_sellable", "Sellable"),
+        ("is_producible", "Producible"),
+        ("is_purchasable", "Purchasable"),
+        ("is_auto_assembly", "Auto-assembly"),
+        ("batch_tracked", "Batch tracked"),
+        ("serial_tracked", "Serial tracked"),
+        ("operations_in_sequence", "Operations in sequence"),
+        ("is_archived", "Archived"),
+    ):
+        flag_change = changes.get(flag_field)
+        if flag_change is not None and flag_change.kind != "unchanged":
+            _render_field_diff_line(flag_label, change=flag_change)
     variants = item.get("variants") or []
     if not (collapse_single_variant and len(variants) == 1):
         Text(content=f"Variants: {len(variants)}")
@@ -1418,6 +1464,7 @@ def _item_reference_section(
     *,
     collapse_single_variant: bool = False,
     changes: dict[str, FieldChangeView] | None = None,
+    suppress_variants: bool = False,
 ) -> None:
     """Render Tier 3 reference data: UoM, category, purchase UoM,
     default supplier (Linked), configs, additional info, and the
@@ -1429,11 +1476,17 @@ def _item_reference_section(
     result didn't echo a variants array so the SKU is never lost.
 
     ``changes`` (modify card) decorates the editable scalar lines (UoM,
-    Category, Notes) and the supplier line with before→after diffs. Purchase
-    UoM (a composite line) and config axes (a nested collection) keep their
-    plain rendering for now; the variants collection diffs via the separate
-    variant diff-table the modify card renders below this section. Empty
-    ``changes`` → every line falls through to its plain form.
+    Category, Notes), the supplier line, and the service-only pricing/SKU
+    fields (``sku`` / ``sales_price`` / ``default_cost`` — services have no
+    variant table to carry them) with before→after diffs. Purchase UoM (a
+    composite line) and config axes (a nested collection) keep their plain
+    rendering for now; the product/material variants collection diffs via the
+    separate variant diff-table the modify card renders below this section.
+    Empty ``changes`` → every line falls through to its plain form.
+
+    ``suppress_variants`` (modify card) skips the embedded read-only variants
+    table entirely — the modify card renders the per-row variant *diff* table
+    in its place, so rendering both would duplicate the collection.
     """
     changes = changes or {}
     uom_change = changes.get("uom")
@@ -1454,6 +1507,23 @@ def _item_reference_section(
         _render_field_diff_line("Notes", change=notes_change)
     elif item.get("additional_info"):
         Text(content=f"Notes: {item['additional_info']}")
+    # Service-only header pricing/SKU diffs (modify card). Services carry SKU +
+    # pricing on the header itself and have no variant table, so without these
+    # lines a service price/SKU modify would surface no field-level diff. Diff-
+    # only: products/materials never set these header fields, and on create/
+    # detail ``changes`` is empty, so this loop renders nothing there.
+    for field_name, label in (
+        ("sku", "SKU"),
+        ("sales_price", "Sales Price"),
+        ("default_cost", "Default Cost"),
+    ):
+        field_change = changes.get(field_name)
+        if field_change is not None and field_change.kind != "unchanged":
+            _render_field_diff_line(label, change=field_change)
+    if suppress_variants:
+        # Modify card: the per-row variant diff table replaces the embedded
+        # read-only table; rendering both would duplicate the collection.
+        return
     variants = item.get("variants") or []
     if collapse_single_variant and len(variants) <= 1:
         variant = variants[0] if variants else None
@@ -1551,6 +1621,7 @@ def _render_item_entity_view(
     *,
     changes: dict[str, FieldChangeView] | None = None,
     collapse_single_variant: bool = False,
+    suppress_variants: bool = False,
 ) -> list[str]:
     """Render the item entity view (Tier 2 metrics + Tier 3 reference),
     returning the block-warning list for the caller to surface/gate on.
@@ -1560,8 +1631,9 @@ def _render_item_entity_view(
     =False``), ``build_item_create_ui`` (a freshly-created single-variant item,
     ``collapse_single_variant=True``), and ``build_item_modify_ui`` (which passes
     ``changes`` to overlay before→after diffs on the editable header/reference
-    lines, #726). Empty ``changes`` → plain rendering, byte-identical to the
-    create/detail cards.
+    lines, plus ``suppress_variants=True`` so its per-row variant *diff* table
+    replaces the embedded read-only one, #726). Empty ``changes`` → plain
+    rendering, byte-identical to the create/detail cards.
 
     Must be called inside ``with CardContent(), Column(gap=3):``.
     """
@@ -1570,7 +1642,10 @@ def _render_item_entity_view(
     )
     Separator()
     _item_reference_section(
-        item, collapse_single_variant=collapse_single_variant, changes=changes
+        item,
+        collapse_single_variant=collapse_single_variant,
+        changes=changes,
+        suppress_variants=suppress_variants,
     )
     return _render_warnings_block(item.get("warnings"))
 
@@ -2839,16 +2914,26 @@ def _index_changes_by_field(
 def _format_diff_value(value: Any) -> str:
     """Coerce a diff-side value (old or new) to display text.
 
-    Wire shape allows None, str, int, float, bool, list, dict; the entity
-    view renders each as text. Strings, numbers, and booleans render
+    Wire shape allows None, str, int, float, bool, Decimal, list, dict; the
+    entity view renders each as text. Strings, ints, and booleans render
     directly; lists/dicts fall back to ``repr`` (rare — the diff producer
-    avoids nested types). None renders as ``(unset)`` so a transition
-    from blank to populated reads naturally as ``(unset) → Net-30``.
+    avoids nested types). None renders as ``(unset)`` so a transition from
+    blank to populated reads naturally as ``(unset) → Net-30``.
+
+    ``Decimal`` renders trimmed via ``:g`` — every modify diff flows through
+    ``compute_field_diff`` → ``_normalize``, which coerces numeric /
+    decimal-looking values (prices, quantities, costs) to
+    :class:`~decimal.Decimal`. Without the explicit branch a price change would
+    ``repr`` as ``Decimal('50.0000000000')`` instead of ``50``. ``float`` keeps
+    its plain ``str`` form (raw test fixtures; production values are already
+    Decimal by the time they reach here).
     """
     if value is None:
         return "(unset)"
     if isinstance(value, bool):
         return "yes" if value else "no"
+    if isinstance(value, Decimal):
+        return f"{float(value):g}"
     if isinstance(value, (int, float, str)):
         return str(value)
     return repr(value)
@@ -4239,6 +4324,40 @@ def _init_modify_card_state(response: dict[str, Any]) -> dict[str, Any]:
     return _init_create_card_state(response)
 
 
+def _render_apply_outcome_badge(*, css_class: str = "min-w-32 text-center") -> None:
+    """Render the reactive Tier-1 state Badge for a collection modify card.
+
+    Shows ``PREVIEW`` until the apply lands, then morphs to the outcome label
+    (``APPLIED`` / ``PARTIAL FAILURE`` / ``FAILED``) with the variant tracking
+    the outcome (``destructive`` for partial/total failure, ``default`` for
+    success). Reads the state slots ``applied`` / ``applied_outcome_label`` /
+    ``applied_outcome_variant`` — seeded by the builder with preview-time
+    defaults and overwritten by the apply ``on_success`` SetState chain from
+    ``$result.state.<slot>``.
+
+    Badge.variant isn't reactive on its own, so the success/failure split is
+    rendered as parallel components under an ``If`` chain and the renderer
+    picks the right one at morph time. Shared by ``build_bom_modify_ui`` and
+    ``build_item_modify_ui`` (both render a collection diff table whose header
+    needs the same morphing outcome pill). Must be called inside a header Row.
+    """
+    with If("applied"):
+        with If(Rx("applied_outcome_variant") == "destructive"):
+            Badge(
+                label="{{ applied_outcome_label }}",
+                variant="destructive",
+                css_class=css_class,
+            )
+        with Else():
+            Badge(
+                label="{{ applied_outcome_label }}",
+                variant="default",
+                css_class=css_class,
+            )
+    with Else():
+        Badge(label="PREVIEW", variant="secondary", css_class=css_class)
+
+
 def build_po_modify_ui(
     response: dict[str, Any],
     *,
@@ -4686,25 +4805,7 @@ def build_bom_modify_ui(
                 Badge(label=variant_sku, variant="outline")
             if uom:
                 Badge(label=uom, variant="secondary")
-            with If("applied"):
-                with If(Rx("applied_outcome_variant") == "destructive"):
-                    Badge(
-                        label="{{ applied_outcome_label }}",
-                        variant="destructive",
-                        css_class="min-w-32 text-center",
-                    )
-                with Else():
-                    Badge(
-                        label="{{ applied_outcome_label }}",
-                        variant="default",
-                        css_class="min-w-32 text-center",
-                    )
-            with Else():
-                Badge(
-                    label="PREVIEW",
-                    variant="secondary",
-                    css_class="min-w-32 text-center",
-                )
+            _render_apply_outcome_badge()
 
         # Tier 2 — Decision summary. Reads "+N added, ~M updated, -K
         # deleted" so the user knows the shape of the plan before
@@ -4775,6 +4876,316 @@ def build_bom_modify_ui(
             # above + overwritten by the on_success chain) so the footer
             # body morphs to "BOM partially applied." / "BOM failed." in
             # lockstep with the Tier-1 outcome Badge.
+            applied_verb="{{ applied_verb }}",
+        )
+    return app
+
+
+# ============================================================================
+# Item modify / delete card (#726) — the second collection-bearing modify card
+# (after BOM). Header scalar fields diff via the shared
+# ``_render_item_entity_view`` overlay (#555); the variants collection diffs via
+# the shared collection-diff table element (``item_variant_table`` →
+# ``merge_collection_diff_rows``). Mirrors ``build_po_modify_ui`` for the
+# preview→apply rail and ``build_bom_modify_ui`` for the diff-table morph.
+# ============================================================================
+
+
+# DataTable columns for the item modify card's variant diff table. The SKU
+# column carries the kind gutter (``+ ``/``- ``/``~ ``/``  ``) glued on in
+# ``prepare_variant_table_rows``; the Status column renders plain text
+# (PLANNED / APPLIED / FAILED) since DataTable has no per-cell Badge.
+_ITEM_MODIFY_VARIANT_COLUMNS: list[DataTableColumn] = [
+    DataTableColumn(key="sku_label", header="SKU"),
+    DataTableColumn(
+        key="sales_price_label", header="Sales Price", align="right", width="11rem"
+    ),
+    DataTableColumn(
+        key="purchase_price_label",
+        header="Purchase Price",
+        align="right",
+        width="11rem",
+    ),
+    DataTableColumn(key="status_label", header="Status", width="7rem"),
+]
+
+_ITEM_MODIFY_VARIANT_KEY = "variant_rows"
+_ITEM_MODIFY_VARIANT_REF = f"{{{{ {_ITEM_MODIFY_VARIANT_KEY} }}}}"
+
+
+def _normalize_item_prior_state(prior_state: dict[str, Any] | None) -> dict[str, Any]:
+    """Map an item ``prior_state`` snapshot (wire shape of
+    ``Product`` / ``Material`` / ``Service`` ``.to_dict()``) to the shape the
+    item entity-view renderer consumes.
+
+    The attrs snapshot mostly shares field names with the render shape
+    (``name`` / ``uom`` / ``category_name`` / ``additional_info`` /
+    ``default_supplier_id`` / ``variants`` / ``configs`` / the status flags),
+    so it passes through. The two derivations the renderer needs:
+
+    - ``is_archived`` ← ``archived_at is not None`` (the snapshot carries the
+      timestamp; the card renders a boolean badge).
+    - ``default_supplier_name`` is *not* on the raw snapshot — only the FK is.
+      ``_modify_item_impl`` resolves it server-side via the typed cache
+      (anti-pattern #7) and stamps it onto ``prior_state`` before the response
+      leaves the impl, so it's already present here when resolution succeeded.
+
+    Returns ``{}`` for a missing snapshot (failed diff fetch) so the renderer
+    falls back to whatever the response payload carries.
+    """
+    if not prior_state:
+        return {}
+    out = dict(prior_state)
+    if "archived_at" in prior_state and "is_archived" not in out:
+        out["is_archived"] = prior_state.get("archived_at") is not None
+    return out
+
+
+def _item_failed_summary(actions: list[dict[str, Any]]) -> str:
+    """Pre-format the consolidated failed-action summary for the morph Alert.
+
+    One ``Failed — <op> <target>: <error>`` line per failed action. Empty on
+    preview (no action has ``succeeded is False`` yet) and on a clean apply.
+    """
+    lines: list[str] = []
+    for a in actions:
+        if a.get("succeeded") is not False:
+            continue
+        op = str(a.get("operation") or "change").replace("_", " ")
+        target_id = a.get("target_id")
+        label = f"{op} {target_id}" if target_id is not None else op
+        err = a.get("error") or "unknown error"
+        lines.append(f"Failed — {label}: {err}")
+    return "\n".join(lines)
+
+
+def _item_applied_verb(verb_label: str, outcome_label: str) -> str:
+    """Footer verb for the applied state — tracks both the operation and the
+    outcome so the copy never contradicts the Tier-1 badge.
+    """
+    if outcome_label == "FAILED":
+        return "failed"
+    if outcome_label == "PARTIAL FAILURE":
+        return "partially applied"
+    return "deleted" if verb_label == "Delete" else "applied"
+
+
+def _item_modify_labels(verb_label: str, n_actions: int) -> tuple[str, str]:
+    """Return ``(confirm_label, cancel_operation_label)`` for the item card.
+
+    Delete cards say "Confirm Delete" + "that item deletion"; modify cards
+    scale the confirm label with the action count and read "those item
+    changes" for the cancel phrasing.
+    """
+    if verb_label == "Delete":
+        return "Confirm Delete", "that item deletion"
+    confirm = f"Confirm {n_actions} changes" if n_actions > 1 else "Confirm Changes"
+    return confirm, "those item changes"
+
+
+def _render_item_modify_header(entity: dict[str, Any], *, entity_id: Any) -> None:
+    """Render the item modify card's Tier-1 header.
+
+    Item name (linked to Katana when a URL is present), the sub-type badge,
+    an archived badge, then the reactive PREVIEW → outcome state badge; the
+    sub-type status-pills row follows (shared with the create / detail cards).
+    Must be called inside ``with PrefabApp(...) as app, Card():``.
+    """
+    katana_url = entity.get("katana_url")
+    title_content = entity.get("name") or f"Item {entity_id}"
+    item_type = entity.get("type")
+    with CardHeader(), Column(gap=2):
+        with Row(gap=2):
+            with CardTitle():
+                if katana_url:
+                    Link(content=title_content, href=katana_url, target="_blank")
+                else:
+                    Text(content=title_content)
+            if item_type:
+                Badge(label=str(item_type), variant="secondary")
+            if entity.get("is_archived"):
+                Badge(label="Archived", variant="secondary")
+            _render_apply_outcome_badge()
+        _item_status_pills_row(entity)
+
+
+def build_item_modify_ui(
+    response: dict[str, Any],
+    *,
+    confirm_request: BaseModel,
+    confirm_tool: str,
+) -> PrefabApp:
+    """Build the modify-/delete-item card (#726).
+
+    Handles every item write path that returns a :class:`ModificationResponse`:
+    ``modify_item`` (header + variant CRUD) and ``delete_item``. Sub-type
+    variance (product / material / service) shows in the type badge + status
+    pills; the variant diff table renders only for product / material (services
+    carry pricing on the header, not on variants).
+
+    Two diff surfaces, both from the shared modify-card machinery:
+
+    - **Header scalars** — ``_render_item_entity_view`` with the per-field
+      ``changes`` overlay (built from the ``update_header`` action's
+      ``changes`` via :func:`_index_changes_by_field`, scoped to that
+      operation so variant-field diffs don't leak into header lines).
+    - **Variants collection** — the shared collection-diff table
+      (:func:`merge_variant_rows_for_modify_card`): existing variants render
+      plain, ``add_variant`` rows append with a ``+ `` gutter, ``update_variant``
+      rows show before→after on SKU / prices, ``delete_variant`` rows mark
+      ``- ``. The table is state-bound (``state.variant_rows``) and morphs in
+      place on apply via the SetState chain reading ``$result.state.variant_rows``.
+
+    The preview→Confirm→apply rail mirrors ``build_po_modify_ui`` /
+    ``build_bom_modify_ui``: a build-time ``summarize_apply_outcome`` seeds the
+    outcome label/variant/failed-summary state slots (preview-time defaults on
+    the preview render; real outcome on the apply rebuild), and the apply
+    ``on_success`` chain copies them from ``$result.state.<slot>`` so the whole
+    applied-state chrome morphs in lockstep. Inherits the #760 in-place-morph
+    optimism for per-field ``✗`` glyphs (build-time-fixed from the preview
+    actions); the table rows + header/footer outcome chrome do morph.
+    """
+    is_preview = bool(response.get("is_preview", True))
+    # Apply path: extend with the unattempted plan tail (synthesized NOT-RUN
+    # actions in ``extras``) so a fail-fast partial doesn't silently drop the
+    # not-run variant rows from the morphed table. Inert on preview.
+    actions = _actions_with_not_run_tail(response, is_preview=is_preview)
+    entity_id = response.get("entity_id")
+    entity_type = response.get("entity_type")
+    verb_label = _verb_label(confirm_tool)
+
+    prior_state = _normalize_item_prior_state(response.get("prior_state"))
+    # Compose the entity-view source: prior_state (full pre-change snapshot)
+    # overlaid with non-None response scalars (katana_url, warnings). Same
+    # overlay shape as ``build_po_modify_ui``.
+    entity = {**prior_state, **{k: v for k, v in response.items() if v is not None}}
+    if entity_id is not None:
+        entity.setdefault("id", entity_id)
+    # Raw ``Product``/``Material``/``Service`` snapshots have no ``type`` echo
+    # the header badge can read; seed it from the response's entity_type.
+    if entity_type:
+        entity.setdefault("type", entity_type)
+
+    # Header field diffs — scope to ``update_header`` so variant-field changes
+    # (sku / sales_price / lead_time / MOQ, which overlap header-ish names)
+    # never decorate the header lines; they belong in the variant table.
+    changes_by_field = _index_changes_by_field(
+        actions, include_operations=frozenset({"update_header"})
+    )
+
+    # Variant diff table — product / material only (services have no variant
+    # CRUD; their pricing diffs surface on the header lines instead).
+    show_variant_table = entity_type in ("product", "material")
+    variant_rows = (
+        prepare_variant_table_rows(
+            merge_variant_rows_for_modify_card(prior_state, actions)
+        )
+        if show_variant_table
+        else []
+    )
+    summary_line = collection_diff_summary(variant_rows)
+
+    # Outcome chrome. On the standalone-applied path and the apply rebuild the
+    # actions carry real succeeded flags, so ``summarize_apply_outcome`` gives
+    # the true label; on the preview render every action is ``succeeded=None``
+    # (which ``summarize_apply_outcome`` can't bucket), so seed the optimistic
+    # ``APPLIED`` default — the Tier-1 badge shows PREVIEW until the morph
+    # overwrites these slots from ``$result.state.<slot>`` anyway.
+    if is_preview:
+        outcome_label, outcome_variant = "APPLIED", "default"
+    else:
+        outcome_label, outcome_variant = _summarize_apply_outcome(actions)
+    applied_verb = _item_applied_verb(verb_label, outcome_label)
+    failed_summary = _item_failed_summary(actions)
+    failed_count = sum(1 for a in actions if a.get("succeeded") is False)
+
+    apply_action = _build_apply_action(
+        confirm_tool,
+        confirm_request,
+        extra_on_success=[
+            SetState(_ITEM_MODIFY_VARIANT_KEY, "{{ $result.state.variant_rows }}"),
+            SetState(
+                "applied_outcome_label", "{{ $result.state.applied_outcome_label }}"
+            ),
+            SetState(
+                "applied_outcome_variant",
+                "{{ $result.state.applied_outcome_variant }}",
+            ),
+            SetState(
+                "applied_failed_count", "{{ $result.state.applied_failed_count }}"
+            ),
+            SetState(
+                "applied_failed_summary",
+                "{{ $result.state.applied_failed_summary }}",
+            ),
+            SetState("applied_verb", "{{ $result.state.applied_verb }}"),
+        ],
+    )
+    confirm_label, cancel_operation_label = _item_modify_labels(
+        verb_label, len(actions)
+    )
+    cancel_action = _build_cancel_action(cancel_operation_label)
+
+    state = _init_modify_card_state(response)
+    state[_ITEM_MODIFY_VARIANT_KEY] = variant_rows
+    state["applied_outcome_label"] = outcome_label
+    state["applied_outcome_variant"] = outcome_variant
+    state["applied_failed_count"] = failed_count
+    state["applied_failed_summary"] = failed_summary
+    state["applied_verb"] = applied_verb
+
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
+        _render_item_modify_header(entity, entity_id=entity_id)
+
+        with CardContent(), Column(gap=3):
+            if response.get("message"):
+                Muted(content=response["message"])
+
+            # Tier 2 + 3 — header metrics + reference fields with diff overlay.
+            # Variants suppressed here; the diff table below replaces them.
+            block_warnings = _render_item_entity_view(
+                entity, changes=changes_by_field, suppress_variants=True
+            )
+
+            # Variant diff table (product / material). Summary line first so
+            # the user sees "+N ~M -K" before scanning the rows.
+            if show_variant_table:
+                if summary_line:
+                    Text(content=summary_line)
+                if variant_rows:
+                    DataTable(
+                        columns=_ITEM_MODIFY_VARIANT_COLUMNS,
+                        rows=_ITEM_MODIFY_VARIANT_REF,
+                        paginated=True,
+                        pageSize=20,
+                    )
+
+            # Consolidated failed-rows Alert — state-driven so the in-place
+            # morph after Confirm surfaces failures (mirrors the BOM card).
+            with (
+                If(Rx("applied_failed_count") > 0),
+                Alert(variant="destructive", icon="circle-alert"),
+            ):
+                AlertTitle(content="{{ applied_failed_count }} failed action(s)")
+                AlertDescription(content="{{ applied_failed_summary }}")
+
+            if is_preview:
+                with If("error"):
+                    Separator()
+                    with Alert(variant="destructive", icon="circle-alert"):
+                        AlertTitle(content="Apply failed")
+                        AlertDescription(content="{{ error }}")
+
+        # Tier 4 — Footer. Shared apply/cancel/morph rail. No next-action
+        # buttons (the user already had the item they wanted to change; a
+        # deleted item has nothing useful to suggest).
+        _render_preview_footer(
+            title_prefix=f"Item {verb_label}",
+            block_warnings=block_warnings,
+            confirm_label=confirm_label,
+            apply_action=apply_action,
+            cancel_action=cancel_action,
+            next_action_buttons=(),
             applied_verb="{{ applied_verb }}",
         )
     return app
@@ -5916,7 +6327,7 @@ def _so_header_op_skipped_alert_text(
     """Pre-format the consolidated header-level NOT-RUN summary text.
 
     Walks the merged action list (executed + synthesized NOT-RUN tail, see
-    :func:`_so_actions_with_not_run_tail`), picks the ones whose
+    :func:`_actions_with_not_run_tail`), picks the ones whose
     ``status_label == "NOT RUN"`` AND whose operation is in
     :data:`_SO_HEADER_OPS`. Emits one ``"Step skipped: <verb> (NOT RUN —
     earlier phase failed before this step ran)."`` line per skipped op.
@@ -6280,29 +6691,29 @@ def _seed_so_modify_card_state(
     return state
 
 
-def _so_actions_with_not_run_tail(
+def _actions_with_not_run_tail(
     response: dict[str, Any],
     *,
     is_preview: bool,
 ) -> list[dict[str, Any]]:
-    """Return the SO modify card's effective action list, extended (on
-    the apply path only) with the unattempted plan tail synthesized by
-    :func:`_modify_sales_order_impl`.
+    """Return a modify card's effective action list, extended (on the apply
+    path only) with the unattempted plan tail synthesized by the impl.
 
-    ``execute_plan`` is fail-fast — ``response.actions`` ends at the
-    first failed action. The impl stashes the leftover :class:`ActionSpec`
-    entries under ``response.extras["not_run_actions"]`` so they
-    participate in per-section row bucketing in :func:`build_so_modify_ui`
-    (bucketed by ``operation`` prefix the same way executed actions are).
-    Without this merge the morph path's per-section ``so_<section>_rows``
-    slot would overwrite the preview's full row list with the apply
-    response's SHORTER list, silently HIDING every planned action past
-    the failure (#858 finding B; same family as the BOM fix in
-    ``_modify_product_bom_impl``).
+    ``execute_plan`` is fail-fast — ``response.actions`` ends at the first
+    failed action. The impl stashes the leftover :class:`ActionSpec` entries
+    under ``response.extras["not_run_actions"]`` so they participate in the
+    collection-table row merge (classified by ``operation`` the same way
+    executed actions are, rendered with the ``NOT RUN`` status pill). Without
+    this merge the morph path would overwrite the preview's full row list with
+    the apply response's SHORTER list, silently HIDING every planned action
+    past the failure (#858 finding B / Copilot #875; same family as the BOM
+    fix in ``_modify_product_bom_impl``).
 
-    On the preview path we deliberately ignore the extras (every action
-    is already PLANNED) — guards against accidental leakage from a test
-    or future code path that puts NOT-RUN entries on a preview response.
+    Shared by ``build_so_modify_ui`` and ``build_item_modify_ui`` — both feed
+    the result into their collection-diff merge. On the preview path the extras
+    are deliberately ignored (every action is already PLANNED) — guards against
+    accidental leakage from a test or future code path that puts NOT-RUN
+    entries on a preview response.
     """
     actions: list[dict[str, Any]] = list(response.get("actions") or [])
     if is_preview:
@@ -6362,7 +6773,7 @@ def build_so_modify_ui(
       it morphs in lockstep with the outcome Badge.
     """
     is_preview = bool(response.get("is_preview", True))
-    actions: list[dict[str, Any]] = _so_actions_with_not_run_tail(
+    actions: list[dict[str, Any]] = _actions_with_not_run_tail(
         response, is_preview=is_preview
     )
     entity_id = response.get("entity_id")

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -32,6 +32,7 @@ from katana_mcp.tools.prefab_ui import (
     build_inventory_at_ui,
     build_inventory_check_ui,
     build_item_detail_ui,
+    build_item_modify_ui,
     build_modification_preview_ui,
     build_modification_result_ui,
     build_product_bom_ui,
@@ -967,6 +968,98 @@ def _bom_modify_response(*, is_preview: bool, succeeded: bool | None) -> dict:
     }
 
 
+def _item_modify_response(*, is_preview: bool, succeeded: bool | None) -> dict:
+    """Build a canned item modify response with a header change + variant CRUD.
+
+    Mirrors the production shape for the #726 item modify card: a header
+    ``uom`` change plus 1 variant add + 1 variant update + 1 variant delete
+    against a 2-variant product, with the pre-action snapshot threaded as
+    ``prior_state`` (raw ``Product.to_dict()`` shape) and the supplier name
+    pre-resolved (``_resolve_prior_supplier_name``). Pins the dual diff
+    surface — header scalar diff + variant diff table — end to end.
+    """
+    actions = [
+        ActionResult(
+            index=1,
+            operation="update_header",
+            target_id=500,
+            changes=[FieldChange(field="uom", old="pcs", new="set")],
+            succeeded=succeeded,
+            verified=True if succeeded else None,
+        ).model_dump(),
+        ActionResult(
+            index=2,
+            operation="add_variant",
+            target_id=None,
+            changes=[
+                FieldChange(field="sku", old=None, new="WHL-CARB-DISC", is_added=True),
+                FieldChange(field="sales_price", old=None, new=1300.0, is_added=True),
+            ],
+            succeeded=succeeded,
+        ).model_dump(),
+        ActionResult(
+            index=3,
+            operation="update_variant",
+            target_id=9001,
+            changes=[FieldChange(field="sales_price", old=1200.0, new=1250.0)],
+            succeeded=succeeded,
+            verified=True if succeeded else None,
+        ).model_dump(),
+        ActionResult(
+            index=4,
+            operation="delete_variant",
+            target_id=9002,
+            changes=[],
+            succeeded=succeeded,
+        ).model_dump(),
+    ]
+    return {
+        "entity_type": "product",
+        "entity_id": 500,
+        "is_preview": is_preview,
+        "operation": "",
+        "changes": [],
+        "actions": actions,
+        "prior_state": {
+            "id": 500,
+            "name": "Carbon Wheelset",
+            "uom": "pcs",
+            "category_name": "Wheels",
+            "additional_info": "Hand-built",
+            "is_sellable": True,
+            "is_producible": True,
+            "batch_tracked": False,
+            "serial_tracked": False,
+            "archived_at": None,
+            "default_supplier_id": 77,
+            "default_supplier_name": "Acme Carbon Co",
+            "lead_time": 14,
+            "minimum_order_quantity": 2,
+            "variants": [
+                {
+                    "id": 9001,
+                    "sku": "WHL-CARB-700C",
+                    "sales_price": 1200.0,
+                    "purchase_price": 800.0,
+                },
+                {
+                    "id": 9002,
+                    "sku": "WHL-CARB-650B",
+                    "sales_price": 1150.0,
+                    "purchase_price": 760.0,
+                },
+            ],
+        },
+        "extras": {},
+        "warnings": [],
+        "next_actions": [],
+        "katana_url": "https://factory.katanamrp.com/product/500",
+        "message": (
+            "Preview: 4 action(s) planned" if is_preview else "Applied 4 action(s)"
+        ),
+    }
+
+
 def _so_failed_delete_response(*, is_preview: bool = False) -> dict:
     """Build a canned SO delete response where the apply fails.
 
@@ -1646,9 +1739,12 @@ SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
         confirm_request=_StubRequest(),
         confirm_tool="create_sales_order",
     ),
-    "modify_item_single_preview": lambda: build_modification_preview_ui(
+    # Generic single-action modify card (manufacturing_order — not yet
+    # migrated to a per-entity card, so it exercises the legacy
+    # ``build_modification_preview_ui`` single-action path).
+    "modify_mo_single_preview": lambda: build_modification_preview_ui(
         {
-            "entity_type": "product",
+            "entity_type": "manufacturing_order",
             "entity_id": 1,
             "is_preview": True,
             "operation": "",
@@ -1657,7 +1753,7 @@ SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
                 ActionResult(
                     operation="update_header",
                     target_id=1,
-                    changes=[FieldChange(field="name", old="x", new="y")],
+                    changes=[FieldChange(field="status", old="x", new="y")],
                     succeeded=None,
                 ).model_dump()
             ],
@@ -1667,6 +1763,19 @@ SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
             "katana_url": None,
             "message": "Preview: 1 action(s) planned",
         },
+        confirm_request=_StubRequest(),
+        confirm_tool="modify_manufacturing_order",
+    ),
+    # #726 — item modify card: header scalar diff + variant diff table (add +
+    # update + delete). Pins the dual diff surface + the resolved supplier name
+    # + the per-variant status pills end-to-end in a real browser render.
+    "item_modify_mixed_preview": lambda: build_item_modify_ui(
+        _item_modify_response(is_preview=True, succeeded=None),
+        confirm_request=_StubRequest(),
+        confirm_tool="modify_item",
+    ),
+    "item_modify_mixed_applied": lambda: build_item_modify_ui(
+        _item_modify_response(is_preview=False, succeeded=True),
         confirm_request=_StubRequest(),
         confirm_tool="modify_item",
     ),

--- a/katana_mcp_server/tests/browser/test_modification_render.py
+++ b/katana_mcp_server/tests/browser/test_modification_render.py
@@ -42,8 +42,12 @@ class TestModificationCardRender:
         assert templated.locator("td").count() >= 4  # 2 rows x 2 cells
 
     def test_modify_single_action_preview_renders(self, render_scenario):
-        """Single-action modify card: 1 action row, Confirm button visible."""
-        frame = render_scenario("modify_item_single_preview")
+        """Single-action generic modify card: 1 action row, Confirm visible.
+
+        Uses an MO modify (still on the legacy generic card) now that item
+        modify routes to its dedicated ``build_item_modify_ui`` (#726).
+        """
+        frame = render_scenario("modify_mo_single_preview")
         assert frame.locator("table").count() == 1
         # Header + 1 action row.
         assert frame.locator("table tr").count() == 2
@@ -120,6 +124,42 @@ class TestModificationCardRender:
         # 4 actions (1 add + 1 update + 2 delete), so 4 APPLIED cells in
         # the rendered table.
         assert frame.locator("td").filter(has_text="APPLIED").count() >= 4
+
+    def test_item_modify_mixed_preview_renders_dual_diff(self, render_scenario):
+        """#726 item modify card — a header ``uom`` change + (1 variant add +
+        1 update + 1 delete) renders both diff surfaces: the decorated header
+        line and the variant diff table with every kind visible. The resolved
+        supplier name surfaces (never a bare ``#id``).
+        """
+        frame = render_scenario("item_modify_mixed_preview")
+        # Header identity + resolved supplier name (anti-pattern #7).
+        assert frame.locator("text=Carbon Wheelset").count() >= 1
+        assert frame.locator("text=Acme Carbon Co").count() >= 1
+        # Header scalar diff arrow.
+        assert frame.locator("text=pcs → set").count() >= 1
+        # Variant diff table: added SKU (+ gutter), updated price arrow,
+        # deleted SKU (- gutter).
+        assert frame.locator("td").filter(has_text="WHL-CARB-DISC").count() >= 1
+        assert frame.locator("td").filter(has_text="1200 → 1250").count() >= 1
+        assert frame.locator("td").filter(has_text="WHL-CARB-650B").count() >= 1
+        # Plan summary line.
+        assert frame.locator("text=+1 added").count() >= 1
+        assert frame.locator("text=~1 updated").count() >= 1
+        assert frame.locator("text=-1 deleted").count() >= 1
+        # Confirm button (preview state).
+        assert frame.locator("button").filter(has_text="Confirm").count() == 1
+        # Anti-pattern guard: no internal ActionResult labels leak.
+        assert frame.locator("td").filter(has_text="Add Variant").count() == 0
+        assert frame.locator("td").filter(has_text="field(s) set").count() == 0
+
+    def test_item_modify_mixed_applied_renders_per_row_status(self, render_scenario):
+        """#726 applied item modify card — every plan-derived variant row
+        shows APPLIED in the Status column; the header badge says APPLIED.
+        """
+        frame = render_scenario("item_modify_mixed_applied")
+        assert frame.locator("table").count() >= 1
+        # 3 variant actions (add + update + delete) → 3 APPLIED status cells.
+        assert frame.locator("td").filter(has_text="APPLIED").count() >= 3
 
     def test_so_modify_partial_failure_applied_renders(self, render_scenario):
         """#723 SO modify card — partial-failure applied state renders the
@@ -345,7 +385,7 @@ class TestModificationCardRender:
         dropping them.
 
         Same wire shape as the ``modify_sales_order`` fail-fast scenario
-        above — proves the row merge in :func:`_so_actions_with_not_run_tail`
+        above — proves the row merge in :func:`_actions_with_not_run_tail`
         is tool-agnostic (it keys on ``response.extras``, not ``confirm_tool``).
         Standalone-applied test, not click-through: the impl-side fix is
         verified in :file:`test_corrections.py`; this proves the JS-side

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -24,6 +24,7 @@ from katana_mcp.tools.prefab_ui import (
     build_inventory_check_ui,
     build_item_create_ui,
     build_item_detail_ui,
+    build_item_modify_ui,
     build_low_stock_ui,
     build_mo_create_ui,
     build_modification_preview_ui,
@@ -5287,6 +5288,486 @@ class TestBuildBOMModifyUI:
         kinds = [r["kind"] for r in plan_rows]
         assert kinds.count("existing") == 2
         assert kinds.count("added") == 1
+
+
+class TestBuildItemModifyUI:
+    """``build_item_modify_ui`` (#726) — the diff-decorated item modify/delete
+    card.
+
+    Two diff surfaces: header scalar fields (``_render_item_entity_view``
+    overlay) and the variants collection (shared collection-diff table). Sub-
+    type variance: product/material render the variant table, services don't.
+    Mirrors the BOM modify card's preview→apply morph + outcome chrome.
+    """
+
+    # Raw ``Product.to_dict()`` shape — the wire form ``serialize_for_prior_state``
+    # produces for the item modify ``prior_state`` snapshot. ``default_supplier_name``
+    # is stamped on server-side (``_resolve_prior_supplier_name``); the card
+    # reads it for the supplier line.
+    _ITEM_PRIOR: ClassVar[dict[str, Any]] = {
+        "id": 500,
+        "name": "Carbon Wheelset",
+        "uom": "pcs",
+        "category_name": "Wheels",
+        "additional_info": "Hand-built",
+        "is_sellable": True,
+        "is_producible": True,
+        "batch_tracked": False,
+        "serial_tracked": False,
+        "archived_at": None,
+        "default_supplier_id": 77,
+        "default_supplier_name": "Acme Carbon Co",
+        "lead_time": 14,
+        "minimum_order_quantity": 2,
+        "variants": [
+            {
+                "id": 9001,
+                "sku": "WHL-CARB-700C",
+                "sales_price": 1200.0,
+                "purchase_price": 800.0,
+            },
+            {
+                "id": 9002,
+                "sku": "WHL-CARB-650B",
+                "sales_price": 1150.0,
+                "purchase_price": 760.0,
+            },
+        ],
+    }
+
+    @classmethod
+    def _preview(
+        cls,
+        actions: list[dict[str, Any]] | None = None,
+        *,
+        entity_type: str = "product",
+        **overrides: Any,
+    ) -> dict[str, Any]:
+        return {
+            "entity_type": entity_type,
+            "entity_id": 500,
+            "is_preview": True,
+            "actions": actions or [],
+            "prior_state": dict(cls._ITEM_PRIOR),
+            "extras": {},
+            "warnings": [],
+            "next_actions": [],
+            "message": "Preview",
+            "katana_url": "https://factory.katanamrp.com/product/500",
+            **overrides,
+        }
+
+    @classmethod
+    def _applied(
+        cls, actions: list[dict[str, Any]] | None = None, **overrides: Any
+    ) -> dict[str, Any]:
+        return cls._preview(actions, is_preview=False, **overrides)
+
+    @staticmethod
+    def _header_action(*, field: str, old: Any, new: Any, **overrides: Any) -> dict:
+        return {
+            "operation": "update_header",
+            "target_id": 500,
+            "succeeded": None,
+            "changes": [{"field": field, "old": old, "new": new}],
+            "status_label": "PLANNED",
+            **overrides,
+        }
+
+    @staticmethod
+    def _add_variant_action(
+        *, sku: str, sales_price: float | None = None, **overrides: Any
+    ) -> dict:
+        changes: list[dict[str, Any]] = [
+            {"field": "sku", "old": None, "new": sku, "is_added": True}
+        ]
+        if sales_price is not None:
+            changes.append(
+                {
+                    "field": "sales_price",
+                    "old": None,
+                    "new": sales_price,
+                    "is_added": True,
+                }
+            )
+        return {
+            "operation": "add_variant",
+            "target_id": None,
+            "succeeded": None,
+            "changes": changes,
+            "status_label": "PLANNED",
+            **overrides,
+        }
+
+    @staticmethod
+    def _update_variant_action(
+        *, target_id: int, old_price: float, new_price: float, **overrides: Any
+    ) -> dict:
+        return {
+            "operation": "update_variant",
+            "target_id": target_id,
+            "succeeded": None,
+            "changes": [
+                {"field": "sales_price", "old": old_price, "new": new_price},
+            ],
+            "status_label": "PLANNED",
+            **overrides,
+        }
+
+    @staticmethod
+    def _delete_variant_action(*, target_id: int, **overrides: Any) -> dict:
+        return {
+            "operation": "delete_variant",
+            "target_id": target_id,
+            "succeeded": None,
+            "changes": [],
+            "status_label": "PLANNED",
+            **overrides,
+        }
+
+    def test_header_only_modify_decorates_scalar_diff(self):
+        """A header-field change renders a before→after diff line; the resolved
+        supplier name surfaces (never a bare ``#id``)."""
+        actions = [self._header_action(field="uom", old="pcs", new="set")]
+        app = build_item_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Carbon Wheelset" in rendered
+        # Diff arrow on the changed UoM line.
+        assert "pcs → set" in rendered
+        # Supplier name resolved server-side — not a raw "#77".
+        assert "Acme Carbon Co" in rendered
+        assert "#77" not in rendered
+
+    def test_rename_surfaces_name_diff(self):
+        """A header ``name`` rename must surface a before→after diff — the
+        card title is built from the prior snapshot, so without the name diff
+        line the rename would show nowhere (Copilot #875)."""
+        actions = [
+            self._header_action(field="name", old="Carbon Wheelset", new="Carbon Pro")
+        ]
+        app = build_item_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Carbon Wheelset → Carbon Pro" in rendered
+
+    def test_service_pricing_change_surfaces_diff(self):
+        """Services carry pricing/SKU on the header and have no variant table,
+        so a service ``sales_price`` / ``sku`` modify must still render a
+        field-level diff. Prices arrive as Decimal (compute_field_diff →
+        _normalize), so the shared diff formatter must trim them, not ``repr``
+        as ``Decimal('50.00…')`` (Copilot #875)."""
+        from decimal import Decimal
+
+        actions = [
+            self._header_action(
+                field="sales_price",
+                old=Decimal("50.0000000000"),
+                new=Decimal("65.0000000000"),
+            ),
+            self._header_action(field="sku", old="SVC-OLD", new="SVC-NEW"),
+        ]
+        app = build_item_modify_ui(
+            self._preview(actions, entity_type="service"),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "50 → 65" in rendered
+        assert "Decimal" not in rendered
+        assert "SVC-OLD → SVC-NEW" in rendered
+
+    def test_status_flag_change_surfaces_diff(self):
+        """Boolean header flags (is_sellable / is_producible / tracking) aren't
+        carried by the diff-unaware Tier-1 pills, so a flag modify must render
+        an explicit ``yes → no`` diff line (Copilot #875)."""
+        actions = [
+            self._header_action(field="is_sellable", old=True, new=False),
+            self._header_action(field="batch_tracked", old=False, new=True),
+        ]
+        app = build_item_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "yes → no" in rendered  # is_sellable True → False
+        assert "no → yes" in rendered  # batch_tracked False → True
+
+    def test_variant_crud_renders_all_kinds_and_summary(self):
+        """1 add + 1 update + 1 delete + 1 untouched: every row kind appears
+        in the variant table and the summary line counts them."""
+        actions = [
+            self._add_variant_action(sku="WHL-CARB-DISC", sales_price=1300.0),
+            self._update_variant_action(
+                target_id=9001, old_price=1200.0, new_price=1250.0
+            ),
+            self._delete_variant_action(target_id=9002),
+        ]
+        app = build_item_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        # Added variant SKU with the "+ " gutter.
+        assert "+ WHL-CARB-DISC" in rendered
+        # Updated variant's price diff arrow.
+        assert "1200 → 1250" in rendered
+        # Deleted variant's identity preserved with the "- " gutter.
+        assert "- WHL-CARB-650B" in rendered
+        # Summary line.
+        assert "+1 added" in rendered
+        assert "~1 updated" in rendered
+        assert "-1 deleted" in rendered
+
+    def test_variant_rows_land_in_state_for_datatable_binding(self):
+        """The variant rows seed ``state.variant_rows`` so the state-bound
+        DataTable resolves (and morphs on apply)."""
+        actions = [self._add_variant_action(sku="WHL-NEW")]
+        app = build_item_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        assert app.state is not None
+        rows = app.state.get("variant_rows")
+        assert isinstance(rows, list)
+        # 2 existing + 1 added.
+        assert len(rows) == 3
+        kinds = [r["kind"] for r in rows]
+        assert kinds.count("existing") == 2
+        assert kinds.count("added") == 1
+
+    def test_service_has_no_variant_table(self):
+        """Services carry pricing on the header, not on variants — the variant
+        diff table is suppressed even if the snapshot carries variants."""
+        actions = [self._header_action(field="sales_price", old=50.0, new=60.0)]
+        app = build_item_modify_ui(
+            self._preview(actions, entity_type="service"),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        assert app.state is not None
+        # No variant rows seeded for a service.
+        assert app.state.get("variant_rows") == []
+
+    def test_subtype_badge_reflects_entity_type(self):
+        """The type badge reads from the response entity_type (the raw item
+        snapshot has no ``type`` echo)."""
+        for entity_type in ("product", "material", "service"):
+            app = build_item_modify_ui(
+                self._preview(
+                    [self._header_action(field="uom", old="pcs", new="kg")],
+                    entity_type=entity_type,
+                ),
+                confirm_request=_StubRequest(),
+                confirm_tool="modify_item",
+            )
+            rendered = str(app.to_json())
+            assert entity_type in rendered
+
+    def test_delete_uses_delete_verb_and_confirm_label(self):
+        """A delete routes through the same card with the Delete verb +
+        ``Confirm Delete`` affordance."""
+        actions = [
+            {
+                "operation": "delete",
+                "target_id": 500,
+                "succeeded": None,
+                "changes": [],
+                "status_label": "PLANNED",
+            }
+        ]
+        app = build_item_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="delete_item",
+        )
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Confirm Delete" in rendered
+
+    def test_applied_state_seeds_outcome_slots(self):
+        """On the standalone-applied path the outcome label/variant track the
+        real action outcomes (all-success → APPLIED / default)."""
+        actions = [
+            self._update_variant_action(
+                target_id=9001,
+                old_price=1200.0,
+                new_price=1250.0,
+                succeeded=True,
+                status_label="APPLIED",
+            )
+        ]
+        app = build_item_modify_ui(
+            self._applied(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        assert app.state is not None
+        assert app.state.get("applied_outcome_label") == "APPLIED"
+        assert app.state.get("applied_outcome_variant") == "default"
+
+    def test_partial_failure_surfaces_failed_summary(self):
+        """A mixed applied outcome seeds the failed-count + summary slots and
+        flips the outcome variant to destructive."""
+        actions = [
+            self._update_variant_action(
+                target_id=9001,
+                old_price=1200.0,
+                new_price=1250.0,
+                succeeded=True,
+                status_label="APPLIED",
+            ),
+            self._delete_variant_action(
+                target_id=9002,
+                succeeded=False,
+                status_label="FAILED",
+                error="variant in use by an open SO",
+            ),
+        ]
+        app = build_item_modify_ui(
+            self._applied(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        assert app.state is not None
+        assert app.state.get("applied_outcome_label") == "PARTIAL FAILURE"
+        assert app.state.get("applied_outcome_variant") == "destructive"
+        assert app.state.get("applied_failed_count") == 1
+        assert "variant in use by an open SO" in str(
+            app.state.get("applied_failed_summary")
+        )
+
+    def test_not_run_tail_surfaces_in_variant_table(self):
+        """Fail-fast partial apply: the impl stashes the unattempted plan tail
+        in ``extras["not_run_actions"]``; the card must merge them so the
+        morphed table shows the not-run variant rows (NOT RUN) instead of
+        silently dropping them (Copilot #875)."""
+        # Action 1 (delete 9001) failed → execute_plan stopped; the planned
+        # update of 9002 never ran and is synthesized as NOT RUN.
+        applied_actions = [
+            self._delete_variant_action(
+                target_id=9001,
+                succeeded=False,
+                status_label="FAILED",
+                error="variant in use",
+            )
+        ]
+        not_run = [
+            {
+                "operation": "update_variant",
+                "target_id": 9002,
+                "succeeded": None,
+                "error": None,
+                "changes": [{"field": "sales_price", "old": 1150.0, "new": 1200.0}],
+                "status_label": "NOT RUN",
+            }
+        ]
+        app = build_item_modify_ui(
+            self._applied(applied_actions, extras={"not_run_actions": not_run}),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        _assert_valid_prefab(app)
+        assert app.state is not None
+        rows = app.state.get("variant_rows")
+        assert isinstance(rows, list)
+        # Both variants surface: 9001 deleted (FAILED), 9002 updated (NOT RUN).
+        statuses = {r["id"]: r["status_label"] for r in rows}
+        assert statuses.get(9001) == "FAILED"
+        assert statuses.get(9002) == "NOT RUN"
+
+    def test_decimal_prices_render_trimmed_in_card(self):
+        """Prices arrive as Decimal from `compute_field_diff`; the variant
+        table must render them trimmed, not `1200.0000000000` (Copilot #875)."""
+        from decimal import Decimal
+
+        actions = [
+            {
+                "operation": "update_variant",
+                "target_id": 9001,
+                "succeeded": None,
+                "status_label": "PLANNED",
+                "changes": [
+                    {
+                        "field": "sales_price",
+                        "old": Decimal("1200.0000000000"),
+                        "new": Decimal("1250.5000000000"),
+                    }
+                ],
+            }
+        ]
+        app = build_item_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        rendered = str(app.to_json())
+        assert "1200 → 1250.5" in rendered
+        assert "0000000000" not in rendered
+
+    def test_preview_shows_preview_badge_default_outcome(self):
+        """On preview the outcome slots seed the optimistic APPLIED default
+        (the Tier-1 badge shows PREVIEW until the morph overwrites them)."""
+        app = build_item_modify_ui(
+            self._preview([self._add_variant_action(sku="X")]),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_item",
+        )
+        assert app.state is not None
+        # Preview-time defaults — never bucketed from succeeded=None actions.
+        assert app.state.get("applied_outcome_label") == "APPLIED"
+        rendered = str(app.to_json())
+        assert "PREVIEW" in rendered
+
+
+class TestItemModifyDispatch:
+    """``to_tool_result`` routes product / material / service modify responses
+    to ``build_item_modify_ui`` (not the legacy generic card)."""
+
+    @pytest.mark.parametrize("entity_type", ["product", "material", "service"])
+    def test_item_types_route_to_item_modify_card(self, entity_type):
+        from katana_mcp.tools._modification import (
+            ConfirmableRequest,
+            ModificationResponse,
+            to_tool_result,
+        )
+
+        class _StubConfirmable(ConfirmableRequest):
+            id: int = 500
+
+        response = ModificationResponse(
+            entity_type=entity_type,
+            entity_id=500,
+            is_preview=True,
+            actions=[],
+            prior_state={"id": 500, "name": "Thing", "variants": []},
+            warnings=[],
+            next_actions=[],
+            message="Preview",
+        )
+        result = to_tool_result(
+            response, confirm_request=_StubConfirmable(), confirm_tool="modify_item"
+        )
+        envelope = result.structured_content
+        # The item card titles its footer "Item Modify ..."; the generic
+        # legacy card does not. Presence of the item name in the identity
+        # header confirms the item builder ran.
+        rendered = str(envelope)
+        assert "Thing" in rendered
 
 
 class TestPOEntityViewSharedBetweenCreateAndModify:

--- a/katana_mcp_server/tests/tools/test_corrections.py
+++ b/katana_mcp_server/tests/tools/test_corrections.py
@@ -864,7 +864,7 @@ async def test_correct_so_fail_fast_synthesizes_not_run_tail_for_morph():
     assert response.actions[2].succeeded is False  # update_row (boom)
 
     # The two unattempted phases must surface as NOT-RUN extras so the
-    # SO modify-card morph picks them up via ``_so_actions_with_not_run_tail``.
+    # SO modify-card morph picks them up via ``_actions_with_not_run_tail``.
     not_run = response.extras.get("not_run_actions") or []
     assert len(not_run) == 2, (
         f"Expected 2 NOT-RUN entries (recreate + close); got {len(not_run)}: "
@@ -884,7 +884,7 @@ async def test_correct_so_fail_fast_morph_renders_not_run_rows():
     This is the consumer-side proof — the impl-side test above proves
     extras are populated; this one proves the renderer actually reads them.
     """
-    from katana_mcp.tools.prefab_ui import _so_actions_with_not_run_tail
+    from katana_mcp.tools.prefab_ui import _actions_with_not_run_tail
 
     context, _ = create_mock_context()
     picked = datetime(2026, 4, 15, 21, 18, 0, tzinfo=UTC)
@@ -951,7 +951,7 @@ async def test_correct_so_fail_fast_morph_renders_not_run_rows():
     # Hand the response to the merge helper exactly as ``build_so_modify_ui``
     # does. Result: 3 executed + 2 NOT-RUN = 5 rows visible on the morph.
     response_dict = response.model_dump()
-    merged = _so_actions_with_not_run_tail(response_dict, is_preview=False)
+    merged = _actions_with_not_run_tail(response_dict, is_preview=False)
     assert len(merged) == 5
 
     # Plan order preserved: APPLIED, APPLIED, FAILED, NOT RUN, NOT RUN.

--- a/katana_mcp_server/tests/tools/test_item_variant_table.py
+++ b/katana_mcp_server/tests/tools/test_item_variant_table.py
@@ -1,0 +1,199 @@
+"""Tests for the item-variant collection-diff table (#726).
+
+Exercises the variant-specific cell builders + merge wiring layered on top of
+the shared collection-diff skeleton: SKU / sales-price / purchase-price cells,
+the kind gutter on the SKU column, and the add/update/delete projection from
+variant-CRUD actions + a prior-state snapshot.
+"""
+
+from decimal import Decimal
+from typing import ClassVar
+
+from katana_mcp.tools.foundation.item_variant_table import (
+    _format_price,
+    _format_price_diff,
+    merge_variant_rows_for_modify_card,
+    prepare_variant_table_rows,
+)
+
+
+class TestFormatPrice:
+    def test_none_is_em_dash(self):
+        assert _format_price(None) == "—"
+
+    def test_trims_trailing_zeros(self):
+        assert _format_price(299.0) == "299"
+        assert _format_price(2.5) == "2.5"
+
+    def test_numeric_string_coerced(self):
+        assert _format_price("150.00") == "150"
+
+    def test_decimal_trimmed(self):
+        # Real modify diffs normalize prices to Decimal (compute_field_diff →
+        # _normalize). Must trim like floats, not render "1200.0000000000".
+        assert _format_price(Decimal("1200.0000000000")) == "1200"
+        assert _format_price(Decimal("2.50")) == "2.5"
+
+    def test_decimal_diff_form(self):
+        assert (
+            _format_price_diff(
+                Decimal("100.00"), Decimal("125.50"), unknown_prior=False
+            )
+            == "100 → 125.5"
+        )
+
+    def test_non_numeric_string_passthrough(self):
+        assert _format_price("free") == "free"
+
+    def test_diff_form(self):
+        assert _format_price_diff(100.0, 120.0, unknown_prior=False) == "100 → 120"
+
+    def test_diff_unknown_prior(self):
+        assert _format_price_diff(None, 120.0, unknown_prior=True) == (
+            "(prior unknown) → 120"
+        )
+
+
+class TestMergeVariantRows:
+    _PRIOR: ClassVar[dict] = {
+        "variants": [
+            {"id": 9001, "sku": "AAA", "sales_price": 100.0, "purchase_price": 60.0},
+            {"id": 9002, "sku": "BBB", "sales_price": 110.0, "purchase_price": 70.0},
+        ]
+    }
+
+    def _merge(self, actions):
+        return prepare_variant_table_rows(
+            merge_variant_rows_for_modify_card(self._PRIOR, actions)
+        )
+
+    def test_no_actions_yields_existing_rows_sorted_by_sku(self):
+        rows = self._merge([])
+        assert [r["sku"] for r in rows] == ["AAA", "BBB"]
+        assert all(r["kind"] == "existing" for r in rows)
+        # Existing rows reserve the 2-char gutter (no visible marker).
+        assert all(r["sku_label"].startswith("  ") for r in rows)
+
+    def test_add_variant_appends_with_added_kind_and_prices(self):
+        action = {
+            "operation": "add_variant",
+            "target_id": None,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [
+                {"field": "sku", "old": None, "new": "CCC", "is_added": True},
+                {"field": "sales_price", "old": None, "new": 130.0, "is_added": True},
+            ],
+        }
+        rows = self._merge([action])
+        assert [r["kind"] for r in rows] == ["existing", "existing", "added"]
+        added = rows[-1]
+        assert added["sku_label"] == "+ CCC"
+        assert added["sales_price_label"] == "130"
+        # No purchase price supplied → em-dash.
+        assert added["purchase_price_label"] == "—"
+        assert added["status_label"] == "PLANNED"
+
+    def test_update_variant_decorates_price_diff(self):
+        action = {
+            "operation": "update_variant",
+            "target_id": 9001,
+            "succeeded": True,
+            "status_label": "APPLIED",
+            "changes": [{"field": "sales_price", "old": 100.0, "new": 125.0}],
+        }
+        rows = self._merge([action])
+        updated = next(r for r in rows if r["id"] == 9001)
+        assert updated["kind"] == "updated"
+        assert updated["sku_label"] == "~ AAA"
+        assert updated["sales_price_label"] == "100 → 125"
+        assert updated["status_label"] == "APPLIED"
+
+    def test_update_variant_sku_change_shows_arrow(self):
+        action = {
+            "operation": "update_variant",
+            "target_id": 9001,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [{"field": "sku", "old": "AAA", "new": "AAA-V2"}],
+        }
+        rows = self._merge([action])
+        updated = next(r for r in rows if r["id"] == 9001)
+        assert updated["sku_label"] == "~ AAA → AAA-V2"
+
+    def test_delete_variant_marks_deleted_and_keeps_identity(self):
+        action = {
+            "operation": "delete_variant",
+            "target_id": 9002,
+            "succeeded": True,
+            "status_label": "APPLIED",
+            "changes": [],
+        }
+        rows = self._merge([action])
+        deleted = next(r for r in rows if r["id"] == 9002)
+        assert deleted["kind"] == "deleted"
+        assert deleted["sku_label"] == "- BBB"
+
+    def test_failed_action_carries_error(self):
+        action = {
+            "operation": "delete_variant",
+            "target_id": 9001,
+            "succeeded": False,
+            "status_label": "FAILED",
+            "error": "in use",
+            "changes": [],
+        }
+        rows = self._merge([action])
+        row = next(r for r in rows if r["id"] == 9001)
+        assert row["status_label"] == "FAILED"
+        assert row["error"] == "in use"
+
+    def test_sku_less_variant_renders_no_sku_placeholder(self):
+        prior = {"variants": [{"id": 9003, "sku": None, "sales_price": 5.0}]}
+        rows = prepare_variant_table_rows(merge_variant_rows_for_modify_card(prior, []))
+        assert rows[0]["sku_label"] == "  (no SKU)"
+
+    def test_missing_prior_state_yields_empty(self):
+        assert merge_variant_rows_for_modify_card(None, []) == []
+
+    def test_non_variant_ops_filtered_without_warning(self, caplog):
+        """The item action list also carries ``update_header`` / ``delete``
+        (handled outside the variant table). These must be filtered before the
+        shared merge so it doesn't log a spurious "dropped action — unknown
+        operation" warning on every header-only modify (Copilot #875). Existing
+        variant rows still render."""
+        import logging
+
+        from katana_mcp.logging import setup_logging
+
+        setup_logging(log_level="WARNING", log_format="json")
+        actions = [
+            {
+                "operation": "update_header",
+                "target_id": 500,
+                "succeeded": None,
+                "changes": [{"field": "uom", "old": "pcs", "new": "kg"}],
+            },
+            {"operation": "delete", "target_id": 500, "succeeded": None, "changes": []},
+        ]
+        with caplog.at_level(
+            logging.WARNING, logger="katana_mcp.tools.foundation.collection_diff"
+        ):
+            rows = self._merge(actions)
+        # Existing variants still render, untouched.
+        assert [r["kind"] for r in rows] == ["existing", "existing"]
+        # No "dropped action" warning leaked from the shared merge.
+        assert not any("dropped action" in rec.getMessage() for rec in caplog.records)
+
+    def test_orphan_update_target_synthesized(self):
+        action = {
+            "operation": "update_variant",
+            "target_id": 99999,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [{"field": "sales_price", "old": None, "new": 9.0}],
+        }
+        rows = self._merge([action])
+        ghost = next((r for r in rows if str(r["id"]) == "99999"), None)
+        assert ghost is not None
+        assert ghost["kind"] == "updated"

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -2463,3 +2463,89 @@ def test_build_update_variant_request_passes_config_attributes():
     assert body["config_attributes"] == [{"config_name": "Teeth", "config_value": "34"}]
     # ``id`` is the path parameter, not a body field — must not appear in body.
     assert "id" not in body
+
+
+# ============================================================================
+# Modify-card supplier-name resolution (anti-pattern #7) — the modify/delete
+# prior_state snapshot carries only the supplier FK; the impl resolves the
+# name from the typed cache so the card never shows a bare "#id".
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_resolve_prior_supplier_name_fills_name_from_cache():
+    from katana_mcp.tools._modification import ModificationResponse
+    from katana_mcp.tools.foundation.items import _resolve_prior_supplier_name
+
+    response = ModificationResponse(
+        entity_type="product",
+        entity_id=500,
+        is_preview=True,
+        actions=[],
+        prior_state={"id": 500, "default_supplier_id": 77},
+        warnings=[],
+        next_actions=[],
+        message="Preview",
+    )
+    services = MagicMock()
+    with patch(
+        "katana_mcp.tools.foundation.items.resolve_entity_name",
+        new=AsyncMock(return_value=("Acme Carbon Co", None)),
+    ):
+        await _resolve_prior_supplier_name(services, response)
+
+    assert response.prior_state is not None
+    assert response.prior_state["default_supplier_name"] == "Acme Carbon Co"
+
+
+@pytest.mark.asyncio
+async def test_resolve_prior_supplier_name_noop_without_fk():
+    from katana_mcp.tools._modification import ModificationResponse
+    from katana_mcp.tools.foundation.items import _resolve_prior_supplier_name
+
+    response = ModificationResponse(
+        entity_type="service",
+        entity_id=500,
+        is_preview=True,
+        actions=[],
+        prior_state={"id": 500},
+        warnings=[],
+        next_actions=[],
+        message="Preview",
+    )
+    services = MagicMock()
+    resolver = AsyncMock(return_value=("X", None))
+    with patch("katana_mcp.tools.foundation.items.resolve_entity_name", new=resolver):
+        await _resolve_prior_supplier_name(services, response)
+
+    # No FK → no cache hit, no name written.
+    resolver.assert_not_awaited()
+    assert response.prior_state is not None
+    assert "default_supplier_name" not in response.prior_state
+
+
+@pytest.mark.asyncio
+async def test_resolve_prior_supplier_name_warning_appended_on_miss():
+    from katana_mcp.tools._modification import ModificationResponse
+    from katana_mcp.tools.foundation.items import _resolve_prior_supplier_name
+
+    response = ModificationResponse(
+        entity_type="material",
+        entity_id=500,
+        is_preview=True,
+        actions=[],
+        prior_state={"id": 500, "default_supplier_id": 999},
+        warnings=[],
+        next_actions=[],
+        message="Preview",
+    )
+    services = MagicMock()
+    with patch(
+        "katana_mcp.tools.foundation.items.resolve_entity_name",
+        new=AsyncMock(return_value=(None, "Default supplier 999 not in cache")),
+    ):
+        await _resolve_prior_supplier_name(services, response)
+
+    assert response.prior_state is not None
+    assert "default_supplier_name" not in response.prior_state
+    assert any("999" in w for w in response.warnings)

--- a/uv.lock
+++ b/uv.lock
@@ -1329,7 +1329,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.102.0"
+version = "0.103.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Phase 2 of the modify-card umbrella (#721): the net-new **item modify/delete
card** (#726), built on the shared collection-diff element landed in Phase 1
(#872). `modify_item` / `delete_item` previews + applies now render a
four-tier card instead of the generic `ActionResult` table.

Two diff surfaces, both reusing the shared modify-card machinery:

- **Header scalars** — `_render_item_entity_view`'s `changes=` overlay (#555),
  scoped to the `update_header` action so variant-field diffs don't leak into
  header lines. Editable fields (UoM, category, notes, supplier, …) render
  `before → after`; unchanged fields render plain — byte-identical to the
  create/detail cards when `changes` is empty.
- **Variants collection** — a new `item_variant_table` element layered on the
  shared collection-diff skeleton (`merge_collection_diff_rows`): add / update
  / delete variants render as `+`/`~`/`-` gutter rows with SKU / sales price /
  purchase price cells and a per-row Status, state-bound so the table morphs in
  place on apply.

### Shared-element reuse / refactors

- Extracted `_render_apply_outcome_badge` (the reactive PREVIEW → outcome
  Tier-1 pill) and adopted it in **both** the BOM and item cards.
- Extracted `_item_status_pills_row` from `_item_header_section` so the modify
  header reuses the sub-type pills alongside its reactive badge.
- `_render_item_entity_view` gained `suppress_variants` so the per-row variant
  diff table replaces the embedded read-only one on the modify card.

### Supporting

- `_resolve_prior_supplier_name` resolves the default supplier's name from the
  typed cache on the modify/delete path (anti-pattern #7) — the supplier line
  never shows a bare `#id`.
- Dispatch branch in `to_tool_result` for `entity_type` product / material /
  service. Services suppress the variant table (no variant CRUD; pricing diffs
  surface on the header).

## Test plan

- [x] `uv run poe agent-check` (lint + ty) — clean
- [x] `uv run pyright` on touched files — 0 errors
- [x] `uv run poe test` — 3810 passed
- [x] `uv run poe test-browser` — 44 passed, incl. new
  `item_modify_mixed_{preview,applied}` rendering in a real browser
- New unit coverage: `TestBuildItemModifyUI`, `TestItemModifyDispatch`,
  `test_item_variant_table`, `_resolve_prior_supplier_name` impl tests
- BOM card regression covered by the existing `TestBuildBOMModifyUI` + browser
  scenarios (it now shares `_render_apply_outcome_badge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)