### PR TITLE
fix(client)!: make ManufacturingOrder.production_deadline_date nullable

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -3255,9 +3255,11 @@ components:
               format: date-time
               description: Date and time when the manufacturing order was created
             production_deadline_date:
-              type: string
+              type:
+                - string
+                - "null"
               format: date-time
-              description: Target deadline for completing production
+              description: Target deadline for completing production (null when none is set)
             done_date:
               type:
                 - string

--- a/katana_public_api_client/models/manufacturing_order.py
+++ b/katana_public_api_client/models/manufacturing_order.py
@@ -59,7 +59,7 @@ class ManufacturingOrder:
     batch_transactions: list[BatchTransaction] | Unset = UNSET
     location_id: int | Unset = UNSET
     order_created_date: datetime.datetime | Unset = UNSET
-    production_deadline_date: datetime.datetime | Unset = UNSET
+    production_deadline_date: datetime.datetime | None | Unset = UNSET
     done_date: datetime.datetime | None | Unset = UNSET
     additional_info: str | Unset = UNSET
     is_linked_to_sales_order: bool | Unset = UNSET
@@ -138,9 +138,13 @@ class ManufacturingOrder:
         if not isinstance(self.order_created_date, Unset):
             order_created_date = self.order_created_date.isoformat()
 
-        production_deadline_date: str | Unset = UNSET
-        if not isinstance(self.production_deadline_date, Unset):
+        production_deadline_date: None | str | Unset
+        if isinstance(self.production_deadline_date, Unset):
+            production_deadline_date = UNSET
+        elif isinstance(self.production_deadline_date, datetime.datetime):
             production_deadline_date = self.production_deadline_date.isoformat()
+        else:
+            production_deadline_date = self.production_deadline_date
 
         done_date: None | str | Unset
         if isinstance(self.done_date, Unset):
@@ -368,12 +372,26 @@ class ManufacturingOrder:
         else:
             order_created_date = isoparse(_order_created_date)
 
-        _production_deadline_date = d.pop("production_deadline_date", UNSET)
-        production_deadline_date: datetime.datetime | Unset
-        if isinstance(_production_deadline_date, Unset):
-            production_deadline_date = UNSET
-        else:
-            production_deadline_date = isoparse(_production_deadline_date)
+        def _parse_production_deadline_date(
+            data: object,
+        ) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                production_deadline_date_type_0 = isoparse(data)
+
+                return production_deadline_date_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        production_deadline_date = _parse_production_deadline_date(
+            d.pop("production_deadline_date", UNSET)
+        )
 
         def _parse_done_date(data: object) -> datetime.datetime | None | Unset:
             if data is None:

--- a/katana_public_api_client/models_pydantic/_generated/manufacturing.py
+++ b/katana_public_api_client/models_pydantic/_generated/manufacturing.py
@@ -620,7 +620,9 @@ class ManufacturingOrder(DeletableEntity):
     ] = None
     production_deadline_date: Annotated[
         AwareDatetime | None,
-        Field(description="Target deadline for completing production"),
+        Field(
+            description="Target deadline for completing production (null when none is set)"
+        ),
     ] = None
     done_date: Annotated[
         AwareDatetime | None,
@@ -1141,7 +1143,9 @@ class CachedManufacturingOrder(DeletableEntity, table=True):
     ] = None
     production_deadline_date: Annotated[
         Mapped[datetime | None],
-        Field(description="Target deadline for completing production"),
+        Field(
+            description="Target deadline for completing production (null when none is set)"
+        ),
     ] = None
     done_date: Annotated[
         Mapped[datetime | None],

--- a/tests/test_models_pydantic.py
+++ b/tests/test_models_pydantic.py
@@ -396,6 +396,54 @@ class TestVariantNullSku:
         assert pydantic_product.variants[1].sku is None
 
 
+class TestManufacturingOrderNullDeadline:
+    """ManufacturingOrder.production_deadline_date must accept None.
+
+    Pinning the wire-contract relaxation in this PR: the spec previously declared
+    ``production_deadline_date: type: string`` (non-nullable), so the generated
+    ``ManufacturingOrder.from_dict`` parsed it with a bare ``isoparse(value)`` that
+    only guarded ``Unset`` — an API ``null`` (key present, value None) raised
+    ``TypeError: object of type 'NoneType' has no len()`` inside ``isoparse``.
+    ``POST /manufacturing_order_make_to_order`` returns exactly that shape (an MO
+    with no deadline), which crashed any typed read of the response (get / list /
+    make_to_order). Spec corrected to ``[string, "null"]``; pinned here so a
+    future regen can't silently revert it.
+    """
+
+    def test_attrs_from_dict_accepts_null_deadline(self) -> None:
+        """The crash path: ``ManufacturingOrder.from_dict`` with a null deadline."""
+        from katana_public_api_client.models import ManufacturingOrder
+
+        mo = ManufacturingOrder.from_dict(
+            {"id": 16920725, "production_deadline_date": None}
+        )
+        assert mo.production_deadline_date is None
+        assert mo.id == 16920725
+
+    def test_pydantic_accepts_null_deadline(self) -> None:
+        from katana_public_api_client.models_pydantic._generated import (
+            ManufacturingOrder,
+        )
+
+        mo = ManufacturingOrder(id=16920725, production_deadline_date=None)
+        assert mo.production_deadline_date is None
+
+    def test_from_attrs_with_null_deadline(self) -> None:
+        from katana_public_api_client.models import (
+            ManufacturingOrder as AttrsManufacturingOrder,
+        )
+        from katana_public_api_client.models_pydantic._generated import (
+            ManufacturingOrder,
+        )
+
+        attrs_mo = AttrsManufacturingOrder.from_dict(
+            {"id": 16920725, "production_deadline_date": None}
+        )
+        pydantic_mo = ManufacturingOrder.from_attrs(attrs_mo)
+        assert pydantic_mo.production_deadline_date is None
+        assert pydantic_mo.id == 16920725
+
+
 class TestProductionSerialNumbers:
     """Wire-shape pin for ``CreateManufacturingOrderProductionRequest.serial_numbers``.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1329,7 +1329,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.105.1"
+version = "0.106.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

`ManufacturingOrder.production_deadline_date` was declared non-nullable in the spec, but the live API returns `null` for it (any MO with no deadline — and **every** MO created via `POST /manufacturing_order_make_to_order`). The generated `ManufacturingOrder.from_dict` parsed it with a bare `isoparse(value)` guarded only against `Unset`, so a `null` value (key present, value `None`) raised:

```
TypeError: object of type 'NoneType' has no len()   # inside dateutil isoparse(None)
```

That crashes **every typed read** of such a response — `get_manufacturing_order`, `get_all_manufacturing_orders`, `make_to_order_manufacturing_order` — and the MCP MO tools that consume them through the typed cache.

## Fix

Mark `production_deadline_date` as `[string, "null"]` in the `ManufacturingOrder` response schema (mirroring the adjacent `done_date` / `sales_order_delivery_deadline`). Regenerated client + pydantic now emit the None-guarded `_parse_production_deadline_date` and type the field `datetime | None | Unset`.

## How it surfaced

Found while running the live test-tenant probe for **#784** (serial-tracked SO fulfillment): the `make_to_order` 200 response carried `production_deadline_date: null` and crashed the typed client mid-probe. (The make-to-order path is itself a key discovery for #784 — separate follow-up.)

## Breaking change

`ManufacturingOrder.production_deadline_date` is now `datetime | None | Unset` (was `datetime | Unset`). Consumers that assumed a non-null datetime must handle `None`. Mirrors the prior `Variant.sku` nullable correction (`fix(client)!`).

## Test plan

- [x] New regression class `TestManufacturingOrderNullDeadline` (attrs `from_dict`, pydantic, `from_attrs`) — all assert a `null` deadline round-trips to `None` without crashing
- [x] `uv run poe test` green (3849 passed)
- [x] `validate-openapi` OK; `agent-check` (ruff/format/mdformat/ty) clean
- [x] Regenerated client + pydantic are in sync with the spec

Refs #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)