### PR TITLE
feat(mcp): diff-decorated MO modify/delete card (refs #721)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -651,6 +651,7 @@ def to_tool_result(
     from katana_mcp.tools.prefab_ui import (
         build_bom_modify_ui,
         build_item_modify_ui,
+        build_mo_modify_ui,
         build_modification_preview_ui,
         build_modification_result_ui,
         build_po_modify_ui,
@@ -660,9 +661,9 @@ def to_tool_result(
     response_dict = response.model_dump()
 
     # Per-entity dispatch — PO migrated in #722, BOM in #811, SO in #723,
-    # item (product / material / service) in #726; remaining entities
-    # (MO, stock_transfer) fall through to the legacy builders until their
-    # respective child PRs land.
+    # item (product / material / service) in #726, MO in #724; remaining
+    # entities (stock_transfer) fall through to the legacy builders until
+    # their respective child PRs land.
     if response.entity_type == "purchase_order":
         ui = build_po_modify_ui(
             response_dict,
@@ -689,6 +690,14 @@ def to_tool_result(
 
     if response.entity_type in ("product", "material", "service"):
         ui = build_item_modify_ui(
+            response_dict,
+            confirm_request=confirm_request,
+            confirm_tool=confirm_tool,
+        )
+        return make_tool_result(response, ui=ui)
+
+    if response.entity_type == "manufacturing_order":
+        ui = build_mo_modify_ui(
             response_dict,
             confirm_request=confirm_request,
             confirm_tool=confirm_tool,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -3240,7 +3240,7 @@ async def _modify_manufacturing_order_impl(
         async with _log_step_duration("verify_refetch", manufacturing_order_id=eid):
             return await _fetch_mo_recipe_row_attrs_for_cache_merge(services, eid)
 
-    return await run_modify_plan(
+    response = await run_modify_plan(
         request=request,
         naming=EntityNaming(
             entity_type="manufacturing_order",
@@ -3269,6 +3269,170 @@ async def _modify_manufacturing_order_impl(
             ),
         ),
     )
+
+    # Populate the modify card's three collection diff tables (#721 Phase 4).
+    # The MO snapshot doesn't embed recipe / operation / production rows (they
+    # live at separate endpoints), so fetch each — gated on whether that
+    # collection has CRUD in this plan — and attach to ``prior_state`` so the
+    # card shows existing rows as context alongside the diffs. Added recipe
+    # rows carry only ``variant_id``; resolve their SKU / name into
+    # ``extras["resolved_variants"]`` (existing recipe rows already carry
+    # resolved names via ``RecipeRowInfo``). All best-effort: a fetch failure
+    # degrades that table to changed-rows-only, never blocks the modify.
+    await _populate_mo_modify_collections(services, request, response)
+
+    # Apply-path: synthesize NOT-RUN entries for the unattempted plan tail so
+    # a fail-fast partial doesn't drop the not-run rows from the morphed
+    # tables. Mirrors the SO / BOM / item / PO fail-fast handling.
+    if not response.is_preview:
+        not_run_actions = [
+            {
+                "operation": spec.operation,
+                "target_id": spec.target_id,
+                "succeeded": None,
+                "error": None,
+                "changes": [
+                    c.model_dump() if hasattr(c, "model_dump") else dict(c)
+                    for c in spec.diff
+                ],
+                "status_label": "NOT RUN",
+            }
+            for spec in plan[len(response.actions) :]
+        ]
+        if not_run_actions:
+            response.extras["not_run_actions"] = not_run_actions
+
+    return response
+
+
+def _collect_recipe_variant_ids(request: ModifyManufacturingOrderRequest) -> set[int]:
+    """Variant ids referenced by added / variant-swapped recipe rows — the only
+    ones the card's recipe table can't resolve from the enriched existing rows.
+    """
+    ids: set[int] = set()
+    for add in request.add_recipe_rows or []:
+        ids.add(int(add.variant_id))
+    for upd in request.update_recipe_rows or []:
+        if upd.variant_id is not None:
+            ids.add(int(upd.variant_id))
+    return ids
+
+
+async def _resolve_mo_recipe_variants(
+    services: Any, variant_ids: set[int]
+) -> dict[int, dict[str, str | None]]:
+    """Batch-resolve ``{variant_id: {sku, display_name}}`` for added recipe rows.
+
+    Enrichment lookup by id — include archived + deleted so a recipe row
+    referencing an archived/deleted variant still resolves (per
+    typed_cache/README). Serializable dict for ``response.extras``.
+    """
+    if not variant_ids:
+        return {}
+    variants = await services.typed_cache.catalog.get_many_by_ids(
+        CachedVariant, variant_ids, include_archived=True, include_deleted=True
+    )
+
+    def _field(v: Any, name: str) -> Any:
+        if v is None:
+            return None
+        return v.get(name) if isinstance(v, dict) else getattr(v, name, None)
+
+    return {
+        vid: {
+            "sku": _field(variants.get(vid), "sku"),
+            "display_name": _field(variants.get(vid), "display_name"),
+        }
+        for vid in variant_ids
+    }
+
+
+async def _populate_mo_modify_collections(
+    services: Any,
+    request: ModifyManufacturingOrderRequest,
+    response: ModificationResponse,
+) -> None:
+    """Attach the recipe / operation / production collections + resolved
+    recipe variants to the modify response for the card's diff tables.
+
+    Each collection fetch is gated on that collection having CRUD in the plan
+    (header-only / single-collection modifies skip the others' fetches) and is
+    best-effort — a failure leaves that table to changed-rows-only.
+    """
+    prior_state = response.prior_state if isinstance(response.prior_state, dict) else {}
+
+    has_recipe = bool(
+        request.add_recipe_rows
+        or request.update_recipe_rows
+        or request.delete_recipe_row_ids
+    )
+    has_operation = bool(
+        request.add_operation_rows
+        or request.update_operation_rows
+        or request.delete_operation_row_ids
+    )
+    has_production = bool(
+        request.add_productions
+        or request.update_productions
+        or request.delete_production_ids
+    )
+
+    async def _safe(coro: Any, label: str) -> list[Any] | None:
+        try:
+            return await coro
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.info(
+                f"Could not fetch MO {label} for modify card: "
+                f"{type(exc).__name__}: {exc} — table shows changed rows only."
+            )
+            return None
+
+    if has_recipe:
+        rows = await _safe(_fetch_mo_recipe_rows(services, request.id), "recipe rows")
+        if rows is not None:
+            prior_state["recipe_rows"] = [r.model_dump(mode="json") for r in rows]
+        resolved = await _resolve_mo_recipe_variants(
+            services, _collect_recipe_variant_ids(request)
+        )
+        if resolved:
+            response.extras["resolved_variants"] = resolved
+    if has_operation:
+        rows = await _safe(
+            _fetch_mo_operation_rows(services, request.id), "operation rows"
+        )
+        if rows is not None:
+            prior_state["operation_rows"] = [r.model_dump(mode="json") for r in rows]
+    if has_production:
+        rows = await _safe(_fetch_mo_productions(services, request.id), "productions")
+        if rows is not None:
+            prior_state["productions"] = [r.model_dump(mode="json") for r in rows]
+
+    # Resolve the MO's own produced-variant SKU + production-location name for
+    # the card header (anti-pattern #7) — the raw snapshot carries only the
+    # FKs, so without this the header Variant / Location lines show bare ids.
+    mo_variant_id = prior_state.get("variant_id")
+    if mo_variant_id is not None and not prior_state.get("sku"):
+        vmap = await _resolve_mo_recipe_variants(services, {int(mo_variant_id)})
+        hit = vmap.get(int(mo_variant_id))
+        if hit and hit.get("sku"):
+            prior_state["sku"] = hit["sku"]
+    mo_location_id = prior_state.get("location_id")
+    if mo_location_id is not None and not prior_state.get("location_name"):
+        location_name, warning = await resolve_entity_name(
+            services.typed_cache.catalog,
+            CachedLocation,
+            mo_location_id,
+            entity_label="Production location",
+        )
+        if location_name:
+            prior_state["location_name"] = location_name
+        if warning:
+            response.warnings.append(warning)
+
+    if prior_state:
+        response.prior_state = prior_state
 
 
 @observe_tool

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/mo_tables.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/mo_tables.py
@@ -1,0 +1,528 @@
+"""Manufacturing-order collection table-merge helpers (non-UI).
+
+A manufacturing order has three editable collections — recipe rows
+(ingredients), operation rows (production steps), and production records — each
+of which the MO modify card renders as its own diff table. This module projects
+a modify plan (``prior_state`` snapshot + CRUD ``ActionResult`` list) onto the
+DataTable row list for each, layered on the shared collection-diff skeleton
+(:func:`merge_collection_diff_rows`, #859 / #872). Sibling of
+:mod:`po_row_table` / :mod:`item_variant_table` / :mod:`bom_table`.
+
+Per-collection cell builders live here as closures; the skeleton owns the
+add/update/delete classification, status stamping, orphan handling, and order.
+Row dicts are wire-format (no Prefab types) so they round-trip through
+``response.extras`` / iframe ``state`` + JSON.
+
+Net-new MO modify card under the #721 umbrella (Phase 4) — replaces the generic
+``ActionResult`` table for ``modify_manufacturing_order`` / ``delete_manufacturing_order``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from katana_mcp.tools.foundation.collection_diff import (
+    STATUS_PREFIX,
+    STATUS_VARIANTS,
+    CollectionDiffSpec,
+    merge_collection_diff_rows,
+)
+
+# Resolved-variant lookup ``{variant_id: {"sku", "display_name"}}`` threaded
+# from the impl's batched cache lookup (``extras["resolved_variants"]``) —
+# needed for *added* recipe rows (existing rows already carry resolved names).
+ResolvedVariants = dict[int, dict[str, str | None]]
+
+# ``MOOperation`` StrEnum values, grouped per collection (manufacturing_orders.py).
+_RECIPE_ADD = frozenset({"add_recipe_row"})
+_RECIPE_UPDATE = frozenset({"update_recipe_row"})
+_RECIPE_DELETE = frozenset({"delete_recipe_row"})
+_OP_ADD = frozenset({"add_operation_row"})
+_OP_UPDATE = frozenset({"update_operation_row"})
+_OP_DELETE = frozenset({"delete_operation_row"})
+_PROD_ADD = frozenset({"add_production"})
+_PROD_UPDATE = frozenset({"update_production"})
+_PROD_DELETE = frozenset({"delete_production"})
+
+
+def _changes_by_field(
+    changes: list[dict[str, Any]] | None,
+) -> dict[str, dict[str, Any]]:
+    """Index an action's ``changes`` list by field name (raw FieldChange dicts)."""
+    out: dict[str, dict[str, Any]] = {}
+    for c in changes or []:
+        if isinstance(c, dict) and isinstance(c.get("field"), str):
+            out[c["field"]] = c
+    return out
+
+
+def _format_number(value: Any) -> str:
+    """Render a quantity / time for a table cell, trimmed of trailing zeros.
+
+    ``None`` → em-dash. ``Decimal`` (the shape ``compute_field_diff`` →
+    ``_normalize`` produces) and ``float`` render via ``:g``; numeric strings
+    coerce first. Mirrors ``po_row_table._format_number``.
+    """
+    if value is None:
+        return "—"
+    if isinstance(value, str):
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return value
+        return f"{numeric:g}"
+    if isinstance(value, (int, float, Decimal)):
+        return f"{float(value):g}"
+    return str(value)
+
+
+def _format_number_diff(old: Any, new: Any, *, unknown_prior: bool) -> str:
+    """Render a numeric update as ``old → new`` (or ``(prior unknown) → new``)."""
+    after = _format_number(new)
+    if unknown_prior:
+        return f"(prior unknown) → {after}"
+    return f"{_format_number(old)} → {after}"
+
+
+def _format_text(value: Any) -> str:
+    """Render a text cell (``None`` / empty → em-dash)."""
+    if value is None or value == "":
+        return "—"
+    return str(value)
+
+
+def _format_text_diff(old: Any, new: Any) -> str:
+    """Render a text update as ``old → new`` (em-dash for missing sides)."""
+    return f"{_format_text(old)} → {_format_text(new)}"
+
+
+def _format_date(value: Any) -> str:
+    """Trim an ISO datetime string to its ``YYYY-MM-DD`` date (or em-dash)."""
+    if not value:
+        return "—"
+    text = str(value)
+    return text[:10] if len(text) >= 10 else text
+
+
+def _format_date_diff(old: Any, new: Any) -> str:
+    return f"{_format_date(old)} → {_format_date(new)}"
+
+
+def _resolved_name(
+    resolved: ResolvedVariants, variant_id: Any
+) -> tuple[str | None, str | None]:
+    """Look up ``(sku, display_name)`` for a variant id (``(None, None)`` miss)."""
+    if isinstance(variant_id, int):
+        hit = resolved.get(variant_id)
+        if hit:
+            return hit.get("sku"), hit.get("display_name")
+    return None, None
+
+
+def _base_row(
+    *, kind: str, prefix: str, status_label: str, status_variant: str
+) -> dict[str, Any]:
+    """Shared row scaffold (kind + status bookkeeping)."""
+    return {
+        "kind": kind,
+        "status_label": status_label,
+        "status_variant": status_variant,
+        "status_prefix": prefix,
+        "error": None,
+    }
+
+
+def _prior_rows(prior_state: dict[str, Any] | None, key: str) -> list[dict[str, Any]]:
+    if not isinstance(prior_state, dict):
+        return []
+    candidate = prior_state.get(key)
+    return (
+        [r for r in candidate if isinstance(r, dict)]
+        if isinstance(candidate, list)
+        else []
+    )
+
+
+def _key_of(row: dict[str, Any]) -> str | None:
+    return str(row["id"]) if row.get("id") is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Recipe rows (ingredients): SKU / Name / Qty per unit
+# ---------------------------------------------------------------------------
+
+
+def merge_recipe_rows_for_modify_card(
+    prior_state: dict[str, Any] | None,
+    actions: list[dict[str, Any]],
+    resolved_variants: ResolvedVariants | None,
+) -> list[dict[str, Any]]:
+    """Project prior recipe rows + recipe-row actions into a unified row list.
+
+    Existing rows (``prior_state["recipe_rows"]``, enriched ``RecipeRowInfo``
+    dumps carrying resolved ``sku`` / ``display_name``) render unchanged; adds
+    resolve their SKU/name from the new ``variant_id`` via ``resolved_variants``;
+    updates decorate the ``planned_quantity_per_unit`` diff (and re-resolve on a
+    variant swap); deletes preserve identity.
+    """
+    resolved = resolved_variants or {}
+
+    def existing(row: dict[str, Any]) -> dict[str, Any]:
+        return {
+            **_base_row(
+                kind="existing",
+                prefix=STATUS_PREFIX["existing"],
+                status_label="",
+                status_variant=STATUS_VARIANTS[""],
+            ),
+            "id": row.get("id"),
+            "variant_id": row.get("variant_id"),
+            "sku": row.get("sku"),
+            "display_name": row.get("display_name"),
+            "quantity_label": _format_number(row.get("planned_quantity_per_unit")),
+        }
+
+    def orphan(target_id: str) -> dict[str, Any]:
+        return {
+            **_base_row(
+                kind="existing",
+                prefix=STATUS_PREFIX["existing"],
+                status_label="",
+                status_variant=STATUS_VARIANTS[""],
+            ),
+            "id": target_id,
+            "variant_id": None,
+            "sku": None,
+            "display_name": None,
+            "quantity_label": "—",
+        }
+
+    def add(action, *, status_label, status_variant, error) -> dict[str, Any]:
+        ch = _changes_by_field(action.get("changes"))
+        vid = ch.get("variant_id", {}).get("new")
+        sku, name = _resolved_name(resolved, vid)
+        qty = ch.get("planned_quantity_per_unit")
+        return {
+            **_base_row(
+                kind="added",
+                prefix=STATUS_PREFIX["added"],
+                status_label=status_label,
+                status_variant=status_variant,
+            ),
+            "id": "",
+            "variant_id": vid,
+            "sku": sku,
+            "display_name": name,
+            "quantity_label": _format_number(qty.get("new") if qty else None),
+            "error": error,
+        }
+
+    def update(row, action, *, status_label, status_variant, error) -> None:
+        row.update(
+            _base_row(
+                kind="updated",
+                prefix=STATUS_PREFIX["updated"],
+                status_label=status_label,
+                status_variant=status_variant,
+            )
+        )
+        row["error"] = error
+        ch = _changes_by_field(action.get("changes"))
+        qty = ch.get("planned_quantity_per_unit")
+        if qty is not None:
+            row["quantity_label"] = _format_number_diff(
+                qty.get("old"),
+                qty.get("new"),
+                unknown_prior=bool(qty.get("is_unknown_prior")),
+            )
+        variant = ch.get("variant_id")
+        if variant is not None:
+            sku, name = _resolved_name(resolved, variant.get("new"))
+            row["variant_id"] = variant.get("new")
+            row["sku"] = sku
+            row["display_name"] = name
+
+    def delete(row, _action, *, status_label, status_variant, error) -> None:
+        row.update(
+            _base_row(
+                kind="deleted",
+                prefix=STATUS_PREFIX["deleted"],
+                status_label=status_label,
+                status_variant=status_variant,
+            )
+        )
+        row["error"] = error
+
+    return merge_collection_diff_rows(
+        prior_rows=_prior_rows(prior_state, "recipe_rows"),
+        actions=[
+            a
+            for a in actions
+            if str(a.get("operation") or "").lower()
+            in (_RECIPE_ADD | _RECIPE_UPDATE | _RECIPE_DELETE)
+        ],
+        spec=CollectionDiffSpec(
+            add_ops=_RECIPE_ADD,
+            update_ops=_RECIPE_UPDATE,
+            delete_ops=_RECIPE_DELETE,
+            key_of=_key_of,
+            existing_row=existing,
+            synth_orphan=orphan,
+            add_row=add,
+            apply_update=update,
+            apply_delete=delete,
+            sort_key=lambda r: 0,
+        ),
+    )
+
+
+def prepare_recipe_table_rows(merged: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """SKU column carries the kind gutter; name falls back to ``variant <id>``."""
+    out: list[dict[str, Any]] = []
+    for r in merged:
+        sku = r.get("sku") or "(unresolved)"
+        name = r.get("display_name") or ""
+        if not name and r.get("variant_id") is not None:
+            name = f"variant {r['variant_id']}"
+        out.append(
+            {**r, "sku_label": f"{r['status_prefix']}{sku}", "display_name": name}
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Operation rows: Operation name / workflow status
+# ---------------------------------------------------------------------------
+
+
+def merge_operation_rows_for_modify_card(
+    prior_state: dict[str, Any] | None,
+    actions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Project prior operation rows + operation-row actions into a row list.
+
+    Cells: operation name + the operation's *workflow* status (NOT_STARTED /
+    IN_PROGRESS / … — distinct from the diff-table action Status). Adds /
+    updates decorate name + status; deletes preserve identity.
+    """
+
+    def existing(row: dict[str, Any]) -> dict[str, Any]:
+        return {
+            **_base_row(
+                kind="existing",
+                prefix=STATUS_PREFIX["existing"],
+                status_label="",
+                status_variant=STATUS_VARIANTS[""],
+            ),
+            "id": row.get("id"),
+            "operation_label": _format_text(row.get("operation_name")),
+            "op_status_label": _format_text(row.get("status")),
+        }
+
+    def orphan(target_id: str) -> dict[str, Any]:
+        return {
+            **_base_row(
+                kind="existing",
+                prefix=STATUS_PREFIX["existing"],
+                status_label="",
+                status_variant=STATUS_VARIANTS[""],
+            ),
+            "id": target_id,
+            "operation_label": "—",
+            "op_status_label": "—",
+        }
+
+    def add(action, *, status_label, status_variant, error) -> dict[str, Any]:
+        ch = _changes_by_field(action.get("changes"))
+        name = ch.get("operation_name", {}).get("new")
+        op_status = ch.get("status", {}).get("new")
+        return {
+            **_base_row(
+                kind="added",
+                prefix=STATUS_PREFIX["added"],
+                status_label=status_label,
+                status_variant=status_variant,
+            ),
+            "id": "",
+            "operation_label": _format_text(name),
+            "op_status_label": _format_text(op_status),
+            "error": error,
+        }
+
+    def update(row, action, *, status_label, status_variant, error) -> None:
+        row.update(
+            _base_row(
+                kind="updated",
+                prefix=STATUS_PREFIX["updated"],
+                status_label=status_label,
+                status_variant=status_variant,
+            )
+        )
+        row["error"] = error
+        ch = _changes_by_field(action.get("changes"))
+        name = ch.get("operation_name")
+        if name is not None:
+            row["operation_label"] = _format_text_diff(name.get("old"), name.get("new"))
+        op_status = ch.get("status")
+        if op_status is not None:
+            row["op_status_label"] = _format_text_diff(
+                op_status.get("old"), op_status.get("new")
+            )
+
+    def delete(row, _action, *, status_label, status_variant, error) -> None:
+        row.update(
+            _base_row(
+                kind="deleted",
+                prefix=STATUS_PREFIX["deleted"],
+                status_label=status_label,
+                status_variant=status_variant,
+            )
+        )
+        row["error"] = error
+
+    return merge_collection_diff_rows(
+        prior_rows=_prior_rows(prior_state, "operation_rows"),
+        actions=[
+            a
+            for a in actions
+            if str(a.get("operation") or "").lower()
+            in (_OP_ADD | _OP_UPDATE | _OP_DELETE)
+        ],
+        spec=CollectionDiffSpec(
+            add_ops=_OP_ADD,
+            update_ops=_OP_UPDATE,
+            delete_ops=_OP_DELETE,
+            key_of=_key_of,
+            existing_row=existing,
+            synth_orphan=orphan,
+            add_row=add,
+            apply_update=update,
+            apply_delete=delete,
+            sort_key=lambda r: 0,
+        ),
+    )
+
+
+def prepare_operation_table_rows(merged: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Operation column carries the kind gutter."""
+    return [
+        {**r, "operation_label_gutter": f"{r['status_prefix']}{r['operation_label']}"}
+        for r in merged
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Productions: quantity / date
+# ---------------------------------------------------------------------------
+
+
+def merge_productions_for_modify_card(
+    prior_state: dict[str, Any] | None,
+    actions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Project prior production records + production actions into a row list.
+
+    Existing rows (``ProductionInfo``: ``quantity`` / ``production_date``);
+    adds read the ``completed_quantity`` / ``completed_date`` payload fields;
+    updates decorate the ``production_date`` diff.
+    """
+
+    def existing(row: dict[str, Any]) -> dict[str, Any]:
+        return {
+            **_base_row(
+                kind="existing",
+                prefix=STATUS_PREFIX["existing"],
+                status_label="",
+                status_variant=STATUS_VARIANTS[""],
+            ),
+            "id": row.get("id"),
+            "quantity_label": _format_number(row.get("quantity")),
+            "date_label": _format_date(row.get("production_date")),
+        }
+
+    def orphan(target_id: str) -> dict[str, Any]:
+        return {
+            **_base_row(
+                kind="existing",
+                prefix=STATUS_PREFIX["existing"],
+                status_label="",
+                status_variant=STATUS_VARIANTS[""],
+            ),
+            "id": target_id,
+            "quantity_label": "—",
+            "date_label": "—",
+        }
+
+    def add(action, *, status_label, status_variant, error) -> dict[str, Any]:
+        ch = _changes_by_field(action.get("changes"))
+        qty = ch.get("completed_quantity", {}).get("new")
+        date = ch.get("completed_date", {}).get("new")
+        return {
+            **_base_row(
+                kind="added",
+                prefix=STATUS_PREFIX["added"],
+                status_label=status_label,
+                status_variant=status_variant,
+            ),
+            "id": "",
+            "quantity_label": _format_number(qty),
+            "date_label": _format_date(date),
+            "error": error,
+        }
+
+    def update(row, action, *, status_label, status_variant, error) -> None:
+        row.update(
+            _base_row(
+                kind="updated",
+                prefix=STATUS_PREFIX["updated"],
+                status_label=status_label,
+                status_variant=status_variant,
+            )
+        )
+        row["error"] = error
+        ch = _changes_by_field(action.get("changes"))
+        date = ch.get("production_date")
+        if date is not None:
+            row["date_label"] = _format_date_diff(date.get("old"), date.get("new"))
+
+    def delete(row, _action, *, status_label, status_variant, error) -> None:
+        row.update(
+            _base_row(
+                kind="deleted",
+                prefix=STATUS_PREFIX["deleted"],
+                status_label=status_label,
+                status_variant=status_variant,
+            )
+        )
+        row["error"] = error
+
+    return merge_collection_diff_rows(
+        prior_rows=_prior_rows(prior_state, "productions"),
+        actions=[
+            a
+            for a in actions
+            if str(a.get("operation") or "").lower()
+            in (_PROD_ADD | _PROD_UPDATE | _PROD_DELETE)
+        ],
+        spec=CollectionDiffSpec(
+            add_ops=_PROD_ADD,
+            update_ops=_PROD_UPDATE,
+            delete_ops=_PROD_DELETE,
+            key_of=_key_of,
+            existing_row=existing,
+            synth_orphan=orphan,
+            add_row=add,
+            apply_update=update,
+            apply_delete=delete,
+            sort_key=lambda r: 0,
+        ),
+    )
+
+
+def prepare_production_table_rows(merged: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Quantity column carries the kind gutter."""
+    return [
+        {**r, "quantity_label_gutter": f"{r['status_prefix']}{r['quantity_label']}"}
+        for r in merged
+    ]

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -122,6 +122,14 @@ from katana_mcp.tools.foundation.item_variant_table import (
     merge_variant_rows_for_modify_card,
     prepare_variant_table_rows,
 )
+from katana_mcp.tools.foundation.mo_tables import (
+    merge_operation_rows_for_modify_card,
+    merge_productions_for_modify_card,
+    merge_recipe_rows_for_modify_card,
+    prepare_operation_table_rows,
+    prepare_production_table_rows,
+    prepare_recipe_table_rows,
+)
 from katana_mcp.tools.foundation.po_row_table import (
     merge_po_row_rows_for_modify_card,
     prepare_po_row_table_rows,
@@ -4388,11 +4396,21 @@ def _coerce_resolved_id_map(value: Any) -> dict[int, dict[str, str | None]]:
     return out
 
 
-def _po_applied_state_labels(
+def _modify_confirm_label(verb_label: str, n_actions: int) -> str:
+    """Confirm-button label for a modify card — ``Confirm Delete`` for deletes,
+    else scaled with the action count (``Confirm 4 changes`` / ``Confirm
+    Changes``). Shared by the PO + MO modify cards.
+    """
+    if verb_label == "Delete":
+        return "Confirm Delete"
+    return f"Confirm {n_actions} changes" if n_actions > 1 else "Confirm Changes"
+
+
+def _modify_applied_state_labels(
     verb_label: str, *, is_preview: bool, actions: list[dict[str, Any]]
 ) -> tuple[str, str, str, str]:
-    """Compute ``(title_suffix, state_label, state_variant, verb)`` for the PO
-    modify card's applied-state chrome.
+    """Compute ``(title_suffix, state_label, state_variant, verb)`` for a
+    modify card's applied-state chrome (shared by the PO + MO modify cards).
 
     Delete reads "Deleted" / "deleted"; modify / correct read "Applied" /
     "applied". On the standalone-applied path (``is_preview=False``) the actual
@@ -4605,7 +4623,9 @@ def build_po_modify_ui(
             applied_state_label,
             applied_state_variant,
             applied_verb,
-        ) = _po_applied_state_labels(verb_label, is_preview=is_preview, actions=actions)
+        ) = _modify_applied_state_labels(
+            verb_label, is_preview=is_preview, actions=actions
+        )
 
         _render_preview_header(
             title_prefix=f"{verb_label} Purchase Order",
@@ -7158,6 +7178,114 @@ def build_so_modify_ui(
     return app
 
 
+def _render_mo_identity_lines(
+    mo: dict[str, Any], changes: dict[str, FieldChangeView]
+) -> None:
+    """Render the MO Variant + Location identity lines (diff-aware).
+
+    Variants have no per-variant page in Katana web UI (their parent product /
+    material page owns the variant configuration), so the line stays plain
+    text; a SKU-less variant still drops a ``Variant ID: <id>`` fallback via
+    :func:`_render_party_line`. Location resolves to ``location_name``
+    impl-side (anti-pattern #7); the fallback shows ``Location ID: <id>`` only
+    on a cache miss. A swap on either renders the composite before→after party
+    diff. Extracted from :func:`_render_mo_entity_view` to keep it under the
+    branch limit.
+    """
+    variant_change = changes.get("variant_id")
+    if variant_change is not None and variant_change.kind != "unchanged":
+        _render_party_diff_line(
+            "Variant",
+            id_change=variant_change,
+            name_change=changes.get("variant_name"),
+            prior_name=mo.get("sku"),
+        )
+    elif mo.get("sku"):
+        Text(content=f"Variant: {mo['sku']}")
+    else:
+        _render_party_line("Variant", name=None, entity_id=mo.get("variant_id"))
+
+    location_change = changes.get("location_id")
+    if location_change is not None and location_change.kind != "unchanged":
+        _render_party_diff_line(
+            "Location",
+            id_change=location_change,
+            name_change=changes.get("location_name"),
+            prior_name=mo.get("location_name"),
+        )
+    else:
+        _render_party_line(
+            "Location",
+            name=mo.get("location_name"),
+            entity_id=mo.get("location_id"),
+        )
+
+
+def _render_mo_entity_view(
+    mo: dict[str, Any],
+    *,
+    changes: dict[str, FieldChangeView] | None = None,
+) -> list[str]:
+    """Render the MO entity view (Tier 2 metrics + Tier 3 reference fields +
+    warnings), returning the block-warning list for the caller to gate on.
+
+    Shared between ``build_mo_create_ui`` (no diff overlay) and
+    ``build_mo_modify_ui`` (``changes`` overlay, #721 Phase 4). When ``changes``
+    is empty every line falls through to its plain form — byte-identical to the
+    create card. Changing scalar header fields (planned_quantity / deadline /
+    status / order_no / variant / location / notes) render their before→after
+    diff instead; ``planned_quantity`` / ``Deadline`` drop their Metric when
+    changing (the diff line carries the value) and stay Metrics otherwise.
+
+    Must be called inside ``with CardContent(), Column(gap=3):``.
+    """
+    changes = changes or {}
+    planned_change = changes.get("planned_quantity")
+    deadline_change = changes.get("production_deadline_date")
+    planned_changing = planned_change is not None and planned_change.kind != "unchanged"
+    deadline_changing = (
+        deadline_change is not None and deadline_change.kind != "unchanged"
+    )
+
+    # Tier 2 — Metrics row, for the metric fields that AREN'T changing (a
+    # changing one renders as a before→after diff line below so old→new shows).
+    metric_items: list[tuple[str, str]] = []
+    if not planned_changing and mo.get("planned_quantity") is not None:
+        metric_items.append(("Planned Qty", str(mo["planned_quantity"])))
+    if not deadline_changing and mo.get("production_deadline_date"):
+        metric_items.append(
+            ("Deadline", _iso_date_only(mo["production_deadline_date"]))
+        )
+    if metric_items:
+        with Row(gap=4):
+            for label, value in metric_items:
+                Metric(label=label, value=value)
+
+    # Changing scalar header diffs.
+    if planned_changing:
+        _render_field_diff_line("Planned Qty", change=planned_change)
+    if deadline_changing:
+        _render_field_diff_line("Deadline", change=deadline_change)
+    status_change = changes.get("status")
+    if status_change is not None and status_change.kind != "unchanged":
+        _render_field_diff_line("Status", change=status_change)
+    order_no_change = changes.get("order_no")
+    if order_no_change is not None and order_no_change.kind != "unchanged":
+        _render_field_diff_line("Order No", change=order_no_change)
+
+    _render_mo_identity_lines(mo, changes)
+
+    if mo.get("order_created_date"):
+        Text(content=f"Created: {_iso_date_only(mo['order_created_date'])}")
+    notes_change = changes.get("additional_info")
+    if notes_change is not None and notes_change.kind != "unchanged":
+        _render_field_diff_line("Notes", change=notes_change)
+    elif mo.get("additional_info"):
+        Text(content=f"Notes: {mo['additional_info']}")
+
+    return _render_warnings_block(mo.get("warnings"))
+
+
 def build_mo_create_ui(
     response: dict[str, Any],
     *,
@@ -7172,21 +7300,14 @@ def build_mo_create_ui(
     Four-tier content:
     - Tier 1: title, order_no badge, PREVIEW/CREATED, status (variant from
       ``status_badge_variant("manufacturing_order", status)``).
-    - Tier 2: Planned Qty, Deadline.
-    - Tier 3: variant (sku + id), location ID, created date, notes
-      (additional_info), warnings.
+    - Tier 2 + 3: :func:`_render_mo_entity_view` (Planned Qty / Deadline
+      metrics; variant / location / created / notes; warnings) — shared with
+      ``build_mo_modify_ui``.
     - Tier 4: Confirm/Cancel (preview) or View in Katana + Complete Order
       (applied).
     """
     order_number = response.get("order_no") or "N/A"
     status = response.get("status")
-    variant_id = response.get("variant_id")
-    sku = response.get("sku")
-    planned_quantity = response.get("planned_quantity")
-    location_id = response.get("location_id")
-    order_created_date = response.get("order_created_date")
-    production_deadline_date = response.get("production_deadline_date")
-    additional_info = response.get("additional_info")
 
     apply_action = _build_apply_action(confirm_tool, confirm_request)
     cancel_action = _build_cancel_action("that manufacturing order")
@@ -7202,48 +7323,7 @@ def build_mo_create_ui(
             status=status,
         )
         with CardContent(), Column(gap=3):
-            if planned_quantity is not None or production_deadline_date:
-                with Row(gap=4):
-                    if planned_quantity is not None:
-                        Metric(label="Planned Qty", value=str(planned_quantity))
-                    if production_deadline_date:
-                        Metric(
-                            label="Deadline",
-                            value=_iso_date_only(production_deadline_date),
-                        )
-            # Variant identity: render SKU as the user-facing name when
-            # resolved. Variants have no per-variant page in Katana web
-            # UI (their parent product/material pages own the variant
-            # configuration), so no ``entity_kind`` — the line stays as
-            # plain text. When SKU is missing we still drop a "Variant
-            # ID: <id>" fallback via ``_render_party_line`` so a
-            # SKU-less variant (NetSuite imports — see CLAUDE.md "Variants
-            # can have null SKUs") isn't invisible to the operator.
-            if sku:
-                Text(content=f"Variant: {sku}")
-            else:
-                _render_party_line(
-                    "Variant",
-                    name=None,
-                    entity_id=variant_id,
-                )
-            # Location resolves to ``location_name`` impl-side via
-            # ``resolve_entity_name(catalog, CachedLocation, ...)``;
-            # ``entity_kind`` is omitted because Katana web UI has no
-            # per-location page (the resolved name is the user-facing
-            # identifier). The helper's fallback shows ``"Location ID:
-            # <id>"`` only when the cache miss can't be filled, and the
-            # underlying response carries a warning explaining why.
-            _render_party_line(
-                "Location",
-                name=response.get("location_name"),
-                entity_id=location_id,
-            )
-            if order_created_date:
-                Text(content=f"Created: {_iso_date_only(order_created_date)}")
-            if additional_info:
-                Text(content=f"Notes: {additional_info}")
-            block_warnings = _render_warnings_block(response.get("warnings"))
+            block_warnings = _render_mo_entity_view(response)
         _render_preview_footer(
             title_prefix="Manufacturing Order",
             block_warnings=block_warnings,
@@ -7268,6 +7348,255 @@ def build_mo_create_ui(
                     ),
                 ),
             ),
+        )
+    return app
+
+
+# ============================================================================
+# MO modify / delete card (#721 Phase 4) — header entity-view + three
+# collection diff tables (recipe rows / operation rows / productions), each on
+# the shared collection-diff element (``mo_tables``). Replaces the generic
+# ActionResult table for modify_/delete_manufacturing_order.
+# ============================================================================
+
+_MO_RECIPE_COLUMNS: list[DataTableColumn] = [
+    DataTableColumn(key="sku_label", header="SKU"),
+    DataTableColumn(key="display_name", header="Ingredient"),
+    DataTableColumn(
+        key="quantity_label", header="Qty / unit", align="right", width="11rem"
+    ),
+    DataTableColumn(key="status_label", header="Status", width="7rem"),
+]
+_MO_OPERATION_COLUMNS: list[DataTableColumn] = [
+    DataTableColumn(key="operation_label_gutter", header="Operation"),
+    DataTableColumn(key="op_status_label", header="Op Status"),
+    DataTableColumn(key="status_label", header="Status", width="7rem"),
+]
+_MO_PRODUCTION_COLUMNS: list[DataTableColumn] = [
+    DataTableColumn(
+        key="quantity_label_gutter", header="Quantity", align="right", width="11rem"
+    ),
+    DataTableColumn(key="date_label", header="Date", width="12rem"),
+    DataTableColumn(key="status_label", header="Status", width="7rem"),
+]
+_MO_RECIPE_KEY = "mo_recipe_rows"
+_MO_OPERATION_KEY = "mo_operation_rows"
+_MO_PRODUCTION_KEY = "mo_production_rows"
+
+
+def _mo_recipe_rows(
+    prior_state: dict[str, Any] | None,
+    actions: list[dict[str, Any]],
+    extras: dict[str, Any],
+) -> tuple[list[dict[str, Any]], str]:
+    """Recipe-row diff rows + summary, short-circuiting when no recipe CRUD."""
+    if not any(
+        str(a.get("operation") or "").lower()
+        in ("add_recipe_row", "update_recipe_row", "delete_recipe_row")
+        for a in actions
+    ):
+        return [], ""
+    rows = prepare_recipe_table_rows(
+        merge_recipe_rows_for_modify_card(
+            prior_state,
+            actions,
+            _coerce_resolved_id_map(extras.get("resolved_variants")),
+        )
+    )
+    return rows, collection_diff_summary(rows)
+
+
+def _mo_operation_rows(
+    prior_state: dict[str, Any] | None, actions: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], str]:
+    """Operation-row diff rows + summary, short-circuiting when no op CRUD."""
+    if not any(
+        str(a.get("operation") or "").lower()
+        in ("add_operation_row", "update_operation_row", "delete_operation_row")
+        for a in actions
+    ):
+        return [], ""
+    rows = prepare_operation_table_rows(
+        merge_operation_rows_for_modify_card(prior_state, actions)
+    )
+    return rows, collection_diff_summary(rows)
+
+
+def _mo_production_rows(
+    prior_state: dict[str, Any] | None, actions: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], str]:
+    """Production diff rows + summary, short-circuiting when no production CRUD."""
+    if not any(
+        str(a.get("operation") or "").lower()
+        in ("add_production", "update_production", "delete_production")
+        for a in actions
+    ):
+        return [], ""
+    rows = prepare_production_table_rows(
+        merge_productions_for_modify_card(prior_state, actions)
+    )
+    return rows, collection_diff_summary(rows)
+
+
+def _render_mo_collection_table(
+    *, summary: str, label: str, columns: list[DataTableColumn], state_key: str
+) -> None:
+    """Render one MO collection diff table (summary line + state-bound table).
+
+    Caller gates on ``summary`` being non-empty (the collection changed).
+    """
+    Separator()
+    Muted(content=label)
+    Text(content=summary)
+    DataTable(
+        columns=columns,
+        rows=f"{{{{ {state_key} }}}}",
+        paginated=True,
+        pageSize=20,
+    )
+
+
+def _mo_modify_rail(
+    response: dict[str, Any],
+    shown: list[tuple[Any, ...]],
+    *,
+    verb_label: str,
+    confirm_tool: str,
+    confirm_request: BaseModel,
+) -> tuple[list[Action] | None, list[Action], dict[str, Any]]:
+    """Build the MO modify card's apply/cancel actions + seeded state.
+
+    The apply ``on_success`` morph-wires only the shown collections'
+    state keys; ``state`` seeds those same collections' rows. Factored out
+    to keep ``build_mo_modify_ui`` under the branch limit.
+    """
+    apply_action = _build_apply_action(
+        confirm_tool,
+        confirm_request,
+        extra_on_success=[
+            SetState(key, f"{{{{ $result.state.{key} }}}}") for _, _, key, _, _ in shown
+        ]
+        or None,
+    )
+    cancel_label = (
+        "that manufacturing order deletion"
+        if verb_label == "Delete"
+        else "those manufacturing order changes"
+    )
+    cancel_action = _build_cancel_action(cancel_label)
+    state = _init_modify_card_state(response)
+    for _, rows, key, _, _ in shown:
+        state[key] = rows
+    return apply_action, cancel_action, state
+
+
+def build_mo_modify_ui(
+    response: dict[str, Any],
+    *,
+    confirm_request: BaseModel,
+    confirm_tool: str,
+) -> PrefabApp:
+    """Build the modify-/delete-manufacturing-order card (#721 Phase 4).
+
+    Header scalar diffs share :func:`_render_mo_entity_view` with
+    ``build_mo_create_ui`` (the ``changes`` overlay decorates planned_quantity /
+    deadline / status / variant / location / notes). The three editable
+    collections — recipe rows, operation rows, production records — each render
+    a diff table on the shared collection-diff element (:mod:`mo_tables`),
+    shown only when that collection changes; a header-only modify shows just
+    the header diffs. Tables are state-bound and morph in place on apply.
+
+    Replaces the generic ActionResult card for ``modify_manufacturing_order`` /
+    ``delete_manufacturing_order``.
+    """
+    is_preview = bool(response.get("is_preview", True))
+    actions = _actions_with_not_run_tail(response, is_preview=is_preview)
+    entity_id = response.get("entity_id")
+    verb_label = _verb_label(confirm_tool)
+
+    raw_prior_state = response.get("prior_state")
+    prior_state = raw_prior_state if isinstance(raw_prior_state, dict) else {}
+    entity = {**prior_state, **{k: v for k, v in response.items() if v is not None}}
+    if entity_id is not None:
+        entity.setdefault("id", entity_id)
+
+    changes_by_field = _index_changes_by_field(
+        actions, include_operations=frozenset({"update_header"})
+    )
+
+    extras = response.get("extras") or {}
+    recipe_rows, recipe_summary = _mo_recipe_rows(raw_prior_state, actions, extras)
+    operation_rows, operation_summary = _mo_operation_rows(raw_prior_state, actions)
+    production_rows, production_summary = _mo_production_rows(raw_prior_state, actions)
+
+    # (summary, rows, state_key, columns, section_label) per collection — each
+    # rendered / seeded / morph-wired only when its summary is non-empty (the
+    # collection changed). Looping over the shown ones keeps the three
+    # collections from tripling the function's branch count.
+    collections = [
+        (
+            recipe_summary,
+            recipe_rows,
+            _MO_RECIPE_KEY,
+            _MO_RECIPE_COLUMNS,
+            "Recipe (ingredients):",
+        ),
+        (
+            operation_summary,
+            operation_rows,
+            _MO_OPERATION_KEY,
+            _MO_OPERATION_COLUMNS,
+            "Operations:",
+        ),
+        (
+            production_summary,
+            production_rows,
+            _MO_PRODUCTION_KEY,
+            _MO_PRODUCTION_COLUMNS,
+            "Productions:",
+        ),
+    ]
+    shown = [c for c in collections if c[0]]
+    apply_action, cancel_action, state = _mo_modify_rail(
+        response,
+        shown,
+        verb_label=verb_label,
+        confirm_tool=confirm_tool,
+        confirm_request=confirm_request,
+    )
+    confirm_label = _modify_confirm_label(verb_label, len(actions))
+
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
+        title_suffix, state_label, state_variant, applied_verb = (
+            _modify_applied_state_labels(
+                verb_label, is_preview=is_preview, actions=actions
+            )
+        )
+        _render_preview_header(
+            title_prefix=f"{verb_label} Manufacturing Order",
+            entity="manufacturing_order",
+            order_number=str(entity.get("order_no") or entity_id or "N/A"),
+            status=entity.get("status"),
+            applied_title_suffix=title_suffix,
+            applied_state_label=state_label,
+            applied_state_variant=state_variant,
+        )
+        with CardContent(), Column(gap=3):
+            if response.get("message"):
+                Muted(content=response["message"])
+            block_warnings = _render_mo_entity_view(entity, changes=changes_by_field)
+            for summary, _, key, columns, label in shown:
+                _render_mo_collection_table(
+                    summary=summary, label=label, columns=columns, state_key=key
+                )
+        _render_preview_footer(
+            title_prefix=f"Manufacturing Order {verb_label}",
+            block_warnings=block_warnings,
+            confirm_label=confirm_label,
+            apply_action=apply_action,
+            cancel_action=cancel_action,
+            next_action_buttons=(),
+            applied_verb=applied_verb,
         )
     return app
 

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -33,6 +33,7 @@ from katana_mcp.tools.prefab_ui import (
     build_inventory_check_ui,
     build_item_detail_ui,
     build_item_modify_ui,
+    build_mo_modify_ui,
     build_modification_preview_ui,
     build_modification_result_ui,
     build_po_modify_ui,
@@ -1154,6 +1155,98 @@ def _po_modify_rows_response(*, is_preview: bool, succeeded: bool | None) -> dic
     }
 
 
+def _mo_modify_response(*, is_preview: bool, succeeded: bool | None) -> dict:
+    """Build a canned MO modify response exercising all three collection diff
+    tables (#721 Phase 4): a header change + recipe add + operation status
+    update + production add, with the collections attached to ``prior_state``
+    and the added recipe variant resolved in ``extras``.
+    """
+    actions = [
+        ActionResult(
+            index=1,
+            operation="update_header",
+            target_id=500,
+            changes=[FieldChange(field="planned_quantity", old=10, new=20)],
+            succeeded=succeeded,
+            verified=True if succeeded else None,
+        ).model_dump(),
+        ActionResult(
+            index=2,
+            operation="add_recipe_row",
+            target_id=None,
+            changes=[
+                FieldChange(field="variant_id", old=None, new=403, is_added=True),
+                FieldChange(
+                    field="planned_quantity_per_unit", old=None, new=2.0, is_added=True
+                ),
+            ],
+            succeeded=succeeded,
+        ).model_dump(),
+        ActionResult(
+            index=3,
+            operation="update_operation_row",
+            target_id=21,
+            changes=[FieldChange(field="status", old="NOT_STARTED", new="COMPLETED")],
+            succeeded=succeeded,
+            verified=True if succeeded else None,
+        ).model_dump(),
+        ActionResult(
+            index=4,
+            operation="add_production",
+            target_id=None,
+            changes=[
+                FieldChange(
+                    field="completed_quantity", old=None, new=3.0, is_added=True
+                )
+            ],
+            succeeded=succeeded,
+        ).model_dump(),
+    ]
+    return {
+        "entity_type": "manufacturing_order",
+        "entity_id": 500,
+        "is_preview": is_preview,
+        "order_no": "MO-2026-001",
+        "status": "NOT_STARTED",
+        "operation": "",
+        "changes": [],
+        "actions": actions,
+        "prior_state": {
+            "order_no": "MO-2026-001",
+            "status": "NOT_STARTED",
+            "variant_id": 9,
+            "sku": "WIDGET-A",
+            "planned_quantity": 10,
+            "location_id": 1,
+            "location_name": "Main Factory",
+            "recipe_rows": [
+                {
+                    "id": 11,
+                    "variant_id": 402,
+                    "sku": "BOLT",
+                    "display_name": "M5 bolt",
+                    "planned_quantity_per_unit": 4.0,
+                },
+            ],
+            "operation_rows": [
+                {"id": 21, "operation_name": "Cut", "status": "NOT_STARTED"},
+            ],
+            "productions": [
+                {"id": 31, "quantity": 5.0, "production_date": "2026-05-01T00:00:00Z"},
+            ],
+        },
+        "extras": {
+            "resolved_variants": {403: {"sku": "WASHER", "display_name": "M5 washer"}}
+        },
+        "warnings": [],
+        "next_actions": [],
+        "katana_url": "https://factory.katanamrp.com/manufacturingorder/500",
+        "message": (
+            "Preview: 4 action(s) planned" if is_preview else "Applied 4 action(s)"
+        ),
+    }
+
+
 def _so_failed_delete_response(*, is_preview: bool = False) -> dict:
     """Build a canned SO delete response where the apply fails.
 
@@ -1885,6 +1978,19 @@ SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
         _po_modify_rows_response(is_preview=False, succeeded=True),
         confirm_request=_StubRequest(),
         confirm_tool="modify_purchase_order",
+    ),
+    # #721 Phase 4 — MO modify card with all three collection diff tables
+    # (recipe / operation / production) + a header diff. Pins the multi-table
+    # render + resolved recipe SKU + operation status diff end to end.
+    "mo_modify_preview": lambda: build_mo_modify_ui(
+        _mo_modify_response(is_preview=True, succeeded=None),
+        confirm_request=_StubRequest(),
+        confirm_tool="modify_manufacturing_order",
+    ),
+    "mo_modify_applied": lambda: build_mo_modify_ui(
+        _mo_modify_response(is_preview=False, succeeded=True),
+        confirm_request=_StubRequest(),
+        confirm_tool="modify_manufacturing_order",
     ),
     # #811 — BOM modify card with adds + updates + deletes against a
     # realistic 5-row existing recipe. Pins the row-content + status-pill

--- a/katana_mcp_server/tests/browser/test_modification_render.py
+++ b/katana_mcp_server/tests/browser/test_modification_render.py
@@ -194,6 +194,35 @@ class TestModificationCardRender:
         # 3 row actions → 3 APPLIED status cells.
         assert frame.locator("td").filter(has_text="APPLIED").count() >= 3
 
+    def test_mo_modify_preview_renders_three_collection_tables(self, render_scenario):
+        """#721 Phase 4 — MO modify card renders all three collection diff
+        tables (recipe / operation / production) + the header diff, with
+        resolved recipe SKU + operation status diff, in a real browser.
+        """
+        frame = render_scenario("mo_modify_preview")
+        # Header scalar diff.
+        assert frame.locator("text=10 → 20").count() >= 1
+        # Three collection sections.
+        assert frame.locator("text=Recipe (ingredients):").count() >= 1
+        assert frame.locator("text=Operations:").count() >= 1
+        assert frame.locator("text=Productions:").count() >= 1
+        # Recipe add resolved SKU (no bare id) + operation status diff.
+        assert frame.locator("td").filter(has_text="WASHER").count() >= 1
+        assert (
+            frame.locator("td").filter(has_text="NOT_STARTED → COMPLETED").count() >= 1
+        )
+        # Three diff tables rendered.
+        assert frame.locator("table").count() >= 3
+
+    def test_mo_modify_applied_renders_per_row_status(self, render_scenario):
+        """#721 Phase 4 — applied MO modify: collection row actions show APPLIED
+        in their Status columns across the three tables.
+        """
+        frame = render_scenario("mo_modify_applied")
+        assert frame.locator("table").count() >= 3
+        # recipe add + operation update + production add → ≥3 APPLIED cells.
+        assert frame.locator("td").filter(has_text="APPLIED").count() >= 3
+
     def test_so_modify_partial_failure_applied_renders(self, render_scenario):
         """#723 SO modify card — partial-failure applied state renders the
         card-level PARTIAL FAILURE badge, the per-action APPLIED / FAILED

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -27,6 +27,7 @@ from katana_mcp.tools.prefab_ui import (
     build_item_modify_ui,
     build_low_stock_ui,
     build_mo_create_ui,
+    build_mo_modify_ui,
     build_modification_preview_ui,
     build_modification_result_ui,
     build_po_create_ui,
@@ -3398,6 +3399,253 @@ class TestPOModifyRowTable:
         # Added row FAILED; the not-run update of 7001 shows NOT RUN.
         assert statuses.get(7001) == "NOT RUN"
         assert any(r["status_label"] == "FAILED" for r in rows)
+
+
+class TestBuildMOModifyUI:
+    """``build_mo_modify_ui`` (#721 Phase 4) — header diffs + three collection
+    diff tables (recipe / operation / production), each shown only when that
+    collection changes. Net-new card replacing the generic ActionResult table.
+    """
+
+    _PRIOR: ClassVar[dict[str, Any]] = {
+        "order_no": "MO-2026-001",
+        "status": "NOT_STARTED",
+        "variant_id": 9,
+        "sku": "WIDGET-A",
+        "planned_quantity": 10,
+        "location_id": 1,
+        "location_name": "Main Factory",
+        "additional_info": "rush",
+        # Collections fetched + attached impl-side (RecipeRowInfo /
+        # OperationRowInfo / ProductionInfo dumps).
+        "recipe_rows": [
+            {
+                "id": 11,
+                "variant_id": 402,
+                "sku": "BOLT",
+                "display_name": "M5 bolt",
+                "planned_quantity_per_unit": 4.0,
+            },
+        ],
+        "operation_rows": [
+            {"id": 21, "operation_name": "Cut", "status": "NOT_STARTED"},
+        ],
+        "productions": [
+            {"id": 31, "quantity": 5.0, "production_date": "2026-05-01T00:00:00Z"},
+        ],
+    }
+
+    @classmethod
+    def _preview(
+        cls, actions: list[dict[str, Any]] | None = None, **overrides: Any
+    ) -> dict[str, Any]:
+        return {
+            "entity_type": "manufacturing_order",
+            "entity_id": 500,
+            "is_preview": True,
+            "order_no": "MO-2026-001",
+            "status": "NOT_STARTED",
+            "actions": actions or [],
+            "prior_state": dict(cls._PRIOR),
+            "extras": {
+                "resolved_variants": {
+                    403: {"sku": "WASHER", "display_name": "M5 washer"}
+                }
+            },
+            "warnings": [],
+            "next_actions": [],
+            "message": "Preview",
+            "katana_url": "https://factory.katanamrp.com/manufacturingorder/500",
+            **overrides,
+        }
+
+    @classmethod
+    def _applied(
+        cls, actions: list[dict[str, Any]] | None = None, **overrides: Any
+    ) -> dict[str, Any]:
+        return cls._preview(actions, is_preview=False, **overrides)
+
+    @staticmethod
+    def _header(field: str, old: Any, new: Any) -> dict:
+        return {
+            "operation": "update_header",
+            "target_id": 500,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [{"field": field, "old": old, "new": new}],
+        }
+
+    def test_header_diff_and_collections_render(self):
+        actions = [
+            self._header("planned_quantity", 10, 20),
+            {
+                "operation": "add_recipe_row",
+                "target_id": None,
+                "succeeded": None,
+                "status_label": "PLANNED",
+                "changes": [
+                    {"field": "variant_id", "old": None, "new": 403, "is_added": True},
+                    {
+                        "field": "planned_quantity_per_unit",
+                        "old": None,
+                        "new": 2.0,
+                        "is_added": True,
+                    },
+                ],
+            },
+            {
+                "operation": "update_operation_row",
+                "target_id": 21,
+                "succeeded": None,
+                "status_label": "PLANNED",
+                "changes": [
+                    {"field": "status", "old": "NOT_STARTED", "new": "COMPLETED"}
+                ],
+            },
+            {
+                "operation": "add_production",
+                "target_id": None,
+                "succeeded": None,
+                "status_label": "PLANNED",
+                "changes": [
+                    {
+                        "field": "completed_quantity",
+                        "old": None,
+                        "new": 3.0,
+                        "is_added": True,
+                    }
+                ],
+            },
+        ]
+        app = build_mo_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_manufacturing_order",
+        )
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        # Header scalar diff.
+        assert "Modify Manufacturing Order" in rendered
+        assert "10 → 20" in rendered
+        # All three collection sections present.
+        assert "Recipe (ingredients):" in rendered
+        assert "Operations:" in rendered
+        assert "Productions:" in rendered
+        # Recipe add resolved SKU; operation status diff.
+        assert "+ WASHER" in rendered
+        assert "NOT_STARTED → COMPLETED" in rendered
+
+    def test_header_only_modify_renders_no_collection_tables(self):
+        app = build_mo_modify_ui(
+            self._preview([self._header("status", "NOT_STARTED", "IN_PROGRESS")]),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_manufacturing_order",
+        )
+        assert app.state is not None
+        rendered = str(app.to_json())
+        # Header diff shows; no collection sections / state keys.
+        assert "NOT_STARTED → IN_PROGRESS" in rendered
+        assert "Recipe (ingredients):" not in rendered
+        assert "Operations:" not in rendered
+        assert "Productions:" not in rendered
+        for key in ("mo_recipe_rows", "mo_operation_rows", "mo_production_rows"):
+            assert key not in app.state
+
+    def test_single_collection_seeds_only_that_state_key(self):
+        actions = [
+            {
+                "operation": "delete_recipe_row",
+                "target_id": 11,
+                "succeeded": None,
+                "status_label": "PLANNED",
+                "changes": [],
+            },
+        ]
+        app = build_mo_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_manufacturing_order",
+        )
+        assert app.state is not None
+        assert "mo_recipe_rows" in app.state
+        assert "mo_operation_rows" not in app.state
+        assert "mo_production_rows" not in app.state
+        rendered = str(app.to_json())
+        assert "- BOLT" in rendered  # deleted recipe row keeps identity
+
+    def test_delete_verb(self):
+        actions = [
+            {
+                "operation": "delete",
+                "target_id": 500,
+                "succeeded": None,
+                "status_label": "PLANNED",
+                "changes": [],
+            }
+        ]
+        app = build_mo_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="delete_manufacturing_order",
+        )
+        _assert_valid_prefab(app)
+        assert "Confirm Delete" in str(app.to_json())
+
+    def test_applied_recipe_row_morph_state(self):
+        actions = [
+            {
+                "operation": "add_recipe_row",
+                "target_id": None,
+                "succeeded": True,
+                "status_label": "APPLIED",
+                "changes": [
+                    {"field": "variant_id", "old": None, "new": 403, "is_added": True}
+                ],
+            },
+        ]
+        app = build_mo_modify_ui(
+            self._applied(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_manufacturing_order",
+        )
+        assert app.state is not None
+        rows = app.state.get("mo_recipe_rows")
+        assert isinstance(rows, list)
+        assert any(r["status_label"] == "APPLIED" for r in rows)
+
+
+class TestMOModifyDispatch:
+    """``to_tool_result`` routes manufacturing_order modify responses to
+    ``build_mo_modify_ui`` (not the legacy generic card)."""
+
+    def test_mo_routes_to_mo_modify_card(self):
+        from katana_mcp.tools._modification import (
+            ConfirmableRequest,
+            ModificationResponse,
+            to_tool_result,
+        )
+
+        class _StubConfirmable(ConfirmableRequest):
+            id: int = 500
+
+        response = ModificationResponse(
+            entity_type="manufacturing_order",
+            entity_id=500,
+            is_preview=True,
+            actions=[],
+            prior_state={"order_no": "MO-9", "status": "NOT_STARTED"},
+            warnings=[],
+            next_actions=[],
+            message="Preview",
+        )
+        result = to_tool_result(
+            response,
+            confirm_request=_StubConfirmable(),
+            confirm_tool="modify_manufacturing_order",
+        )
+        # The MO card titles "Modify Manufacturing Order"; the generic card
+        # does not — its presence confirms the MO builder ran.
+        assert "Manufacturing Order" in str(result.structured_content)
 
 
 class TestBuildSOModifyUI:

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -2724,6 +2724,73 @@ async def test_modify_mo_preview_emits_planned_actions():
 
 
 @pytest.mark.asyncio
+async def test_modify_mo_header_only_skips_collection_fetches():
+    """A header-only modify must not fetch the recipe / operation / production
+    collections for the card (the card renders no collection tables) — gated
+    per-collection on that collection having CRUD (#721 Phase 4)."""
+    context, _ = create_mock_context()
+    existing = _mock_mo(mo_id=42, order_no="MO-1")
+    mod = "katana_mcp.tools.foundation.manufacturing_orders"
+
+    with (
+        patch(
+            f"{mod}._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(f"{mod}._fetch_mo_recipe_rows", new_callable=AsyncMock) as recipe,
+        patch(f"{mod}._fetch_mo_operation_rows", new_callable=AsyncMock) as operation,
+        patch(f"{mod}._fetch_mo_productions", new_callable=AsyncMock) as production,
+    ):
+        await _modify_manufacturing_order_impl(
+            ModifyManufacturingOrderRequest(
+                id=42, update_header=MOHeaderPatch(status="IN_PROGRESS"), preview=True
+            ),
+            context,
+        )
+
+    recipe.assert_not_awaited()
+    operation.assert_not_awaited()
+    production.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_modify_mo_recipe_crud_fetches_only_recipe_collection():
+    """A recipe-only modify fetches the recipe collection (for the card's
+    recipe table) but not operations / productions (#721 Phase 4)."""
+    context, _ = create_mock_context()
+    existing = _mock_mo(mo_id=42, order_no="MO-1")
+    mod = "katana_mcp.tools.foundation.manufacturing_orders"
+
+    with (
+        patch(
+            f"{mod}._fetch_manufacturing_order_attrs",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            f"{mod}._fetch_mo_recipe_rows", new_callable=AsyncMock, return_value=[]
+        ) as recipe,
+        patch(f"{mod}._fetch_mo_operation_rows", new_callable=AsyncMock) as operation,
+        patch(f"{mod}._fetch_mo_productions", new_callable=AsyncMock) as production,
+    ):
+        await _modify_manufacturing_order_impl(
+            ModifyManufacturingOrderRequest(
+                id=42,
+                add_recipe_rows=[
+                    MORecipeRowAdd(variant_id=100, planned_quantity_per_unit=2.0)
+                ],
+                preview=True,
+            ),
+            context,
+        )
+
+    recipe.assert_awaited_once()
+    operation.assert_not_awaited()
+    production.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_modify_mo_confirm_executes_in_canonical_order():
     """Header → recipe adds → recipe updates → ..."""
     context, _ = create_mock_context()

--- a/katana_mcp_server/tests/tools/test_mo_tables.py
+++ b/katana_mcp_server/tests/tools/test_mo_tables.py
@@ -1,0 +1,253 @@
+"""Tests for the MO collection diff tables (#721 Phase 4).
+
+Recipe rows (ingredients), operation rows, and production records each project
+onto the shared collection-diff skeleton with their own cell builders.
+"""
+
+from typing import ClassVar
+
+from katana_mcp.tools.foundation.mo_tables import (
+    merge_operation_rows_for_modify_card,
+    merge_productions_for_modify_card,
+    merge_recipe_rows_for_modify_card,
+    prepare_operation_table_rows,
+    prepare_production_table_rows,
+    prepare_recipe_table_rows,
+)
+
+
+class TestRecipeRows:
+    _PRIOR: ClassVar[dict] = {
+        "recipe_rows": [
+            {
+                "id": 11,
+                "variant_id": 401,
+                "sku": "BOLT",
+                "display_name": "M5 bolt",
+                "planned_quantity_per_unit": 4.0,
+            },
+            {
+                "id": 12,
+                "variant_id": 402,
+                "sku": "NUT",
+                "display_name": "M5 nut",
+                "planned_quantity_per_unit": 4.0,
+            },
+        ]
+    }
+    _RESOLVED: ClassVar[dict] = {403: {"sku": "WASHER", "display_name": "M5 washer"}}
+
+    def _merge(self, actions):
+        return prepare_recipe_table_rows(
+            merge_recipe_rows_for_modify_card(self._PRIOR, actions, self._RESOLVED)
+        )
+
+    def test_existing_rows_carry_resolved_names(self):
+        rows = self._merge([])
+        assert [r["sku"] for r in rows] == ["BOLT", "NUT"]
+        assert all(r["sku_label"].startswith("  ") for r in rows)
+
+    def test_add_resolves_variant(self):
+        action = {
+            "operation": "add_recipe_row",
+            "target_id": None,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [
+                {"field": "variant_id", "old": None, "new": 403, "is_added": True},
+                {
+                    "field": "planned_quantity_per_unit",
+                    "old": None,
+                    "new": 2.0,
+                    "is_added": True,
+                },
+            ],
+        }
+        added = self._merge([action])[-1]
+        assert added["kind"] == "added"
+        assert added["sku_label"] == "+ WASHER"
+        assert added["display_name"] == "M5 washer"
+        assert added["quantity_label"] == "2"
+
+    def test_update_decorates_quantity(self):
+        action = {
+            "operation": "update_recipe_row",
+            "target_id": 11,
+            "succeeded": True,
+            "status_label": "APPLIED",
+            "changes": [{"field": "planned_quantity_per_unit", "old": 4.0, "new": 6.0}],
+        }
+        row = next(r for r in self._merge([action]) if r["id"] == 11)
+        assert row["kind"] == "updated"
+        assert row["quantity_label"] == "4 → 6"
+
+    def test_delete_keeps_identity(self):
+        action = {
+            "operation": "delete_recipe_row",
+            "target_id": 12,
+            "succeeded": True,
+            "status_label": "APPLIED",
+            "changes": [],
+        }
+        row = next(r for r in self._merge([action]) if r["id"] == 12)
+        assert row["kind"] == "deleted"
+        assert row["sku_label"] == "- NUT"
+
+    def test_unresolved_add_falls_back(self):
+        action = {
+            "operation": "add_recipe_row",
+            "target_id": None,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [
+                {"field": "variant_id", "old": None, "new": 999, "is_added": True}
+            ],
+        }
+        added = prepare_recipe_table_rows(
+            merge_recipe_rows_for_modify_card(self._PRIOR, [action], {})
+        )[-1]
+        assert added["sku_label"] == "+ (unresolved)"
+        assert added["display_name"] == "variant 999"
+
+    def test_other_collection_ops_filtered(self):
+        # An operation-row action must not appear in the recipe table.
+        action = {
+            "operation": "add_operation_row",
+            "target_id": None,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [],
+        }
+        rows = self._merge([action])
+        assert [r["kind"] for r in rows] == ["existing", "existing"]
+
+
+class TestOperationRows:
+    _PRIOR: ClassVar[dict] = {
+        "operation_rows": [
+            {"id": 21, "operation_name": "Cut", "status": "NOT_STARTED"},
+            {"id": 22, "operation_name": "Weld", "status": "IN_PROGRESS"},
+        ]
+    }
+
+    def _merge(self, actions):
+        return prepare_operation_table_rows(
+            merge_operation_rows_for_modify_card(self._PRIOR, actions)
+        )
+
+    def test_existing_rows(self):
+        rows = self._merge([])
+        assert [r["operation_label"] for r in rows] == ["Cut", "Weld"]
+        assert [r["op_status_label"] for r in rows] == ["NOT_STARTED", "IN_PROGRESS"]
+
+    def test_add_operation(self):
+        action = {
+            "operation": "add_operation_row",
+            "target_id": None,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [
+                {
+                    "field": "operation_name",
+                    "old": None,
+                    "new": "Paint",
+                    "is_added": True,
+                },
+                {
+                    "field": "status",
+                    "old": None,
+                    "new": "NOT_STARTED",
+                    "is_added": True,
+                },
+            ],
+        }
+        added = self._merge([action])[-1]
+        assert added["operation_label_gutter"] == "+ Paint"
+        assert added["op_status_label"] == "NOT_STARTED"
+
+    def test_update_status_diff(self):
+        action = {
+            "operation": "update_operation_row",
+            "target_id": 21,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [{"field": "status", "old": "NOT_STARTED", "new": "COMPLETED"}],
+        }
+        row = next(r for r in self._merge([action]) if r["id"] == 21)
+        assert row["op_status_label"] == "NOT_STARTED → COMPLETED"
+        assert row["operation_label_gutter"] == "~ Cut"
+
+    def test_delete(self):
+        action = {
+            "operation": "delete_operation_row",
+            "target_id": 22,
+            "succeeded": True,
+            "status_label": "APPLIED",
+            "changes": [],
+        }
+        row = next(r for r in self._merge([action]) if r["id"] == 22)
+        assert row["kind"] == "deleted"
+        assert row["operation_label_gutter"] == "- Weld"
+
+
+class TestProductions:
+    _PRIOR: ClassVar[dict] = {
+        "productions": [
+            {"id": 31, "quantity": 10.0, "production_date": "2026-05-01T00:00:00Z"},
+        ]
+    }
+
+    def _merge(self, actions):
+        return prepare_production_table_rows(
+            merge_productions_for_modify_card(self._PRIOR, actions)
+        )
+
+    def test_existing_row(self):
+        row = self._merge([])[0]
+        assert row["quantity_label_gutter"] == "  10"
+        assert row["date_label"] == "2026-05-01"
+
+    def test_add_production_reads_completed_fields(self):
+        action = {
+            "operation": "add_production",
+            "target_id": None,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [
+                {
+                    "field": "completed_quantity",
+                    "old": None,
+                    "new": 5.0,
+                    "is_added": True,
+                },
+                {
+                    "field": "completed_date",
+                    "old": None,
+                    "new": "2026-05-08T12:00:00Z",
+                    "is_added": True,
+                },
+            ],
+        }
+        added = self._merge([action])[-1]
+        assert added["quantity_label_gutter"] == "+ 5"
+        assert added["date_label"] == "2026-05-08"
+
+    def test_update_date_diff(self):
+        action = {
+            "operation": "update_production",
+            "target_id": 31,
+            "succeeded": None,
+            "status_label": "PLANNED",
+            "changes": [
+                {
+                    "field": "production_date",
+                    "old": "2026-05-01T00:00:00Z",
+                    "new": "2026-05-09T00:00:00Z",
+                }
+            ],
+        }
+        row = next(r for r in self._merge([action]) if r["id"] == 31)
+        assert row["date_label"] == "2026-05-01 → 2026-05-09"
+
+    def test_missing_prior_yields_empty(self):
+        assert merge_productions_for_modify_card(None, []) == []


### PR DESCRIPTION
## Summary

Phase 4 of the #721 modify-card umbrella — the net-new **manufacturing-order
modify card**, replacing the generic `ActionResult` table for
`modify_manufacturing_order` / `delete_manufacturing_order`. The largest card in
the umbrella: a header entity-view plus **three** collection diff tables, all on
the shared collection-diff element (the fourth consumer after BOM, item
variants, and PO rows).

### What changed

- **New `mo_tables` module** — three `CollectionDiffSpec`s + merges:
  - **recipe rows** (ingredients): SKU / name / qty-per-unit, resolves added-row
    variants
  - **operation rows**: operation name / workflow status
  - **production records**: quantity / date
  Each filters to its own collection's ops; Decimal-safe formatting.
- **`_render_mo_entity_view`** extracted from `build_mo_create_ui` so create +
  modify share the header rendering; the `changes=` overlay decorates the
  editable scalars (planned_quantity / deadline / status / order_no / variant /
  location / notes). Create card stays byte-identical.
- **`build_mo_modify_ui`** — header diffs + the three tables, each rendered only
  when its collection changes (header-only modify → just header diffs);
  state-bound + apply-morph.
- **Impl** — the MO snapshot doesn't embed the collections (separate endpoints),
  so `_populate_mo_modify_collections` fetches recipe / operation / production —
  **each gated on that collection having CRUD** — and attaches them to
  prior_state so the tables show existing rows as context. Resolves the
  added-recipe variants + the MO's own produced-variant SKU + production-location
  name (anti-pattern #7); synthesizes the fail-fast NOT-RUN tail.
- Dispatch branch for `manufacturing_order`; generalized the PO applied-state /
  confirm-label helpers for reuse.

### Test plan

- [x] `uv run poe agent-check` (lint + ty) — clean
- [x] `uv run pyright` on touched files — 0 errors
- [x] `uv run poe test` — 3868 passed
- [x] `uv run poe test-browser` — 48 passed, incl. new `mo_modify_{preview,applied}`
  (all three tables render with resolved identity + per-row status in a real browser)
- New coverage: `test_mo_tables`, `TestBuildMOModifyUI`, `TestMOModifyDispatch`,
  MO impl fetch-gating tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)