### PR TITLE
fix(mcp): paginate DataTables only when rows overflow one page

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -139,6 +139,34 @@ from katana_mcp.web_urls import EntityKind, katana_web_url
 
 logger = get_logger(__name__)
 
+# Default rows-per-page for the module's DataTables. See ``_paginate`` for why
+# pagination is opt-in rather than always-on.
+_DEFAULT_TABLE_PAGE_SIZE = 20
+
+
+def _paginate(
+    row_count: int, *, page_size: int = _DEFAULT_TABLE_PAGE_SIZE
+) -> dict[str, Any]:
+    """DataTable pagination kwargs that avoid blank filler rows.
+
+    The renderer pads a *paginated* table with empty filler rows up to
+    ``pageSize`` to keep height stable across pages, and there's no prop to
+    disable that — so a short table that fits on one page renders blank rows
+    below its data (the renderer gate is ``paginated && rowCount < pageSize``).
+    The only lever we control is whether to paginate at all.
+
+    Returns ``paginated=True`` (with ``pageSize``) only when ``row_count``
+    overflows a single page; otherwise pagination — and the filler rows and
+    now-pointless ``Page 1 of 1`` footer — is disabled. Pass the length of the
+    Python list backing the table's ``rows`` (whatever it's named at the call
+    site), then spread the result into ``DataTable``::
+
+        DataTable(columns=..., rows="{{ items }}", **_paginate(len(items)))
+    """
+    if row_count > page_size:
+        return {"paginated": True, "pageSize": page_size}
+    return {"paginated": False}
+
 
 def _split_warnings(
     warnings: list[str] | None,
@@ -623,7 +651,8 @@ def build_search_results_ui(
     """Build an interactive search results table with drill-down.
 
     Features:
-    - Sortable, searchable, paginated DataTable
+    - Sortable, searchable DataTable (paginated only when results overflow
+      one page — see ``_paginate``)
     - Row-click fires CallTool to get_variant_details, renders in Slot
     - Summary badges for query and count
 
@@ -676,8 +705,7 @@ def build_search_results_ui(
             ],
             rows="{{ items }}",
             search=True,
-            paginated=True,
-            pageSize=20,
+            **_paginate(len(items)),
             # Per-row binding via ``$event``: the renderer spreads the
             # clicked row's dict into the action-scope as ``$event``, so
             # ``{{ $event.sku }}`` resolves to the row's SKU. The naive
@@ -1094,8 +1122,7 @@ def build_variant_batch_ui(
                     ],
                     rows="{{ rows }}",
                     search=True,
-                    paginated=True,
-                    pageSize=20,
+                    **_paginate(len(rows)),
                     # Drill into the single-variant card by id (the
                     # row dict's ``id`` is the variant's primary key
                     # from ``VariantDetailsResponse.model_dump()``).
@@ -1425,8 +1452,7 @@ def _item_variants_table(item: dict[str, Any]) -> None:
         ],
         rows="{{ item.variants }}",
         search=True,
-        paginated=True,
-        pageSize=20,
+        **_paginate(len(variants)),
         # Per-row click invokes get_variant_details using the row's
         # variant id, not its SKU. ``ItemVariantSummary.sku`` is
         # nullable (Katana allows variants without a SKU on the wire),
@@ -1796,8 +1822,7 @@ def _bom_rows_table(bom: dict[str, Any]) -> None:
         ],
         rows="{{ bom.rows }}",
         search=True,
-        paginated=True,
-        pageSize=20,
+        **_paginate(len(rows)),
         # Per-row click drills into the ingredient's variant card.
         # ``EVENT.ingredient_variant_id`` is always present on
         # ``BomRowInfo`` — every row carries the FK, even when the
@@ -2292,8 +2317,7 @@ def build_inventory_check_batch_ui(
             columns=columns,
             rows="{{ items }}",
             search=True,
-            paginated=True,
-            pageSize=25,
+            **_paginate(total_items, page_size=25),
         )
 
         for slot, item in multi_location_slots:
@@ -2425,7 +2449,12 @@ def build_low_stock_ui(
             ],
             rows="{{ items }}",
             search=True,
-            paginated=True,
+            # Deliberate per-card policy: 10 rows/page (smaller than the
+            # module's 20 because the restock list is meant to be scanned and
+            # acted on, not browsed). This was the prior behavior — the table
+            # carried no explicit pageSize and the component defaults to 10 —
+            # now pinned explicitly so it's independent of component updates.
+            **_paginate(len(items), page_size=10),
         )
 
         # "Create Restock Orders" is batch-composition work (group rows
@@ -4655,8 +4684,7 @@ def build_po_modify_ui(
                 DataTable(
                     columns=_PO_MODIFY_ROW_COLUMNS,
                     rows=_PO_MODIFY_ROW_REF,
-                    paginated=True,
-                    pageSize=20,
+                    **_paginate(len(po_row_rows)),
                 )
         # Confirm label scales with the number of planned actions —
         # ``Confirm 4 changes`` is more informative than the generic
@@ -4973,8 +5001,7 @@ def build_bom_modify_ui(
                 DataTable(
                     columns=_BOM_MODIFY_COLUMNS,
                     rows=_BOM_MODIFY_PLAN_REF,
-                    paginated=True,
-                    pageSize=20,
+                    **_paginate(len(table_rows)),
                 )
             else:
                 Muted(
@@ -5306,8 +5333,7 @@ def build_item_modify_ui(
                     DataTable(
                         columns=_ITEM_MODIFY_VARIANT_COLUMNS,
                         rows=_ITEM_MODIFY_VARIANT_REF,
-                        paginated=True,
-                        pageSize=20,
+                        **_paginate(len(variant_rows)),
                     )
 
             # Consolidated failed-rows Alert — state-driven so the in-place
@@ -7439,11 +7465,18 @@ def _mo_production_rows(
 
 
 def _render_mo_collection_table(
-    *, summary: str, label: str, columns: list[DataTableColumn], state_key: str
+    *,
+    summary: str,
+    label: str,
+    columns: list[DataTableColumn],
+    state_key: str,
+    row_count: int,
 ) -> None:
     """Render one MO collection diff table (summary line + state-bound table).
 
     Caller gates on ``summary`` being non-empty (the collection changed).
+    ``row_count`` is the collection's row count, used to suppress the
+    renderer's blank filler rows when the table fits on one page.
     """
     Separator()
     Muted(content=label)
@@ -7451,8 +7484,7 @@ def _render_mo_collection_table(
     DataTable(
         columns=columns,
         rows=f"{{{{ {state_key} }}}}",
-        paginated=True,
-        pageSize=20,
+        **_paginate(row_count),
     )
 
 
@@ -7585,9 +7617,13 @@ def build_mo_modify_ui(
             if response.get("message"):
                 Muted(content=response["message"])
             block_warnings = _render_mo_entity_view(entity, changes=changes_by_field)
-            for summary, _, key, columns, label in shown:
+            for summary, rows, key, columns, label in shown:
                 _render_mo_collection_table(
-                    summary=summary, label=label, columns=columns, state_key=key
+                    summary=summary,
+                    label=label,
+                    columns=columns,
+                    state_key=key,
+                    row_count=len(rows),
                 )
         _render_preview_footer(
             title_prefix=f"Manufacturing Order {verb_label}",
@@ -9259,8 +9295,7 @@ def build_batch_recipe_update_ui(
             columns=columns,
             rows="{{ rows }}",
             search=True,
-            paginated=True,
-            pageSize=25,
+            **_paginate(len(flat_rows), page_size=25),
         )
 
         if warnings:

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -16,6 +16,7 @@ from katana_mcp.tools.foundation.bom_table import _merge_bom_rows_for_modify_car
 from katana_mcp.tools.prefab_ui import (
     PREVIEW_APPLY_COACHING,
     _format_money,
+    _paginate,
     build_batch_recipe_update_ui,
     build_bom_modify_ui,
     build_fulfill_preview_ui,
@@ -3220,6 +3221,39 @@ class TestPOModifyRowTable:
         # 2 existing + 1 added.
         assert len(rows) == 3
         assert [r["kind"] for r in rows].count("added") == 1
+
+    def test_short_row_table_disables_pagination(self):
+        """End-to-end guard that the state-bound row table is wired through
+        ``_paginate`` (not a hardcoded ``paginated=True``): a 3-row table
+        fits one page, so the renderer's blank filler rows are suppressed.
+        """
+        app = build_po_modify_ui(
+            self._preview([self._add_row(variant_id=403, qty=1.0, price=1.0)]),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        table = _bound_data_table(app.to_json(), "{{ po_row_rows }}")
+        assert table.get("paginated") is False
+
+    def test_overflowing_row_table_enables_pagination(self):
+        """The same row table paginates (page size 20) once the rows
+        overflow one page — confirms ``_paginate`` is fed the real row
+        count, not a constant.
+        """
+        actions = [
+            self._add_row(variant_id=403, qty=float(i), price=1.0) for i in range(25)
+        ]
+        app = build_po_modify_ui(
+            self._preview(actions),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        # 2 prior rows + 25 added = 27 > 20.
+        assert app.state is not None
+        assert len(app.state["po_row_rows"]) == 27
+        table = _bound_data_table(app.to_json(), "{{ po_row_rows }}")
+        assert table.get("paginated") is True
+        assert table.get("pageSize") == 20
 
     def test_header_only_modify_renders_no_row_table(self):
         actions = [
@@ -10723,3 +10757,90 @@ class TestPreviewCoachingLeadsWithNoIframeFallback:
         result = with_preview_coaching(fn)
         assert result.startswith("My tool's own purpose.")
         assert "does NOT render" in result
+
+
+def _bound_data_table(envelope: dict[str, Any], rows_ref: str) -> dict[str, Any]:
+    """The single DataTable in ``envelope`` whose ``rows`` binds ``rows_ref``.
+
+    Pins a pagination assertion to a specific table (by its ``{{ key }}``
+    binding) rather than "the only DataTable" — robust if a card later grows
+    a second table. Built on the file's existing ``_find_components_by_type``.
+    """
+    tables = [
+        t
+        for t in _find_components_by_type(envelope, "DataTable")
+        if t.get("rows") == rows_ref
+    ]
+    assert len(tables) == 1, f"expected exactly one DataTable bound to {rows_ref!r}"
+    return tables[0]
+
+
+class TestDataTablePagination:
+    """``_paginate`` opts into pagination only when the data overflows one
+    page, so short tables don't render the renderer's blank filler rows
+    (the renderer pads a *paginated* table up to ``pageSize``). Guards the
+    module-wide DataTable fix.
+    """
+
+    @pytest.mark.parametrize(
+        ("row_count", "page_size", "expected"),
+        [
+            (0, 20, {"paginated": False}),
+            (1, 20, {"paginated": False}),
+            (19, 20, {"paginated": False}),
+            # Boundary: rowCount == pageSize fits one page with no filler.
+            (20, 20, {"paginated": False}),
+            (21, 20, {"paginated": True, "pageSize": 20}),
+            (50, 25, {"paginated": True, "pageSize": 25}),
+            (25, 25, {"paginated": False}),
+        ],
+    )
+    def test_paginate_thresholds(
+        self, row_count: int, page_size: int, expected: dict[str, Any]
+    ) -> None:
+        assert _paginate(row_count, page_size=page_size) == expected
+
+    @pytest.mark.parametrize(
+        ("n_items", "paginated"),
+        [
+            (1, False),  # short → no pagination, no blank filler rows
+            (50, True),  # overflow → paginate at the configured page size
+        ],
+    )
+    def test_search_results_paginate_only_on_overflow(
+        self, n_items: int, paginated: bool
+    ) -> None:
+        """End-to-end: ``build_search_results_ui`` routes its ``{{ items }}``
+        table through ``_paginate`` — short results don't paginate (so the
+        renderer adds no filler rows), overflowing results do.
+        """
+        items = [
+            {"id": i, "sku": f"SKU-{i:03d}", "name": "Widget", "is_sellable": True}
+            for i in range(n_items)
+        ]
+        table = _bound_data_table(
+            build_search_results_ui(items, "widget", n_items).to_json(), "{{ items }}"
+        )
+        assert table.get("paginated") is paginated
+        if paginated:
+            assert table.get("pageSize") == 20
+
+    def test_no_hardcoded_paginated_true_in_module(self) -> None:
+        """Enforce the convention for the next DataTable author: pagination
+        is decided by ``_paginate``, never a hardcoded ``paginated=True``
+        kwarg (which would reintroduce blank filler rows for any table that
+        fits on one page). Converts the convention into a tripwire.
+        """
+        from pathlib import Path
+
+        import katana_mcp.tools.prefab_ui as prefab_ui_module
+
+        source = Path(prefab_ui_module.__file__).read_text(encoding="utf-8")
+        # Match the kwarg form (``paginated=True``) but not backtick-quoted
+        # prose mentions of it in the ``_paginate`` docstring.
+        offenders = re.findall(r"(?<!`)paginated=True", source)
+        assert not offenders, (
+            "Found a hardcoded `paginated=True` DataTable kwarg in prefab_ui.py "
+            "— route pagination through `**_paginate(len(rows))` instead so "
+            "short tables don't render blank filler rows."
+        )


### PR DESCRIPTION
## Summary

Short DataTables across the MCP cards rendered a column of **blank filler rows** below their data (e.g. the 1-variant `modify_item` card). Root cause: the vendored Prefab renderer pads a *paginated* table with empty rows up to `pageSize` to keep height stable across pages — gated by `paginated && rowCount < pageSize` — and exposes no prop to turn that padding off. Every DataTable in `prefab_ui.py` hardcoded `paginated=True`, so any table shorter than a page got padded.

- Added `_paginate(row_count, *, page_size)` — returns `paginated=True` (with `pageSize`) only when the data overflows one page, else `paginated=False`.
- Spread `**_paginate(len(rows))` into all **11** DataTable call sites, each fed its build-time row count.
- For single-page tables this removes both the blank filler rows **and** the now-pointless `Page 1 of 1 / Previous / Next` footer; larger tables keep full pagination unchanged.
- Per-card page sizes preserved (20 default; 25 for inventory-batch / batch-recipe; 10 for low-stock, now pinned explicitly rather than relying on the component default).

## Test plan

- [x] `uv run poe check` green (3882 unit + 48 browser tests)
- [x] `test_paginate_thresholds` — pure-function coverage incl. the `rowCount == pageSize` boundary
- [x] End-to-end pagination assertions on the `{{ items }}` search-results table and the state-bound PO-modify row table (short → `paginated=False`, overflow → `paginated=True, pageSize=20`)
- [x] Module-wide guard test fails if any future DataTable reintroduces a hardcoded `paginated=True` kwarg
- [x] Existing browser render tests still pass (the already-short 2-location inventory table now renders without padding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)