### PR TITLE
docs: mark serial-fulfillment escalation submitted + caveat fulfill_order

### DIFF
--- a/docs/escalations/katana-serial-fulfillment-gap.md
+++ b/docs/escalations/katana-serial-fulfillment-gap.md
@@ -5,7 +5,8 @@
 via make-to-order\
 **Public API base:** `https://api.katanamrp.com/v1`
 
-> Escalation prepared for the Katana API team. Internal tracking:
+> **Status:** Submitted to Katana 2026-06-02 (awaiting response).\
+> Internal tracking:
 > [#784](https://github.com/dougborg/katana-openapi-client/issues/784),
 > [#849](https://github.com/dougborg/katana-openapi-client/issues/849).
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -1879,10 +1879,10 @@ async def fulfill_order(
     serial was produced by a *linked* make-to-order MO cannot be fulfilled via the
     public API. Passing the serial is rejected ("already assigned"); omitting it is
     rejected ("serial quantity must match"). This is a Katana-side gap (escalated
-    2026-06-02 — see ``docs/escalations/katana-serial-fulfillment-gap.md`` and #784);
-    until Katana exposes a serial-transfer verb these orders must be delivered in the
-    Katana web UI. Serial-tracked sales rows NOT linked to an MO, and all
-    manufacturing-order completions, fulfill normally.
+    2026-06-02, tracked in dougborg/katana-openapi-client#784); until Katana exposes a
+    serial-transfer verb these orders must be delivered in the Katana web UI.
+    Serial-tracked sales rows NOT linked to an MO, and all manufacturing-order
+    completions, fulfill normally.
     """
     response = await _fulfill_order_impl(request, context)
     return _fulfill_response_to_tool_result(response, request=request)

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/orders.py
@@ -1874,6 +1874,15 @@ async def fulfill_order(
 
     Manufacturing: marks order DONE, adds finished goods, consumes raw materials.
     Sales: creates a fulfillment record, reduces available inventory.
+
+    Known gap — serial-tracked make-to-order sales rows: a sales-order row whose
+    serial was produced by a *linked* make-to-order MO cannot be fulfilled via the
+    public API. Passing the serial is rejected ("already assigned"); omitting it is
+    rejected ("serial quantity must match"). This is a Katana-side gap (escalated
+    2026-06-02 — see ``docs/escalations/katana-serial-fulfillment-gap.md`` and #784);
+    until Katana exposes a serial-transfer verb these orders must be delivered in the
+    Katana web UI. Serial-tracked sales rows NOT linked to an MO, and all
+    manufacturing-order completions, fulfill normally.
     """
     response = await _fulfill_order_impl(request, context)
     return _fulfill_response_to_tool_result(response, request=request)

--- a/uv.lock
+++ b/uv.lock
@@ -1329,7 +1329,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.107.0"
+version = "0.107.1"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Follow-up to #886 (escalation doc) now that the gap has been sent to Katana.

- **Escalation doc** (`docs/escalations/katana-serial-fulfillment-gap.md`): status → **Submitted to Katana 2026-06-02** (awaiting response).
- **`fulfill_order` docstring**: document the known gap so agents don't attempt the impossible — a serial-tracked sales-order row whose serial was produced by a *linked* make-to-order MO can't be fulfilled via the public API (passing the serial → "already assigned"; omitting it → "quantity must match"). Until Katana exposes a transfer verb, deliver these in the web UI. Non-MO-linked serial rows and all MO completions fulfill normally.

Refs #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)