### PR TITLE
docs(escalations): refine serial-fulfillment gap with UI-traced ledger lifecycle (#784)

### DIFF
--- a/docs/escalations/katana-serial-fulfillment-gap.md
+++ b/docs/escalations/katana-serial-fulfillment-gap.md
@@ -5,7 +5,10 @@
 via make-to-order\
 **Public API base:** `https://api.katanamrp.com/v1`
 
-> **Status:** Submitted to Katana 2026-06-02 (awaiting response).\
+> **Status:** Submitted to Katana 2026-06-02 (awaiting response). A second investigation
+> (2026-06-02) narrowed the gap to **make-to-order specifically** and found that
+> **make-to-stock has a clean public path** — see
+> [Update — second investigation](#update--second-investigation-2026-06-02) below.\
 > Internal tracking:
 > [#784](https://github.com/dougborg/katana-openapi-client/issues/784),
 > [#849](https://github.com/dougborg/katana-openapi-client/issues/849).
@@ -132,6 +135,146 @@ serial.
 1. **Accept the already-assigned serial** on `POST /sales_order_fulfillments` when the
    serial is already bound to the *same* SO row being fulfilled (treat "already assigned
    to this row" as valid rather than an error).
+
+## Update — second investigation (2026-06-02)
+
+A deeper probe refined the picture. **The gap is specific to make-to-order.** The public
+API *does* expose the transfer verb the UI uses — `serial_number_transactions` on
+`PATCH /sales_order_rows/{id}` (`{serial_number_id, quantity}`, the same
+`UpdateSerialNumberTransactionDto` shape as the UI's `serialNumberTransactions`). It
+just cannot be applied in a make-to-order flow, because make-to-order auto-consumes the
+serial onto the row at production time.
+
+### Make-to-STOCK works cleanly (verified end-to-end)
+
+Producing to stock first, then selling, has a fully working public path that preserves
+the serial ledger:
+
+```http
+1. POST /manufacturing_orders                      # standalone MO (NOT make_to_order)
+2. POST /serial_numbers (ManufacturingOrder)        # mint on the MO
+   POST /manufacturing_order_productions (serial)   # → serial enters stock
+3. POST /sales_orders                               # order the same variant
+4. PATCH /sales_order_rows/{id}
+   { "serial_number_transactions": [ { "serial_number_id": <id>, "quantity": 1 } ] }
+                                                     # ← the transfer (in-stock serial → row)
+5. POST /sales_order_fulfillments  { …, "serial_numbers": [ <id> ] }   # → 200, DELIVERED
+```
+
+Resulting serial trail (`GET /serial_numbers_stock`) is **identical to the UI's**:
+
+```text
+Production#…           qty_change=+1
+ManufacturingOrder#…   qty_change=+1
+SalesOrderRow#…        qty_change=-1      (net +1, in_stock=false)
+```
+
+So integrators who can produce-to-stock have a supportable public path today. The only
+cost is the lost formal SO↔MO link (the MO is standalone, not make-to-order).
+
+### Make-to-order is still blocked (representation ruled out)
+
+On a make-to-order row whose serial was produced through the linked MO, every
+representation of the fulfillment serial fails:
+
+| `POST /sales_order_fulfillments` row payload                 | Result                                                             |
+| ------------------------------------------------------------ | ------------------------------------------------------------------ |
+| `serial_numbers: [<integer id>]`                             | `422` "given serial numbers have already been assigned" (semantic) |
+| `serial_numbers: ["<name>"]`                                 | `422` schema — *must be number*                                    |
+| `serial_numbers: ["<id-as-string>"]`                         | `422` schema — *must be number*                                    |
+| `serial_number_transactions: [{serial_number_id, quantity}]` | `422` "Unexpected property" (not a fulfillment-row field)          |
+
+And the row-level transfer that works for make-to-stock is rejected here:
+`PATCH /sales_order_rows` `serial_number_transactions` → `422` "row already has serial
+number with id (…)" — the make-to-order link already consumed it onto the row. Producing
+*without* a serial and minting afterward doesn't help: minting on a make-to-order MO
+immediately writes a `SalesOrderRow -1` with **no** `Production +1`, i.e. a different
+broken trail.
+
+### The make-to-order serial-ledger lifecycle (UI-traced, 2026-06-02)
+
+Tracing `GET /serial_numbers_stock` after each UI action — with the browser network
+panel open to capture the UI-API calls — pins down exactly which transition the public
+API is missing. A serial-tracked make-to-order order books its serial ledger in three
+steps, and **delivery does not add a transaction — it stamps a reservation already
+written at serial-generation time**:
+
+| UI action                                        | Serial-ledger effect (`quantity_change`)                                                |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| Generate the serial on the make-to-order MO      | `SalesOrderRow -1` written **undated** (a reservation)                                  |
+| Build / complete the MO                          | `Production +1`, `ManufacturingOrder +1` (the `MO 0` placeholder becomes `+1`)          |
+| Deliver (UI `salesFulfillmentEvents/createMany`) | the existing `SalesOrderRow -1` is **stamped** with the delivery timestamp — no new row |
+
+Observed verbatim (serial `904176` on row `111966287`):
+
+```text
+after MO build:   SalesOrderRow -1 (date=null)   Production +1   ManufacturingOrder +1   net=+1
+after delivery:   SalesOrderRow -1 (date=19:58:42) Production +1  ManufacturingOrder +1   net=+1
+```
+
+So by the time you deliver, the serial is already fully consumed onto its row; the
+ledger is complete (`net=+1`, `in_stock=false`) **before** any fulfillment call. The
+delivery step only needs to *confirm* that reservation.
+
+The UI does this via its internal endpoint (captured from the browser, real values):
+
+```http
+POST https://sales-fulfillments.katanamrp.com/api/salesFulfillmentEvents/createMany
+[
+  { "salesOrderId": 46356252, "status": "delivered",
+    "serialNumberTransactions": [
+      { "salesOrderRowId": 111966287,
+        "serialNumber":   "784-UI-429952/1-0001",   // name
+        "serialNumberId": 904176 }                  // id — the UI sends BOTH
+    ] }
+]
+```
+
+Response row carries the serial as **traceability**, not an assignment:
+
+```json
+"rows": [ { "salesOrderRowId": 111966287, "quantity": 1,
+            "traceability": [ { "serialNumberId": 904176, "quantity": "1" } ] } ]
+```
+
+`serialNumberTransactions` is therefore a **confirm-the-reservation** verb. The public
+`POST /sales_order_fulfillments` only exposes `serial_numbers` (an
+**assign-a-new-serial** operation): passing the already-reserved serial → "already
+assigned"; omitting it → "current 0" (nothing new to assign). **There is no public verb
+to confirm/stamp the existing make-to-order reservation** — which is the single missing
+primitive.
+
+### The `DELETE /serial_numbers` path returns 200 but corrupts the ledger — do not use it
+
+`DELETE /serial_numbers` ("unassign from a resource") *can* free the serial from
+Production + ManufacturingOrder, after which `POST /sales_order_fulfillments` returns
+`200` and the SO shows `DELIVERED`. **It is data corruption, not a workaround.** It
+deletes the `+1` production transactions, leaving the serial with a lone
+`SalesOrderRow -1` (net **-1**) — a unit shipped that the ledger says was never
+produced. Side by side:
+
+```text
+UI / make-to-stock (correct):  Production +1 | MO +1 | SalesOrderRow -1   net +1
+DELETE-then-fulfill (broken):                              SalesOrderRow -1   net -1
+```
+
+(Note: the `DELETE /serial_numbers` `ids` field is typed `string` in the published docs
+but the live API requires **integer** ids — sending the documented type returns
+"`/ids/0` must be number".)
+
+### Narrowed ask
+
+The blocker is precisely: **a serial that has been consumed onto its own make-to-order
+SO row cannot have a delivered fulfillment recorded against it via the public API.** Any
+one of these resolves it, mirroring what already works for make-to-stock:
+
+1. Accept the already-consumed serial on `POST /sales_order_fulfillments` when it is
+   bound to the *same* row being fulfilled; **or**
+1. Auto-adopt the row's serial when `serial_numbers` is omitted for a serial-tracked,
+   make-to-order row; **or**
+1. Don't auto-consume the serial onto the row at production — leave it in stock and let
+   `serial_number_transactions` / the fulfillment record the consumption (as in
+   make-to-stock).
 
 ## Minor adjacent findings (not blocking, FYI)
 

--- a/docs/escalations/katana-serial-fulfillment-gap.md
+++ b/docs/escalations/katana-serial-fulfillment-gap.md
@@ -5,30 +5,28 @@
 via make-to-order\
 **Public API base:** `https://api.katanamrp.com/v1`
 
-> **Status:** Submitted to Katana 2026-06-02 (awaiting response). A second investigation
-> (2026-06-02) narrowed the gap to **make-to-order specifically** and found that
-> **make-to-stock has a clean public path** — see
-> [Update — second investigation](#update--second-investigation-2026-06-02) below.\
+> **Status:** Submitted to Katana 2026-06-02; this is the consolidated statement after a
+> live investigation (test tenant + a browser network-trace of the UI close-out).\
 > Internal tracking:
 > [#784](https://github.com/dougborg/katana-openapi-client/issues/784),
 > [#849](https://github.com/dougborg/katana-openapi-client/issues/849).
 
 ## Summary
 
-There is no public-REST sequence that records a **delivered fulfillment** for a
-serial-tracked sales-order row whose serial was produced through a **make-to-order**
-manufacturing order. Every `POST /sales_order_fulfillments` payload is rejected. The
-Katana web UI performs this routinely via
-`POST https://sales-fulfillments.katanamrp.com/api/salesFulfillmentEvents/createMany`
-using a `serialNumberTransactions` array — a **transfer** verb the public API does not
-expose.
+A serial-tracked sales-order row whose serial was produced through a **make-to-order**
+manufacturing order cannot have a delivered fulfillment recorded via the public REST
+API. By production time the serial is already consumed onto its SO row, and
+`POST /sales_order_fulfillments` only knows how to **assign a new** serial — so it
+rejects the already-consumed one. The web UI does it through an internal endpoint
+(`salesFulfillmentEvents/createMany`) that **confirms** the existing reservation; there
+is no public equivalent. Driving that internal endpoint with a web-UI session token is
+the only working path today, which is not a supportable integration.
 
-This is the normal lifecycle for any serialized finished good built to order, so it
-blocks API-based close-out for that entire class of orders. The only working path today
-is driving the internal `salesFulfillmentEvents` endpoint with a web UI session token,
-which is not a supportable integration.
+The gap is specific to **make-to-order**. **Make-to-stock has a clean public path** (see
+below), so integrators who can produce to stock are unblocked; build-to-order close-out
+is not.
 
-## What we're trying to do (standard make-to-order flow)
+## What we're trying to do (make-to-order flow)
 
 1. `POST /sales_orders` — order a serial-tracked product (qty 1).
 1. `POST /manufacturing_order_make_to_order` — create the linked MO from the SO row.
@@ -41,163 +39,48 @@ which is not a supportable integration.
 
 Steps 1–4 all succeed. Step 5 cannot be made to succeed by any payload.
 
-## The blocking call (verbatim)
+## The core gap — the catch-22
 
-At step 5 the serial is simultaneously bound to three resources (all created by steps
-3–4):
-
-```text
-serial 903402 → Production           14429383
-serial 903402 → ManufacturingOrder   17233151
-serial 903402 → SalesOrderRow        111795735   ← already on the row we're fulfilling
-```
-
-Request:
-
-```http
-POST /sales_order_fulfillments
-{
-  "sales_order_id": 46242059,
-  "status": "DELIVERED",
-  "sales_order_fulfillment_rows": [
-    { "sales_order_row_id": 111795735, "quantity": 1, "serial_numbers": [903402] }
-  ]
-}
-```
-
-Response:
-
-```http
-422 Unprocessable Entity
-{ "error": { "statusCode": 422, "name": "UnprocessableEntityError",
-             "message": "given serial numbers have already been assigned" } }
-```
-
-## The catch-22
-
-`serial_numbers` accepts only integer SerialNumber IDs, and for this row the only
-relevant serial is the one production already created. Every possible value is rejected:
-
-| `serial_numbers` on the fulfillment row | Response                                                                                               |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `[903402]` (the produced serial)        | `422` — "given serial numbers have already been assigned"                                              |
-| omitted / `[]`                          | `422` — "sum of serial number quantity (current: 0) must match fulfillment row quantity (expected: 1)" |
-
-- **Provide the serial** → rejected because production already assigned it (to the MO,
-  the production, and the SO row).
-- **Omit the serial** → rejected because the row requires one and the fulfillment does
-  **not** auto-adopt the serial already attached to the SO row.
-
-There is no third option.
-
-## Everything else we tried (all rejected)
-
-| Attempt                                                                    | Result                                                                                         |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Fulfillment with **no rows**                                               | `422` — `sales_order_fulfillment_rows` required                                                |
-| `PATCH /sales_orders/{id}` `{status: DELIVERED}`                           | `200` but **no-op** — status stays `NOT_SHIPPED` (it's computed from fulfillments)             |
-| `POST /serial_numbers` (`resource_type: SalesOrderRow`) to move the serial | `422` — "SalesOrderRow … is linked, serial info must be updated on MO"                         |
-| `POST /manufacturing_order_unlink` → then fulfill                          | unlink succeeds (`204`, row link cleared) but serial still MO-bound → `422` "already assigned" |
-| unlink → `POST /serial_numbers` (SalesOrderRow) → fulfill                  | the add returns `200` but is a no-op (`resource_id: null`); fulfill still `422`                |
-| Mint the serial directly on the SO row (`resource_type: SalesOrderRow`)    | `422` — "serial numbers not found" (serials can only be *minted* on a ManufacturingOrder)      |
-| `serial_number_transactions` / `serialNumberTransactions` field on the row | `422` — "Unexpected property" (rejected as unknown)                                            |
-| Produce **without** a serial, then fulfill with a freshly minted one       | produce ok; fresh serial is MO-bound → `422` "already assigned"                                |
-
-## What the web UI does (and works)
-
-```http
-POST https://sales-fulfillments.katanamrp.com/api/salesFulfillmentEvents/createMany
-[
-  {
-    "salesOrderId": <so>,
-    "status": "delivered",
-    "serialNumberTransactions": [
-      { "salesOrderRowId": <row>, "serialNumber": "<name>", "serialNumberId": <id> }
-    ]
-  }
-]
-```
-
-`serialNumberTransactions` is a **transfer** — it moves the serial's binding onto the
-fulfillment atomically. The public `serial_numbers` field is an
-**assign-unassigned-serials** operation, which is the wrong verb for an already-produced
-serial.
-
-## What we need (any one of these unblocks us)
-
-1. **A public transfer verb** — e.g. accept a
-   `serial_number_transactions`/`serialNumberTransactions`-shaped body on
-   `POST /sales_order_fulfillments` that moves an already-assigned serial onto the
-   fulfillment; **or**
-1. **Auto-adopt the row's serial** — when a fulfillment row for a serial-tracked,
-   make-to-order-linked SO row omits `serial_numbers`, use the serial already attached
-   to that SO row; **or**
-1. **Accept the already-assigned serial** on `POST /sales_order_fulfillments` when the
-   serial is already bound to the *same* SO row being fulfilled (treat "already assigned
-   to this row" as valid rather than an error).
-
-## Update — second investigation (2026-06-02)
-
-A deeper probe refined the picture. **The gap is specific to make-to-order.** The public
-API *does* expose the transfer verb the UI uses — `serial_number_transactions` on
-`PATCH /sales_order_rows/{id}` (`{serial_number_id, quantity}`, the same
-`UpdateSerialNumberTransactionDto` shape as the UI's `serialNumberTransactions`). It
-just cannot be applied in a make-to-order flow, because make-to-order auto-consumes the
-serial onto the row at production time.
-
-### Make-to-STOCK works cleanly (verified end-to-end)
-
-Producing to stock first, then selling, has a fully working public path that preserves
-the serial ledger:
-
-```http
-1. POST /manufacturing_orders                      # standalone MO (NOT make_to_order)
-2. POST /serial_numbers (ManufacturingOrder)        # mint on the MO
-   POST /manufacturing_order_productions (serial)   # → serial enters stock
-3. POST /sales_orders                               # order the same variant
-4. PATCH /sales_order_rows/{id}
-   { "serial_number_transactions": [ { "serial_number_id": <id>, "quantity": 1 } ] }
-                                                     # ← the transfer (in-stock serial → row)
-5. POST /sales_order_fulfillments  { …, "serial_numbers": [ <id> ] }   # → 200, DELIVERED
-```
-
-Resulting serial trail (`GET /serial_numbers_stock`) is **identical to the UI's**:
+After step 4 the serial is bound to three resources, and the **SO row already carries
+it** (`serial_numbers: [<id>]`, `linked_manufacturing_order_id: <mo>`):
 
 ```text
-Production#…           qty_change=+1
-ManufacturingOrder#…   qty_change=+1
-SalesOrderRow#…        qty_change=-1      (net +1, in_stock=false)
+serial 904179 → Production           14472037
+serial 904179 → ManufacturingOrder   17293071
+serial 904179 → SalesOrderRow        111978788   ← already on the row we're fulfilling
 ```
 
-So integrators who can produce-to-stock have a supportable public path today. The only
-cost is the lost formal SO↔MO link (the MO is standalone, not make-to-order).
+Every minimal payload is rejected. Each request is
+`{ "sales_order_id": 46366857, "status": "DELIVERED", "sales_order_fulfillment_rows": [ <row> ] }`
+with the `<row>` (`SalesOrderFulfillmentRowRequest`) varied as below — there is no third
+option:
 
-### Make-to-order is still blocked (representation ruled out)
+| `sales_order_fulfillment_rows[]` item (+ top-level `status`)            | Response                                                                      |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `{sales_order_row_id, quantity: 1}` (no serial)                         | `422` "sum of serial number quantity (current: 0) must match … (expected: 1)" |
+| `{sales_order_row_id, quantity: 1, serial_numbers: [904179]}`           | `422` "given serial numbers have already been assigned"                       |
+| …same row, but top-level `status: "PACKED"`                             | `422` "already assigned"                                                      |
+| `{sales_order_row_id, quantity: 1, serial_numbers: []}`                 | `422` "current 0 … expected 1"                                                |
+| `{sales_order_row_id, quantity: 0}`                                     | `422` schema — quantity must be `> 0`                                         |
+| `serial_numbers: ["<name>"]` / `["<id-as-string>"]`                     | `422` schema — *must be number* (the field takes integer ids only)            |
+| `serial_number_transactions: [{serial_number_id, quantity}]` on the row | `422` "Unexpected property" (not a fulfillment-row field)                     |
 
-On a make-to-order row whose serial was produced through the linked MO, every
-representation of the fulfillment serial fails:
+- **Provide the serial** → "already assigned" (production already assigned it to the MO,
+  the production, and the SO row). It is not a representation problem: the integer id is
+  the only schema-valid form, and it is rejected *semantically*.
+- **Omit the serial** → "current 0" — the fulfillment does **not** read the serial off
+  the row; it only counts serials declared in the request.
 
-| `POST /sales_order_fulfillments` row payload                 | Result                                                             |
-| ------------------------------------------------------------ | ------------------------------------------------------------------ |
-| `serial_numbers: [<integer id>]`                             | `422` "given serial numbers have already been assigned" (semantic) |
-| `serial_numbers: ["<name>"]`                                 | `422` schema — *must be number*                                    |
-| `serial_numbers: ["<id-as-string>"]`                         | `422` schema — *must be number*                                    |
-| `serial_number_transactions: [{serial_number_id, quantity}]` | `422` "Unexpected property" (not a fulfillment-row field)          |
+The request that *should* be simplest — "deliver row `111978788`, quantity 1, using the
+serial already on it" — has **no public form**. The fulfillment endpoint's only serial
+input is the *assign* path, which the make-to-order link has already foreclosed.
 
-And the row-level transfer that works for make-to-stock is rejected here:
-`PATCH /sales_order_rows` `serial_number_transactions` → `422` "row already has serial
-number with id (…)" — the make-to-order link already consumed it onto the row. Producing
-*without* a serial and minting afterward doesn't help: minting on a make-to-order MO
-immediately writes a `SalesOrderRow -1` with **no** `Production +1`, i.e. a different
-broken trail.
-
-### The make-to-order serial-ledger lifecycle (UI-traced, 2026-06-02)
+## Why — the serial-ledger lifecycle (UI-traced)
 
 Tracing `GET /serial_numbers_stock` after each UI action — with the browser network
-panel open to capture the UI-API calls — pins down exactly which transition the public
-API is missing. A serial-tracked make-to-order order books its serial ledger in three
-steps, and **delivery does not add a transaction — it stamps a reservation already
-written at serial-generation time**:
+panel open to capture the UI-API calls — pins down which transition is missing. A
+make-to-order order books its serial ledger in three steps, and **delivery does not add
+a transaction — it stamps a reservation written back at serial-generation time**:
 
 | UI action                                        | Serial-ledger effect (`quantity_change`)                                                |
 | ------------------------------------------------ | --------------------------------------------------------------------------------------- |
@@ -208,15 +91,14 @@ written at serial-generation time**:
 Observed verbatim (serial `904176` on row `111966287`):
 
 ```text
-after MO build:   SalesOrderRow -1 (date=null)   Production +1   ManufacturingOrder +1   net=+1
-after delivery:   SalesOrderRow -1 (date=19:58:42) Production +1  ManufacturingOrder +1   net=+1
+after MO build:   SalesOrderRow -1 (date=null)     Production +1   ManufacturingOrder +1   net=+1
+after delivery:   SalesOrderRow -1 (date=19:58:42)  Production +1   ManufacturingOrder +1   net=+1
 ```
 
-So by the time you deliver, the serial is already fully consumed onto its row; the
-ledger is complete (`net=+1`, `in_stock=false`) **before** any fulfillment call. The
-delivery step only needs to *confirm* that reservation.
-
-The UI does this via its internal endpoint (captured from the browser, real values):
+So by delivery time the serial is already fully consumed onto its row and the ledger is
+complete (`net=+1`, `in_stock=false`) **before** any fulfillment call. Delivery only
+needs to *confirm* that reservation. The UI does exactly that via its internal endpoint
+(captured from the browser, real values):
 
 ```http
 POST https://sales-fulfillments.katanamrp.com/api/salesFulfillmentEvents/createMany
@@ -230,51 +112,95 @@ POST https://sales-fulfillments.katanamrp.com/api/salesFulfillmentEvents/createM
 ]
 ```
 
-Response row carries the serial as **traceability**, not an assignment:
+The response row carries the serial as **traceability**, not an assignment:
 
 ```json
 "rows": [ { "salesOrderRowId": 111966287, "quantity": 1,
             "traceability": [ { "serialNumberId": 904176, "quantity": "1" } ] } ]
 ```
 
-`serialNumberTransactions` is therefore a **confirm-the-reservation** verb. The public
-`POST /sales_order_fulfillments` only exposes `serial_numbers` (an
-**assign-a-new-serial** operation): passing the already-reserved serial → "already
-assigned"; omitting it → "current 0" (nothing new to assign). **There is no public verb
-to confirm/stamp the existing make-to-order reservation** — which is the single missing
-primitive.
+`serialNumberTransactions` here is a **confirm-the-reservation** verb. The public
+`POST /sales_order_fulfillments` only exposes `serial_numbers`, an
+**assign-a-new-serial** operation. **There is no public verb to confirm/stamp the
+existing make-to-order reservation** — that is the single missing primitive.
 
-### The `DELETE /serial_numbers` path returns 200 but corrupts the ledger — do not use it
+(Note the field-name collision: `serial_number_transactions` *also* exists on
+`PATCH /sales_order_rows/{id}`, but there it is an **assign** verb — "put this serial on
+the row." On a make-to-order row it returns `422` "row already has serial number with id
+(…)", because the link already put the serial there. Same name, opposite semantics from
+the UI's confirm verb.)
 
-`DELETE /serial_numbers` ("unassign from a resource") *can* free the serial from
-Production + ManufacturingOrder, after which `POST /sales_order_fulfillments` returns
-`200` and the SO shows `DELIVERED`. **It is data corruption, not a workaround.** It
-deletes the `+1` production transactions, leaving the serial with a lone
-`SalesOrderRow -1` (net **-1**) — a unit shipped that the ledger says was never
-produced. Side by side:
+## Make-to-stock works cleanly (verified end-to-end)
 
-```text
-UI / make-to-stock (correct):  Production +1 | MO +1 | SalesOrderRow -1   net +1
-DELETE-then-fulfill (broken):                              SalesOrderRow -1   net -1
+Producing to stock first, then selling, has a fully working public path that preserves
+the serial ledger — because the serial sits in free stock until the row transfer
+consumes it (no make-to-order link pre-consuming it):
+
+```http
+1. POST /manufacturing_orders                       # standalone MO (NOT make_to_order)
+2. POST /serial_numbers (ManufacturingOrder)         # mint on the MO
+   POST /manufacturing_order_productions (serial)    # → serial enters stock
+3. POST /sales_orders                                # order the same variant
+4. PATCH /sales_order_rows/{id}
+   { "serial_number_transactions": [ { "serial_number_id": <id>, "quantity": 1 } ] }
+                                                      # ← transfer the in-stock serial onto the row
+5. POST /sales_order_fulfillments                     # → 200, DELIVERED
+   { "sales_order_id": <so>, "status": "DELIVERED",
+     "sales_order_fulfillment_rows": [
+       { "sales_order_row_id": <row>, "quantity": 1, "serial_numbers": [ <id> ] } ] }
 ```
 
-(Note: the `DELETE /serial_numbers` `ids` field is typed `string` in the published docs
+Resulting trail is **identical to the UI's**
+(`Production +1 / ManufacturingOrder +1 / SalesOrderRow -1`, `net=+1`,
+`in_stock=false`). The only cost is the lost formal SO↔MO link (the MO is standalone,
+not make-to-order).
+
+## Everything else we tried (all rejected)
+
+| Attempt                                                                          | Result                                                                                                                   |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `PATCH /sales_orders/{id}` `{status: DELIVERED}`                                 | `200` but **no-op** — status stays `NOT_SHIPPED` (computed from fulfillments)                                            |
+| `POST /serial_numbers` (`resource_type: SalesOrderRow`) to (re)assign the serial | `422` "SalesOrderRow … is linked, serial info must be updated on MO"                                                     |
+| Mint the serial directly on the SO row (`resource_type: SalesOrderRow`)          | `422` "serial numbers not found" (serials can only be *minted* on an MO)                                                 |
+| `PATCH /sales_order_rows/{id}` `serial_number_transactions` (the transfer)       | `422` "row already has serial number with id (…)" — the link already consumed it                                         |
+| Produce **without** a serial, then mint afterward                                | mint immediately writes a `SalesOrderRow -1` with **no** `Production +1` (a different broken trail); fulfill still `422` |
+| `POST /manufacturing_order_unlink` → then fulfill                                | unlink succeeds but the serial is still MO-bound → `422` "already assigned" (and unlinking tears down a legitimate link) |
+
+## Deleting the serial bindings then fulfilling succeeds but corrupts the ledger — not a workaround
+
+`DELETE /serial_numbers` ("unassign from a resource", returns `204`) *can* free the
+serial from Production + ManufacturingOrder, after which
+`POST /sales_order_fulfillments` then succeeds (`200`) and the SO shows `DELIVERED`.
+**It is data corruption, not a fix.** It deletes the `+1` production transactions,
+leaving a lone `SalesOrderRow -1` (net **-1**) — a unit shipped that the ledger says was
+never produced:
+
+```text
+UI / make-to-stock (correct):  Production +1 | ManufacturingOrder +1 | SalesOrderRow -1   net +1
+DELETE-then-fulfill (broken):                                          SalesOrderRow -1   net -1
+```
+
+(Aside: the `DELETE /serial_numbers` `ids` field is typed `string` in the published docs
 but the live API requires **integer** ids — sending the documented type returns
 "`/ids/0` must be number".)
 
-### Narrowed ask
+## What we need (any one of these unblocks us)
 
-The blocker is precisely: **a serial that has been consumed onto its own make-to-order
-SO row cannot have a delivered fulfillment recorded against it via the public API.** Any
-one of these resolves it, mirroring what already works for make-to-stock:
+The blocker, precisely: **a serial that has been consumed onto its own make-to-order SO
+row cannot have a delivered fulfillment recorded against it via the public API.** Any
+one of these resolves it, mirroring what already works for make-to-stock and the UI:
 
-1. Accept the already-consumed serial on `POST /sales_order_fulfillments` when it is
-   bound to the *same* row being fulfilled; **or**
-1. Auto-adopt the row's serial when `serial_numbers` is omitted for a serial-tracked,
-   make-to-order row; **or**
-1. Don't auto-consume the serial onto the row at production — leave it in stock and let
-   `serial_number_transactions` / the fulfillment record the consumption (as in
-   make-to-stock).
+1. **Accept the already-consumed serial** on `POST /sales_order_fulfillments` when it is
+   bound to the *same* row being fulfilled (treat "already on this row" as valid);
+   **or**
+1. **Auto-adopt the row's serial** — when a serial-tracked, make-to-order row omits
+   `serial_numbers`, use the serial already on the row instead of returning "current 0";
+   **or**
+1. **Expose the confirm verb** — a public `serialNumberTransactions`-shaped body on
+   `POST /sales_order_fulfillments` that stamps the existing reservation (what
+   `salesFulfillmentEvents/createMany` does internally); **or**
+1. **Don't auto-consume at production** — leave the serial in stock and let the
+   fulfillment record the consumption, as make-to-stock already does.
 
 ## Minor adjacent findings (not blocking, FYI)
 
@@ -287,5 +213,6 @@ one of these resolves it, mirroring what already works for make-to-stock:
 
 ______________________________________________________________________
 
-*All IDs above are from disposable test-tenant fixtures, since deleted; the sequence
-reproduces from a clean tenant. Probed against the public API on 2026-06-01.*
+*All IDs above are from disposable test-tenant fixtures; the sequence reproduces from a
+clean tenant. Probed against the public API on 2026-06-01 and 2026-06-02, with the UI
+close-out captured via browser devtools on 2026-06-02.*


### PR DESCRIPTION
## Summary

Updates the `katana-serial-fulfillment-gap.md` escalation with a second, deeper investigation — the test tenant probed live and the UI close-out captured via browser devtools. Refs #784, #849.

**Key refinements:**

- **The gap is make-to-order specific.** Make-to-**stock** has a clean, ledger-preserving public path (standalone MO → produce serial into stock → `PATCH /sales_order_rows` `serial_number_transactions` transfer → fulfill), verified to match the UI serial trail (`Production +1 / MO +1 / SalesOrderRow −1`).
- **Representation fix ruled out.** Fulfillment `serial_numbers` requires the integer id (name/string are schema-rejected); the id is rejected *semantically* ("already assigned"); `serial_number_transactions` is not a fulfillment-row field.
- **Make-to-order serial-ledger lifecycle, traced action-by-action in the UI:** serial generation writes an **undated `SalesOrderRow −1` reservation**; MO build adds `Production +1 / MO +1`; delivery **stamps** the existing `−1` with the delivery timestamp (no new transaction). Captured the UI's `salesFulfillmentEvents/createMany` request (`serialNumberTransactions` with both `serialNumber` + `serialNumberId`) and its `traceability` response. The missing public primitive is **"confirm an existing make-to-order reservation,"** which `POST /sales_order_fulfillments` (assign-a-new-serial only) cannot express.
- **`DELETE /serial_numbers` is a data-corrupting false positive** — returns `200` but severs the production provenance (lone `SalesOrderRow −1`, net `−1`). Documented so nobody ships it as a workaround. (Also: the `ids` field is typed `string` in docs but the live API requires `integer`.)
- Narrowed the ask to Katana accordingly.

All IDs are disposable test-tenant fixtures (per the doc's existing note).

## Test plan
- [x] `mdformat` + full test suite pass (pre-commit hooks)
- [x] Docs-only change; no code/spec/generated files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)