### PR TITLE
fix(ci): re-lock uv.lock against post-release main so it never lags (closes #901)

### DIFF
--- a/.github/agents/guides/shared/COMMIT_STANDARDS.md
+++ b/.github/agents/guides/shared/COMMIT_STANDARDS.md
@@ -288,9 +288,14 @@ and the upstream-drift audit workflow.
 
 ## Lockfile Drift
 
-When `uv.lock` shows up modified but you didn't touch dependencies (e.g., a
-sibling-package release on `main` bumped a workspace version), `git add uv.lock` and
-bundle it into your current commit.
+The release workflow re-locks `uv.lock` to the just-released versions and commits it to
+`main` as part of every release (the `sync-lockfile` job in `release.yml`), so `main`
+should always ship a lockfile that matches its `pyproject.toml` versions (#901). You
+should rarely see workspace-version drift on a fresh branch anymore.
+
+If `uv.lock` *does* show up modified but you didn't touch dependencies (e.g. you
+branched in the brief window between a release commit and its lock-sync commit, or a
+genuine transitive bump), `git add uv.lock` and bundle it into your current commit.
 
 **Don't `git checkout -- uv.lock` to drop it**: pre-commit's auto-stash/restore fights
 with the lockfile being regenerated mid-hook (pytest's `uv run` re-syncs it), producing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,13 +230,34 @@ jobs:
       (needs.release-client.outputs.released == 'true' ||
        needs.release-mcp.outputs.released == 'true')
     runs-on: ubuntu-latest
+    # Serialize this job across overlapping Release runs: it pushes to main, so
+    # two concurrent instances could race (the second push rejected as
+    # non-fast-forward). Queueing (cancel-in-progress: false) means a later run
+    # re-locks on top of the earlier run's lock commit instead of clobbering it.
+    concurrency:
+      group: sync-lockfile
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
+      # CRITICAL: check out the *post-release* tip of main, not the workflow's
+      # triggering SHA. python-semantic-release (in the release-client /
+      # release-mcp jobs this job `needs`) pushes the `chore(release)` version
+      # bump commits to main *after* this run started, so the default
+      # checkout (github.sha = the pre-release commit) would carry the OLD
+      # pyproject versions — re-locking there would be a no-op and the lock
+      # would never catch up (#901). `ref: main` + an explicit reset to
+      # origin/main guarantees we see the bumped versions before re-locking.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: main
           token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+
+      - name: Fast-forward to the post-release tip of main
+        run: |
+          git fetch origin main
+          git reset --hard origin/main
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -245,13 +266,15 @@ jobs:
           cache-dependency-glob: "uv.lock"
           python-version: "3.14"
 
-      - name: Sync lockfile
-        run: uv sync --all-extras
+      # `uv lock` updates only the lockfile (no env install needed) to match the
+      # just-bumped package versions in pyproject.toml.
+      - name: Re-lock to match the released versions
+        run: uv lock
 
       - name: Commit if changed
         run: |
           if git diff --quiet uv.lock; then
-            echo "uv.lock is up to date"
+            echo "uv.lock already matches the released versions"
           else
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

`main` keeps shipping a `uv.lock` whose workspace-package version lags the just-released `pyproject.toml`, so every feature branch that runs `uv` (pre-commit / pre-push) re-resolves the lock, produces a spurious one-line version diff, and collides with pre-commit's stash/pop dance (#901). During #837 this forced ~5 manual `chore: sync uv.lock` commits in one session; it bit again on the `0.109.0` release an hour ago.

## Root cause

A `sync-lockfile` job **already exists** to prevent this — but it never worked. Its `actions/checkout` had no `ref:`, so on a `push` event it checks out `github.sha`, the commit that *triggered* the run (**pre-release**). `python-semantic-release` pushes the `chore(release)` version-bump commits *afterward*, in the sibling `release-client` / `release-mcp` jobs. So `sync-lockfile` ran `uv sync` against the **old** pyproject versions, the lock already matched → it committed nothing. Tell-tale: its commit message `"chore: sync uv.lock after release"` appears **nowhere** in git history — only manual/agent catch-ups (`"sync root uv.lock to…"`) do.

## Fix

In the `sync-lockfile` job:
- check out `ref: main` and `git reset --hard origin/main` so it sees the just-pushed version bumps before re-locking;
- run `uv lock` (lockfile-only, no env install) instead of `uv sync --all-extras`;
- the existing commit-if-changed step now actually has a diff to commit + push.

**Why the post-release job (not a semantic-release hook):** two independent release jobs (client + mcp) share one root `uv.lock`. Re-locking once, after *both* releases, captures *both* bumps. A per-job PSR `build_command` hook can't — PSR only commits its own version/changelog files, and each job would see only its own bump.

Also updated `COMMIT_STANDARDS.md` "Lockfile Drift" — main now ships a synced lock, so fresh-branch drift should be rare (only the brief window between a release commit and its lock-sync commit, or a genuine transitive bump).

## Test plan
- [x] `yamllint` + YAML parse clean on `release.yml`
- [x] `uv lock` is a no-op on current `main` (confirms the lockfile matches and the command produces no spurious diff when in sync)
- [ ] **Verified at next release**: after a client/mcp release, `main`'s `uv.lock` matches the bumped versions and a fresh `uv lock` / `uv sync` leaves the tree clean (the issue's acceptance criterion). Can't be exercised pre-merge — only a real release on `main` triggers the job.

## Note / optional follow-up
There's still a short window between the `chore(release)` commit and the `sync-lockfile` commit where `main`'s lock is briefly stale. A defensive `uv lock --locked` CI check on PRs would turn any residual drift into a loud, early failure instead of a pre-commit stash fight — happy to add it if you want, but it can false-positive during that window so I left it out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)