### PR TITLE
ci(integration): live-integration.yml workflow (#837 Phase 3)

### DIFF
--- a/.github/workflows/live-integration.yml
+++ b/.github/workflows/live-integration.yml
@@ -1,0 +1,111 @@
+name: Live integration
+
+# Phase 3 of #837: run the live-tenant integration suite against a real
+# Katana *test* tenant (separate ``KATANA_TEST_API_KEY``, same
+# ``api.katanamrp.com/v1`` base URL — different tenant, never production).
+#
+# REQUIRED ONE-TIME SETUP (repo owner):
+#
+#     gh secret set KATANA_TEST_API_KEY --body '<test-tenant-key>'
+#     # optional, only if the test tenant lives on a non-default base URL:
+#     gh variable set KATANA_TEST_BASE_URL --body 'https://api.katanamrp.com/v1'
+#
+# Until ``KATANA_TEST_API_KEY`` exists, this workflow is a green no-op:
+# ``make_test_client()`` raises ``MissingTestCredentialsError`` and the
+# ``live_client`` fixture turns that into a skip. The same is true for PRs
+# from forks (secrets aren't exposed there) — by design.
+#
+# Triggers:
+#   - schedule  : nightly, surfaces drift even when nobody touches the code
+#   - dispatch  : manual run from the Actions tab
+#   - PR + label: opt-in only, via the ``needs-live-test`` label. There is no
+#                 automatic live run on every PR (live calls cost real API
+#                 quota and mutate nothing only because these tests are
+#                 read-only — a write test would need the SDT-cleanup path).
+#
+# Soft-fail by design (mirrors ``spec-drift-audit.yml``): results surface via
+# the job summary + an uploaded artifact; a red suite does not block. Promote
+# to a hard gate once the suite is proven stable on the test tenant.
+#
+# Phase 4 (#837) adds an MCP-server smoke-test job alongside this one.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'  # nightly at 07:00 UTC (off-peak)
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  live-integration:
+    # Schedule / manual dispatch always run. PRs run only when explicitly
+    # opted in with the ``needs-live-test`` label.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'needs-live-test')
+    runs-on: ubuntu-latest
+    # Map the secret to a job-level env var so steps can branch on its
+    # presence (the ``secrets`` context isn't available in ``if:``).
+    env:
+      KATANA_TEST_API_KEY: ${{ secrets.KATANA_TEST_API_KEY }}
+      KATANA_TEST_BASE_URL: ${{ vars.KATANA_TEST_BASE_URL }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Warn when the test key is absent
+        if: env.KATANA_TEST_API_KEY == ''
+        run: |
+          echo "::notice title=Live tests skipped::KATANA_TEST_API_KEY is not \
+          set, so the live suite will skip. Set it with \`gh secret set \
+          KATANA_TEST_API_KEY\` to exercise the test tenant."
+
+      - name: Run live client integration tests
+        continue-on-error: true
+        shell: bash
+        run: |
+          # pipefail so the step reflects pytest's exit code, not tee's —
+          # otherwise a failing suite would show green and defeat the
+          # "visible but non-blocking" intent of continue-on-error.
+          set -o pipefail
+          uv run poe test-integration-live | tee live-integration-report.txt
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: live-integration-report
+          path: live-integration-report.txt
+          retention-days: 30
+
+      - name: Render summary
+        if: always()
+        run: |
+          {
+            echo "# Live integration"
+            echo
+            if [ -z "$KATANA_TEST_API_KEY" ]; then
+              echo "> \`KATANA_TEST_API_KEY\` is not set — the suite skipped."
+              echo "> Set the repo secret to exercise the test tenant."
+              echo
+            fi
+            echo '## `poe test-integration-live`'
+            echo
+            echo '```'
+            cat live-integration-report.txt 2>/dev/null || echo "(no report)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,9 +436,11 @@ Set the env vars in `.env` (uncommented in `.env.example`). Phase 1 landed the h
 `make_test_client()`, run via `uv run poe test-integration-live`, auto-skipping when
 `KATANA_TEST_API_KEY` is unset (the skip lives in the `live_client` fixture, not the
 helper). See [`tests/integration/README.md`](tests/integration/README.md) for the
-SDT-tagging + cleanup contract any *write* test must follow. Later phases add GitHub
-Actions wiring and MCP-server smoke tests — track progress on the
-[project board](https://github.com/users/dougborg/projects/5).
+SDT-tagging + cleanup contract any *write* test must follow. Phase 3 added the
+[`live-integration.yml`](.github/workflows/live-integration.yml) workflow (nightly +
+`workflow_dispatch` + `needs-live-test`-labeled PRs; soft-fail; needs the
+`KATANA_TEST_API_KEY` repo secret). A later phase adds MCP-server smoke tests — track
+progress on the [project board](https://github.com/users/dougborg/projects/5).
 
 ## Detailed Documentation
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -27,6 +27,27 @@ export KATANA_TEST_API_KEY=...                       # test tenant, NOT prod
 export KATANA_TEST_BASE_URL=https://api.katanamrp.com/v1   # optional; this is the default
 ```
 
+## Running in CI
+
+The [`live-integration.yml`](../../.github/workflows/live-integration.yml) workflow runs
+this suite on a nightly schedule, on manual dispatch, and on any PR carrying the
+`needs-live-test` label (no automatic live run on every PR). It is **soft-fail** — a red
+suite surfaces in the job summary + an uploaded artifact but does not block.
+
+One-time setup by a repo owner — the workflow is a green no-op until the secret exists:
+
+```bash
+gh secret set KATANA_TEST_API_KEY            # test-tenant key
+gh variable set KATANA_TEST_BASE_URL --body 'https://api.katanamrp.com/v1'  # optional
+```
+
+> **CI safety net.** It's worth also setting the repo's `KATANA_API_KEY` secret to the
+> **same test-tenant key**. Nothing maps it to an env var today, but if a workflow ever
+> accidentally constructs a default `KatanaClient()` (which reads `KATANA_API_KEY`), it
+> then lands on the *test* tenant instead of production. The trade-off: don't assume
+> `KATANA_API_KEY` means "production" in CI — in this repo's CI it points at the test
+> tenant by design.
+
 ## Safety model — why this can't hit prod
 
 - **No prod fallback.** The `live_client` fixture calls

--- a/uv.lock
+++ b/uv.lock
@@ -1375,7 +1375,7 @@ requires-dist = [
 
 [[package]]
 name = "katana-openapi-client"
-version = "0.75.0"
+version = "0.76.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

Phase 3 of the live test-environment epic (#837). Adds
`.github/workflows/live-integration.yml`, which runs the Phase 2 live client
suite (`poe test-integration-live`) against the Katana **test** tenant.

- **Triggers:** nightly cron (07:00 UTC), `workflow_dispatch`, and PRs gated by
  the **`needs-live-test`** label — no automatic live run on every PR.
- **Secret handling:** `KATANA_TEST_API_KEY` is mapped to a job-level env var so
  steps can branch on its presence (the `secrets` context isn't available in
  `if:`). `KATANA_TEST_BASE_URL` is optional via a repo variable.
- **Soft-fail by design** (mirrors `spec-drift-audit.yml`): results surface in
  the job summary + an uploaded artifact; a red suite does **not** block. It's a
  green no-op until the repo secret exists — the `live_client` fixture skips —
  which also covers fork PRs where secrets aren't exposed.
- **Docs + label:** documented the `gh secret set KATANA_TEST_API_KEY` setup in
  the workflow header, `tests/integration/README.md` (new "Running in CI"
  section), and `CLAUDE.md`. Created the `needs-live-test` label.

Phase 4 will add an MCP-server smoke-test job alongside this one.

## Verification

- [x] `uv run yamllint .github/workflows/live-integration.yml` — clean (only the
      repo-wide `on:` truthy warning every workflow shares; warnings don't fail)
- [x] Dry-ran the exact workflow command locally: `poe test-integration-live` →
      3 passed against the test tenant
- [x] YAML parses; triggers/label-gate/env/steps structurally validated
- [x] `uv run poe agent-check` — format, lint, ty all pass
- [x] Repo secret `KATANA_TEST_API_KEY` is set (confirmed by repo owner)

## Note on the separate `chore:` commit

`69ac5dcc` syncs the root `uv.lock` to `katana-openapi-client 0.75.0` — the
release bumped the package `pyproject.toml` but not the root lock, and `uv run`
re-syncs it on every invocation. Kept separate from the CI change.

Refs #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)