### PR TITLE
feat(mcp): render PO line-item diff table in the modify card

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/po_row_table.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/po_row_table.py
@@ -1,0 +1,347 @@
+"""Purchase-order row table-merge domain helpers (non-UI).
+
+Projects a PO modify plan (``prior_state`` snapshot + row-CRUD ``ActionResult``
+list + a resolved-variant lookup) into the DataTable row list the PO modify card
+renders for its line-items collection. Sibling of :mod:`item_variant_table` and
+:mod:`bom_table` — same split-by-kind-of-work: this module shapes plan-action
+data into wire-format row dicts; ``prefab_ui.py`` wraps them in Prefab
+components.
+
+Layered on the shared collection-diff skeleton
+(:func:`merge_collection_diff_rows`, #859 / #872): this module supplies the
+PO-row cell builders (SKU / variant name / quantity / unit price) as closures;
+the skeleton owns the add/update/delete classification, status stamping, orphan
+handling, and materialization order.
+
+Closes the PO modify card's content-drop (#722 follow-up under the #721
+umbrella): ``build_po_modify_ui`` previously rendered header scalar diffs only
+and silently dropped every ``modify_purchase_order`` row CRUD action.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Literal
+
+from katana_mcp.tools.foundation.collection_diff import (
+    STATUS_PREFIX,
+    STATUS_VARIANTS,
+    CollectionDiffSpec,
+    merge_collection_diff_rows,
+)
+
+_PORowKind = Literal["existing", "added", "updated", "deleted"]
+
+# ``POOperation`` StrEnum values for the row-CRUD ops (purchase_orders.py).
+_ADD_OPS = frozenset({"add_row"})
+_UPDATE_OPS = frozenset({"update_row"})
+_DELETE_OPS = frozenset({"delete_row"})
+
+# A resolved-variant lookup: ``{variant_id: {"sku": ..., "display_name": ...}}``,
+# threaded from the impl's batched cache lookup (``extras["resolved_variants"]``).
+ResolvedVariants = dict[int, dict[str, str | None]]
+
+
+def _changes_by_field(
+    changes: list[dict[str, Any]] | None,
+) -> dict[str, dict[str, Any]]:
+    """Index an action's ``changes`` list by field name (raw FieldChange dicts)."""
+    out: dict[str, dict[str, Any]] = {}
+    for c in changes or []:
+        if isinstance(c, dict) and isinstance(c.get("field"), str):
+            out[c["field"]] = c
+    return out
+
+
+def _format_number(value: Any) -> str:
+    """Render a quantity / price for a table cell, trimmed of trailing zeros.
+
+    ``None`` → em-dash. ``Decimal`` (the shape ``compute_field_diff`` →
+    ``_normalize`` produces for prices/quantities) and ``float`` render via
+    ``:g``; numeric strings coerce first. Mirrors
+    ``item_variant_table._format_price``.
+    """
+    if value is None:
+        return "—"
+    if isinstance(value, str):
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return value
+        return f"{numeric:g}"
+    if isinstance(value, (int, float, Decimal)):
+        return f"{float(value):g}"
+    return str(value)
+
+
+def _format_number_diff(old: Any, new: Any, *, unknown_prior: bool) -> str:
+    """Render a numeric update as ``old → new`` (or ``(prior unknown) → new``)."""
+    after = _format_number(new)
+    if unknown_prior:
+        return f"(prior unknown) → {after}"
+    return f"{_format_number(old)} → {after}"
+
+
+def _resolved_name(
+    resolved: ResolvedVariants, variant_id: Any
+) -> tuple[str | None, str | None]:
+    """Look up ``(sku, display_name)`` for a variant id (``(None, None)`` miss)."""
+    if isinstance(variant_id, int):
+        hit = resolved.get(variant_id)
+        if hit:
+            return hit.get("sku"), hit.get("display_name")
+    return None, None
+
+
+def _existing_row_from_snapshot(
+    row: dict[str, Any], resolved: ResolvedVariants
+) -> dict[str, Any]:
+    """Project a prior-state PO row (raw ``PurchaseOrderRow.to_dict()``) into the
+    merge-row shape. SKU / name come from the resolved-variant map (the raw row
+    carries only ``variant_id``); quantity / unit price from the row itself.
+    """
+    sku, display_name = _resolved_name(resolved, row.get("variant_id"))
+    kind: _PORowKind = "existing"
+    return {
+        "id": row.get("id"),
+        "variant_id": row.get("variant_id"),
+        "sku": sku,
+        "display_name": display_name,
+        "quantity_label": _format_number(row.get("quantity")),
+        "price_label": _format_number(row.get("price_per_unit")),
+        "kind": kind,
+        "status_label": "",
+        "status_variant": STATUS_VARIANTS[""],
+        "status_prefix": STATUS_PREFIX["existing"],
+        "error": None,
+    }
+
+
+def _synth_orphan_row(target_id: str) -> dict[str, Any]:
+    """Minimal row for an update/delete target absent from the snapshot."""
+    kind: _PORowKind = "existing"
+    return {
+        "id": target_id,
+        "variant_id": None,
+        "sku": None,
+        "display_name": None,
+        "quantity_label": "—",
+        "price_label": "—",
+        "kind": kind,
+        "status_label": "",
+        "status_variant": STATUS_VARIANTS[""],
+        "status_prefix": STATUS_PREFIX["existing"],
+        "error": None,
+    }
+
+
+def _add_action_to_row(
+    action: dict[str, Any],
+    resolved: ResolvedVariants,
+    *,
+    status_label: str,
+    status_variant: str,
+    error: str | None,
+) -> dict[str, Any]:
+    """Synthesize an ``added``-kind row from an ``add_row`` action.
+
+    SKU / name resolve from the action's new ``variant_id``; quantity + unit
+    price from the action's ``changes`` (the ``PORowAdd`` payload, reported as
+    added).
+    """
+    changes = _changes_by_field(action.get("changes"))
+    variant_change = changes.get("variant_id")
+    variant_id = variant_change.get("new") if variant_change else None
+    sku, display_name = _resolved_name(resolved, variant_id)
+    qty_change = changes.get("quantity")
+    price_change = changes.get("price_per_unit")
+    kind: _PORowKind = "added"
+    return {
+        "id": "",  # No row id yet — server assigns on POST.
+        "variant_id": variant_id,
+        "sku": sku,
+        "display_name": display_name,
+        "quantity_label": _format_number(qty_change.get("new") if qty_change else None),
+        "price_label": _format_number(
+            price_change.get("new") if price_change else None
+        ),
+        "kind": kind,
+        "status_label": status_label,
+        "status_variant": status_variant,
+        "status_prefix": STATUS_PREFIX["added"],
+        "error": error,
+    }
+
+
+def _apply_update_to_row(
+    row: dict[str, Any],
+    action: dict[str, Any],
+    resolved: ResolvedVariants,
+    *,
+    status_label: str,
+    status_variant: str,
+    error: str | None,
+) -> None:
+    """Decorate a snapshot row in-place with an ``update_row`` action's diff.
+
+    Flips ``kind`` to ``updated`` and overlays before→after on quantity / unit
+    price. A variant swap re-resolves SKU + name from the new ``variant_id``.
+    """
+    kind: _PORowKind = "updated"
+    row["kind"] = kind
+    row["status_label"] = status_label
+    row["status_variant"] = status_variant
+    row["status_prefix"] = STATUS_PREFIX["updated"]
+    row["error"] = error
+    changes = _changes_by_field(action.get("changes"))
+    qty_change = changes.get("quantity")
+    if qty_change is not None:
+        row["quantity_label"] = _format_number_diff(
+            qty_change.get("old"),
+            qty_change.get("new"),
+            unknown_prior=bool(qty_change.get("is_unknown_prior")),
+        )
+    price_change = changes.get("price_per_unit")
+    if price_change is not None:
+        row["price_label"] = _format_number_diff(
+            price_change.get("old"),
+            price_change.get("new"),
+            unknown_prior=bool(price_change.get("is_unknown_prior")),
+        )
+    variant_change = changes.get("variant_id")
+    if variant_change is not None:
+        new_variant = variant_change.get("new")
+        sku, display_name = _resolved_name(resolved, new_variant)
+        row["variant_id"] = new_variant
+        row["sku"] = sku
+        row["display_name"] = display_name
+
+
+def _apply_delete_to_row(
+    row: dict[str, Any],
+    _action: dict[str, Any],
+    *,
+    status_label: str,
+    status_variant: str,
+    error: str | None,
+) -> None:
+    """Decorate a snapshot row in-place with a ``delete_row`` action.
+
+    Identity (SKU / name / qty / price) is preserved so the user sees *what* is
+    going away; the ``- `` gutter + ``deleted`` kind carry the signal. The
+    ``_action`` slot is required by the ``apply_delete`` call convention.
+    """
+    kind: _PORowKind = "deleted"
+    row["kind"] = kind
+    row["status_label"] = status_label
+    row["status_variant"] = status_variant
+    row["status_prefix"] = STATUS_PREFIX["deleted"]
+    row["error"] = error
+
+
+def merge_po_row_rows_for_modify_card(
+    prior_state: dict[str, Any] | None,
+    actions: list[dict[str, Any]],
+    resolved_variants: ResolvedVariants | None,
+) -> list[dict[str, Any]]:
+    """Project the prior PO line items + plan actions into a unified row list.
+
+    Existing rows render unchanged; ``add_row`` actions append as ``added``
+    rows; ``update_row`` actions decorate the matched row with before→after on
+    quantity / unit price; ``delete_row`` actions mark the matched row
+    ``deleted``. Header / additional-cost ops in the same plan are filtered out
+    (handled outside this table) so they don't trip the shared merge's
+    unknown-op warning.
+
+    Match key: ``str(row["id"])`` against ``str(action["target_id"])``. Adds
+    have no target_id and synthesize fresh from their ``changes``.
+    """
+    resolved = resolved_variants or {}
+    prior_rows: list[dict[str, Any]] = []
+    if isinstance(prior_state, dict):
+        candidate = prior_state.get("purchase_order_rows")
+        if isinstance(candidate, list):
+            prior_rows = [r for r in candidate if isinstance(r, dict)]
+
+    row_ops = _ADD_OPS | _UPDATE_OPS | _DELETE_OPS
+    row_actions = [
+        a for a in actions if str(a.get("operation") or "").lower() in row_ops
+    ]
+
+    def _add(
+        action: dict[str, Any],
+        *,
+        status_label: str,
+        status_variant: str,
+        error: str | None,
+    ) -> dict[str, Any]:
+        return _add_action_to_row(
+            action,
+            resolved,
+            status_label=status_label,
+            status_variant=status_variant,
+            error=error,
+        )
+
+    def _update(
+        row: dict[str, Any],
+        action: dict[str, Any],
+        *,
+        status_label: str,
+        status_variant: str,
+        error: str | None,
+    ) -> None:
+        _apply_update_to_row(
+            row,
+            action,
+            resolved,
+            status_label=status_label,
+            status_variant=status_variant,
+            error=error,
+        )
+
+    return merge_collection_diff_rows(
+        prior_rows=prior_rows,
+        actions=row_actions,
+        spec=CollectionDiffSpec(
+            add_ops=_ADD_OPS,
+            update_ops=_UPDATE_OPS,
+            delete_ops=_DELETE_OPS,
+            key_of=lambda r: str(r["id"]) if r.get("id") is not None else None,
+            existing_row=lambda r: _existing_row_from_snapshot(r, resolved),
+            synth_orphan=_synth_orphan_row,
+            add_row=_add,
+            apply_update=_update,
+            apply_delete=_apply_delete_to_row,
+            # Snapshot order is the PO's row order; adds trail (server assigns
+            # the slot). No reliable sort key on the raw row, so preserve
+            # insertion order via a constant key.
+            sort_key=lambda r: 0,
+        ),
+    )
+
+
+def prepare_po_row_table_rows(
+    merged: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Compose the final DataTable row dicts.
+
+    The SKU column carries the kind gutter (``+ ``/``- ``/``~ ``/``  ``); the
+    name column falls back to ``variant <id>`` when the cache miss left the
+    display_name unresolved so the row is never blank. Mirrors
+    ``bom_table._prepare_bom_table_rows``.
+    """
+    out: list[dict[str, Any]] = []
+    for r in merged:
+        sku = r.get("sku") or "(unresolved)"
+        display_name = r.get("display_name") or ""
+        if not display_name and r.get("variant_id") is not None:
+            display_name = f"variant {r['variant_id']}"
+        out.append(
+            {
+                **r,
+                "sku_label": f"{r['status_prefix']}{sku}",
+                "display_name": display_name,
+            }
+        )
+    return out

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -3003,6 +3003,68 @@ def _build_update_cost_request(
     )
 
 
+def _collect_po_row_variant_ids(
+    existing_po: RegularPurchaseOrder | None,
+    request: ModifyPurchaseOrderRequest,
+) -> set[int]:
+    """Gather every variant id the PO modify card's row table needs resolved.
+
+    Union of the existing rows' variants (the snapshot the card renders) and
+    the variants referenced by ``add_rows`` / ``update_rows`` (so added /
+    variant-swapped rows show a SKU + name, not a bare id). One set → one
+    batched cache lookup in :func:`_resolve_po_row_variants`.
+    """
+    ids: set[int] = set()
+    if existing_po is not None:
+        for r in unwrap_unset(existing_po.purchase_order_rows, None) or []:
+            vid = unwrap_unset(getattr(r, "variant_id", None), None)
+            if vid is not None:
+                ids.add(int(vid))
+    for add in request.add_rows or []:
+        ids.add(int(add.variant_id))
+    for upd in request.update_rows or []:
+        if upd.variant_id is not None:
+            ids.add(int(upd.variant_id))
+    return ids
+
+
+async def _resolve_po_row_variants(
+    services: Any, variant_ids: set[int]
+) -> dict[int, dict[str, str | None]]:
+    """Batch-resolve ``{variant_id: {"sku", "display_name"}}`` via the typed
+    cache for the PO modify card's row table. Misses degrade to ``None`` fields
+    so the row still renders (``variant <id>`` fallback). Serializable dict so
+    it round-trips through ``response.extras`` + ``model_dump``.
+    """
+    if not variant_ids:
+        return {}
+    from katana_public_api_client.models_pydantic._generated import CachedVariant
+
+    # Enrichment lookup by ID — include archived + deleted so a PO row that
+    # references an archived/deleted variant still resolves its SKU + name
+    # (per typed_cache/README "Enrichment (batch lookups by ID) — always
+    # include_*=True"). Without this the card falls back to "variant <id>".
+    variants = await services.typed_cache.catalog.get_many_by_ids(
+        CachedVariant, variant_ids, include_archived=True, include_deleted=True
+    )
+    resolved: dict[int, dict[str, str | None]] = {}
+    for vid in variant_ids:
+        v = variants.get(vid)
+        if v is None:
+            resolved[vid] = {"sku": None, "display_name": None}
+        elif isinstance(v, dict):
+            resolved[vid] = {
+                "sku": v.get("sku"),
+                "display_name": v.get("display_name"),
+            }
+        else:
+            resolved[vid] = {
+                "sku": getattr(v, "sku", None),
+                "display_name": getattr(v, "display_name", None),
+            }
+    return resolved
+
+
 async def _modify_purchase_order_impl(
     request: ModifyPurchaseOrderRequest, context: Context
 ) -> ModificationResponse:
@@ -3132,7 +3194,29 @@ async def _modify_purchase_order_impl(
         )
     )
 
-    return await run_modify_plan(
+    # Resolve variant SKU / display_name for every row variant the card's row
+    # diff table touches (existing rows + add/update variants) so it renders
+    # user-facing identities, not bare ids (anti-pattern #2 / #7). One batched
+    # cache lookup; threaded onto the response so ``build_po_modify_ui`` reads
+    # it without a second hit at render time. Mirrors the BOM card's
+    # ``resolved_ingredients``.
+    #
+    # Skip the lookup for header-only / additional-cost-only plans: the card
+    # short-circuits and never renders the row table (no row CRUD), so
+    # resolving every existing-row variant would be wasted work + a needlessly
+    # large ``extras`` payload on big POs. Mirrors the UI-side short-circuit.
+    has_row_crud = bool(
+        request.add_rows or request.update_rows or request.delete_row_ids
+    )
+    resolved_variants = (
+        await _resolve_po_row_variants(
+            services, _collect_po_row_variant_ids(existing_po, request)
+        )
+        if has_row_crud
+        else {}
+    )
+
+    response = await run_modify_plan(
         request=request,
         naming=EntityNaming(
             entity_type="purchase_order",
@@ -3142,6 +3226,7 @@ async def _modify_purchase_order_impl(
         web_url_kind="purchase_order",
         existing=existing_po,
         plan=plan,
+        extras={"resolved_variants": resolved_variants},
         cache_merge=CacheMerge(
             cache=services.typed_cache,
             refetch_for_merge=lambda eid: _fetch_purchase_order_attrs(services, eid),
@@ -3159,6 +3244,33 @@ async def _modify_purchase_order_impl(
             ),
         ),
     )
+
+    # Apply-path: synthesize NOT-RUN entries for the unattempted plan tail.
+    # ``execute_plan`` is fail-fast — ``response.actions`` ends at the first
+    # failed action. Without these the card's row-table morph would silently
+    # HIDE every planned row action past the failure. The card merges them via
+    # ``extras["not_run_actions"]`` (``_actions_with_not_run_tail``), rendering
+    # the "NOT RUN" status pill. Mirrors the SO / BOM / item fail-fast handling.
+    if not response.is_preview:
+        not_run_specs = plan[len(response.actions) :]
+        not_run_actions = [
+            {
+                "operation": spec.operation,
+                "target_id": spec.target_id,
+                "succeeded": None,
+                "error": None,
+                "changes": [
+                    c.model_dump() if hasattr(c, "model_dump") else dict(c)
+                    for c in spec.diff
+                ],
+                "status_label": "NOT RUN",
+            }
+            for spec in not_run_specs
+        ]
+        if not_run_actions:
+            response.extras["not_run_actions"] = not_run_actions
+
+    return response
 
 
 @observe_tool

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -122,6 +122,10 @@ from katana_mcp.tools.foundation.item_variant_table import (
     merge_variant_rows_for_modify_card,
     prepare_variant_table_rows,
 )
+from katana_mcp.tools.foundation.po_row_table import (
+    merge_po_row_rows_for_modify_card,
+    prepare_po_row_table_rows,
+)
 from katana_mcp.tools.tool_result_utils import BLOCK_WARNING_PREFIX
 from katana_mcp.web_urls import EntityKind, katana_web_url
 
@@ -4358,6 +4362,107 @@ def _render_apply_outcome_badge(*, css_class: str = "min-w-32 text-center") -> N
         Badge(label="PREVIEW", variant="secondary", css_class=css_class)
 
 
+def _coerce_resolved_id_map(value: Any) -> dict[int, dict[str, str | None]]:
+    """Coerce a wire ``{variant_id: {sku, display_name}}`` map back to int keys.
+
+    ``model_dump`` round-trips a ``dict[int, ...]`` with string keys on the
+    wire; coerce them back so the row-table merge's ``int`` variant-id lookups
+    hit. Non-int keys / non-dict values are skipped. Shared shape with the BOM
+    card's ``resolved_ingredients`` coercion.
+    """
+    out: dict[int, dict[str, str | None]] = {}
+    if not isinstance(value, dict):
+        # Missing / malformed extras (None, list, …) → no resolved names; the
+        # table still renders with the ``variant <id>`` fallback.
+        return out
+    for key, val in value.items():
+        try:
+            int_key = int(key)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(val, dict):
+            out[int_key] = {
+                "sku": val.get("sku"),
+                "display_name": val.get("display_name"),
+            }
+    return out
+
+
+def _po_applied_state_labels(
+    verb_label: str, *, is_preview: bool, actions: list[dict[str, Any]]
+) -> tuple[str, str, str, str]:
+    """Compute ``(title_suffix, state_label, state_variant, verb)`` for the PO
+    modify card's applied-state chrome.
+
+    Delete reads "Deleted" / "deleted"; modify / correct read "Applied" /
+    "applied". On the standalone-applied path (``is_preview=False``) the actual
+    outcome overrides — a fully-failed apply reads "Failed" / FAILED /
+    destructive, a partial reads "Partially Applied" / PARTIAL FAILURE /
+    destructive — so the title + badge + footer verb never contradict the
+    outcome. The in-place-morph path keeps the optimistic defaults (#760).
+    """
+    if verb_label == "Delete":
+        title_suffix, state_label, verb = "Deleted", "DELETED", "deleted"
+    else:
+        title_suffix, state_label, verb = "Applied", "APPLIED", "applied"
+    variant = "default"
+    if not is_preview:
+        outcome_label, outcome_variant = _summarize_apply_outcome(actions)
+        if outcome_label != "APPLIED":
+            state_label, variant = outcome_label, outcome_variant
+            if outcome_label == "FAILED":
+                title_suffix, verb = "Failed", "failed"
+            else:  # PARTIAL FAILURE
+                title_suffix, verb = "Partially Applied", "partially applied"
+    return title_suffix, state_label, variant, verb
+
+
+_PO_ROW_OP_NAMES = frozenset({"add_row", "update_row", "delete_row"})
+
+
+def _po_modify_row_rows(
+    prior_state: dict[str, Any] | None,
+    actions: list[dict[str, Any]],
+    *,
+    extras: dict[str, Any],
+) -> tuple[list[dict[str, Any]], str]:
+    """Build the PO line-item diff rows + summary, short-circuiting when the
+    plan has no row CRUD.
+
+    A header-only / additional-cost-only modify never touches the rows, so we
+    skip the merge entirely (no projection over a large PO's row snapshot) and
+    return ``([], "")`` — the card then renders just the header diffs. Resolved
+    SKU / name come from ``extras["resolved_variants"]`` (the impl's batched
+    cache lookup); JSON re-stringifies the int keys, which
+    :func:`_coerce_resolved_id_map` coerces back.
+    """
+    if not any(
+        str(a.get("operation") or "").lower() in _PO_ROW_OP_NAMES for a in actions
+    ):
+        return [], ""
+    resolved_variants = _coerce_resolved_id_map(extras.get("resolved_variants"))
+    rows = prepare_po_row_table_rows(
+        merge_po_row_rows_for_modify_card(prior_state, actions, resolved_variants)
+    )
+    return rows, collection_diff_summary(rows)
+
+
+# DataTable columns for the PO modify card's line-item diff table. SKU carries
+# the kind gutter (``+ ``/``- ``/``~ ``/``  ``); Status renders plain text
+# (PLANNED / APPLIED / FAILED / NOT RUN). Mirrors the BOM / item variant tables.
+_PO_MODIFY_ROW_COLUMNS: list[DataTableColumn] = [
+    DataTableColumn(key="sku_label", header="SKU"),
+    DataTableColumn(key="display_name", header="Item"),
+    DataTableColumn(key="quantity_label", header="Qty", align="right", width="9rem"),
+    DataTableColumn(
+        key="price_label", header="Unit Price", align="right", width="11rem"
+    ),
+    DataTableColumn(key="status_label", header="Status", width="7rem"),
+]
+_PO_MODIFY_ROW_KEY = "po_row_rows"
+_PO_MODIFY_ROW_REF = f"{{{{ {_PO_MODIFY_ROW_KEY} }}}}"
+
+
 def build_po_modify_ui(
     response: dict[str, Any],
     *,
@@ -4387,15 +4492,19 @@ def build_po_modify_ui(
     response payload (rare — `ModificationResponse` keeps the full
     pre-change snapshot for revert reference and for renderer use).
     """
-    actions = response.get("actions") or []
     is_preview = bool(response.get("is_preview", True))
+    # Apply path: extend with the unattempted plan tail (synthesized NOT-RUN
+    # actions in ``extras``) so a fail-fast partial doesn't drop the not-run
+    # row actions from the morphed line-item table. Inert on preview.
+    actions = _actions_with_not_run_tail(response, is_preview=is_preview)
     entity_id = response.get("entity_id")
     # ``prior_state`` arrives in the wire shape from ``serialize_for_prior_state``
     # (``RegularPurchaseOrder.to_dict()`` etc.) — ``order_no``, ``total``,
-    # ``additional_info``, nested ``supplier``. Normalize to the response
-    # shape the entity-view renderer reads so unchanged-field rows
-    # surface real values in the rendered card.
-    prior_state = _normalize_po_prior_state(response.get("prior_state"))
+    # ``additional_info``, nested ``supplier``, ``purchase_order_rows``.
+    # Normalize to the response shape the entity-view renderer reads so
+    # unchanged-field rows surface real values in the rendered card.
+    raw_prior_state = response.get("prior_state")
+    prior_state = _normalize_po_prior_state(raw_prior_state)
     # Note: katana_url is read from RESULT via the Prefab template
     # ``{{ result.katana_url }}`` in _render_preview_footer's
     # applied-state View-in-Katana button — no need to pass it through
@@ -4432,9 +4541,38 @@ def build_po_modify_ui(
     # Prefab Rx-bound rendering of every field-level decision from
     # ``state.result.actions`` or a rebuild-on-morph primitive. Tracked
     # at #760 — see issue for design options.
-    changes_by_field = _index_changes_by_field(actions)
+    # Scope header field diffs to ``update_header`` so row / additional-cost
+    # changes (which share field names like ``currency``) don't leak into the
+    # header entity-view lines — they belong in the line-item table below.
+    changes_by_field = _index_changes_by_field(
+        actions, include_operations=frozenset({"update_header"})
+    )
 
-    apply_action = _build_apply_action(confirm_tool, confirm_request)
+    # PO line-item diff table — the content-drop fix (#722 follow-up): the card
+    # previously rendered header scalar diffs only and silently dropped every
+    # row CRUD action. ``_po_modify_row_rows`` short-circuits to ``([], "")``
+    # for header-only / additional-cost-only plans (no merge over a large PO's
+    # rows). When the table renders, we seed ``state.po_row_rows`` + wire the
+    # apply-morph SetState; otherwise neither, avoiding copying the row
+    # snapshot into UI state for no benefit.
+    po_row_rows, po_row_summary = _po_modify_row_rows(
+        raw_prior_state, actions, extras=response.get("extras") or {}
+    )
+    show_row_table = bool(po_row_summary)
+
+    apply_action = _build_apply_action(
+        confirm_tool,
+        confirm_request,
+        # Morph the line-item table in place on apply — the apply rebuild seeds
+        # ``state.po_row_rows`` with the merged-with-outcomes rows; this copies
+        # them off the apply tool's envelope (``$result.state.<key>``). Only
+        # wired when the table is rendered.
+        extra_on_success=(
+            [SetState(_PO_MODIFY_ROW_KEY, "{{ $result.state.po_row_rows }}")]
+            if show_row_table
+            else None
+        ),
+    )
     # ``_build_cancel_action`` interpolates its arg into "Cancel: do not
     # apply X.", so the noun phrase has to read naturally there. Verb
     # forms like ``"that purchase order modify"`` (the previous shape)
@@ -4454,46 +4592,20 @@ def build_po_modify_ui(
     # the rendered state-badge in Tier 1 is the create-card-style
     # PREVIEW → APPLIED (or DELETED / FAILED / PARTIAL FAILURE) switch.
 
+    state = _init_modify_card_state(response)
+    if show_row_table:
+        state[_PO_MODIFY_ROW_KEY] = po_row_rows
+
     with (
-        PrefabApp(state=_init_modify_card_state(response), css_class="p-4") as app,
+        PrefabApp(state=state, css_class="p-4") as app,
         Card(),
     ):
-        # Delete: applied-state copy reads "Deleted" / "deleted"; modify
-        # and correct read "Applied" / "applied". The verb_label drives
-        # the title-suffix mapping so e.g. ``"Purchase Order Modify"``
-        # title in preview becomes ``"Purchase Order Applied"`` in the
-        # rendered applied state — not the misleading "Created" the
-        # shared helpers default to.
-        if verb_label == "Delete":
-            applied_title_suffix = "Deleted"
-            applied_state_label = "DELETED"
-            applied_verb = "deleted"
-        else:
-            applied_title_suffix = "Applied"
-            applied_state_label = "APPLIED"
-            applied_verb = "applied"
-        applied_state_variant = "default"
-
-        # On the standalone-applied path (is_preview=False), let the
-        # actual outcome drive both the state label AND the badge
-        # variant — so a fully-failed apply reads "FAILED" with the
-        # destructive (red) variant, not "APPLIED" with the success
-        # (green) variant. Partial failures also surface in the
-        # destructive variant. The title suffix and footer verb track
-        # the outcome too — a failed delete reads "Purchase Order
-        # Failed" / "failed.", NOT "Purchase Order Deleted" / "deleted."
-        # which would contradict the FAILED badge.
-        if not is_preview:
-            outcome_label, outcome_variant = _summarize_apply_outcome(actions)
-            if outcome_label != "APPLIED":
-                applied_state_label = outcome_label
-                applied_state_variant = outcome_variant
-                if outcome_label == "FAILED":
-                    applied_title_suffix = "Failed"
-                    applied_verb = "failed"
-                else:  # PARTIAL FAILURE
-                    applied_title_suffix = "Partially Applied"
-                    applied_verb = "partially applied"
+        (
+            applied_title_suffix,
+            applied_state_label,
+            applied_state_variant,
+            applied_verb,
+        ) = _po_applied_state_labels(verb_label, is_preview=is_preview, actions=actions)
 
         _render_preview_header(
             title_prefix=f"{verb_label} Purchase Order",
@@ -4508,6 +4620,24 @@ def build_po_modify_ui(
             if response.get("message"):
                 Muted(content=response["message"])
             block_warnings = _render_po_entity_view(entity, changes=changes_by_field)
+            # Line-item diff table — rendered only when the plan actually
+            # changes a row (``po_row_summary`` is non-empty). A header-only /
+            # additional-cost-only modify leaves the existing rows untouched,
+            # so listing them here would be noise; the header diffs above
+            # carry the change. The full merged list (existing + changed)
+            # seeds ``state.po_row_rows`` so when the table shows, unchanged
+            # rows provide context alongside the diffs (BOM-style), and the
+            # per-row Status morphs in place on apply.
+            if show_row_table:
+                Separator()
+                Muted(content="Line items:")
+                Text(content=po_row_summary)
+                DataTable(
+                    columns=_PO_MODIFY_ROW_COLUMNS,
+                    rows=_PO_MODIFY_ROW_REF,
+                    paginated=True,
+                    pageSize=20,
+                )
         # Confirm label scales with the number of planned actions —
         # ``Confirm 4 changes`` is more informative than the generic
         # form. Delete cards say "Delete" not "Confirm" to mirror the

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -35,6 +35,7 @@ from katana_mcp.tools.prefab_ui import (
     build_item_modify_ui,
     build_modification_preview_ui,
     build_modification_result_ui,
+    build_po_modify_ui,
     build_product_bom_ui,
     build_search_results_ui,
     build_so_create_ui,
@@ -1060,6 +1061,99 @@ def _item_modify_response(*, is_preview: bool, succeeded: bool | None) -> dict:
     }
 
 
+def _po_modify_rows_response(*, is_preview: bool, succeeded: bool | None) -> dict:
+    """Build a canned PO modify response with line-item row CRUD.
+
+    Mirrors the production shape for the PO row-table content-drop fix (#722
+    follow-up): a header change + (1 add + 1 update + 1 delete) on the line
+    items, with the raw ``purchase_order_rows`` snapshot as ``prior_state`` and
+    the resolved-variant map in ``extras`` so the row table renders SKU + name.
+    """
+    actions = [
+        ActionResult(
+            index=1,
+            operation="update_header",
+            target_id=9001,
+            changes=[FieldChange(field="status", old="NOT_RECEIVED", new="RECEIVED")],
+            succeeded=succeeded,
+            verified=True if succeeded else None,
+        ).model_dump(),
+        ActionResult(
+            index=2,
+            operation="add_row",
+            target_id=None,
+            changes=[
+                FieldChange(field="variant_id", old=None, new=403, is_added=True),
+                FieldChange(field="quantity", old=None, new=20.0, is_added=True),
+                FieldChange(field="price_per_unit", old=None, new=2.5, is_added=True),
+            ],
+            succeeded=succeeded,
+        ).model_dump(),
+        ActionResult(
+            index=3,
+            operation="update_row",
+            target_id=7001,
+            changes=[FieldChange(field="quantity", old=10.0, new=15.0)],
+            succeeded=succeeded,
+            verified=True if succeeded else None,
+        ).model_dump(),
+        ActionResult(
+            index=4,
+            operation="delete_row",
+            target_id=7002,
+            changes=[],
+            succeeded=succeeded,
+        ).model_dump(),
+    ]
+    return {
+        "entity_type": "purchase_order",
+        "entity_id": 9001,
+        "is_preview": is_preview,
+        "operation": "",
+        "changes": [],
+        "actions": actions,
+        "prior_state": {
+            "id": 9001,
+            "order_no": "PO-2026-001",
+            "supplier_id": 100,
+            "supplier": {"id": 100, "name": "Acme Supply Co"},
+            "location_id": 1,
+            "status": "NOT_RECEIVED",
+            "entity_type": "regular",
+            "total": 1250.0,
+            "currency": "USD",
+            "additional_info": "Net-30",
+            "purchase_order_rows": [
+                {
+                    "id": 7001,
+                    "variant_id": 401,
+                    "quantity": 10.0,
+                    "price_per_unit": 25.0,
+                },
+                {
+                    "id": 7002,
+                    "variant_id": 402,
+                    "quantity": 5.0,
+                    "price_per_unit": 40.0,
+                },
+            ],
+        },
+        "extras": {
+            "resolved_variants": {
+                401: {"sku": "BOLT-M5", "display_name": "M5 bolt"},
+                402: {"sku": "NUT-M5", "display_name": "M5 nut"},
+                403: {"sku": "WASHER-M5", "display_name": "M5 washer"},
+            }
+        },
+        "warnings": [],
+        "next_actions": [],
+        "katana_url": "https://factory.katanamrp.com/purchaseorder/9001",
+        "message": (
+            "Preview: 4 action(s) planned" if is_preview else "Applied 4 action(s)"
+        ),
+    }
+
+
 def _so_failed_delete_response(*, is_preview: bool = False) -> dict:
     """Build a canned SO delete response where the apply fails.
 
@@ -1778,6 +1872,19 @@ SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
         _item_modify_response(is_preview=False, succeeded=True),
         confirm_request=_StubRequest(),
         confirm_tool="modify_item",
+    ),
+    # #722 follow-up — PO modify card line-item diff table: a header change +
+    # (1 add + 1 update + 1 delete) on the rows. Pins the content-drop fix —
+    # row CRUD now renders with resolved SKU/name + per-row status — end to end.
+    "po_modify_rows_preview": lambda: build_po_modify_ui(
+        _po_modify_rows_response(is_preview=True, succeeded=None),
+        confirm_request=_StubRequest(),
+        confirm_tool="modify_purchase_order",
+    ),
+    "po_modify_rows_applied": lambda: build_po_modify_ui(
+        _po_modify_rows_response(is_preview=False, succeeded=True),
+        confirm_request=_StubRequest(),
+        confirm_tool="modify_purchase_order",
     ),
     # #811 — BOM modify card with adds + updates + deletes against a
     # realistic 5-row existing recipe. Pins the row-content + status-pill

--- a/katana_mcp_server/tests/browser/test_modification_render.py
+++ b/katana_mcp_server/tests/browser/test_modification_render.py
@@ -161,6 +161,39 @@ class TestModificationCardRender:
         # 3 variant actions (add + update + delete) → 3 APPLIED status cells.
         assert frame.locator("td").filter(has_text="APPLIED").count() >= 3
 
+    def test_po_modify_rows_preview_renders_line_item_table(self, render_scenario):
+        """#722 follow-up — PO modify card line-item table renders the row CRUD
+        that was previously dropped: added row's resolved SKU/name, updated
+        row's qty diff arrow, deleted row's preserved identity, summary line.
+        """
+        frame = render_scenario("po_modify_rows_preview")
+        # Header diff still present.
+        assert frame.locator("text=RECEIVED").count() >= 1
+        # Line-item section + table.
+        assert frame.locator("text=Line items:").count() >= 1
+        assert frame.locator("table").count() >= 1
+        # Added row's resolved SKU/name (the content-drop fix — no bare id).
+        assert frame.locator("td").filter(has_text="WASHER-M5").count() >= 1
+        assert frame.locator("td").filter(has_text="M5 washer").count() >= 1
+        # Updated row's qty diff arrow + deleted row identity.
+        assert frame.locator("td").filter(has_text="10 → 15").count() >= 1
+        assert frame.locator("td").filter(has_text="NUT-M5").count() >= 1
+        # Summary line.
+        assert frame.locator("text=+1 added").count() >= 1
+        assert frame.locator("text=~1 updated").count() >= 1
+        assert frame.locator("text=-1 deleted").count() >= 1
+        # Anti-pattern guard: no internal ActionResult labels leak.
+        assert frame.locator("td").filter(has_text="Add Row").count() == 0
+
+    def test_po_modify_rows_applied_renders_per_row_status(self, render_scenario):
+        """#722 follow-up — applied PO modify: the row actions (add + update +
+        delete) show APPLIED in the line-item table's Status column.
+        """
+        frame = render_scenario("po_modify_rows_applied")
+        assert frame.locator("table").count() >= 1
+        # 3 row actions → 3 APPLIED status cells.
+        assert frame.locator("td").filter(has_text="APPLIED").count() >= 3
+
     def test_so_modify_partial_failure_applied_renders(self, render_scenario):
         """#723 SO modify card — partial-failure applied state renders the
         card-level PARTIAL FAILURE badge, the per-action APPLIED / FAILED

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -3076,6 +3076,330 @@ class TestBuildPOModifyUI:
         assert result["entity_id"] == 9001
 
 
+class TestPOModifyRowTable:
+    """``build_po_modify_ui`` line-item diff table (#722 follow-up under #721).
+
+    The card previously rendered header scalar diffs only and silently dropped
+    every ``modify_purchase_order`` row CRUD action. These pin the row table:
+    add/update/delete rows render with resolved SKU/name, the table is
+    state-bound + morphs, and a header-only modify renders no table.
+    """
+
+    _PO_PRIOR: ClassVar[dict[str, Any]] = {
+        "id": 9001,
+        "order_no": "PO-2026-001",
+        "supplier_id": 100,
+        "supplier": {"id": 100, "name": "Acme Supply Co"},
+        "location_id": 1,
+        "status": "NOT_RECEIVED",
+        "entity_type": "regular",
+        "total": 1250.0,
+        "currency": "USD",
+        "additional_info": "Net-30",
+        # Raw PurchaseOrderRow.to_dict() shape — variant_id + qty + price,
+        # NO resolved sku/display_name (those come from extras.resolved_variants).
+        "purchase_order_rows": [
+            {"id": 7001, "variant_id": 401, "quantity": 10.0, "price_per_unit": 25.0},
+            {"id": 7002, "variant_id": 402, "quantity": 5.0, "price_per_unit": 40.0},
+        ],
+    }
+    _RESOLVED: ClassVar[dict[int, dict[str, Any]]] = {
+        401: {"sku": "BOLT-M5", "display_name": "M5 bolt"},
+        402: {"sku": "NUT-M5", "display_name": "M5 nut"},
+        403: {"sku": "WASHER-M5", "display_name": "M5 washer"},
+    }
+
+    @classmethod
+    def _preview(
+        cls, actions: list[dict[str, Any]] | None = None, **overrides: Any
+    ) -> dict[str, Any]:
+        return {
+            "entity_type": "purchase_order",
+            "entity_id": 9001,
+            "is_preview": True,
+            "actions": actions or [],
+            "prior_state": dict(cls._PO_PRIOR),
+            "extras": {"resolved_variants": dict(cls._RESOLVED)},
+            "warnings": [],
+            "next_actions": [],
+            "message": "Preview",
+            "katana_url": "https://factory.katanamrp.com/purchaseorder/9001",
+            **overrides,
+        }
+
+    @classmethod
+    def _applied(
+        cls, actions: list[dict[str, Any]] | None = None, **overrides: Any
+    ) -> dict[str, Any]:
+        return cls._preview(actions, is_preview=False, **overrides)
+
+    @staticmethod
+    def _add_row(*, variant_id: int, qty: float, price: float, **o: Any) -> dict:
+        return {
+            "operation": "add_row",
+            "target_id": None,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [
+                {
+                    "field": "variant_id",
+                    "old": None,
+                    "new": variant_id,
+                    "is_added": True,
+                },
+                {"field": "quantity", "old": None, "new": qty, "is_added": True},
+                {
+                    "field": "price_per_unit",
+                    "old": None,
+                    "new": price,
+                    "is_added": True,
+                },
+            ],
+            **o,
+        }
+
+    @staticmethod
+    def _update_row(
+        *, target_id: int, old_qty: float, new_qty: float, **o: Any
+    ) -> dict:
+        return {
+            "operation": "update_row",
+            "target_id": target_id,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [{"field": "quantity", "old": old_qty, "new": new_qty}],
+            **o,
+        }
+
+    @staticmethod
+    def _delete_row(*, target_id: int, **o: Any) -> dict:
+        return {
+            "operation": "delete_row",
+            "target_id": target_id,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [],
+            **o,
+        }
+
+    def test_row_crud_renders_all_kinds_and_summary(self):
+        actions = [
+            self._add_row(variant_id=403, qty=20.0, price=2.5),
+            self._update_row(target_id=7001, old_qty=10.0, new_qty=15.0),
+            self._delete_row(target_id=7002),
+        ]
+        app = build_po_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        # Added row's resolved SKU + name (the user-centric piece — no bare id).
+        assert "+ WASHER-M5" in rendered
+        assert "M5 washer" in rendered
+        # Updated row's quantity diff arrow.
+        assert "10 → 15" in rendered
+        # Deleted row's preserved identity.
+        assert "- NUT-M5" in rendered
+        # Summary line.
+        assert "+1 added" in rendered
+        assert "~1 updated" in rendered
+        assert "-1 deleted" in rendered
+
+    def test_rows_seed_state_for_datatable_binding(self):
+        app = build_po_modify_ui(
+            self._preview([self._add_row(variant_id=403, qty=1.0, price=1.0)]),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        assert app.state is not None
+        rows = app.state.get("po_row_rows")
+        assert isinstance(rows, list)
+        # 2 existing + 1 added.
+        assert len(rows) == 3
+        assert [r["kind"] for r in rows].count("added") == 1
+
+    def test_header_only_modify_renders_no_row_table(self):
+        actions = [
+            {
+                "operation": "update_header",
+                "target_id": 9001,
+                "succeeded": None,
+                "changes": [
+                    {"field": "status", "old": "NOT_RECEIVED", "new": "RECEIVED"}
+                ],
+            }
+        ]
+        app = build_po_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        # No row change → the line-item diff table isn't rendered (the header
+        # diff carries the change); existing rows aren't listed as noise.
+        assert "Line items:" not in rendered
+        # The header diff still shows.
+        assert "NOT_RECEIVED" in rendered and "RECEIVED" in rendered
+
+    def test_unresolved_variant_falls_back_to_variant_id(self):
+        # Add a variant absent from resolved_variants → "variant <id>" fallback.
+        app = build_po_modify_ui(
+            self._preview(
+                [self._add_row(variant_id=99999, qty=1.0, price=1.0)],
+                extras={"resolved_variants": {}},
+            ),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        rendered = str(app.to_json())
+        assert "(unresolved)" in rendered
+        assert "variant 99999" in rendered
+
+    def test_decimal_price_renders_trimmed(self):
+        from decimal import Decimal
+
+        actions = [
+            {
+                "operation": "update_row",
+                "target_id": 7001,
+                "succeeded": None,
+                "status_label": "PLANNED",
+                "changes": [
+                    {
+                        "field": "price_per_unit",
+                        "old": Decimal("25.0000000000"),
+                        "new": Decimal("27.5000000000"),
+                    }
+                ],
+            }
+        ]
+        app = build_po_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        rendered = str(app.to_json())
+        assert "25 → 27.5" in rendered
+        assert "0000000000" not in rendered
+
+    def test_malformed_resolved_variants_does_not_crash(self):
+        """A missing / malformed ``extras.resolved_variants`` (None, list) must
+        not crash the card — it degrades to the ``variant <id>`` fallback
+        (Copilot #881)."""
+        from katana_mcp.tools.prefab_ui import _coerce_resolved_id_map
+
+        assert _coerce_resolved_id_map(None) == {}
+        assert _coerce_resolved_id_map([1, 2, 3]) == {}
+        assert _coerce_resolved_id_map("nope") == {}
+        # Well-formed still works (string keys coerced back to int).
+        assert _coerce_resolved_id_map({"401": {"sku": "X", "display_name": "Y"}}) == {
+            401: {"sku": "X", "display_name": "Y"}
+        }
+        # End-to-end: a non-dict extras value renders the row with the fallback.
+        app = build_po_modify_ui(
+            self._preview(
+                [self._add_row(variant_id=403, qty=1.0, price=1.0)],
+                extras={"resolved_variants": ["malformed"]},
+            ),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        _assert_valid_prefab(app)
+        assert "variant 403" in str(app.to_json())
+
+    def test_header_only_modify_short_circuits_row_merge(self):
+        """Header-only / additional-cost-only plans skip the row merge entirely
+        — ``_po_modify_row_rows`` returns ``([], "")`` without projecting over
+        the PO's row snapshot (Copilot #881)."""
+        from katana_mcp.tools.prefab_ui import _po_modify_row_rows
+
+        header_actions = [
+            {
+                "operation": "update_header",
+                "target_id": 9001,
+                "succeeded": None,
+                "changes": [{"field": "status", "old": "X", "new": "Y"}],
+            },
+            {
+                "operation": "add_additional_cost",
+                "target_id": None,
+                "succeeded": None,
+                "changes": [],
+            },
+        ]
+        rows, summary = _po_modify_row_rows(
+            dict(self._PO_PRIOR), header_actions, extras={}
+        )
+        assert rows == []
+        assert summary == ""
+        # A row op does produce rows.
+        rows2, summary2 = _po_modify_row_rows(
+            dict(self._PO_PRIOR),
+            [self._add_row(variant_id=403, qty=1.0, price=1.0)],
+            extras={"resolved_variants": dict(self._RESOLVED)},
+        )
+        assert len(rows2) == 3 and summary2 == "+1 added"
+
+    def test_header_only_modify_does_not_seed_row_state(self):
+        """Header-only modify: no row change → the (potentially large) PO row
+        snapshot is NOT copied into UI state (Copilot #881)."""
+        actions = [
+            {
+                "operation": "update_header",
+                "target_id": 9001,
+                "succeeded": None,
+                "changes": [
+                    {"field": "status", "old": "NOT_RECEIVED", "new": "RECEIVED"}
+                ],
+            }
+        ]
+        app = build_po_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        assert app.state is not None
+        assert "po_row_rows" not in app.state
+
+    def test_not_run_tail_surfaces_in_row_table(self):
+        applied_actions = [
+            self._add_row(
+                variant_id=403,
+                qty=1.0,
+                price=1.0,
+                succeeded=False,
+                status_label="FAILED",
+                error="variant archived",
+            )
+        ]
+        not_run = [
+            self._update_row(
+                target_id=7001, old_qty=10.0, new_qty=15.0, status_label="NOT RUN"
+            )
+        ]
+        app = build_po_modify_ui(
+            self._applied(
+                applied_actions,
+                extras={
+                    "resolved_variants": dict(self._RESOLVED),
+                    "not_run_actions": not_run,
+                },
+            ),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        assert app.state is not None
+        rows = app.state.get("po_row_rows")
+        assert isinstance(rows, list)
+        statuses = {r["id"]: r["status_label"] for r in rows}
+        # Added row FAILED; the not-run update of 7001 shows NOT RUN.
+        assert statuses.get(7001) == "NOT RUN"
+        assert any(r["status_label"] == "FAILED" for r in rows)
+
+
 class TestBuildSOModifyUI:
     """``build_so_modify_ui`` handles preview/applied/partial-failure for
     every SO write tool (``modify_sales_order``, ``delete_sales_order``,

--- a/katana_mcp_server/tests/tools/test_po_row_table.py
+++ b/katana_mcp_server/tests/tools/test_po_row_table.py
@@ -1,0 +1,177 @@
+"""Tests for the PO line-item collection-diff table (#722 follow-up / #721).
+
+Exercises the PO-row cell builders + merge wiring on the shared collection-diff
+skeleton: SKU / variant-name / quantity / unit-price cells, the kind gutter on
+the SKU column, resolved-variant lookup, and the add/update/delete projection
+from row-CRUD actions + a prior-state snapshot.
+"""
+
+import logging
+from decimal import Decimal
+from typing import ClassVar
+
+from katana_mcp.tools.foundation.po_row_table import (
+    _format_number,
+    _format_number_diff,
+    merge_po_row_rows_for_modify_card,
+    prepare_po_row_table_rows,
+)
+
+
+class TestFormatNumber:
+    def test_none_is_em_dash(self):
+        assert _format_number(None) == "—"
+
+    def test_trims_trailing_zeros(self):
+        assert _format_number(25.0) == "25"
+        assert _format_number(2.5) == "2.5"
+
+    def test_decimal_trimmed(self):
+        assert _format_number(Decimal("25.0000000000")) == "25"
+        assert _format_number(Decimal("2.50")) == "2.5"
+
+    def test_numeric_string_coerced(self):
+        assert _format_number("40.00") == "40"
+
+    def test_diff_form(self):
+        assert _format_number_diff(10.0, 15.0, unknown_prior=False) == "10 → 15"
+
+    def test_diff_unknown_prior(self):
+        assert (
+            _format_number_diff(None, 15.0, unknown_prior=True)
+            == "(prior unknown) → 15"
+        )
+
+
+class TestMergePORows:
+    _PRIOR: ClassVar[dict] = {
+        "purchase_order_rows": [
+            {"id": 7001, "variant_id": 401, "quantity": 10.0, "price_per_unit": 25.0},
+            {"id": 7002, "variant_id": 402, "quantity": 5.0, "price_per_unit": 40.0},
+        ]
+    }
+    _RESOLVED: ClassVar[dict] = {
+        401: {"sku": "BOLT-M5", "display_name": "M5 bolt"},
+        402: {"sku": "NUT-M5", "display_name": "M5 nut"},
+        403: {"sku": "WASHER-M5", "display_name": "M5 washer"},
+    }
+
+    def _merge(self, actions):
+        return prepare_po_row_table_rows(
+            merge_po_row_rows_for_modify_card(self._PRIOR, actions, self._RESOLVED)
+        )
+
+    def test_existing_rows_resolve_sku_and_name(self):
+        rows = self._merge([])
+        assert [r["sku"] for r in rows] == ["BOLT-M5", "NUT-M5"]
+        assert [r["display_name"] for r in rows] == ["M5 bolt", "M5 nut"]
+        assert all(r["kind"] == "existing" for r in rows)
+        assert all(r["sku_label"].startswith("  ") for r in rows)
+
+    def test_add_row_resolves_variant_and_appends(self):
+        action = {
+            "operation": "add_row",
+            "target_id": None,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [
+                {"field": "variant_id", "old": None, "new": 403, "is_added": True},
+                {"field": "quantity", "old": None, "new": 20.0, "is_added": True},
+                {"field": "price_per_unit", "old": None, "new": 2.5, "is_added": True},
+            ],
+        }
+        rows = self._merge([action])
+        added = rows[-1]
+        assert added["kind"] == "added"
+        assert added["sku_label"] == "+ WASHER-M5"
+        assert added["display_name"] == "M5 washer"
+        assert added["quantity_label"] == "20"
+        assert added["price_label"] == "2.5"
+
+    def test_update_row_decorates_quantity_diff(self):
+        action = {
+            "operation": "update_row",
+            "target_id": 7001,
+            "succeeded": True,
+            "status_label": "APPLIED",
+            "changes": [{"field": "quantity", "old": 10.0, "new": 15.0}],
+        }
+        rows = self._merge([action])
+        updated = next(r for r in rows if r["id"] == 7001)
+        assert updated["kind"] == "updated"
+        assert updated["sku_label"] == "~ BOLT-M5"
+        assert updated["quantity_label"] == "10 → 15"
+
+    def test_update_row_variant_swap_reresolves_name(self):
+        action = {
+            "operation": "update_row",
+            "target_id": 7001,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [{"field": "variant_id", "old": 401, "new": 403}],
+        }
+        rows = self._merge([action])
+        updated = next(r for r in rows if r["id"] == 7001)
+        assert updated["sku"] == "WASHER-M5"
+        assert updated["display_name"] == "M5 washer"
+
+    def test_delete_row_marks_deleted_and_keeps_identity(self):
+        action = {
+            "operation": "delete_row",
+            "target_id": 7002,
+            "succeeded": True,
+            "status_label": "APPLIED",
+            "changes": [],
+        }
+        rows = self._merge([action])
+        deleted = next(r for r in rows if r["id"] == 7002)
+        assert deleted["kind"] == "deleted"
+        assert deleted["sku_label"] == "- NUT-M5"
+
+    def test_unresolved_variant_falls_back(self):
+        action = {
+            "operation": "add_row",
+            "target_id": None,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [
+                {"field": "variant_id", "old": None, "new": 99999, "is_added": True},
+                {"field": "quantity", "old": None, "new": 1.0, "is_added": True},
+            ],
+        }
+        rows = prepare_po_row_table_rows(
+            merge_po_row_rows_for_modify_card(self._PRIOR, [action], {})
+        )
+        added = rows[-1]
+        assert added["sku_label"] == "+ (unresolved)"
+        assert added["display_name"] == "variant 99999"
+
+    def test_non_row_ops_filtered_without_warning(self, caplog):
+        """Header / additional-cost ops in the same plan must be filtered before
+        the shared merge so it doesn't log a spurious unknown-op warning."""
+        from katana_mcp.logging import setup_logging
+
+        setup_logging(log_level="WARNING", log_format="json")
+        actions = [
+            {
+                "operation": "update_header",
+                "target_id": 9001,
+                "succeeded": None,
+                "changes": [{"field": "status", "old": "X", "new": "Y"}],
+            },
+            {
+                "operation": "add_additional_cost",
+                "target_id": None,
+                "succeeded": None,
+                "changes": [],
+            },
+        ]
+        with caplog.at_level(
+            logging.WARNING, logger="katana_mcp.tools.foundation.collection_diff"
+        ):
+            rows = self._merge(actions)
+        assert [r["kind"] for r in rows] == ["existing", "existing"]
+        assert not any("dropped action" in rec.getMessage() for rec in caplog.records)
+
+    def test_missing_prior_state_yields_empty(self):
+        assert merge_po_row_rows_for_modify_card(None, [], {}) == []

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -3912,6 +3912,61 @@ async def test_modify_po_preview_emits_planned_actions(patch_fetch_po):
 
 
 @pytest.mark.asyncio
+async def test_modify_po_header_only_skips_variant_resolution(patch_fetch_po):
+    """Header-only / additional-cost-only modifies skip ``_resolve_po_row_variants``
+    — the card never renders the row table, so resolving every existing-row
+    variant would be wasted work + a large extras payload (Copilot #881)."""
+    context, _ = create_mock_context()
+    existing = create_mock_po(order_id=42, order_no="PO-1", rows=[])
+
+    with (
+        patch_fetch_po(existing),
+        patch(
+            "katana_mcp.tools.foundation.purchase_orders._resolve_po_row_variants",
+            new=AsyncMock(return_value={}),
+        ) as mock_resolve,
+    ):
+        request = ModifyPurchaseOrderRequest(
+            id=42,
+            update_header=POHeaderPatch(
+                expected_arrival_date=datetime(2026, 2, 15, tzinfo=UTC)
+            ),
+            preview=True,
+        )
+        response = await _modify_purchase_order_impl(request, context)
+
+    mock_resolve.assert_not_awaited()
+    assert response.extras.get("resolved_variants") == {}
+
+
+@pytest.mark.asyncio
+async def test_modify_po_with_row_crud_resolves_variants(patch_fetch_po):
+    """A plan with row CRUD DOES resolve variants so the row table renders
+    user-facing identities (Copilot #881)."""
+    context, _ = create_mock_context()
+    existing = create_mock_po(order_id=42, order_no="PO-1", rows=[])
+
+    with (
+        patch_fetch_po(existing),
+        patch(
+            "katana_mcp.tools.foundation.purchase_orders._resolve_po_row_variants",
+            new=AsyncMock(return_value={100: {"sku": "X", "display_name": "Y"}}),
+        ) as mock_resolve,
+    ):
+        request = ModifyPurchaseOrderRequest(
+            id=42,
+            add_rows=[PORowAdd(variant_id=100, quantity=10, price_per_unit=5.0)],
+            preview=True,
+        )
+        response = await _modify_purchase_order_impl(request, context)
+
+    mock_resolve.assert_awaited_once()
+    assert response.extras.get("resolved_variants") == {
+        100: {"sku": "X", "display_name": "Y"}
+    }
+
+
+@pytest.mark.asyncio
 async def test_modify_po_confirm_executes_plan_in_canonical_order(patch_fetch_po):
     """Header → row adds → row updates → row deletes → cost adds/updates/deletes."""
     context, _ = create_mock_context()

--- a/uv.lock
+++ b/uv.lock
@@ -1329,7 +1329,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.105.0"
+version = "0.105.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Fixes a **content-drop bug** in the purchase-order modify card and continues the
#721 modify-card umbrella. `build_po_modify_ui` previously rendered header scalar
diffs only and **silently dropped every `modify_purchase_order` row CRUD action** —
the card claimed nothing changed when line items were added / updated / deleted.
The card now renders a line-item diff table below the header, built on the shared
collection-diff element (the third consumer after BOM and item variants).

### What changed

- **New `po_row_table` module** (sibling of `item_variant_table` / `bom_table`) —
  projects add/update/delete row actions onto SKU / variant-name / quantity /
  unit-price cells with the `+`/`~`/`-` kind gutter + per-row Status. Filters to
  the row-CRUD ops so header / additional-cost actions don't trip the shared
  merge's unknown-op warning. Decimal-safe number formatting.
- **Impl** (`_modify_purchase_order_impl`) — resolves variant SKU / display_name
  for every touched row variant into `extras["resolved_variants"]` via one
  batched typed-cache lookup (user-facing identities, not bare ids —
  anti-pattern #2 / #7); synthesizes the fail-fast NOT-RUN tail into
  `extras["not_run_actions"]` (mirrors SO / BOM / item).
- **Card** — state-bound table (`state.po_row_rows`) that morphs in place on
  apply; rendered only when a row actually changes (header-only modify shows
  just header diffs, no row noise). Header diffs now scoped to `update_header`
  so row-level `currency` etc. can't leak into header lines.

### Test plan

- [x] `uv run poe agent-check` (lint + ty) — clean
- [x] `uv run pyright` on touched files — 0 errors
- [x] `uv run poe test` — 3838 passed
- [x] Browser render: `po_modify_rows_{preview,applied}` pass in a real browser
  (resolved SKU/name + per-row status; the content-drop fix verified end-to-end)
- New unit + card coverage: `test_po_row_table`, `TestPOModifyRowTable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)