### PR TITLE
feat(mcp): make CachedVariant.service_id durable; drop search_items re-read

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -41,7 +41,7 @@ from katana_mcp.tools._modification_dispatch import (
     safe_fetch_for_diff,
     unset_dict,
 )
-from katana_mcp.tools.decorators import cache_read, ensure_cache_synced
+from katana_mcp.tools.decorators import cache_read
 from katana_mcp.tools.list_coercion import CoercedIntListOpt, CoercedStrListOpt
 from katana_mcp.tools.tool_result_utils import (
     UI_META,
@@ -309,7 +309,7 @@ def _search_response_to_tool_result(
     )
 
 
-@cache_read(CachedVariant)
+@cache_read(CachedVariant, CachedService)
 async def _search_items_impl(
     request: SearchItemsRequest, context: Context
 ) -> SearchItemsResponse:
@@ -337,57 +337,30 @@ async def _search_items_impl(
             return "unknown"
         return type_val.value if hasattr(type_val, "value") else str(type_val)
 
-    # Resolve each row's type once and reuse it below (the parent-id join, the
-    # service guard, and the ItemInfo build all need it).
+    # Resolve each row's type once and reuse it below (the parent-id resolution
+    # and the ItemInfo build both need it).
     typed_variants = [(v, _item_type(v)) for v in variants]
 
     # The parent *item* id that modify_item/get_item need differs from the
     # variant ``id`` search returns. Products/materials carry it on the row
     # (``product_id``/``material_id``); a service variant has null
     # ``product_id`` AND null ``material_id``, so it reads from the cache-only
-    # ``service_id`` column denormalized at sync time (see
-    # ``_backfill_service_variant_links`` in ``typed_cache/sync.py``).
-    #
-    # Only do this when a service is actually in the result set, so
-    # product/material-only searches pay nothing (the common case). Two-step,
-    # because ``smart_search`` above returned *detached* rows whose
-    # ``service_id`` was frozen at fetch time — possibly before this sync's
-    # backfill, or stale from a ``/variants`` delta that nulled it: (1) sync
-    # services, which runs the ``post_sync`` backfill onto the variant rows;
-    # (2) re-read just the service variant rows so we see the backfilled
-    # value. ``include_archived/deleted=True`` so a row ``smart_search``
-    # already surfaced isn't dropped by the re-fetch's soft-state filter.
-    service_parent_by_variant: dict[int, int] = {}
-    service_variant_ids = [
-        int(vid)
-        for v, item_type in typed_variants
-        if item_type == "service" and (vid := _attr(v, "id")) is not None
-    ]
-    if service_variant_ids:
-        await ensure_cache_synced(services, CachedService)
-        fresh = await services.typed_cache.catalog.get_many_by_ids(
-            CachedVariant,
-            service_variant_ids,
-            include_archived=True,
-            include_deleted=True,
-        )
-        for vid, row in fresh.items():
-            service_id = _attr(row, "service_id")
-            if service_id is not None:
-                service_parent_by_variant[int(vid)] = int(service_id)
-
+    # ``service_id`` column. That column is a plain row read here because the
+    # ``@cache_read(CachedVariant, CachedService)`` decorator syncs services
+    # (running ``_backfill_service_variant_links``) *before* this function's
+    # ``smart_search``, and ``_VARIANT_SPEC.preserve_columns_on_conflict``
+    # keeps a backfilled ``service_id`` from being nulled by a ``/variants``
+    # delta — so the value ``smart_search`` returns is already correct, with
+    # no second sync-and-re-read needed.
     def _parent_id(v: Any, item_type: str) -> int | None:
         if item_type == "product":
             return _attr(v, "product_id")
         if item_type == "material":
             return _attr(v, "material_id")
         if item_type == "service":
-            # None when the service sync hasn't backfilled this row yet —
-            # degrade gracefully rather than emitting the (wrong) variant id.
-            variant_id = _attr(v, "id")
-            if variant_id is None:
-                return None
-            return service_parent_by_variant.get(int(variant_id))
+            # None only for a service variant whose row predates any service
+            # sync — degrade gracefully rather than emitting the variant id.
+            return _attr(v, "service_id")
         return None
 
     items_info = [

--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -209,6 +209,15 @@ class EntitySpec:
       variant. Lives on the spec (not just the ``ensure_*`` wrapper) so
       ``force_resync`` inherits it: a ``rebuild_cache`` of services
       re-establishes the variant links rather than leaving them stale.
+
+    - ``preserve_columns_on_conflict`` — column names excluded from the
+      ``ON CONFLICT DO UPDATE SET`` clause of this entity's upsert, so their
+      existing value survives a re-sync instead of being overwritten by the
+      incoming payload. For cache-only columns a *different* sync owns: the
+      variant spec preserves ``service_id`` (written by the service spec's
+      ``post_sync``) so a ``/variants`` delta — whose payload has no
+      ``service_id`` — can't null it back out. Without this the column would
+      only be trustworthy immediately after a service sync.
     """
 
     entity_key: str
@@ -223,6 +232,7 @@ class EntitySpec:
     depends_on: tuple[str, ...] = ()
     attrs_postprocess: Callable[[Any, Any], None] | None = None
     post_sync: Callable[[TypedCacheEngine], Awaitable[None]] | None = None
+    preserve_columns_on_conflict: frozenset[str] = frozenset()
     extra_fetch_kwargs: dict[str, Any] = field(default_factory=dict)
     supports_incremental: bool = True
     supports_include_deleted: bool = True
@@ -405,7 +415,10 @@ _SQLITE_PARAM_BUDGET = 900
 
 
 async def _bulk_upsert(
-    session: AsyncSession, table_cls: type[SQLModel], rows: list[Any]
+    session: AsyncSession,
+    table_cls: type[SQLModel],
+    rows: list[Any],
+    preserve_columns: frozenset[str] = frozenset(),
 ) -> None:
     """One ``INSERT ... ON CONFLICT(id) DO UPDATE`` per chunk; no-op on empty rows.
 
@@ -417,6 +430,16 @@ async def _bulk_upsert(
     The include-set is driven from ``__table__.columns`` rather than a
     hardcoded exclude list, so adding a new ``Relationship`` field to a
     cache class can never silently leak into the values payload.
+
+    ``preserve_columns`` are excluded from the ``ON CONFLICT DO UPDATE SET``
+    clause: their existing value survives the upsert instead of being
+    overwritten by the incoming payload. This protects cache-only columns
+    that the entity's own wire payload never carries — e.g. a service
+    variant's ``service_id`` is denormalized from ``/services`` by a
+    ``post_sync`` backfill, so re-upserting that row from a ``/variants``
+    delta (whose payload has no ``service_id``) must not null it back out.
+    On INSERT the column still lands its default; only UPDATE-on-conflict
+    is suppressed.
     """
     if not rows:
         return
@@ -427,6 +450,7 @@ async def _bulk_upsert(
     mapper = sqla_inspect(table_cls)
     column_names = {col.name for col in mapper.columns}
     chunk_size = max(1, _SQLITE_PARAM_BUDGET // len(column_names))
+    frozen = {"id", *preserve_columns}
 
     # ``model_dump`` per chunk (not eagerly across the whole batch) so a
     # cold sync of thousands of rows doesn't double-buffer the cache rows
@@ -434,7 +458,7 @@ async def _bulk_upsert(
     for chunk in batched(rows, chunk_size):
         values = [r.model_dump(include=column_names) for r in chunk]
         stmt = sqlite_insert(table_cls).values(values)
-        update_cols = {c.name: c for c in stmt.excluded if c.name != "id"}
+        update_cols = {c.name: c for c in stmt.excluded if c.name not in frozen}
         stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_cols)
         await session.exec(stmt)
 
@@ -551,7 +575,12 @@ async def _sync_one_locked(
         # SQLAlchemy mapper events would silently miss this Core path,
         # but SQLite triggers fire for every write mode (ORM, Core,
         # raw SQL).
-        await _bulk_upsert(session, spec.cache_cls, cached_parents)
+        await _bulk_upsert(
+            session,
+            spec.cache_cls,
+            cached_parents,
+            preserve_columns=spec.preserve_columns_on_conflict,
+        )
 
         if (
             spec.reconcile_children
@@ -882,13 +911,12 @@ async def _backfill_service_variant_links(cache: TypedCacheEngine) -> None:
     ``variant_au`` FTS trigger doesn't fire) once the column is already
     correct, so the full pass on every service sync stays cheap.
 
-    The full pass (not a delta-scoped one) is deliberate: ``_bulk_upsert``
-    sets every non-id column from the payload, so a ``/variants`` delta can
-    transiently null a previously-backfilled ``service_id`` *without* the
-    service itself reappearing in the service delta. Re-linking every service
-    each pass self-heals that case; a delta-scoped backfill would not.
-    ``search_items`` re-reads the variant rows after triggering this sync, so
-    it never observes the pre-backfill value.
+    Durability is owned by ``_VARIANT_SPEC.preserve_columns_on_conflict``,
+    which excludes ``service_id`` from the ``/variants`` upsert — once written
+    here it survives subsequent variant deltas. This backfill therefore only
+    has to *establish* the link (cold start, newly-created services). A full
+    pass (rather than delta-scoped) keeps it order-independent: it links any
+    service whose variant row now exists, regardless of which sync ran first.
     """
     variant_id_col: Any = CachedVariant.id
     service_id_col: Any = CachedVariant.service_id
@@ -954,6 +982,11 @@ _VARIANT_SPEC = EntitySpec(
     },
     depends_on=("product", "material"),
     attrs_postprocess=_variant_postprocess,
+    # ``service_id`` is denormalized onto service variants by the service
+    # spec's ``post_sync`` (it lives on /services, never on /variants).
+    # Preserve it across /variants deltas so a re-upsert of a service
+    # variant row can't null the backfilled link.
+    preserve_columns_on_conflict=frozenset({"service_id"}),
 )
 
 

--- a/katana_mcp_server/tests/test_typed_cache_catalog.py
+++ b/katana_mcp_server/tests/test_typed_cache_catalog.py
@@ -594,14 +594,13 @@ class TestServiceVariantLinkBackfill:
     ):
         """Integration: real ``_search_items_impl`` resolves service ``parent_id``.
 
-        Reproduces the original ordering bug end-to-end against a real engine:
-        the variant row is synced with ``service_id=None`` and the service is
-        NOT yet synced, so ``smart_search`` returns a detached row whose
-        ``service_id`` is null. ``_search_items_impl`` then syncs services
-        (firing the ``post_sync`` backfill) and re-reads the variant rows —
-        resolving ``parent_id`` from the fresh value. Reading the stale
-        ``smart_search`` row directly (the pre-fix behavior) returned
-        ``parent_id=None`` here.
+        End-to-end against a real engine: the variant row is synced with
+        ``service_id=None`` and the service is not yet synced. When
+        ``_search_items_impl`` runs, its ``@cache_read(CachedVariant,
+        CachedService)`` decorator syncs services first — firing the
+        ``post_sync`` backfill onto the variant row — so ``smart_search`` then
+        returns the row with ``service_id`` already set and ``parent_id`` is a
+        plain column read (no second-pass re-fetch).
         """
         from katana_mcp.tools.foundation.items import (
             SearchItemsRequest,
@@ -633,10 +632,11 @@ class TestServiceVariantLinkBackfill:
                 "variants": [{"id": 40722022, "sku": "LABOR", "service_id": 17253805}],
             }
         )
-        # ``_search_items_impl`` carries ``@cache_read(CachedVariant)``, which
-        # re-syncs variants (and its product/material parents) before running;
-        # stub those endpoints empty so the in-cache variant row persists. The
-        # service stub feeds the conditional service sync triggered for the hit.
+        # ``_search_items_impl`` carries ``@cache_read(CachedVariant,
+        # CachedService)``, which re-syncs variants (and their product/material
+        # parents) and services before running; stub those endpoints empty so
+        # the in-cache variant row persists. The service stub feeds the service
+        # sync whose post_sync backfill links service_id onto the variant row.
         with (
             _stub_endpoint("get_all_products", empty),
             _stub_endpoint("get_all_materials", empty),
@@ -651,6 +651,58 @@ class TestServiceVariantLinkBackfill:
         assert len(service_rows) == 1
         assert service_rows[0].id == 40722022  # variant id
         assert service_rows[0].parent_id == 17253805  # resolved service item id
+
+    @pytest.mark.asyncio
+    async def test_variant_resync_preserves_backfilled_service_id(
+        self, typed_cache_engine
+    ):
+        """A ``/variants`` delta must NOT null a backfilled ``service_id``.
+
+        ``_VARIANT_SPEC.preserve_columns_on_conflict`` excludes ``service_id``
+        from the variant upsert's ``ON CONFLICT DO UPDATE SET``. Without it, the
+        ``/variants`` payload (which never carries ``service_id``) would re-write
+        the column to NULL on every re-sync, making the link trustworthy only
+        immediately after a service sync. Pin durability across variant deltas.
+        """
+        variant_attrs = AttrsVariantResponse.from_dict(
+            {"id": 40722022, "sku": "LABOR", "type": "service"}
+        )
+        service_attrs = AttrsService.from_dict(
+            {
+                "id": 17253805,
+                "name": "Labor",
+                "variants": [{"id": 40722022, "sku": "LABOR", "service_id": 17253805}],
+            }
+        )
+        empty = _list_response([])
+        # Initial sync: variant row in, then service backfill links service_id.
+        with (
+            _stub_endpoint("get_all_products", empty),
+            _stub_endpoint("get_all_materials", empty),
+            _stub_endpoint("get_all_variants", _list_response([variant_attrs])),
+        ):
+            await ensure_variants_synced(MagicMock(), typed_cache_engine)
+        with _stub_endpoint("get_all_services", _list_response([service_attrs])):
+            await ensure_services_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            linked = await session.get(CachedVariant, 40722022)
+        assert linked is not None
+        assert linked.service_id == 17253805
+
+        # Re-sync variants (a delta re-upserts the same service variant row,
+        # payload has no service_id). Preserve-on-conflict must keep the link.
+        with (
+            _stub_endpoint("get_all_products", empty),
+            _stub_endpoint("get_all_materials", empty),
+            _stub_endpoint("get_all_variants", _list_response([variant_attrs])),
+        ):
+            await ensure_variants_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            after = await session.get(CachedVariant, 40722022)
+        assert after is not None
+        assert after.service_id == 17253805  # NOT nulled by the variant re-sync
 
 
 class TestCatalogQueriesGetters:

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -763,18 +763,16 @@ async def test_search_items_parent_id_for_product_and_material():
 
 
 @pytest.mark.asyncio
-async def test_search_items_parent_id_for_service_reads_refetched_service_id():
-    """Service rows resolve parent_id from a FRESH re-read after the backfill.
+async def test_search_items_parent_id_for_service_reads_service_id_column():
+    """Service rows resolve parent_id from the ``service_id`` column directly.
 
-    ``smart_search`` returns *detached* rows whose ``service_id`` is frozen at
-    fetch time — possibly null (cold cache, or a /variants delta that nulled
-    it). search_items syncs services (running the backfill that writes
-    ``service_id`` onto the variant rows), then re-reads those rows via
-    ``get_many_by_ids`` and resolves parent_id from the fresh value. Pin that
-    the resolved parent_id comes from the re-fetch, NOT the stale search row:
-    the search row carries ``service_id=None`` here, yet parent_id resolves.
-    This is the bug case — the variant id (search ``id``) differs from the
-    service item id (``parent_id``) that modify_item/get_item require.
+    ``@cache_read(CachedVariant, CachedService)`` syncs services (running the
+    ``post_sync`` backfill) before ``smart_search``, and
+    ``preserve_columns_on_conflict`` keeps the link from being nulled — so the
+    row ``smart_search`` returns already carries the correct ``service_id`` and
+    parent_id is a plain column read (no second sync, no re-fetch). This is the
+    bug case — the variant id (search ``id``) differs from the service item id
+    (``parent_id``) that modify_item/get_item require.
     """
     context, lifespan_ctx = create_mock_context()
 
@@ -784,86 +782,31 @@ async def test_search_items_parent_id_for_service_reads_refetched_service_id():
                 "id": 40722022,  # service VARIANT id
                 "product_id": None,
                 "material_id": None,
-                "service_id": None,  # STALE: detached row, pre-backfill
+                "service_id": 17253805,  # service ITEM id, backfilled + durable
                 "sku": "LABOR",
                 "type": "service",
                 "display_name": "LABOR",
             }
         ]
-    )
-    # The re-fetch (after the backfill) returns the linked row.
-    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
-        return_value={
-            40722022: {"id": 40722022, "service_id": 17253805, "type": "service"}
-        }
     )
 
     result = await _search_items_impl(SearchItemsRequest(query="labor"), context)
 
-    from katana_public_api_client.models_pydantic._generated import CachedVariant
-
     assert result.items[0].id == 40722022
-    assert result.items[0].parent_id == 17253805  # from re-fetch, not search row
-    assert result.items[0].parent_id != result.items[0].id
-    # Re-read is keyed by the service variant ids — no full CachedService scan.
-    lifespan_ctx.typed_cache.catalog.get_all.assert_not_awaited()
-    refetch = lifespan_ctx.typed_cache.catalog.get_many_by_ids
-    refetch.assert_awaited_once()
-    assert refetch.await_args is not None
-    assert refetch.await_args.args[0] is CachedVariant
-    assert list(refetch.await_args.args[1]) == [40722022]
-
-
-@pytest.mark.asyncio
-async def test_search_items_service_in_results_triggers_service_sync():
-    """A service hit triggers the incremental service sync before the row read.
-
-    The sync runs the backfill (``post_sync``) that links ``service_id`` onto
-    freshly created/edited service variant rows; search re-reads them after.
-    The sync is conditional — only fired when a service is in the result set.
-    """
-    context, lifespan_ctx = create_mock_context()
-
-    lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
-        return_value=[
-            {
-                "id": 40722022,
-                "product_id": None,
-                "material_id": None,
-                "service_id": None,
-                "sku": "LABOR",
-                "type": "service",
-                "display_name": "LABOR",
-            }
-        ]
-    )
-    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
-        return_value={40722022: {"id": 40722022, "service_id": 17253805}}
-    )
-
-    with patch(
-        "katana_mcp.tools.foundation.items.ensure_cache_synced",
-        new=AsyncMock(),
-    ) as mock_sync:
-        result = await _search_items_impl(SearchItemsRequest(query="labor"), context)
-
     assert result.items[0].parent_id == 17253805
-    # The conditional service sync ran (a service was in the results).
-    from katana_public_api_client.models_pydantic._generated import CachedService
-
-    mock_sync.assert_awaited_once()
-    await_args = mock_sync.await_args
-    assert await_args is not None
-    assert await_args.args[1:] == (CachedService,)
+    assert result.items[0].parent_id != result.items[0].id
+    # No second-pass read: parent_id comes straight off the search row.
+    lifespan_ctx.typed_cache.catalog.get_all.assert_not_awaited()
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_search_items_service_parent_id_none_when_refetch_unlinked():
-    """A service row degrades to parent_id=None when the re-fetch has no link.
+async def test_search_items_service_parent_id_none_when_column_unset():
+    """A service row degrades to parent_id=None when ``service_id`` is unset.
 
-    Better to return None (the caller learns the parent isn't resolvable)
-    than to emit the wrong-id-space variant id as the parent. Covers both the
-    re-fetch missing the row and the row carrying a null ``service_id``.
+    Only happens for a variant row that predates any service sync. Better to
+    return None (caller learns the parent isn't resolvable) than to emit the
+    wrong-id-space variant id as the parent.
     """
     context, lifespan_ctx = create_mock_context()
 
@@ -879,10 +822,6 @@ async def test_search_items_service_parent_id_none_when_refetch_unlinked():
                 "display_name": "LABOR",
             }
         ]
-    )
-    # Re-fetch returns the row but it still isn't linked (service_id null).
-    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
-        return_value={40722022: {"id": 40722022, "service_id": None}}
     )
 
     result = await _search_items_impl(SearchItemsRequest(query="labor"), context)
@@ -892,24 +831,39 @@ async def test_search_items_service_parent_id_none_when_refetch_unlinked():
 
 
 @pytest.mark.asyncio
-async def test_search_items_skips_service_sync_when_no_service_rows():
-    """The service sync + re-fetch are skipped entirely for product/material hits."""
-    context, lifespan_ctx = create_mock_context()
+async def test_search_items_always_syncs_service_table():
+    """``@cache_read`` syncs the service table on every search, before the read.
 
-    lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
-        return_value=[
-            {"id": 1, "product_id": 2, "sku": "P", "type": "product"},
-        ]
+    This is what makes the direct ``service_id`` read correct without a
+    second pass: services (and their backfill) are refreshed even for a
+    product-only result set, so a freshly-created service's link is in place
+    by the time ``smart_search`` runs on the next call. Pin that the service
+    sync fires regardless of result composition.
+    """
+    from katana_mcp.tools import decorators
+
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedService,
+        CachedVariant,
     )
 
-    with patch(
-        "katana_mcp.tools.foundation.items.ensure_cache_synced",
-        new=AsyncMock(),
-    ) as mock_sync:
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
+        return_value=[{"id": 1, "product_id": 2, "sku": "P", "type": "product"}]
+    )
+
+    variant_sync = AsyncMock()
+    service_sync = AsyncMock()
+    with patch.dict(
+        decorators._sync_fns,
+        {CachedVariant: variant_sync, CachedService: service_sync},
+        clear=False,
+    ):
         await _search_items_impl(SearchItemsRequest(query="p"), context)
 
-    mock_sync.assert_not_awaited()
-    lifespan_ctx.typed_cache.catalog.get_many_by_ids.assert_not_awaited()
+    # Services synced even though the result set is product-only.
+    service_sync.assert_awaited_once()
+    variant_sync.assert_awaited_once()
 
 
 # ============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -1329,7 +1329,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.101.0"
+version = "0.102.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Follow-up to #873. That PR resolved a service's `parent_id` from a denormalized `CachedVariant.service_id` column, but leaned on a **sync-then-re-read** dance inside `search_items` to paper over two staleness sources. This fixes both at the source, so the column is trustworthy for **any** reader and `search_items` reads it directly.

**Root cause 1 — recurring corruption.** `_bulk_upsert` does `ON CONFLICT DO UPDATE SET <every non-id column>`. Since `/variants` payloads never carry `service_id`, every variant delta re-wrote a backfilled `service_id` back to `NULL`. Added a per-spec **`preserve_columns_on_conflict`** set to `EntitySpec`; `_bulk_upsert` excludes those columns from the `ON CONFLICT` update clause (INSERT still lands the default). `_VARIANT_SPEC` preserves `service_id`, so a `/variants` re-upsert can no longer null the backfilled link.

**Root cause 2 — read-before-write ordering.** `smart_search` returned *detached* rows whose `service_id` was frozen at fetch time, before the old conditional service sync ran. Promoted the service sync into the decorator (**`@cache_read(CachedVariant, CachedService)`**) so services + their `post_sync` backfill refresh *before* `smart_search`. Combined with preserve-on-conflict, the row `smart_search` returns already carries the right `service_id` — `search_items` reads it directly, dropping the conditional sync **and** the `get_many_by_ids` re-fetch.

**Trade-off (intentional):** every search now syncs services (a small set; the incremental delta is one usually-empty fetch), losing the "product-only searches pay nothing" optimization from #870 — accepted for the simpler, race-free read path.

The `post_sync` backfill stays a full, order-independent pass, but its job narrows from "re-heal the null-out every sync" to "establish the link"; durability is now owned by preserve-on-conflict.

## Verification

- `uv run poe check` green (3780 non-browser + 42 browser; lint/type/format clean). *(One combined run had browser tests flake on playwright timeouts under concurrent load — a clean isolated `poe test-browser` re-run passed all 42.)*
- **Live test-tenant e2e** (real `make_test_client()` + real cache engine): created a throwaway service, confirmed `parent_id` resolves on first search, **and still resolves after a second search that re-syncs variants** (proves `service_id` survives the delta — the durability guarantee), `services.get(parent_id)` round-trips, cleanup deletes it.

## Test plan

- [x] Durability test: a variant re-sync preserves a backfilled `service_id`
- [x] `search_items` resolves service `parent_id` from the column directly (no re-fetch)
- [x] `@cache_read` syncs the service table on every search (even product-only results)
- [x] End-to-end integration test through the real engine
- [x] Live test-tenant e2e incl. durability across re-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)