### PR TITLE
test(client): live-tenant integration scaffolding — tests/integration/ (#837 Phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,8 +431,13 @@ exists to prevent. Tests that want graceful skipping wire the skip in the fixtur
 in the helper.
 
 Set the env vars in `.env` (uncommented in `.env.example`). Phase 1 landed the helper,
-`.env` updates, and probe-script refactors. Later phases add pytest fixtures, GitHub
-Actions wiring, and the actual live smoke tests — track progress on the
+`.env` updates, and probe-script refactors. Phase 2 added the live client suite at
+[`tests/integration/`](tests/integration/) — read-only smoke tests built on
+`make_test_client()`, run via `uv run poe test-integration-live`, auto-skipping when
+`KATANA_TEST_API_KEY` is unset (the skip lives in the `live_client` fixture, not the
+helper). See [`tests/integration/README.md`](tests/integration/README.md) for the
+SDT-tagging + cleanup contract any *write* test must follow. Later phases add GitHub
+Actions wiring and MCP-server smoke tests — track progress on the
 [project board](https://github.com/users/dougborg/projects/5).
 
 ## Detailed Documentation

--- a/katana_public_api_client/testing.py
+++ b/katana_public_api_client/testing.py
@@ -20,9 +20,19 @@ from dotenv import dotenv_values
 
 from .katana_client import KatanaClient
 
-__all__ = ["make_test_client"]
+__all__ = ["MissingTestCredentialsError", "make_test_client"]
 
 _DEFAULT_TEST_BASE_URL = "https://api.katanamrp.com/v1"
+
+
+class MissingTestCredentialsError(RuntimeError):
+    """Raised when ``KATANA_TEST_API_KEY`` is unset.
+
+    A subclass of :class:`RuntimeError` so existing ``except RuntimeError``
+    callers keep working, but a distinct type so test fixtures can skip on
+    *this* specifically (missing credentials) while letting any *other*
+    helper failure propagate loudly instead of masking it as a skip.
+    """
 
 
 def _read_test_env(name: str, env_values: Mapping[str, str | None]) -> str | None:
@@ -52,10 +62,10 @@ def make_test_client(**kwargs: Any) -> KatanaClient:
     rate limiter, etc.
 
     Raises:
-        RuntimeError: when ``KATANA_TEST_API_KEY`` is unset. There is
-            **no** fallback to ``KATANA_API_KEY`` — test code must not
-            be able to accidentally hit prod when the env is
-            misconfigured.
+        MissingTestCredentialsError: when ``KATANA_TEST_API_KEY`` is unset
+            (a :class:`RuntimeError` subclass). There is **no** fallback to
+            ``KATANA_API_KEY`` — test code must not be able to accidentally
+            hit prod when the env is misconfigured.
 
     Example:
         >>> from katana_public_api_client.testing import make_test_client
@@ -66,7 +76,7 @@ def make_test_client(**kwargs: Any) -> KatanaClient:
     env_values = dotenv_values()
     api_key = _read_test_env("KATANA_TEST_API_KEY", env_values)
     if not api_key:
-        raise RuntimeError(
+        raise MissingTestCredentialsError(
             "KATANA_TEST_API_KEY is not set. make_test_client() will NOT "
             "fall back to KATANA_API_KEY — that fallback would let test "
             "code accidentally hit the production tenant. Set "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,6 +239,7 @@ asyncio_default_fixture_loop_scope = "function"
 markers = [
   "slow: marks tests as slow",
   "integration: marks tests as integration tests",
+  "live: marks live test-tenant integration tests (built on make_test_client(); auto-skip without KATANA_TEST_API_KEY; run sequentially via `poe test-integration-live` since they hit a real API)",
   "unit: marks tests as unit tests",
   "asyncio: marks tests as async tests",
   "docs: marks tests as documentation tests (slow, only run in CI docs jobs)",
@@ -587,12 +588,14 @@ test-verbose = "pytest -n 4 -v -m 'not docs and not schema_validation and not in
 test-coverage = "pytest -n 4 --cov=katana_public_api_client --cov-report=term-missing -m 'not docs and not schema_validation and not integration and not browser'"
 test-coverage-html = "pytest -n 4 --cov=katana_public_api_client --cov-report=html -m 'not docs and not schema_validation and not integration and not browser'"
 test-unit = "pytest -n 4 -m 'unit and not schema_validation'"
-test-integration = "pytest -n 4 -m 'integration and not schema_validation'"
+test-integration = "pytest -n 4 -m 'integration and not schema_validation and not live'"
 # Live client smoke tests against a real Katana *test* tenant (issue #837).
+# Selected by the `live` marker (not just the path) so a bare `pytest -m live`
+# also picks exactly these — and so `test-integration` above can exclude them.
 # Sequential by design: hits a live API, so we don't fan out concurrent calls.
 # Auto-skips when KATANA_TEST_API_KEY is unset (the live_client fixture skips),
 # so this is a green no-op on forks / in CI without the secret.
-test-integration-live = "pytest tests/integration/ --timeout=60"
+test-integration-live = "pytest -m live --timeout=60"
 test-docs = { shell = "CI_DOCS_BUILD=true pytest -m docs -v --timeout=600" }  # 10 minute timeout for docs
 test-no-docs = "pytest -n 4 -m 'not docs and not schema_validation and not integration and not browser'"
 test-all = "pytest -n 4 -m 'not schema_validation and not integration and not browser'"  # Run everything except schema_validation, integration, and browser (each parallel-incompatible or stateful)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -588,6 +588,11 @@ test-coverage = "pytest -n 4 --cov=katana_public_api_client --cov-report=term-mi
 test-coverage-html = "pytest -n 4 --cov=katana_public_api_client --cov-report=html -m 'not docs and not schema_validation and not integration and not browser'"
 test-unit = "pytest -n 4 -m 'unit and not schema_validation'"
 test-integration = "pytest -n 4 -m 'integration and not schema_validation'"
+# Live client smoke tests against a real Katana *test* tenant (issue #837).
+# Sequential by design: hits a live API, so we don't fan out concurrent calls.
+# Auto-skips when KATANA_TEST_API_KEY is unset (the live_client fixture skips),
+# so this is a green no-op on forks / in CI without the secret.
+test-integration-live = "pytest tests/integration/ --timeout=60"
 test-docs = { shell = "CI_DOCS_BUILD=true pytest -m docs -v --timeout=600" }  # 10 minute timeout for docs
 test-no-docs = "pytest -n 4 -m 'not docs and not schema_validation and not integration and not browser'"
 test-all = "pytest -n 4 -m 'not schema_validation and not integration and not browser'"  # Run everything except schema_validation, integration, and browser (each parallel-incompatible or stateful)
@@ -702,6 +707,7 @@ echo "   poe test                - Run all tests"
 echo "   poe test-coverage       - Run tests with coverage report"
 echo "   poe test-unit           - Run unit tests only"
 echo "   poe test-integration    - Run integration tests only"
+echo "   poe test-integration-live - Live client smoke tests (test tenant; skips w/o KATANA_TEST_API_KEY)"
 echo "   poe analyze-coverage    - Analyze coverage by file type"
 echo ""
 echo "📁 Documentation:"

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -85,7 +85,10 @@ the spec-drift probes use:
 
 ## Adding a test
 
-- Mark the module `pytestmark = [pytest.mark.integration, pytest.mark.asyncio]`.
+- Mark the module
+  `pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.asyncio]`. The
+  `live` marker is what `poe test-integration-live` selects and what
+  `poe test-integration` excludes — keep it on every test in this directory.
 - Take the `live_client` fixture; call generated endpoints with
   `await <endpoint>.asyncio_detailed(client=live_client, ...)`.
 - Assert **structurally**, not exactly: the test tenant's data drifts, so check

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,93 @@
+# Live-integration tests (`tests/integration/`)
+
+These tests exercise the **Python client** end-to-end against a real Katana **test
+tenant** — auth, transport-layer resilience, pagination, and response parsing against
+live responses rather than mocks. They are the client-side counterpart to the MCP smoke
+tests in `katana_mcp_server/tests/smoke/`.
+
+Part of the live test-environment epic —
+[#837](https://github.com/dougborg/katana-openapi-client/issues/837), Phase 2. Phase 1
+([#854](https://github.com/dougborg/katana-openapi-client/issues/854)) shipped the
+`make_test_client()` helper these tests build on.
+
+## Running them
+
+```bash
+uv run poe test-integration-live      # selects `-m live` (every test in this dir)
+```
+
+The suite **skips entirely** unless `KATANA_TEST_API_KEY` is set — so a bare
+`uv run poe test-integration-live` on a fork, in CI without the secret, or on a laptop
+that's never been configured is a green no-op, not a failure.
+
+Set the key in `.env` (see `.env.example`) or export it:
+
+```bash
+export KATANA_TEST_API_KEY=...                       # test tenant, NOT prod
+export KATANA_TEST_BASE_URL=https://api.katanamrp.com/v1   # optional; this is the default
+```
+
+## Safety model — why this can't hit prod
+
+- **No prod fallback.** The `live_client` fixture calls
+  [`make_test_client()`](../../katana_public_api_client/testing.py), which reads
+  `KATANA_TEST_API_KEY` and **never** falls back to `KATANA_API_KEY`. A misconfigured
+  environment skips; it does not silently exercise production.
+- **The skip lives in the fixture, not the helper.** `make_test_client()` fails loud
+  (raises `RuntimeError`) so non-test callers can't misuse it; the `live_client` fixture
+  is the one place that turns that into `pytest.skip`.
+- **Same URL, different key.** The test tenant lives on the same `api.katanamrp.com/v1`
+  base URL as production — it is distinguished *only* by the API key. This is why the
+  no-fallback rule matters: the URL alone won't save you.
+
+## Read-only vs. write tests
+
+`test_smoke_readonly.py` only touches `GET` endpoints, so there is nothing to clean up.
+**Any test that creates, updates, or deletes tenant data must follow the SDT-tagging +
+cleanup contract below** — otherwise the test tenant slowly fills with orphaned
+artifacts.
+
+### The SDT-tagging + cleanup contract
+
+Reuse the ledger machinery in
+[`scripts/spec_drift_verify.py`](../../scripts/spec_drift_verify.py) — the same pattern
+the spec-drift probes use:
+
+1. **Tag every created artifact** with the date-stamped `SDT-<date>` prefix so it's
+   greppable in the Katana UI and unambiguously test-owned:
+
+   ```python
+   from scripts.spec_drift_verify import SDT_PREFIX, tagged, record_artifact
+
+   name = f"[{SDT_PREFIX}] Smoke Material"   # or tagged("WIDGET-001") for a SKU
+   ```
+
+1. **Record it to the ledger immediately after the create succeeds** so cleanup can find
+   it even if the test later crashes:
+
+   ```python
+   record_artifact(endpoint="/materials", entity_id=created.id, issue="#837")
+   ```
+
+1. **Clean up** by walking the ledger in reverse and issuing the matching `DELETE`s:
+
+   ```bash
+   uv run python scripts/spec_drift_verify.py cleanup
+   ```
+
+   Re-running cleanup is safe — already-deleted rows are skipped.
+
+> **Note:** the `spec_drift_verify.py` ledger client authenticates with
+> `KATANA_API_KEY`, because it predates this suite and targets the spec-drift probe
+> tenant. When wiring write tests against the **test** tenant, point the cleanup at the
+> same tenant your test wrote to — don't mix `KATANA_API_KEY` and `KATANA_TEST_API_KEY`
+> artifacts in one ledger run.
+
+## Adding a test
+
+- Mark the module `pytestmark = [pytest.mark.integration, pytest.mark.asyncio]`.
+- Take the `live_client` fixture; call generated endpoints with
+  `await <endpoint>.asyncio_detailed(client=live_client, ...)`.
+- Assert **structurally**, not exactly: the test tenant's data drifts, so check
+  "authenticated + parsed into the right model" (`is_success`, `unwrap_as`,
+  `unwrap_data`), never "there are exactly N rows".

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,42 @@
+"""Fixtures for live-tenant integration tests (issue #837, Phase 2).
+
+The single entry point is the ``live_client`` fixture: it builds a
+:class:`~katana_public_api_client.KatanaClient` bound to the test tenant via
+:func:`~katana_public_api_client.testing.make_test_client` and yields it inside
+an ``async with`` block. If ``KATANA_TEST_API_KEY`` is unset the helper raises
+``RuntimeError`` and the fixture turns that into a ``pytest.skip`` — so the
+whole ``tests/integration/`` suite is a no-op for anyone without a test key.
+
+This is the *only* place the skip lives. ``make_test_client`` itself fails
+loud (never falls back to the prod key); the auto-skip is a test-harness
+concern, so it belongs in the fixture, not the helper.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from katana_public_api_client import KatanaClient
+from katana_public_api_client.testing import make_test_client
+
+
+@pytest_asyncio.fixture
+async def live_client() -> AsyncIterator[KatanaClient]:
+    """Yield a KatanaClient bound to the test tenant, or skip if unconfigured.
+
+    Tuned for fast test feedback: fewer retries and a hard page cap so a
+    misbehaving endpoint can't fan out into hundreds of live calls.
+
+    Yields:
+        KatanaClient: entered client whose requests hit the test tenant.
+    """
+    try:
+        client = make_test_client(max_retries=2, max_pages=5)
+    except RuntimeError as exc:
+        pytest.skip(str(exc))
+
+    async with client:
+        yield client

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,8 +4,11 @@ The single entry point is the ``live_client`` fixture: it builds a
 :class:`~katana_public_api_client.KatanaClient` bound to the test tenant via
 :func:`~katana_public_api_client.testing.make_test_client` and yields it inside
 an ``async with`` block. If ``KATANA_TEST_API_KEY`` is unset the helper raises
-``RuntimeError`` and the fixture turns that into a ``pytest.skip`` — so the
-whole ``tests/integration/`` suite is a no-op for anyone without a test key.
+:class:`~katana_public_api_client.testing.MissingTestCredentialsError` and the
+fixture turns *that specific* error into a ``pytest.skip`` — so the whole
+``tests/integration/`` suite is a no-op for anyone without a test key. Any
+*other* failure from the helper propagates and fails the test loudly, rather
+than being masked as a skip.
 
 This is the *only* place the skip lives. ``make_test_client`` itself fails
 loud (never falls back to the prod key); the auto-skip is a test-harness
@@ -20,7 +23,10 @@ import pytest
 import pytest_asyncio
 
 from katana_public_api_client import KatanaClient
-from katana_public_api_client.testing import make_test_client
+from katana_public_api_client.testing import (
+    MissingTestCredentialsError,
+    make_test_client,
+)
 
 
 @pytest_asyncio.fixture
@@ -35,7 +41,7 @@ async def live_client() -> AsyncIterator[KatanaClient]:
     """
     try:
         client = make_test_client(max_retries=2, max_pages=5)
-    except RuntimeError as exc:
+    except MissingTestCredentialsError as exc:
         pytest.skip(str(exc))
 
     async with client:

--- a/tests/integration/test_smoke_readonly.py
+++ b/tests/integration/test_smoke_readonly.py
@@ -1,0 +1,74 @@
+"""Read-only smoke tests against the live test tenant (issue #837, Phase 2).
+
+These are the canary tests for the live-integration path: they exercise the
+full stack — auth, transport-layer resilience, response parsing — against a
+real Katana test tenant, but only touch **read-only** endpoints, so there is
+nothing to clean up and no SDT-tagging contract to honour (see
+``tests/integration/README.md`` for when that contract *does* apply).
+
+Assertions are structural, not exact-match: the test tenant's data drifts over
+time, so we check "the request authenticated and parsed into the right model",
+never "there are exactly N users". Every test skips automatically when
+``KATANA_TEST_API_KEY`` is unset — the skip lives in the ``live_client``
+fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from katana_public_api_client import KatanaClient
+from katana_public_api_client.api.custom_fields import (
+    get_all_custom_fields_collections,
+)
+from katana_public_api_client.api.factory import get_factory
+from katana_public_api_client.api.user import get_all_users
+from katana_public_api_client.models import (
+    CustomFieldsCollectionListResponse,
+    Factory,
+    UserListResponse,
+)
+from katana_public_api_client.utils import is_success, unwrap_as, unwrap_data
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def test_get_factory(live_client: KatanaClient) -> None:
+    """GET /factory authenticates and parses into a Factory model."""
+    response = await get_factory.asyncio_detailed(client=live_client)
+
+    assert is_success(response), f"GET /factory returned {response.status_code}"
+    factory = unwrap_as(response, Factory)
+    # Assert on base_currency_code, not name: ``name`` is Unset on some tenants
+    # (the test tenant identifies via ``display_name``), but every factory has a
+    # base currency. The exact value drifts, so we only assert presence.
+    assert factory.base_currency_code
+
+
+async def test_get_all_users(live_client: KatanaClient) -> None:
+    """GET /users authenticates and parses into a list of users."""
+    # Don't pass limit=1: the transport auto-paginates GETs that have no `page`
+    # param, so limit=1 would fan out to one request *per user* (capped at the
+    # fixture's max_pages). Letting the server use its default page size keeps
+    # this to a single request on the small test tenant.
+    response = await get_all_users.asyncio_detailed(client=live_client)
+
+    assert is_success(response), f"GET /users returned {response.status_code}"
+    unwrap_as(response, UserListResponse)
+    # ``data`` is always a list (possibly empty on a fresh tenant).
+    users = unwrap_data(response)
+    assert isinstance(users, list)
+
+
+async def test_get_all_custom_fields_collections(live_client: KatanaClient) -> None:
+    """GET /custom_fields_collections authenticates and parses into a list."""
+    response = await get_all_custom_fields_collections.asyncio_detailed(
+        client=live_client
+    )
+
+    assert is_success(response), (
+        f"GET /custom_fields_collections returned {response.status_code}"
+    )
+    unwrap_as(response, CustomFieldsCollectionListResponse)
+    collections = unwrap_data(response)
+    assert isinstance(collections, list)

--- a/tests/integration/test_smoke_readonly.py
+++ b/tests/integration/test_smoke_readonly.py
@@ -30,7 +30,7 @@ from katana_public_api_client.models import (
 )
 from katana_public_api_client.utils import is_success, unwrap_as, unwrap_data
 
-pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.asyncio]
 
 
 async def test_get_factory(live_client: KatanaClient) -> None:

--- a/tests/test_testing_helper.py
+++ b/tests/test_testing_helper.py
@@ -15,7 +15,10 @@ from unittest.mock import patch
 import pytest
 
 from katana_public_api_client import KatanaClient
-from katana_public_api_client.testing import make_test_client
+from katana_public_api_client.testing import (
+    MissingTestCredentialsError,
+    make_test_client,
+)
 
 
 @pytest.mark.unit
@@ -59,8 +62,14 @@ class TestMakeTestClient:
 
         assert client._base_url == "https://api.katanamrp.com/v1"
 
-    def test_raises_runtime_error_when_test_key_missing(self):
-        """Safety guarantee: no silent fallback to KATANA_API_KEY."""
+    def test_raises_missing_credentials_error_when_test_key_missing(self):
+        """Safety guarantee: no silent fallback to KATANA_API_KEY.
+
+        Raises :class:`MissingTestCredentialsError` specifically (a
+        ``RuntimeError`` subclass) so test fixtures can skip on *this*
+        while letting other helper failures propagate — see the
+        ``live_client`` fixture in ``tests/integration/conftest.py``.
+        """
         # Even with a prod key present in the environment, the helper
         # must refuse — this is the entire point of the no-fallback rule.
         with (
@@ -69,10 +78,13 @@ class TestMakeTestClient:
                 lambda *_a, **_kw: {},
             ),
             patch.dict(os.environ, {"KATANA_API_KEY": "prod-key"}, clear=True),
-            pytest.raises(RuntimeError) as exc_info,
+            pytest.raises(MissingTestCredentialsError) as exc_info,
         ):
             make_test_client()
 
+        assert isinstance(exc_info.value, RuntimeError), (
+            "must stay a RuntimeError subclass for backward compatibility"
+        )
         msg = str(exc_info.value)
         assert "KATANA_TEST_API_KEY" in msg
         assert "KATANA_API_KEY" in msg, (

--- a/uv.lock
+++ b/uv.lock
@@ -1344,7 +1344,7 @@ wheels = [
 
 [[package]]
 name = "katana-mcp-server"
-version = "0.107.1"
+version = "0.108.0"
 source = { editable = "katana_mcp_server" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Phase 2 of the live test-environment epic (#837). Adds a net-new **client**
integration suite at the repo root, built on the Phase 1 `make_test_client()`
helper (#854). Phase 1 shipped the helper; this wires it into an actual,
runnable test directory.

- **`tests/integration/conftest.py`** — `live_client` fixture yields a
  `KatanaClient` bound to the test tenant via `make_test_client()`, and is the
  **single auto-skip site**: when `KATANA_TEST_API_KEY` is unset it
  `pytest.skip`s, so the suite is a green no-op on forks / in CI without the
  secret. **No prod fallback** — the helper never reads `KATANA_API_KEY`.
- **`tests/integration/test_smoke_readonly.py`** — 3 read-only smoke tests
  (`GET /factory`, `/users`, `/custom_fields_collections`). Assertions are
  **structural** (auth succeeded + parsed into the right model via
  `is_success`/`unwrap_as`/`unwrap_data`), never exact-match, since the test
  tenant's data drifts. (`Factory.name` is `Unset` on the test tenant, so the
  factory test asserts on `base_currency_code` instead.)
- **`tests/integration/README.md`** — data-isolation + `SDT-<date>`-tagging /
  cleanup contract that any future **write** test must follow, reusing the
  `scripts/spec_drift_verify.py` ledger.
- **`poe test-integration-live`** — sequential (live API), auto-skips without
  the key.
- **CLAUDE.md** — Test environment section updated to point at the new suite.

Scope note: this is intentionally separate from the older
`katana_mcp_server/tests/integration/` suite, which authenticates with the
**prod** `KATANA_API_KEY` — the exact pattern `make_test_client()` exists to
replace. Migrating that suite is out of scope here.

## Test plan

- [x] `uv run poe test-integration-live` → **3 passed** against the live test
      tenant ("Katana OpenAPI Client Test Environment")
- [x] Skip path: `make_test_client()` with no key and no `.env` raises
      `RuntimeError` → fixture skips (verified from a clean cwd)
- [x] Default `poe test` deselects the suite (`-m 'not integration'`; 3 deselected)
- [x] `uv run poe check` → 3871 passed, 11 skipped
- [x] All pre-commit hooks pass

Refs #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)