### PR TITLE
fix(mcp): verify archival + wire-vs-literal status in make_response_verifier

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/_modification.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification.py
@@ -459,6 +459,7 @@ def make_response_verifier(
     *,
     field_map: dict[str, str] | None = None,
     value_source: Mapping[str, Callable[[Any], Any]] | None = None,
+    transforms: Mapping[str, Callable[[Any], Any]] | None = None,
 ) -> Callable[[Any], Awaitable[tuple[bool, dict[str, Any] | None]]]:
     """Build a verify closure that checks the API response body against ``diff``.
 
@@ -478,9 +479,25 @@ def make_response_verifier(
     header — without an override those fields read as ``None`` and verify
     spuriously as ``False`` on a successful update. Fields not in the map fall
     back to ``getattr(outcome, attr)`` as before.
+
+    ``transforms`` is a ``{field_name: callable(value) -> value}`` map applied to
+    **both** the requested value (``FieldChange.new``) and the actual response
+    value before they are compared. Use it to bridge wire-vs-literal differences
+    where the request carries a tool-facing literal but the response echoes
+    Katana's wire value — e.g. stock-transfer status sends ``IN_TRANSIT`` and
+    Katana echoes ``inTransit``. The transform must canonicalize both
+    representations to the same form (and be idempotent on already-wire values)
+    so verification reports a mismatch only on genuine divergence. The callable
+    may be invoked with ``None`` (when ``FieldChange.new`` or the response value
+    is ``None``) and must tolerate it without raising. The comparison runs on the
+    transformed values, but the reported ``actual_after`` mismatch dict carries
+    the *pre-transform* response value (after ``_normalize`` only — UNSET→None,
+    datetimes→ISO, enums→``.value``), so debugging shows the response value
+    rather than the transform's canonical form.
     """
     name_map = field_map or {}
     source_map = value_source or {}
+    transform_map = transforms or {}
 
     async def verify(outcome: Any) -> tuple[bool, dict[str, Any] | None]:
         if outcome is None:
@@ -495,8 +512,14 @@ def make_response_verifier(
                 attr = name_map.get(change.field, change.field)
                 raw = getattr(outcome, attr, None)
             actual_val = _normalize(unwrap_unset(raw, None))
+            # Report the normalized pre-transform response value; compare on the
+            # canonical form so a wire-vs-literal skew (``inTransit`` vs
+            # ``IN_TRANSIT``) isn't flagged.
             actual[change.field] = actual_val
-            if change.new is not None and actual_val != change.new:
+            fn = transform_map.get(change.field)
+            expected = fn(change.new) if fn else change.new
+            actual_cmp = fn(actual_val) if fn else actual_val
+            if change.new is not None and actual_cmp != expected:
                 verified = False
         return verified, (actual if not verified else None)
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -1429,11 +1429,13 @@ def coerce_variant_config_attributes(
 # Service header fields that Katana echoes on the nested first variant of the
 # updated ``Service`` rather than on the Service object itself — the response
 # verifier must read them from ``outcome.variants[0]`` or they read as ``None``
-# and verify spuriously as False on a successful update. Only these three need
-# the override: the other ``ItemHeaderPatch`` fields valid for services
-# (``name``, ``uom``, ``category_name``, ``is_sellable``, ``additional_info``,
-# ``is_archived``) echo correctly on the top-level ``Service`` and verify via
-# the default ``getattr(outcome, ...)`` path.
+# and verify spuriously as False on a successful update. ``is_archived`` also
+# needs a ``value_source`` override (derived from ``archived_at`` — see the
+# ``header_value_source`` build below), but that one is wired for ALL item types,
+# not just services. The remaining ``ItemHeaderPatch`` fields valid for services
+# (``name``, ``uom``, ``category_name``, ``is_sellable``, ``additional_info``)
+# echo correctly on the top-level ``Service`` and verify via the default
+# ``getattr(outcome, ...)`` path.
 _SERVICE_VARIANT_VERIFY_FIELDS = ("sales_price", "default_cost", "sku")
 
 
@@ -1641,13 +1643,23 @@ async def _modify_item_impl(
         diff = compute_field_diff(
             existing_item, request.update_header, unknown_prior=existing_item is None
         )
+        # Katana accepts a boolean ``is_archived`` on write but echoes the
+        # post-state as an ``archived_at`` timestamp (no boolean on any read
+        # model) — derive the bool from the timestamp or every archive/unarchive
+        # reports a spurious mismatch. Mirrors the ``is_archived <- archived_at``
+        # convention used across the server (``_fetch_item_for_diff``,
+        # ``prefab_ui``, ``typed_cache.queries``).
+        header_value_source: dict[str, Callable[[Any], Any]] = {
+            "is_archived": lambda o: (
+                unwrap_unset(getattr(o, "archived_at", UNSET), None) is not None
+            )
+        }
         # Services echo pricing/SKU on the nested first variant, not the
         # Service header — point the verifier at the variant for those fields.
-        header_value_source = (
-            {f: _service_variant_value(f) for f in _SERVICE_VARIANT_VERIFY_FIELDS}
-            if request.type == ItemType.SERVICE
-            else None
-        )
+        if request.type == ItemType.SERVICE:
+            header_value_source.update(
+                {f: _service_variant_value(f) for f in _SERVICE_VARIANT_VERIFY_FIELDS}
+            )
         plan.append(
             ActionSpec(
                 operation=ItemOperation.UPDATE_HEADER,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/stock_transfers.py
@@ -99,6 +99,22 @@ def _status_literal_to_enum(status: StatusLiteral) -> StockTransferStatus:
     return _STATUS_API_VALUE[status]
 
 
+def _status_to_wire(value: Any) -> Any:
+    """Canonicalize any status representation to Katana's wire string.
+
+    The response verifier compares the requested value (the tool-facing literal
+    ``IN_TRANSIT``) against the echoed response status (Katana's wire value
+    ``inTransit``). Mapping both sides to the wire form means verification fails
+    only on a genuine divergence. Accepts a ``StockTransferStatus`` enum, a
+    tool-facing literal, or an already-wire string; idempotent on the latter,
+    and unknown values pass through unchanged.
+    """
+    if isinstance(value, StockTransferStatus):
+        return value.value
+    enum = _STATUS_API_VALUE.get(value)
+    return enum.value if enum is not None else value
+
+
 # ============================================================================
 # Shared response models
 # ============================================================================
@@ -933,11 +949,17 @@ async def _modify_stock_transfer_impl(
                     _build_update_status_request(request.update_status),
                     return_type=StockTransfer,
                 ),
-                # No verify — status returned by the API uses Katana's wire
-                # value (``inTransit``) while the request carries the tool-
-                # facing literal (``IN_TRANSIT``); the response-verifier would
-                # report a spurious mismatch. The action's success/error is
-                # still reflected in ``ActionResult.succeeded``.
+                # The status returned by the API uses Katana's wire value
+                # (``inTransit``) while the request carries the tool-facing
+                # literal (``IN_TRANSIT``), and the patch field is ``new_status``
+                # while the response attr is ``status``. ``field_map`` bridges the
+                # name; ``_status_to_wire`` canonicalizes both sides so the
+                # verifier flags a mismatch only on genuine divergence.
+                verify=make_response_verifier(
+                    diff,
+                    field_map={"new_status": "status"},
+                    transforms={"new_status": _status_to_wire},
+                ),
             )
         )
 

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -2131,6 +2131,139 @@ async def test_modify_item_service_header_verifies_pricing_from_variant():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("item_type", "update_path", "get_path"),
+    [
+        (
+            ItemType.PRODUCT,
+            "katana_public_api_client.api.product.update_product.asyncio_detailed",
+            "katana_public_api_client.api.product.get_product.asyncio_detailed",
+        ),
+        (
+            ItemType.MATERIAL,
+            "katana_public_api_client.api.material.update_material.asyncio_detailed",
+            "katana_public_api_client.api.material.get_material.asyncio_detailed",
+        ),
+        (
+            ItemType.SERVICE,
+            "katana_public_api_client.api.services.update_service.asyncio_detailed",
+            "katana_public_api_client.api.services.get_service.asyncio_detailed",
+        ),
+    ],
+    ids=["product", "material", "service"],
+)
+@pytest.mark.parametrize("archive", [True, False], ids=["archive", "unarchive"])
+async def test_modify_item_archival_verifies_off_archived_at(
+    item_type: ItemType, update_path: str, get_path: str, archive: bool
+):
+    """Archive/unarchive verifies via ``archived_at``, not a missing bool.
+
+    Katana accepts a boolean ``is_archived`` on write but echoes the post-state
+    as an ``archived_at`` timestamp — no boolean exists on any read model. The
+    verifier must derive the bool from the timestamp or every archive/unarchive
+    reports a spurious "verification mismatch". Covers both directions across
+    all three item types. Before the fix the archive case verified as ``False``.
+    """
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        ModifyItemRequest,
+        _modify_item_impl,
+    )
+
+    context, _ = create_mock_context()
+    stamp = datetime.datetime(2026, 6, 3, 15, 33, 19, tzinfo=datetime.UTC)
+
+    # Diff fetch: ``archived_at`` reflects the *pre*-state. ``additional_info``
+    # set to None so the bare MagicMock doesn't auto-vivify it into the
+    # additional-info echo path; ``variants`` empty for the service branch.
+    existing = MagicMock()
+    existing.id = 7
+    existing.additional_info = None
+    existing.variants = []
+    existing.archived_at = None if archive else stamp
+
+    # Apply outcome echoes the *post*-state: ``archived_at`` set on archive,
+    # cleared on unarchive. No boolean ``is_archived`` on the response — the
+    # verifier derives it from the timestamp via the header value_source.
+    outcome = MagicMock()
+    outcome.id = 7
+    outcome.variants = []
+    outcome.archived_at = stamp if archive else None
+
+    with (
+        patch(update_path, new_callable=AsyncMock),
+        patch(get_path, new_callable=AsyncMock),
+        # diff-fetch unwrap_as -> existing; apply unwrap_as -> outcome.
+        patch(_MODIFY_ITEM_UNWRAP_AS, side_effect=[existing, outcome]),
+    ):
+        request = ModifyItemRequest(
+            id=7,
+            type=item_type,
+            update_header=ItemHeaderPatch(is_archived=archive),
+            preview=False,
+        )
+        response = await _modify_item_impl(request, context)
+
+    action = response.actions[0]
+    assert action.operation == "update_header"
+    assert action.succeeded is True
+    assert action.verified is True
+    assert action.actual_after is None
+
+
+@pytest.mark.asyncio
+async def test_modify_item_archive_verifies_when_diff_fetch_misses():
+    """Archive still verifies via ``archived_at`` when the prior fetch fails.
+
+    A 404/timeout on the diff fetch makes ``_fetch_item_for_diff`` return None,
+    so the change is marked ``is_unknown_prior`` — but verification still runs
+    against the apply outcome. The ``is_archived`` value_source must derive the
+    bool from ``archived_at`` on that outcome regardless of the missing prior.
+    """
+    from katana_mcp.tools.foundation.items import (
+        ItemHeaderPatch,
+        ModifyItemRequest,
+        _modify_item_impl,
+    )
+
+    context, _ = create_mock_context()
+    stamp = datetime.datetime(2026, 6, 3, 15, 33, 19, tzinfo=datetime.UTC)
+    outcome = MagicMock()
+    outcome.id = 7
+    outcome.variants = []
+    outcome.archived_at = stamp
+
+    with (
+        patch(
+            "katana_public_api_client.api.product.update_product.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "katana_public_api_client.api.product.get_product.asyncio_detailed",
+            new_callable=AsyncMock,
+        ),
+        # diff-fetch unwrap_as raises -> safe_fetch_for_diff returns None
+        # (unknown prior); apply unwrap_as -> outcome.
+        patch(
+            _MODIFY_ITEM_UNWRAP_AS,
+            side_effect=[RuntimeError("diff fetch failed"), outcome],
+        ),
+    ):
+        request = ModifyItemRequest(
+            id=7,
+            type=ItemType.PRODUCT,
+            update_header=ItemHeaderPatch(is_archived=True),
+            preview=False,
+        )
+        response = await _modify_item_impl(request, context)
+
+    action = response.actions[0]
+    assert action.succeeded is True
+    assert action.verified is True
+    assert action.actual_after is None
+
+
+@pytest.mark.asyncio
 async def test_modify_item_add_variant_injects_parent_id_for_product():
     from katana_mcp.tools.foundation.items import (
         ModifyItemRequest,

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -189,6 +189,53 @@ async def test_response_verifier_passes_when_decimal_string_equals_int():
     assert actual is None
 
 
+@pytest.mark.asyncio
+async def test_response_verifier_transforms_bridge_wire_vs_literal():
+    """``transforms`` canonicalizes both sides so a wire-vs-literal value
+    verifies cleanly.
+
+    The stock-transfer status case: the request carries the tool-facing literal
+    ``IN_TRANSIT`` (on the patch field ``new_status``) while Katana echoes the
+    wire value ``inTransit`` (on the response attr ``status``). ``field_map``
+    bridges the name; the transform maps both representations to the wire form,
+    so verification passes. Without it the verifier read ``inTransit != IN_TRANSIT``
+    and reported a spurious mismatch (the reason the action skipped verify).
+    """
+    wire = {"IN_TRANSIT": "inTransit", "DRAFT": "draft", "RECEIVED": "received"}
+
+    def to_wire(value: Any) -> Any:
+        return wire.get(value, value)
+
+    diff = [FieldChange(field="new_status", old=None, new="IN_TRANSIT")]
+    verify = make_response_verifier(
+        diff, field_map={"new_status": "status"}, transforms={"new_status": to_wire}
+    )
+    outcome = MagicMock()
+    outcome.status = "inTransit"
+    verified, actual = await verify(outcome)
+    assert verified is True
+    assert actual is None
+
+
+@pytest.mark.asyncio
+async def test_response_verifier_transforms_still_flags_real_divergence():
+    """A genuine post-canonicalization divergence still reports a mismatch."""
+    wire = {"IN_TRANSIT": "inTransit", "RECEIVED": "received"}
+
+    def to_wire(value: Any) -> Any:
+        return wire.get(value, value)
+
+    diff = [FieldChange(field="new_status", old=None, new="IN_TRANSIT")]
+    verify = make_response_verifier(
+        diff, field_map={"new_status": "status"}, transforms={"new_status": to_wire}
+    )
+    outcome = MagicMock()
+    outcome.status = "received"  # server landed a different status than requested
+    verified, actual = await verify(outcome)
+    assert verified is False
+    assert actual == {"new_status": "received"}
+
+
 def test_compute_field_diff_field_map_renames_attr_lookup():
     existing = MagicMock()
     existing.real_name = "old"  # entity uses `real_name`, request uses `name`

--- a/katana_mcp_server/tests/tools/test_stock_transfers.py
+++ b/katana_mcp_server/tests/tools/test_stock_transfers.py
@@ -839,12 +839,44 @@ async def test_modify_st_status_confirm_dispatches_to_status_endpoint():
     assert len(response.actions) == 1
     assert response.actions[0].operation == "update_status"
     assert response.actions[0].succeeded is True
+    # The status action now verifies: the request literal ``IN_TRANSIT`` and the
+    # echoed wire value ``inTransit`` both canonicalize to ``inTransit`` via the
+    # ``_status_to_wire`` transform. Previously verify was skipped (verified=None)
+    # because a verbatim compare would falsely fail on the wire-vs-literal skew.
+    assert response.actions[0].verified is True
     mock_status.assert_awaited_once()
     assert mock_status.await_args is not None
     kwargs = mock_status.await_args.kwargs
     assert kwargs["id"] == 42
     # The API status enum should be the camelCase wire value ``inTransit``.
     assert kwargs["body"].status.value == "inTransit"
+
+
+@pytest.mark.asyncio
+async def test_modify_st_status_verify_flags_wire_value_divergence():
+    """A status that lands differently server-side reports a real mismatch.
+
+    Requesting ``IN_TRANSIT`` but the API echoing ``received`` must surface as
+    ``verified=False`` — the transform canonicalizes both sides, so this is a
+    genuine divergence, not the wire-vs-literal false positive the skip avoided.
+    """
+    context, _ = create_mock_context()
+    mock_transfer = _make_mock_transfer(id=42, status="received")
+    with (
+        patch(f"{_ST_UPDATE_STATUS}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_MODIFY_ST_UNWRAP_AS, return_value=mock_transfer),
+    ):
+        request = ModifyStockTransferRequest(
+            id=42,
+            update_status=StockTransferStatusPatch(new_status="IN_TRANSIT"),
+            preview=False,
+        )
+        response = await _modify_stock_transfer_impl(request, context)
+
+    action = response.actions[0]
+    assert action.succeeded is True
+    assert action.verified is False
+    assert action.actual_after == {"new_status": "received"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two post-modify-verifier false "verification mismatch" bugs share one root cause: `make_response_verifier` compared the requested value against a response field read **verbatim**, ignoring Katana's write-shape ≠ read-shape asymmetry. A successful mutation then reported `APPLIED (verification mismatch)`.

**Bug A — archive/unarchive.** `modify_item` writes a boolean `is_archived`, but Katana echoes the post-state as an `archived_at` timestamp — no boolean exists on any read model. The verifier read a nonexistent `is_archived` attr → `None != True` → spurious mismatch on every archive. This was previously rationalized as a "known Katana quirk where the archived state shows via the timestamp rather than the boolean" — that was a **misdiagnosis**; Katana's contract is internally consistent. Fixed via the existing `value_source=` param, deriving the bool from `archived_at` for all three item types (mirrors the `is_archived ← archived_at` convention already used across the server in `_fetch_item_for_diff`, `prefab_ui`, and `typed_cache.queries`).

**Bug B — stock-transfer status (#465).** `update_status` skipped verification entirely because the request literal `IN_TRANSIT` differs from Katana's wire value `inTransit`, and the patch field `new_status` differs from the response attr `status`. Added a `transforms=` param to `make_response_verifier` (applied to **both** the requested and actual values before comparison) plus a `_status_to_wire` normalizer, and wired `field_map` + `transforms` so the action verifies instead of silently skipping.

### Scope audit (all 6 verifier call sites)

The fix surface is exactly these two — verified, not assumed:

- **SO / PO / MO `status`** verify cleanly today: `_normalize` already coerces a response enum to its `.value`, and `SalesOrderStatus` / `PurchaseOrderStatus` / `ManufacturingOrderStatus` all have `.value` **equal** to the uppercase tool literal. Only `StockTransferStatus` uses camelCase/lowercase wire values (`draft` / `inTransit` / `received`).
- **`is_deleted`** runs through `run_delete_plan` (HTTP-success verification), not this field-comparison path; no modify/update request writes `is_deleted`/`deleted_at`.
- **Service pricing** (`sales_price`/`default_cost`/`sku`) already handled by the existing `value_source`.

Closes #465

## Test plan

- [x] `uv run poe check` — 3894 unit + 47 browser tests pass
- [x] 6 archival cases (3 item types × archive/unarchive) verify clean; regression-confirmed to fail without the fix
- [x] Unknown-prior (diff-fetch miss) archival case still verifies
- [x] `transforms=` unit tests: wire-vs-literal passes; genuine divergence still flags a mismatch
- [x] Stock-transfer `update_status` now asserts `verified=True`; a divergent landed status reports `verified=False` with raw `actual_after`

🤖 Generated with [Claude Code](https://claude.com/claude-code)