### PR TITLE
feat(mcp): default create_purchase_order to DRAFT status

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1085,7 +1085,9 @@ Create a purchase order with preview/apply pattern.
   purchase_uom_conversion_rate, arrival_date)
 - `notes` (optional): Internal notes (additional_info on the wire)
 - `currency` (optional): Currency code (e.g., USD, EUR)
-- `status` (optional): "DRAFT" or "NOT_RECEIVED" (default NOT_RECEIVED)
+- `status` (optional): "DRAFT" (default) or "NOT_RECEIVED". DRAFT is an unsent
+  draft to review before committing the order; NOT_RECEIVED is an already-placed
+  order awaiting receipt. Move between them later with `modify_purchase_order`.
 - `entity_type` (optional): "regular" (default) or "outsourced". Outsourced
   orders track subcontractor manufacturing. **When `entity_type="outsourced"`,
   `tracking_location_id` is required** — Katana will reject the create call

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -165,9 +165,22 @@ class CreatePurchaseOrderRequest(BaseModel):
     currency: str | None = Field(
         default=None, description="Currency code (e.g., USD, EUR)"
     )
-    status: Literal["DRAFT", "NOT_RECEIVED"] | None = Field(
-        default=None,
-        description="Initial status — 'DRAFT' or 'NOT_RECEIVED' (default: NOT_RECEIVED)",
+    status: Literal["DRAFT", "NOT_RECEIVED"] = Field(
+        default="DRAFT",
+        description=(
+            "Initial status for the new PO. Defaults to 'DRAFT'.\n"
+            "- 'DRAFT': an unsent draft you can review and edit before "
+            "committing the order to the supplier. This is the safe default "
+            "for orders created programmatically that a human hasn't approved "
+            "yet.\n"
+            "- 'NOT_RECEIVED': the order is already placed/sent to the "
+            "supplier and awaiting receipt — use this only when the PO has "
+            "genuinely been ordered.\n"
+            "The later lifecycle states (PARTIALLY_RECEIVED, RECEIVED) are "
+            "reached via receive_purchase_order, not at creation. To move a "
+            "PO between DRAFT and NOT_RECEIVED after creation, use "
+            "modify_purchase_order."
+        ),
     )
     entity_type: PurchaseOrderEntityType | None = Field(
         default=None,
@@ -325,7 +338,7 @@ async def _create_purchase_order_impl(
             supplier_name=supplier_name,
             location_id=request.location_id,
             location_name=location_name,
-            status=request.status or "NOT_RECEIVED",
+            status=request.status,
             entity_type=request.entity_type or "regular",
             total_cost=total_cost,
             currency=request.currency,
@@ -381,9 +394,12 @@ async def _create_purchase_order_impl(
             purchase_order_rows=po_rows,
             entity_type=entity_type_attr,
             currency=to_unset(request.currency),
-            status=CreatePurchaseOrderInitialStatus(request.status)
-            if request.status is not None
-            else UNSET,
+            # Always send status explicitly. The field defaults to DRAFT (see
+            # CreatePurchaseOrderRequest.status) — a programmatically created PO
+            # that a human hasn't approved is a draft, not an already-placed
+            # order — so we never leave it UNSET and inherit Katana's
+            # NOT_RECEIVED default.
+            status=CreatePurchaseOrderInitialStatus(request.status),
             order_created_date=to_unset(request.order_created_date),
             expected_arrival_date=to_unset(request.expected_arrival_date),
             tracking_location_id=to_unset(request.tracking_location_id),
@@ -454,6 +470,13 @@ async def create_purchase_order(
     then preview=false to create. Requires supplier_id,
     location_id, order_number, and at least one line item with variant_id,
     quantity, and price_per_unit. Use get_variant_details to look up variant IDs.
+
+    Status: new POs are created in DRAFT by default — an unsent draft you can
+    review and edit before committing it to the supplier. Pass
+    status="NOT_RECEIVED" to create an order that's already been placed and is
+    awaiting receipt. (The later RECEIVED / PARTIALLY_RECEIVED states are
+    reached via receive_purchase_order; flip a PO between DRAFT and
+    NOT_RECEIVED after creation with modify_purchase_order.)
     """
     response = await _create_purchase_order_impl(request, context)
     return _po_response_to_tool_result(response, request=request)

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -497,6 +497,122 @@ async def test_create_purchase_order_apply_omits_unset_header_fields():
 
 
 @pytest.mark.asyncio
+async def test_create_purchase_order_apply_defaults_to_draft_status():
+    """When status is omitted, the API body must carry an explicit DRAFT — a
+    programmatically created PO that a human hasn't approved is a draft, not an
+    already-placed order. Katana's own default is NOT_RECEIVED, so the MCP layer
+    sends DRAFT explicitly rather than leaving status UNSET.
+    """
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(return_value=None)
+
+    from katana_public_api_client.models import (
+        CreatePurchaseOrderInitialStatus,
+        PurchaseOrderStatus as APIPurchaseOrderStatus,
+    )
+
+    mock_po = mock_entity_for_modify(
+        RegularPurchaseOrder,
+        id=9110,
+        order_no="PO-DRAFT-001",
+        supplier_id=4001,
+        location_id=1,
+        status=APIPurchaseOrderStatus.DRAFT,
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = mock_po
+    mock_api_call = AsyncMock(return_value=mock_response)
+
+    import katana_public_api_client.api.purchase_order.create_purchase_order as create_po_module
+
+    original = create_po_module.asyncio_detailed
+    cast(Any, create_po_module).asyncio_detailed = mock_api_call
+    try:
+        request = CreatePurchaseOrderRequest(
+            supplier_id=4001,
+            location_id=1,
+            order_number="PO-DRAFT-001",
+            items=[PurchaseOrderItem(variant_id=1, quantity=1, price_per_unit=1.0)],
+            preview=False,
+        )
+        await _create_purchase_order_impl(request, context)
+    finally:
+        cast(Any, create_po_module).asyncio_detailed = original
+
+    api_body = mock_api_call.call_args.kwargs["body"]
+    assert api_body.status is CreatePurchaseOrderInitialStatus.DRAFT
+
+
+@pytest.mark.asyncio
+async def test_create_purchase_order_apply_forwards_explicit_not_received():
+    """An explicit status='NOT_RECEIVED' must override the DRAFT default and
+    reach the API body unchanged — callers can still create already-placed
+    orders awaiting receipt.
+    """
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(return_value=None)
+
+    from katana_public_api_client.models import (
+        CreatePurchaseOrderInitialStatus,
+        PurchaseOrderStatus as APIPurchaseOrderStatus,
+    )
+
+    mock_po = mock_entity_for_modify(
+        RegularPurchaseOrder,
+        id=9111,
+        order_no="PO-NR-001",
+        supplier_id=4001,
+        location_id=1,
+        status=APIPurchaseOrderStatus.NOT_RECEIVED,
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = mock_po
+    mock_api_call = AsyncMock(return_value=mock_response)
+
+    import katana_public_api_client.api.purchase_order.create_purchase_order as create_po_module
+
+    original = create_po_module.asyncio_detailed
+    cast(Any, create_po_module).asyncio_detailed = mock_api_call
+    try:
+        request = CreatePurchaseOrderRequest(
+            supplier_id=4001,
+            location_id=1,
+            order_number="PO-NR-001",
+            items=[PurchaseOrderItem(variant_id=1, quantity=1, price_per_unit=1.0)],
+            status="NOT_RECEIVED",
+            preview=False,
+        )
+        await _create_purchase_order_impl(request, context)
+    finally:
+        cast(Any, create_po_module).asyncio_detailed = original
+
+    api_body = mock_api_call.call_args.kwargs["body"]
+    assert api_body.status is CreatePurchaseOrderInitialStatus.NOT_RECEIVED
+
+
+@pytest.mark.asyncio
+async def test_create_purchase_order_preview_defaults_to_draft_status():
+    """The preview card must reflect the DRAFT default so the operator sees the
+    state the PO will be created in before applying.
+    """
+    context, _ = create_mock_context()
+
+    request = CreatePurchaseOrderRequest(
+        supplier_id=4001,
+        location_id=1,
+        order_number="PO-PREVIEW-DRAFT",
+        items=[PurchaseOrderItem(variant_id=1, quantity=1, price_per_unit=1.0)],
+        preview=True,
+    )
+    result = await _create_purchase_order_impl(request, context)
+
+    assert result.is_preview is True
+    assert result.status == "DRAFT"
+
+
+@pytest.mark.asyncio
 async def test_create_purchase_order_apply_fails_fast_on_outsourced_without_tracking():
     """Apply path must raise ValueError immediately when entity_type='outsourced'
     without tracking_location_id, instead of relying on Katana to 422.

--- a/uv.lock
+++ b/uv.lock
@@ -1329,7 +1329,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.102.0"
+version = "0.103.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

`create_purchase_order` now creates new POs in **DRAFT** by default instead of
`NOT_RECEIVED`. An API-created PO that a human hasn't approved is conceptually an
unsent draft — the operator can review and edit it before committing the order to
the supplier. The previous default forced a manual "send back to draft" fixup in
the Katana UI on every programmatically created PO (5–6 per StockTrim split).

DRAFT support itself already shipped in client v0.50.0 (Apr 9); this PR only
flips the **default** and clarifies the docs.

### Changes
- Flip the `status` field default `None` (→ Katana's `NOT_RECEIVED`) → `"DRAFT"`,
  and send `DRAFT` explicitly on the apply path rather than leaving it `UNSET`.
- Preview card reflects `DRAFT` so the operator sees the target state.
- Expand the `status` field description, tool docstring, and `katana://help`
  entry to enumerate `DRAFT` vs `NOT_RECEIVED`, how to opt out
  (`status="NOT_RECEIVED"` for already-placed orders), and how to transition
  later (`modify_purchase_order` / `receive_purchase_order`).
- Regression tests: DRAFT default on apply + preview, and explicit
  `NOT_RECEIVED` still forwards unchanged.

### Opt-out
Callers wanting an already-ordered PO pass `status="NOT_RECEIVED"` explicitly.

## Test plan
- [x] `uv run poe check` — 3783 passed, 8 skipped + 42 browser tests passed
- [x] New regression tests pin DRAFT default (apply + preview) and explicit
      NOT_RECEIVED forwarding
- [x] Verified live MCP `inputSchema` advertises `"default": "DRAFT"` with the
      `["DRAFT", "NOT_RECEIVED"]` enum end-to-end
- [ ] Reviewer: confirm the DRAFT default is the desired cross-cutting behavior
      (affects all PO creation lacking an explicit status — StockTrim split,
      `correct_purchase_order`, etc.)

> Note: requires a `katana-erp-dev` redeploy to reach the live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)