### PR TITLE
test(mcp): live MCP-server smoke tests + workflow job (#837 Phase 4)

### DIFF
--- a/.github/workflows/live-integration.yml
+++ b/.github/workflows/live-integration.yml
@@ -27,7 +27,9 @@ name: Live integration
 # the job summary + an uploaded artifact; a red suite does not block. Promote
 # to a hard gate once the suite is proven stable on the test tenant.
 #
-# Phase 4 (#837) adds an MCP-server smoke-test job alongside this one.
+# Two jobs: the client live suite (`poe test-integration-live`) and the MCP
+# server smoke suite (`poe test-smoke-mcp`, Phase 4 of #837). They share the
+# gating / secret / soft-fail contract but report independently.
 
 on:
   schedule:
@@ -107,5 +109,71 @@ jobs:
             echo
             echo '```'
             cat live-integration-report.txt 2>/dev/null || echo "(no report)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  mcp-smoke:
+    # Phase 4 of #837: live MCP-server smoke tests. Same gating / secret /
+    # soft-fail contract as the client suite above, kept as a separate job so
+    # the two concerns (client vs MCP server) report independently.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'needs-live-test')
+    runs-on: ubuntu-latest
+    env:
+      KATANA_TEST_API_KEY: ${{ secrets.KATANA_TEST_API_KEY }}
+      KATANA_TEST_BASE_URL: ${{ vars.KATANA_TEST_BASE_URL }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Warn when the test key is absent
+        if: env.KATANA_TEST_API_KEY == ''
+        run: |
+          echo "::notice title=MCP smoke skipped::KATANA_TEST_API_KEY is not \
+          set, so the MCP smoke suite will skip. Set it with \`gh secret set \
+          KATANA_TEST_API_KEY\` to exercise the test tenant."
+
+      - name: Run MCP server smoke tests
+        continue-on-error: true
+        shell: bash
+        run: |
+          # pipefail so the step reflects pytest's exit code, not tee's.
+          set -o pipefail
+          uv run poe test-smoke-mcp | tee mcp-smoke-report.txt
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcp-smoke-report
+          path: mcp-smoke-report.txt
+          retention-days: 30
+
+      - name: Render summary
+        if: always()
+        run: |
+          {
+            echo "# MCP server smoke"
+            echo
+            if [ -z "$KATANA_TEST_API_KEY" ]; then
+              echo "> \`KATANA_TEST_API_KEY\` is not set — the suite skipped."
+              echo "> Set the repo secret to exercise the test tenant."
+              echo
+            fi
+            echo '## `poe test-smoke-mcp`'
+            echo
+            echo '```'
+            cat mcp-smoke-report.txt 2>/dev/null || echo "(no report)"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,8 +439,12 @@ helper). See [`tests/integration/README.md`](tests/integration/README.md) for th
 SDT-tagging + cleanup contract any *write* test must follow. Phase 3 added the
 [`live-integration.yml`](.github/workflows/live-integration.yml) workflow (nightly +
 `workflow_dispatch` + `needs-live-test`-labeled PRs; soft-fail; needs the
-`KATANA_TEST_API_KEY` repo secret). A later phase adds MCP-server smoke tests — track
-progress on the [project board](https://github.com/users/dougborg/projects/5).
+`KATANA_TEST_API_KEY` repo secret). Phase 4 added live MCP-server smoke tests at
+[`katana_mcp_server/tests/smoke/`](katana_mcp_server/tests/smoke/) — read-only MCP tool
+impls exercised through a real `Services` (client + typed cache), run via
+`uv run poe test-smoke-mcp` (marker `smoke`) and a parallel `mcp-smoke` job in the
+workflow. Track further progress on the
+[project board](https://github.com/users/dougborg/projects/5).
 
 ## Detailed Documentation
 

--- a/katana_mcp_server/tests/smoke/__init__.py
+++ b/katana_mcp_server/tests/smoke/__init__.py
@@ -1,0 +1,12 @@
+"""Live MCP-server smoke tests (issue #837, Phase 4).
+
+These exercise a handful of high-traffic read-only MCP tool implementations
+end-to-end against a real Katana **test tenant** — through the same
+``Services`` (client + typed cache) path the server uses at runtime, not a
+mock. They build on the Phase 1 ``make_test_client()`` helper and skip
+automatically when ``KATANA_TEST_API_KEY`` is unset.
+
+Marked ``smoke`` (run via ``poe test-smoke-mcp`` and the ``mcp-smoke`` job in
+``live-integration.yml``) to keep them isolated from both the default suite
+and the client-side ``live`` suite.
+"""

--- a/katana_mcp_server/tests/smoke/conftest.py
+++ b/katana_mcp_server/tests/smoke/conftest.py
@@ -1,0 +1,60 @@
+"""Fixtures for live MCP smoke tests (issue #837, Phase 4).
+
+The ``live_smoke_context`` fixture wires up the real runtime dependency graph
+against the test tenant:
+
+* a :class:`KatanaClient` from :func:`make_test_client` (test tenant, never
+  prod — skips when ``KATANA_TEST_API_KEY`` is unset, the single skip site),
+* a fresh in-memory :class:`TypedCacheEngine`, and
+* a :class:`Services` container exposed exactly the way the FastMCP lifespan
+  exposes it, so ``get_services(context)`` resolves inside tool impls.
+
+Tests seed only the reference data they query (via the per-entity
+``ensure_*_synced`` helpers) rather than running the full cache warm-up — a
+smoke test wants speed and determinism, not a complete sync.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from katana_mcp.services.dependencies import Services
+from katana_mcp.typed_cache import TypedCacheEngine
+
+from katana_public_api_client.testing import (
+    MissingTestCredentialsError,
+    make_test_client,
+)
+
+
+@pytest_asyncio.fixture
+async def live_smoke_context() -> AsyncIterator[MagicMock]:
+    """Yield a FastMCP-shaped context backed by the test tenant.
+
+    The yielded object mirrors the structure tools expect:
+    ``context.request_context.lifespan_context`` is a real :class:`Services`
+    (``get_services`` returns it directly), so cache-backed ``list_*`` tools
+    resolve their client + typed cache. Skips when the test key is unset.
+
+    Yields:
+        MagicMock: context whose ``request_context.lifespan_context`` is a
+            live :class:`Services` (client + in-memory typed cache).
+    """
+    try:
+        client = make_test_client(max_retries=2, max_pages=5)
+    except MissingTestCredentialsError as exc:
+        pytest.skip(str(exc))
+
+    async with client:
+        cache = TypedCacheEngine(in_memory=True)
+        await cache.open()
+        try:
+            services = Services(client=client, typed_cache=cache)
+            context = MagicMock()
+            context.request_context.lifespan_context = services
+            yield context
+        finally:
+            await cache.close()

--- a/katana_mcp_server/tests/smoke/test_live_smoke.py
+++ b/katana_mcp_server/tests/smoke/test_live_smoke.py
@@ -1,0 +1,77 @@
+"""Live smoke tests for high-traffic read-only MCP tools (issue #837, Phase 4).
+
+Each test seeds just the reference data it needs into the in-memory typed cache
+(via ``ensure_*_synced``), then calls the tool impl through the
+``live_smoke_context`` and asserts the response is *structurally* valid — the
+right model, a list payload, a non-negative count. Assertions never pin exact
+values: the test tenant's data drifts. The point is "auth + sync + tool wiring
+work end-to-end", not "there are exactly N locations".
+
+These skip automatically when ``KATANA_TEST_API_KEY`` is unset (the skip lives
+in the ``live_smoke_context`` fixture).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from katana_mcp.services.dependencies import get_services
+from katana_mcp.tools.foundation.reference import (
+    ListLocationsRequest,
+    ListLocationsResponse,
+    ListSuppliersRequest,
+    ListSuppliersResponse,
+    ListTaxRatesRequest,
+    ListTaxRatesResponse,
+    _list_locations_impl,
+    _list_suppliers_impl,
+    _list_tax_rates_impl,
+)
+from katana_mcp.typed_cache.sync import (
+    ensure_locations_synced,
+    ensure_suppliers_synced,
+    ensure_tax_rates_synced,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.smoke, pytest.mark.asyncio]
+
+
+async def test_list_locations(live_smoke_context: MagicMock) -> None:
+    """list_locations syncs from the tenant and returns a Locations response."""
+    services = get_services(live_smoke_context)
+    await ensure_locations_synced(services.client, services.typed_cache)
+
+    response = await _list_locations_impl(ListLocationsRequest(), live_smoke_context)
+
+    assert isinstance(response, ListLocationsResponse)
+    assert response.total_count >= 0
+    assert isinstance(response.locations, list)
+    # Every tenant has at least one location; assert presence without pinning it.
+    assert response.locations, "test tenant should have at least one location"
+    assert response.locations[0].name
+
+
+async def test_list_suppliers(live_smoke_context: MagicMock) -> None:
+    """list_suppliers syncs from the tenant and returns a Suppliers response."""
+    services = get_services(live_smoke_context)
+    await ensure_suppliers_synced(services.client, services.typed_cache)
+
+    response = await _list_suppliers_impl(ListSuppliersRequest(), live_smoke_context)
+
+    assert isinstance(response, ListSuppliersResponse)
+    assert response.total_count >= 0
+    # Suppliers may legitimately be empty on a fresh tenant — only assert shape.
+    assert isinstance(response.suppliers, list)
+
+
+async def test_list_tax_rates(live_smoke_context: MagicMock) -> None:
+    """list_tax_rates syncs from the tenant and returns a TaxRates response."""
+    services = get_services(live_smoke_context)
+    await ensure_tax_rates_synced(services.client, services.typed_cache)
+
+    response = await _list_tax_rates_impl(ListTaxRatesRequest(), live_smoke_context)
+
+    assert isinstance(response, ListTaxRatesResponse)
+    assert response.total_count >= 0
+    assert isinstance(response.tax_rates, list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ markers = [
   "slow: marks tests as slow",
   "integration: marks tests as integration tests",
   "live: marks live test-tenant integration tests (built on make_test_client(); auto-skip without KATANA_TEST_API_KEY; run sequentially via `poe test-integration-live` since they hit a real API)",
+  "smoke: marks live MCP-server smoke tests (built on make_test_client() + a real typed cache; auto-skip without KATANA_TEST_API_KEY; run via `poe test-smoke-mcp`)",
   "unit: marks tests as unit tests",
   "asyncio: marks tests as async tests",
   "docs: marks tests as documentation tests (slow, only run in CI docs jobs)",
@@ -588,7 +589,7 @@ test-verbose = "pytest -n 4 -v -m 'not docs and not schema_validation and not in
 test-coverage = "pytest -n 4 --cov=katana_public_api_client --cov-report=term-missing -m 'not docs and not schema_validation and not integration and not browser'"
 test-coverage-html = "pytest -n 4 --cov=katana_public_api_client --cov-report=html -m 'not docs and not schema_validation and not integration and not browser'"
 test-unit = "pytest -n 4 -m 'unit and not schema_validation'"
-test-integration = "pytest -n 4 -m 'integration and not schema_validation and not live'"
+test-integration = "pytest -n 4 -m 'integration and not schema_validation and not live and not smoke'"
 # Live client smoke tests against a real Katana *test* tenant (issue #837).
 # Selected by the `live` marker (not just the path) so a bare `pytest -m live`
 # also picks exactly these — and so `test-integration` above can exclude them.
@@ -596,6 +597,10 @@ test-integration = "pytest -n 4 -m 'integration and not schema_validation and no
 # Auto-skips when KATANA_TEST_API_KEY is unset (the live_client fixture skips),
 # so this is a green no-op on forks / in CI without the secret.
 test-integration-live = "pytest -m live --timeout=60"
+# Live MCP-server smoke tests (issue #837 Phase 4). Selected by the `smoke`
+# marker; exercises read-only MCP tool impls through a real Services (client +
+# typed cache) against the test tenant. Auto-skips without KATANA_TEST_API_KEY.
+test-smoke-mcp = "pytest -m smoke --timeout=120"
 test-docs = { shell = "CI_DOCS_BUILD=true pytest -m docs -v --timeout=600" }  # 10 minute timeout for docs
 test-no-docs = "pytest -n 4 -m 'not docs and not schema_validation and not integration and not browser'"
 test-all = "pytest -n 4 -m 'not schema_validation and not integration and not browser'"  # Run everything except schema_validation, integration, and browser (each parallel-incompatible or stateful)
@@ -711,6 +716,7 @@ echo "   poe test-coverage       - Run tests with coverage report"
 echo "   poe test-unit           - Run unit tests only"
 echo "   poe test-integration    - Run integration tests only"
 echo "   poe test-integration-live - Live client smoke tests (test tenant; skips w/o KATANA_TEST_API_KEY)"
+echo "   poe test-smoke-mcp      - Live MCP-server smoke tests (test tenant; skips w/o KATANA_TEST_API_KEY)"
 echo "   poe analyze-coverage    - Analyze coverage by file type"
 echo ""
 echo "📁 Documentation:"


### PR DESCRIPTION
## Summary

Phase 4 — the **final** phase of the live test-environment epic (#837). Adds
read-only MCP-server smoke tests that exercise tool implementations end-to-end
against the Katana **test** tenant through a real `Services` (client + typed
cache), not a mock.

- **`katana_mcp_server/tests/smoke/conftest.py`** — `live_smoke_context`
  fixture: `make_test_client()` (skips on `MissingTestCredentialsError`, the
  single skip site) + an in-memory `TypedCacheEngine` + a real `Services`
  exposed the way the FastMCP lifespan exposes it, so `get_services()` resolves
  inside tool impls.
- **`test_live_smoke.py`** — 3 high-traffic read-only tools (`list_locations`,
  `list_suppliers`, `list_tax_rates`). Each seeds only its reference data via the
  per-entity `ensure_*_synced` helpers (fast + deterministic, not a full
  cache warm), then asserts **structurally** — right model, list payload,
  non-negative count — never exact values, since tenant data drifts.
- **New `smoke` marker + `poe test-smoke-mcp`** — excluded from the default
  suite (marked `integration`) and from the client `-m live` job, so the two
  live concerns report independently. (No double-run.)
- **`live-integration.yml`** — parallel `mcp-smoke` job, same gating / secret /
  soft-fail contract as the client job. Green no-op until `KATANA_TEST_API_KEY`
  is set (also covers fork PRs).
- Updated `CLAUDE.md` + `poe help`.

## Verification

- [x] `uv run poe test-smoke-mcp` → **3 passed** against the test tenant
      (full client → `ensure_*_synced` → typed cache → tool-impl path)
- [x] Marker isolation: `smoke` deselected by default `poe test` and by
      `-m live`; `-m smoke` selects exactly the 3
- [x] `uv run yamllint` on the workflow — clean (only the shared `on:` warning)
- [x] `uv run poe agent-check` — format, lint, ty all pass

## Epic status

This closes out the 4-phase rollout: Phase 1 (#854, helper) → Phase 2 (#889,
client suite) → Phase 3 (#895, CI workflow) → **Phase 4 (this PR)**. The epic
issue #837 can close once this merges.

Refs #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)