### PR TITLE
fix(mcp): truthful serial-tracked SO block message + close-out discoverability

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1127,9 +1127,9 @@ Receive items from a purchase order.
 **Landed costs:** `receive_purchase_order` does not set customs / freight /
 duties. After receiving, apportion them with
 `modify_purchase_order(add_additional_costs=[{additional_cost_id, price,
-tax_rate_id, distribution_method}])`. Look up `additional_cost_id` via
-`list_additional_costs`. Omit `group_id` and the dispatcher applies the cost
-to the PO's `default_group_id`; pass a specific `group_id` to target one cost
+tax_rate_id, distribution_method, group_id?}])`. Look up `additional_cost_id`
+via `list_additional_costs`. Omit `group_id` and the dispatcher applies the
+cost to the PO's `default_group_id`; pass a specific `group_id` to target one cost
 group. This is MCP-native — it does not require the Katana UI.
 
 ---

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1127,10 +1127,10 @@ Receive items from a purchase order.
 **Landed costs:** `receive_purchase_order` does not set customs / freight /
 duties. After receiving, apportion them with
 `modify_purchase_order(add_additional_costs=[{additional_cost_id, price,
-tax_rate_id, distribution_method, group_id}])`, which can target a specific
-receipt group via `group_id`. Look up `additional_cost_id` via
-`list_additional_costs`. This is MCP-native — it does not require the Katana
-UI.
+tax_rate_id, distribution_method}])`. Look up `additional_cost_id` via
+`list_additional_costs`. Omit `group_id` and the dispatcher applies the cost
+to the PO's `default_group_id`; pass a specific `group_id` to target one cost
+group. This is MCP-native — it does not require the Katana UI.
 
 ---
 

--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1124,6 +1124,14 @@ Receive items from a purchase order.
 
 **Safety:** When preview=false, prompts user for confirmation.
 
+**Landed costs:** `receive_purchase_order` does not set customs / freight /
+duties. After receiving, apportion them with
+`modify_purchase_order(add_additional_costs=[{additional_cost_id, price,
+tax_rate_id, distribution_method, group_id}])`, which can target a specific
+receipt group via `group_id`. Look up `additional_cost_id` via
+`list_additional_costs`. This is MCP-native — it does not require the Katana
+UI.
+
 ---
 
 ### verify_order_document
@@ -1776,6 +1784,14 @@ Complete a manufacturing or sales order.
   equal the row's ordered quantity. **Required** when the row's variant is
   serial-tracked — without it, the tool emits a `BLOCK:` warning at preview
   and refuses on direct apply (Katana would 422 the request).
+  **Caveat (serial minted on a linked MO):** the public-API write paths
+  cannot *transfer* a serial that is currently attached to the row's linked
+  manufacturing order — `POST /sales_order_fulfillments` returns "serial
+  numbers have already been assigned" and `add_serial_numbers(SalesOrderRow)`
+  returns "is linked, serial info must be updated on MO". That common
+  close-out case (finished good came off an MO with the serial already
+  minted) has no MCP-native path today; fulfill it from the Katana UI
+  ("Deliver all"), which performs the MO→SO transfer atomically.
 - `serial_numbers` (optional, manufacturing orders only): List of pre-existing
   `SerialNumber` IDs to attach to the produced units when marking the MO
   DONE. Length must equal `actual_quantity`. **Required** when the MO's
@@ -1785,6 +1801,9 @@ Complete a manufacturing or sales order.
 - `completed_at` (optional, ISO-8601): Backdated completion timestamp. MO →
   production POST `completed_date` (Katana propagates to `MO.done_date`);
   SO → fulfillment `picked_date`. Omit to let Katana stamp server-time.
+  **There is no separate `picked_date` / `delivery_date` parameter** — set
+  the SO picked date (or MO done date) through `completed_at`; it is the
+  single backdating knob for both order types.
 - `acknowledge_inventory_ordering` (optional, default false): Override flag
   for the inventory-ordering guard. The guard fires when `completed_at` is
   supplied and a linked entity's timestamp is known — Katana's

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -1303,9 +1303,9 @@ def _build_row_override_warnings(
             warnings.append(
                 f"{BLOCK_WARNING_PREFIX} Row {rid} ({sku_by_row.get(rid)}) is "
                 "serial-tracked. Pass serial_numbers via the rows= override "
-                "(one SerialNumber ID per unit) when the serials are "
-                "unassigned. Caveat: if a serial was minted on the linked "
-                "manufacturing order, Katana's public API cannot transfer it "
+                "(one SerialNumber ID per unit). Caveat: if this row is "
+                "fulfilled from a linked manufacturing order that already "
+                "minted the serial, Katana's public API cannot transfer it "
                 "onto this row (it returns 'serial numbers have already been "
                 "assigned'); fulfill that row from the Katana UI (\"Deliver "
                 'all") instead.'

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -1303,7 +1303,12 @@ def _build_row_override_warnings(
             warnings.append(
                 f"{BLOCK_WARNING_PREFIX} Row {rid} ({sku_by_row.get(rid)}) is "
                 "serial-tracked. Pass serial_numbers via the rows= override "
-                "(one SerialNumber ID per unit)."
+                "(one SerialNumber ID per unit) when the serials are "
+                "unassigned. Caveat: if a serial was minted on the linked "
+                "manufacturing order, Katana's public API cannot transfer it "
+                "onto this row (it returns 'serial numbers have already been "
+                "assigned'); fulfill that row from the Katana UI (\"Deliver "
+                'all") instead.'
             )
         elif serials is not None and qty is not None and len(serials) != qty:
             warnings.append(

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -999,7 +999,7 @@ async def _receive_purchase_order_impl(
                 "Inventory has been updated",
                 "To apportion landed costs (customs, freight, duties), call "
                 "modify_purchase_order(add_additional_costs=[{additional_cost_id, "
-                "price, tax_rate_id, distribution_method}]) — look up "
+                "price, tax_rate_id, distribution_method, group_id?}]) — look up "
                 "additional_cost_id via list_additional_costs. Omit group_id to "
                 "apply to the PO's default cost group; pass a specific group_id "
                 "to target one.",
@@ -1028,11 +1028,11 @@ async def receive_purchase_order(
     Landed costs (customs, freight, duties) are *not* set here. After
     receiving, apportion them with
     ``modify_purchase_order(add_additional_costs=[{additional_cost_id, price,
-    tax_rate_id, distribution_method}])``. Look up ``additional_cost_id`` via
-    ``list_additional_costs``. Omit ``group_id`` and the dispatcher applies the
-    cost to the PO's ``default_group_id``; pass a specific ``group_id`` to
-    target one cost group. This is an MCP-native path; it does not require the
-    Katana UI.
+    tax_rate_id, distribution_method, group_id?}])``. Look up
+    ``additional_cost_id`` via ``list_additional_costs``. Omit ``group_id`` and
+    the dispatcher applies the cost to the PO's ``default_group_id``; pass a
+    specific ``group_id`` to target one cost group. This is an MCP-native path;
+    it does not require the Katana UI.
     """
     response = await _receive_purchase_order_impl(request, context)
     return _receive_response_to_tool_result(response, request=request)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -997,12 +997,12 @@ async def _receive_purchase_order_impl(
             next_actions=[
                 f"Received {len(request.items)} items",
                 "Inventory has been updated",
-                "To apportion landed costs (customs, freight, duties) to this "
-                "receipt, call modify_purchase_order(add_additional_costs="
-                "[{additional_cost_id, price, tax_rate_id, distribution_method, "
-                "group_id}]) — look up additional_cost_id via "
-                "list_additional_costs and target the receipt's group_id (find "
-                "it on the PO via get_purchase_order).",
+                "To apportion landed costs (customs, freight, duties), call "
+                "modify_purchase_order(add_additional_costs=[{additional_cost_id, "
+                "price, tax_rate_id, distribution_method}]) — look up "
+                "additional_cost_id via list_additional_costs. Omit group_id to "
+                "apply to the PO's default cost group; pass a specific group_id "
+                "to target one.",
             ],
             message=f"Successfully received {len(request.items)} items for PO {order_no}",
         )
@@ -1028,10 +1028,11 @@ async def receive_purchase_order(
     Landed costs (customs, freight, duties) are *not* set here. After
     receiving, apportion them with
     ``modify_purchase_order(add_additional_costs=[{additional_cost_id, price,
-    tax_rate_id, distribution_method, group_id}])`` — ``add_additional_costs``
-    can target a specific receipt group via ``group_id``. Look up
-    ``additional_cost_id`` via ``list_additional_costs``. This is an MCP-native
-    path; it does not require the Katana UI.
+    tax_rate_id, distribution_method}])``. Look up ``additional_cost_id`` via
+    ``list_additional_costs``. Omit ``group_id`` and the dispatcher applies the
+    cost to the PO's ``default_group_id``; pass a specific ``group_id`` to
+    target one cost group. This is an MCP-native path; it does not require the
+    Katana UI.
     """
     response = await _receive_purchase_order_impl(request, context)
     return _receive_response_to_tool_result(response, request=request)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -997,6 +997,12 @@ async def _receive_purchase_order_impl(
             next_actions=[
                 f"Received {len(request.items)} items",
                 "Inventory has been updated",
+                "To apportion landed costs (customs, freight, duties) to this "
+                "receipt, call modify_purchase_order(add_additional_costs="
+                "[{additional_cost_id, price, tax_rate_id, distribution_method, "
+                "group_id}]) — look up additional_cost_id via "
+                "list_additional_costs and target the receipt's group_id (find "
+                "it on the PO via get_purchase_order).",
             ],
             message=f"Successfully received {len(request.items)} items for PO {order_no}",
         )
@@ -1018,6 +1024,14 @@ async def receive_purchase_order(
     PO before receiving. Requires the PO ID and row IDs. Each item may include
     an optional ISO 8601 ``received_date`` for back-dated receives — without it,
     rows land on the call time.
+
+    Landed costs (customs, freight, duties) are *not* set here. After
+    receiving, apportion them with
+    ``modify_purchase_order(add_additional_costs=[{additional_cost_id, price,
+    tax_rate_id, distribution_method, group_id}])`` — ``add_additional_costs``
+    can target a specific receipt group via ``group_id``. Look up
+    ``additional_cost_id`` via ``list_additional_costs``. This is an MCP-native
+    path; it does not require the Katana UI.
     """
     response = await _receive_purchase_order_impl(request, context)
     return _receive_response_to_tool_result(response, request=request)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
@@ -552,7 +552,9 @@ async def list_additional_costs(
 ) -> ToolResult:
     """List or search the additional-cost catalog (freight, duties, handling
     fees, etc.). Returns id and name. Use the ``id`` value when calling
-    ``modify_purchase_order`` with ``add_additional_costs=[...]``. Pair
+    ``modify_purchase_order`` with ``add_additional_costs=[...]`` — including
+    to apportion landed costs to a receipt group after
+    ``receive_purchase_order`` (pass the receipt's ``group_id``). Pair
     with ``list_tax_rates`` for the matching ``tax_rate_id``.
 
     Pass ``query`` to fuzzy-match by name; omit to browse.

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
@@ -552,9 +552,8 @@ async def list_additional_costs(
 ) -> ToolResult:
     """List or search the additional-cost catalog (freight, duties, handling
     fees, etc.). Returns id and name. Use the ``id`` value when calling
-    ``modify_purchase_order`` with ``add_additional_costs=[...]`` — including
-    to apportion landed costs to a receipt group after
-    ``receive_purchase_order`` (pass the receipt's ``group_id``). Pair
+    ``modify_purchase_order`` with ``add_additional_costs=[...]`` — e.g. to
+    apportion landed costs after ``receive_purchase_order``. Pair
     with ``list_tax_rates`` for the matching ``tax_rate_id``.
 
     Pass ``query`` to fuzzy-match by name; omit to browse.

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/serial_numbers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/serial_numbers.py
@@ -479,6 +479,18 @@ async def add_serial_numbers(
       Strings that don't exist anywhere land in ``failed`` with
       ``reason=MISSING`` — the call still succeeds.
 
+    **Exception — a ``SalesOrderRow`` fulfilled from a linked manufacturing
+    order:** when the target SO row's production is driven by a linked MO
+    (the common serial-tracked close-out case — a finished good came off an
+    MO with the serial already minted on it), Katana rejects the transfer
+    outright with ``422 "SalesOrderRow <id> is linked, serial info must be
+    updated on MO"``. Serials on such a row are controlled by the MO, and
+    ``fulfill_order(order_type="sales", rows=[{serial_numbers: [...]}])``
+    likewise 422s ("serial numbers have already been assigned"). There is no
+    public-API path to complete that MO→SO transfer today; perform it from
+    the Katana UI ("Deliver all"), which moves the serial atomically. (The
+    transfer path above works normally for SO rows *not* linked to an MO.)
+
     Partial failure is possible: any string the API rejects (DUPLICATE on
     the mint path, MISSING on the transfer path) lands in ``failed`` while
     the rest succeed.

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/serial_numbers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/serial_numbers.py
@@ -485,8 +485,9 @@ async def add_serial_numbers(
     MO with the serial already minted on it), Katana rejects the transfer
     outright with ``422 "SalesOrderRow <id> is linked, serial info must be
     updated on MO"``. Serials on such a row are controlled by the MO, and
-    ``fulfill_order(order_type="sales", rows=[{serial_numbers: [...]}])``
-    likewise 422s ("serial numbers have already been assigned"). There is no
+    ``fulfill_order(order_type="sales", rows=[{"sales_order_row_id": <id>,
+    "serial_numbers": [<sn_id>]}])`` likewise 422s ("serial numbers have
+    already been assigned"). There is no
     public-API path to complete that MO→SO transfer today; perform it from
     the Katana UI ("Deliver all"), which moves the serial atomically. (The
     transfer path above works normally for SO rows *not* linked to an MO.)

--- a/katana_mcp_server/tests/tools/test_orders.py
+++ b/katana_mcp_server/tests/tools/test_orders.py
@@ -712,9 +712,11 @@ async def test_fulfill_sales_order_preview_blocks_serial_tracked_without_overrid
     assert len(block_warnings) == 1
     assert "serial-tracked" in block_warnings[0]
     assert "WIDGET-V2" in block_warnings[0]
-    # The message must warn about the MO-linked transfer dead-end (Bug 7):
-    # following "pass serial_numbers" blindly hits a 422 when the serial was
-    # minted on the linked MO, so the guidance names the UI fallback.
+    # The block carries the MO-linked transfer caveat (Bug 7).
+    # _build_row_override_warnings can't see linked_manufacturing_order_id, so
+    # the caveat is stated conditionally in every serial-tracked block rather
+    # than gated on linkage; this asserts the caveat text (the 422 wording +
+    # the UI fallback) is present in the warning.
     assert "already been assigned" in block_warnings[0]
     assert "Deliver all" in block_warnings[0]
     assert "Resolve the issue" in result.next_actions[0]

--- a/katana_mcp_server/tests/tools/test_orders.py
+++ b/katana_mcp_server/tests/tools/test_orders.py
@@ -712,6 +712,11 @@ async def test_fulfill_sales_order_preview_blocks_serial_tracked_without_overrid
     assert len(block_warnings) == 1
     assert "serial-tracked" in block_warnings[0]
     assert "WIDGET-V2" in block_warnings[0]
+    # The message must warn about the MO-linked transfer dead-end (Bug 7):
+    # following "pass serial_numbers" blindly hits a 422 when the serial was
+    # minted on the linked MO, so the guidance names the UI fallback.
+    assert "already been assigned" in block_warnings[0]
+    assert "Deliver all" in block_warnings[0]
     assert "Resolve the issue" in result.next_actions[0]
 
 

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -1719,6 +1719,10 @@ async def test_receive_purchase_order_confirm_success():
     assert result.is_preview is False
     assert "Successfully received" in result.message
     assert "Inventory has been updated" in result.next_actions
+    # Landed-cost discoverability: the success path points operators at the
+    # MCP-native apportionment route (modify_purchase_order add_additional_costs)
+    # instead of leaving it as an undiscovered UI-only step.
+    assert any("add_additional_costs" in a for a in result.next_actions)
 
     # Verify API was called with correct data
     cast(Any, api_receive_purchase_order.asyncio_detailed).assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1329,7 +1329,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.103.0"
+version = "0.105.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Three operator-facing friction fixes surfaced by the 2026-05-29 Spot Bikes
end-of-day close-out (5 POs received + 2 SOs closed). All are docs/message
changes — no logic or wire-shape changes — so they're safe to ship ahead of
the heavier blockers they point at.

1. **Truthful serial-tracked SO block message (Bug 7).** The block told
   operators to "Pass serial_numbers via the rows= override", but following
   that hits a Katana 422 (`serial numbers have already been assigned`)
   whenever the serial was minted on the row's linked MO — the normal
   close-out case. The message now adds the caveat and names the only working
   path (Katana UI "Deliver all", which performs the MO→SO transfer the public
   API cannot). Mirrored in `katana://help/tools`.

2. **`picked_date` discoverability (Bug 4).** There is no separate
   `picked_date` / `delivery_date` parameter — `completed_at` is the single
   backdating knob for both order types (shipped in #778, just hard to find).
   The help resource now says so explicitly.

3. **Landed-cost discoverability on receive (Bug 3).** `receive_purchase_order`
   doesn't set customs/freight/duties, and the MCP-native path
   (`modify_purchase_order(add_additional_costs=[…])`, which can target a
   receipt `group_id`) wasn't discoverable at receive time — so agents fell
   back to the Katana UI. Now pointed at via a `next_action`, the receive
   docstring, the help resource, and the `list_additional_costs` description.

## Scope / what this is NOT

The underlying serial-transfer blocker stays open — the public API genuinely
cannot transfer an MO-minted serial onto a linked SO row; that needs a
design decision (UI-API access vs. documented fallback). Tracked in **#784**
(reopened) and verified end-to-end in **#849**. The `additional_costs`-on-
receive *feature* (vs. this discoverability pointer) is **#879**. Bug 6
serial input notes are on **#804**.

## Test plan

- [x] `uv run poe agent-check` (ruff format/check, ty) — clean
- [x] `uv run poe test` — 3780 passed
- [x] `uv run pyright` on every edited file — 0 errors
- [x] Browser render suite for the affected files — 26 passed
- [x] New regression assertions pin the block-message caveat and the receive
      `next_action`

Refs #784 #849 #804 #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)