### PR TITLE
fix(mcp): cut modify_manufacturing_order post-apply latency from the rate-limit gate

### DIFF
--- a/katana_mcp_server/docs/LOGGING.md
+++ b/katana_mcp_server/docs/LOGGING.md
@@ -234,30 +234,48 @@ Example with metrics:
 ### Modify-pipeline sub-step timing (`modify_manufacturing_order`)
 
 `_modify_manufacturing_order_impl`
-(`katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py`) emits
-three sub-step `duration_ms` events on the `preview=false` path so the next 30s+ slow
+(`katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py`) emits up
+to three sub-step `duration_ms` events on the `preview=false` path so the next 30s+ slow
 call leaves a diagnostic breadcrumb (#853, refs #786). Grep your structlog output for:
 
-| Event                                | Step                                        | Wraps                                                      |
-| ------------------------------------ | ------------------------------------------- | ---------------------------------------------------------- |
-| `mo_modify_patch_completed`          | The Katana PATCH apply (header update)      | `api_update_manufacturing_order.asyncio_detailed`          |
-| `mo_modify_verify_refetch_completed` | Sibling recipe-row re-fetch for cache merge | `_fetch_mo_recipe_row_attrs_for_cache_merge`               |
-| `mo_modify_cache_merge_completed`    | Parent MO GET re-fetch inside cache merge   | `_fetch_manufacturing_order_attrs` via `refetch_for_merge` |
+| Event                                | Step                                                                            | Wraps                                                      |
+| ------------------------------------ | ------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `mo_modify_patch_completed`          | The Katana PATCH apply (header update)                                          | `api_update_manufacturing_order.asyncio_detailed`          |
+| `mo_modify_verify_refetch_completed` | Sibling recipe-row re-fetch for cache merge                                     | `_fetch_mo_recipe_row_attrs_for_cache_merge`               |
+| `mo_modify_cache_merge_completed`    | Parent MO GET re-fetch inside cache merge — **fallback-only** (#786, see below) | `_fetch_manufacturing_order_attrs` via `refetch_for_merge` |
 
 Each event carries `step`, `duration_ms`, `success`, and `manufacturing_order_id` (the
 `success` field name matches the sibling `tool_completed` /
 `service_operation_completed` events in `katana_mcp/logging.py`, so any log-aggregation
-query that joins on the `success` boolean will see all of these events too). Note that
-not every `preview=false` call emits all three: `mo_modify_patch_completed` only fires
-when the plan includes a header PATCH (`request.update_header is not None`), and the
-cache-merge / verify-refetch events only fire when at least one action runs (the
-cache-merge pass is gated on `actions` inside `run_modify_plan`). The pre-existing
+query that joins on the `success` boolean will see all of these events too). Note that a
+normal `preview=false` call emits at most two: `mo_modify_patch_completed` only fires
+when the plan includes a header PATCH (`request.update_header is not None`), and
+`mo_modify_verify_refetch_completed` only fires when at least one action runs (the
+cache-merge pass is gated on `actions` inside `run_modify_plan`).
+`mo_modify_cache_merge_completed` is **fallback-only** — see the #786 note below — so on
+the normal path you'll see just patch + verify-refetch. The pre-existing
 `tool_completed` event (from `@observe_tool`) gives end-to-end `duration_ms`; subtract
 whichever sub-step events were emitted to see how much fell to local work (plan build,
 action dispatch, cache write-through).
 
-Pattern is MO-only today — once #786 picks a fix path, the equivalent timing can be
-extracted into a shared dispatcher helper.
+**`mo_modify_cache_merge_completed` no longer fires on the normal path (#786).** The
+diagnostic data this instrumentation captured pinned the 30s+ stall to Katana's
+60-req/min rate-limit reset gate (`RateLimitTransport`), not a genuinely slow fetch:
+when the budget is exhausted mid-workflow a post-apply GET blocks for the remainder of
+the window (observed 40–47s). The fix wired `CacheMerge.parent_from_outcome=True` for
+the MO modify, so the post-apply merge reuses the PATCH response instead of re-GETting
+the parent — the `refetch_for_merge` wrapper (and its `cache_merge` span) now only runs
+as a fallback when a plan has no parent action. The remaining post-apply network
+refetches are time-bounded (`_CACHE_MERGE_FETCH_TIMEOUT_S` in `_modification_dispatch`):
+a refetch that stalls on the gate is abandoned best-effort (cache recovers on the next
+sync) rather than hanging the already-succeeded tool call. **Residual:** if the gate
+engages *before* the PATCH, the essential write itself waits out the window — that is
+fundamental rate-limiting, not a spurious hang, and the change has not yet applied in
+that case.
+
+Pattern is MO-only today; the `parent_from_outcome` + time-bound plumbing lives in the
+shared dispatcher (`CacheMerge` / `_post_apply_cache_merge`) and other `modify_*` tools
+can opt in.
 
 ## Observability Decorators
 

--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -90,6 +90,19 @@ logger = get_logger(__name__)
 _MISSING: Any = object()
 
 
+# Per-fetch ceiling for the best-effort post-apply cache merge (#786). The
+# proactive rate-limit reset gate (``RateLimitTransport``) blocks a request
+# for the remainder of Katana's 60-req/min window — observed at 40-47s — when
+# the budget is exhausted mid-workflow. The post-apply merge is best-effort
+# (its failures already just log and recover on the next sync), so a refetch
+# that lands during a gate window must NOT make a successful write wait out the
+# whole reset. We bound only the *network* refetch awaits (cancel-safe httpx),
+# never the aiosqlite writes (cancelling those mid-statement risks leaving the
+# shared connection in a bad state). 8s clears normal sub-second refetch
+# latency with wide headroom while capping the pathological gate stall.
+_CACHE_MERGE_FETCH_TIMEOUT_S = 8.0
+
+
 # ``apply`` callable: returns whatever the API call yields (typically the
 # parsed response model). Returned to ``verify`` so verification can use it
 # (e.g. confirm a created row's id matches what we expected).
@@ -166,11 +179,24 @@ class CacheMerge:
     Tools that lack a GET-by-id endpoint (stock_transfers) simply omit
     ``cache_merge`` entirely — their cache stays stale on modify until
     the next sync window.
+
+    - ``parent_from_outcome`` — when True, the post-apply merge reuses the
+      parent-targeted action's PATCH response (``apply_outcome``) as the
+      merge source instead of calling ``refetch_for_merge``. The PATCH
+      response is the full updated parent (e.g. an MO endpoint returns a
+      complete ``ManufacturingOrder``), so this saves one GET per modify
+      *and* is strictly fresher than the GET (no read-replica lag — see
+      ``_collect_parent_field_overlay``). #786: each ``modify_*`` post-apply
+      GET can hit the proactive rate-limit reset gate and stall ~40s; cutting
+      the parent GET removes one such opportunity. ``refetch_for_merge`` is
+      still required as the fallback for when no parent ``apply_outcome`` is
+      available (e.g. a plan with only row actions).
     """
 
     cache: TypedCacheEngine
     refetch_for_merge: Callable[[int], Awaitable[Any | None]]
     refetch_related: tuple[tuple[str, Callable[[int], Awaitable[list[Any]]]], ...] = ()
+    parent_from_outcome: bool = False
 
 
 @dataclass
@@ -846,12 +872,22 @@ async def run_modify_plan(
         and not any(a.succeeded is False for a in actions)
     ):
         parent_field_overlay = _collect_parent_field_overlay(actions, request.id)
+        # #786: when the tool opts in, feed the parent's PATCH response straight
+        # into the merge instead of re-GETting it — one fewer call that could
+        # stall on the rate-limit reset gate. Falls back to the (time-bounded)
+        # refetch when no parent action produced an outcome (e.g. row-only plan).
+        parent_override = (
+            _parent_outcome_for_merge(actions, request.id)
+            if cache_merge.parent_from_outcome
+            else None
+        )
         try:
             await _post_apply_cache_merge(
                 cache_merge=cache_merge,
                 entity_type=entity_type,
                 entity_id=request.id,
                 parent_field_overlay=parent_field_overlay,
+                parent_override=parent_override,
             )
         except asyncio.CancelledError:
             # Cooperative cancellation (request timeout, shutdown) must
@@ -915,12 +951,43 @@ def _collect_parent_field_overlay(
     return overlay
 
 
+def _parent_outcome_for_merge(
+    actions: list[ActionResult],
+    entity_id: int | str,
+) -> Any | None:
+    """Return the parent entity's PATCH ``apply_outcome``, or None.
+
+    Used when ``CacheMerge.parent_from_outcome`` is set: the post-apply merge
+    writes this full PATCH response through instead of re-GETting the parent
+    (#786). The **last** successful parent-targeted action (``target_id ==
+    entity_id``) wins — its outcome is the freshest parent post-state. Crucially
+    that holds even when the last such action's ``apply_outcome`` is ``None``
+    (e.g. a 204 PATCH): an *earlier* action's outcome predates the last action's
+    changes and would be stale, so we return ``None`` and let the caller fall
+    back to the time-bounded ``refetch_for_merge`` rather than merging a
+    superseded body. Returns ``None`` when there's no parent-targeted action at
+    all (e.g. a row-only plan), same fallback.
+    """
+    parent_outcome: Any | None = None
+    for action in actions:
+        if action.succeeded is not True:
+            continue
+        if action.target_id != entity_id:
+            continue
+        # Last parent-targeted action wins — assign unconditionally so a None
+        # outcome on the final parent action correctly clears an earlier
+        # (now-stale) one and triggers the refetch fallback.
+        parent_outcome = action.apply_outcome
+    return parent_outcome
+
+
 async def _post_apply_cache_merge(
     *,
     cache_merge: CacheMerge,
     entity_type: str,
     entity_id: int,
     parent_field_overlay: dict[str, Any] | None = None,
+    parent_override: Any | None = None,
 ) -> None:
     """Re-fetch the modified entity from Katana and merge into the typed cache.
 
@@ -934,6 +1001,13 @@ async def _post_apply_cache_merge(
     for fields we just asked to change. See the call-site comment in
     ``run_modify_plan`` for the full reasoning. Empty/None means no
     overlay; the unmodified GET result merges through.
+
+    ``parent_override`` supplies the parent attrs directly (the PATCH
+    ``apply_outcome``) when ``CacheMerge.parent_from_outcome`` is set,
+    skipping the ``refetch_for_merge`` GET entirely (#786). When None the
+    parent is fetched as before, but that fetch is now time-bounded — a
+    refetch that stalls on the rate-limit reset gate is abandoned rather
+    than hanging the whole tool call; the cache recovers on the next sync.
 
     For entities whose ``EntitySpec.related_specs`` reference data at
     separate API endpoints (MO recipe rows, sibling row-watermarks), the
@@ -950,14 +1024,39 @@ async def _post_apply_cache_merge(
     if spec is None:
         return  # entity not cached — nothing to merge
 
-    parent = await cache_merge.refetch_for_merge(entity_id)
+    if parent_override is not None:
+        # PATCH response stands in for the GET (CacheMerge.parent_from_outcome):
+        # no network call, and fresher than a read-replica GET.
+        parent = parent_override
+    else:
+        try:
+            parent = await asyncio.wait_for(
+                cache_merge.refetch_for_merge(entity_id),
+                timeout=_CACHE_MERGE_FETCH_TIMEOUT_S,
+            )
+        # ``wait_for`` raises ``TimeoutError`` (a plain ``Exception``); genuine
+        # external cancellation raises ``CancelledError`` (a ``BaseException``),
+        # which is NOT caught here and propagates cleanly — same contract as the
+        # related-refetch block below, which spells the re-raise out explicitly.
+        except TimeoutError:
+            logger.warning(
+                f"Post-apply parent refetch for {entity_type} {entity_id} "
+                f"exceeded {_CACHE_MERGE_FETCH_TIMEOUT_S}s (likely rate-limit "
+                f"backoff) — skipping merge. Cache recovers on next sync."
+            )
+            return
     if parent is None:
         return  # fetch returned nothing (e.g., the entity was deleted)
 
     # Overlay fresh PATCH-response values onto the (possibly stale) GET
     # refetch. Generated attrs models are mutable (no ``frozen=True``);
     # the ``_MISSING`` sentinel tolerates future PATCH/GET shape divergence.
-    if parent_field_overlay:
+    # Skip entirely when ``parent`` IS the PATCH response (``parent_override``):
+    # the overlay only exists to defeat read-replica lag on the GET, so it's a
+    # no-op there — and applying it would mutate the live ``apply_outcome``
+    # object in place (an aliased write surprising to anyone who later reads
+    # ``ActionResult.apply_outcome``).
+    if parent_field_overlay and parent_override is None:
         for field_name, fresh_value in parent_field_overlay.items():
             if getattr(parent, field_name, _MISSING) is not _MISSING:
                 setattr(parent, field_name, fresh_value)
@@ -983,7 +1082,20 @@ async def _post_apply_cache_merge(
             )
             continue
         try:
-            related_rows = await refetcher(entity_id)
+            related_rows = await asyncio.wait_for(
+                refetcher(entity_id), timeout=_CACHE_MERGE_FETCH_TIMEOUT_S
+            )
+        except TimeoutError:
+            # #786: a related refetch (e.g. MO recipe rows) that lands during
+            # the rate-limit reset gate would otherwise stall the whole tool
+            # call ~40s. Best-effort — skip and let the next sync reconcile.
+            logger.warning(
+                f"Refetch of related {related_key!r} for {entity_type} "
+                f"{entity_id} exceeded {_CACHE_MERGE_FETCH_TIMEOUT_S}s "
+                f"(likely rate-limit backoff). Related cache table may be "
+                f"stale until next sync."
+            )
+            continue
         except asyncio.CancelledError:
             # Propagate cancellation — see the outer handler's note.
             raise

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/manufacturing_orders.py
@@ -3267,6 +3267,13 @@ async def _modify_manufacturing_order_impl(
                     _timed_refetch_recipe_rows,
                 ),
             ),
+            # #786: the MO PATCH response is a full ``ManufacturingOrder``, so
+            # the post-apply parent merge reuses it instead of a separate GET —
+            # one fewer call per modify that could stall on the rate-limit reset
+            # gate (the 30s+ hang). The recipe-row ``refetch_related`` above is
+            # still issued (and now time-bounded by the dispatcher) so row edits
+            # stay cache-consistent.
+            parent_from_outcome=True,
         ),
     )
 

--- a/katana_mcp_server/tests/tools/test_manufacturing_orders.py
+++ b/katana_mcp_server/tests/tools/test_manufacturing_orders.py
@@ -2845,19 +2845,23 @@ async def test_modify_mo_confirm_executes_in_canonical_order():
 
 @pytest.mark.asyncio
 async def test_modify_mo_emits_substep_timing_events(caplog):
-    """#853 / refs #786 — ``_modify_manufacturing_order_impl`` emits three
+    """#853 / refs #786 — ``_modify_manufacturing_order_impl`` emits
     ``mo_modify_*_completed`` events on the apply path so the next 30s+
     slow call leaves a diagnostic breadcrumb. Pattern mirrors
     ``test_unknown_operation_is_logged_and_dropped`` in
     ``tests/test_prefab_ui.py`` (force structlog through stdlib + caplog).
 
-    The three events correspond to the three candidate slow steps:
+    On a header modify the events are:
 
     - ``mo_modify_patch_completed`` — the Katana PATCH apply
     - ``mo_modify_verify_refetch_completed`` — the sibling recipe-rows
       re-fetch (``CacheMerge.refetch_related``)
-    - ``mo_modify_cache_merge_completed`` — the parent MO GET re-fetch
-      (``CacheMerge.refetch_for_merge`` inside ``_post_apply_cache_merge``)
+
+    ``mo_modify_cache_merge_completed`` (the parent MO GET re-fetch) is
+    **not** emitted here: #786 wired ``CacheMerge.parent_from_outcome=True``,
+    so the post-apply merge reuses the PATCH response instead of re-GETting
+    the parent — the ``refetch_for_merge`` wrapper (which carries that timing
+    span) only runs as a fallback when a plan has no parent action.
     """
     import logging
 
@@ -2894,9 +2898,13 @@ async def test_modify_mo_emits_substep_timing_events(caplog):
     # ``_post_apply_cache_merge`` does its own ``merge_filtered_fetch``
     # against the (mocked) cache; patching the late import to a no-op
     # keeps the test focused on the timing events and avoids touching the
-    # typed-cache schema. The parent GET refetch still fires (timed by
-    # ``cache_merge``), and the related recipe-row fetcher still fires
-    # (timed by ``verify_refetch``).
+    # typed-cache schema. The ``_fetch_manufacturing_order_attrs`` mock IS
+    # awaited once — for the pre-apply diff fetch (``existing_mo``). What it is
+    # NOT awaited for is the post-apply cache-merge refetch: ``parent_from_outcome``
+    # reuses the PATCH ``apply_outcome`` there, which is exactly why the
+    # ``cache_merge`` timing span doesn't fire (asserted below via
+    # ``seen_cache_merge``). Only the related recipe-row fetcher fires (timed by
+    # ``verify_refetch``).
     with (
         patch(
             "katana_mcp.tools.foundation.manufacturing_orders._fetch_manufacturing_order_attrs",
@@ -2934,7 +2942,7 @@ async def test_modify_mo_emits_substep_timing_events(caplog):
     assert response.is_preview is False
     assert all(a.succeeded is True for a in response.actions)
 
-    # Verify all three sub-step events fire, each with a ``duration_ms``.
+    # Verify the header-path sub-step events fire, each with a ``duration_ms``.
     # ``setup_logging(json)`` routes structlog through ``JSONRenderer``,
     # so ``rec.getMessage()`` is a JSON blob carrying the ``event`` field.
     # Substring-match the event name (same pattern as
@@ -2946,15 +2954,17 @@ async def test_modify_mo_emits_substep_timing_events(caplog):
     expected_events = {
         "mo_modify_patch_completed",
         "mo_modify_verify_refetch_completed",
-        "mo_modify_cache_merge_completed",
     }
     matched: set[str] = set()
+    seen_cache_merge = False
     for rec in caplog.records:
         if rec.name != "katana_mcp.tools.foundation.manufacturing_orders":
             continue
         if rec.levelname != "INFO":
             continue
         msg = rec.getMessage()
+        if "mo_modify_cache_merge_completed" in msg:
+            seen_cache_merge = True
         for event_name in expected_events:
             if event_name in msg and "duration_ms" in msg:
                 matched.add(event_name)
@@ -2967,9 +2977,17 @@ async def test_modify_mo_emits_substep_timing_events(caplog):
                     f"got: {msg[:200]}"
                 )
     assert matched == expected_events, (
-        f"Expected all three sub-step events {expected_events}; "
+        f"Expected header-path sub-step events {expected_events}; "
         f"saw {sorted(matched)}. Records: "
         f"{[(r.name, r.levelname, r.getMessage()[:120]) for r in caplog.records]}"
+    )
+    # #786: ``parent_from_outcome`` reuses the PATCH response, so the parent
+    # merge-refetch (and its ``cache_merge`` timing span) must NOT run on this
+    # path. (``_fetch_manufacturing_order_attrs`` is still awaited once for the
+    # pre-apply diff fetch — that's a different call site, not the merge.)
+    assert not seen_cache_merge, (
+        "mo_modify_cache_merge_completed should not fire when "
+        "parent_from_outcome reuses the PATCH apply_outcome"
     )
 
 

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -8,6 +8,7 @@ helper through the actual tool flow.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, cast
@@ -1010,6 +1011,380 @@ async def test_run_modify_plan_overlays_patch_response_on_stale_refetch(monkeypa
     merged = captured["attrs_objs"][0]
     assert merged is stale_parent
     assert merged.name == "FRESH"
+
+
+# ============================================================================
+# #786: post-apply merge must not stall on the rate-limit reset gate.
+#   - ``parent_from_outcome`` reuses the PATCH response (no parent GET).
+#   - the remaining network refetches are time-bounded; a stall is abandoned
+#     best-effort rather than hanging the (already-succeeded) tool call.
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_parent_from_outcome_reuses_patch_response_skips_refetch(monkeypatch):
+    """With ``parent_from_outcome``, the merge uses the PATCH ``apply_outcome``
+    and never calls ``refetch_for_merge`` — one fewer GET that could stall on
+    the rate-limit reset gate (#786)."""
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    fresh_outcome = _AttrsStub(name="FRESH")
+    captured: dict[str, Any] = {}
+    refetch_calls = 0
+
+    async def fake_merge(cache, spec, attrs_objs):
+        captured["attrs_objs"] = list(attrs_objs)
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return fresh_outcome
+
+    async def fake_refetch(_eid: int):
+        nonlocal refetch_calls
+        refetch_calls += 1
+        return _AttrsStub(name="FROM_GET")
+
+    request = _SampleRequest(id=42, name="FRESH", preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_header",
+            target_id=42,  # parent-level action → its outcome is the merge source
+            diff=[FieldChange(field="name", old="OLD", new="FRESH")],
+            apply=fake_apply,
+            verify=None,
+        )
+    ]
+    fake_cache = cast(TypedCacheEngine, object())
+    await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 42",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(
+            cache=fake_cache,
+            refetch_for_merge=fake_refetch,
+            parent_from_outcome=True,
+        ),
+    )
+
+    # The PATCH outcome itself is merged; the GET refetch was never issued.
+    assert captured["attrs_objs"] == [fresh_outcome]
+    assert refetch_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_parent_from_outcome_falls_back_to_refetch_for_row_only_plan(monkeypatch):
+    """``parent_from_outcome`` only short-circuits when a parent-targeted
+    action produced an outcome. A row-only plan (no action matching the
+    entity id) falls back to the (time-bounded) ``refetch_for_merge``."""
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    captured: dict[str, Any] = {}
+    refetch_calls = 0
+
+    async def fake_merge(cache, spec, attrs_objs):
+        captured.setdefault("merged", []).append(list(attrs_objs))
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return _AttrsStub(name="ROW_OUTCOME")
+
+    async def fake_refetch(_eid: int):
+        nonlocal refetch_calls
+        refetch_calls += 1
+        return _AttrsStub(name="PARENT_FROM_GET")
+
+    request = _SampleRequest(id=42, name="x", preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_row",
+            target_id=999,  # row id, not the parent (42) → no parent outcome
+            diff=[FieldChange(field="quantity", old=1, new=2)],
+            apply=fake_apply,
+            verify=None,
+        )
+    ]
+    fake_cache = cast(TypedCacheEngine, object())
+    await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 42",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(
+            cache=fake_cache,
+            refetch_for_merge=fake_refetch,
+            parent_from_outcome=True,
+        ),
+    )
+
+    # No parent action → fell back to the GET refetch.
+    assert refetch_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_parent_from_outcome_falls_back_when_parent_outcome_is_none(monkeypatch):
+    """``parent_from_outcome`` falls back to the GET when the parent action
+    produced no outcome (e.g. a 204 PATCH with an empty body) — even though the
+    action targets the parent entity. Without a usable outcome there's nothing
+    to merge from, so the time-bounded ``refetch_for_merge`` must still run."""
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    refetch_calls = 0
+
+    async def fake_merge(cache, spec, attrs_objs):
+        pass
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return None  # 204 / empty-body PATCH → no apply_outcome
+
+    async def fake_refetch(_eid: int):
+        nonlocal refetch_calls
+        refetch_calls += 1
+        return _AttrsStub(name="PARENT_FROM_GET")
+
+    request = _SampleRequest(id=42, name="x", preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_header",
+            target_id=42,  # parent-targeted, but its outcome is None
+            diff=[FieldChange(field="status", old="DRAFT", new="DONE")],
+            apply=fake_apply,
+            verify=None,
+        )
+    ]
+    fake_cache = cast(TypedCacheEngine, object())
+    await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 42",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(
+            cache=fake_cache,
+            refetch_for_merge=fake_refetch,
+            parent_from_outcome=True,
+        ),
+    )
+
+    # Parent action had no outcome → fell back to the GET refetch.
+    assert refetch_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_parent_from_outcome_last_parent_action_wins_even_when_none(monkeypatch):
+    """When a plan has multiple parent-targeted actions, the LAST one wins —
+    even if its outcome is ``None``. An earlier action's outcome predates the
+    last action's changes and would be stale, so a ``None`` final outcome must
+    trigger the GET fallback rather than silently reusing the earlier body."""
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    merged: list[Any] = []
+    refetch_calls = 0
+
+    async def fake_merge(cache, spec, attrs_objs):
+        merged.extend(attrs_objs)
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    stale_first = _AttrsStub(name="STALE_FIRST")
+
+    async def apply_first():
+        return stale_first
+
+    async def apply_second_no_body():
+        return None  # later parent PATCH, 204 / empty body
+
+    refetched = _AttrsStub(name="FRESH_FROM_GET")
+
+    async def fake_refetch(_eid: int):
+        nonlocal refetch_calls
+        refetch_calls += 1
+        return refetched
+
+    request = _SampleRequest(id=42, name="x", preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_header",
+            target_id=42,  # first parent action — has a body
+            diff=[FieldChange(field="name", old="OLD", new="MID")],
+            apply=apply_first,
+            verify=None,
+        ),
+        ActionSpec(
+            operation="update_header_status",
+            target_id=42,  # LAST parent action — no body
+            diff=[FieldChange(field="status", old="DRAFT", new="DONE")],
+            apply=apply_second_no_body,
+            verify=None,
+        ),
+    ]
+    fake_cache = cast(TypedCacheEngine, object())
+    await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 42",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(
+            cache=fake_cache,
+            refetch_for_merge=fake_refetch,
+            parent_from_outcome=True,
+        ),
+    )
+
+    # Last parent outcome was None → fell back to the GET; the stale earlier
+    # outcome was NOT merged.
+    assert refetch_calls == 1
+    assert merged == [refetched]
+    assert stale_first not in merged
+
+
+@pytest.mark.asyncio
+@pytest.mark.looptime
+async def test_post_apply_parent_refetch_timeout_skips_merge(monkeypatch):
+    """A ``refetch_for_merge`` that stalls past the fetch ceiling (the
+    rate-limit reset gate) is abandoned best-effort: no merge, no raise — the
+    tool call still returns. Cache recovers on the next sync (#786)."""
+    from katana_mcp.tools import _modification_dispatch as disp
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    monkeypatch.setattr(disp, "_CACHE_MERGE_FETCH_TIMEOUT_S", 0.02)
+
+    merge_calls = 0
+
+    async def fake_merge(cache, spec, attrs_objs):
+        nonlocal merge_calls
+        merge_calls += 1
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return _AttrsStub(name="OUT")
+
+    async def slow_refetch(_eid: int):
+        await asyncio.sleep(0.5)  # > the 0.02s ceiling → wait_for cancels it
+        return _AttrsStub(name="NEVER")
+
+    request = _SampleRequest(id=42, name="x", preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_header",
+            target_id=42,
+            diff=[FieldChange(field="status", old="DRAFT", new="DONE")],
+            apply=fake_apply,
+            verify=None,
+        )
+    ]
+    fake_cache = cast(TypedCacheEngine, object())
+    # No parent_from_outcome → the (slow) GET refetch is exercised and bounded.
+    response = await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 42",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(cache=fake_cache, refetch_for_merge=slow_refetch),
+    )
+
+    # The plan still succeeded; the merge was skipped (refetch timed out).
+    assert response.is_preview is False
+    assert all(a.succeeded is True for a in response.actions)
+    assert merge_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.looptime
+async def test_post_apply_related_refetch_timeout_keeps_parent_merge(monkeypatch):
+    """A slow ``refetch_related`` (e.g. MO recipe rows hitting the gate) is
+    bounded and skipped, but the parent merge still lands — partial best-effort
+    rather than an all-or-nothing hang (#786)."""
+    from katana_mcp.tools import _modification_dispatch as disp
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    monkeypatch.setattr(disp, "_CACHE_MERGE_FETCH_TIMEOUT_S", 0.02)
+
+    merged_specs: list[str] = []
+
+    async def fake_merge(cache, spec, attrs_objs):
+        merged_specs.append(spec.entity_key)
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return _AttrsStub(name="MO_OUT")
+
+    async def unused_refetch(_eid: int):
+        # parent_from_outcome reuses the PATCH outcome, so this never runs.
+        return _AttrsStub(name="UNUSED")
+
+    async def slow_related(_eid: int):
+        await asyncio.sleep(0.5)  # > ceiling → bounded out
+        return [_AttrsStub(name="recipe_row")]
+
+    request = _SampleRequest(id=42, name="x", preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_header",
+            target_id=42,
+            diff=[FieldChange(field="status", old="NOT_STARTED", new="IN_PROGRESS")],
+            apply=fake_apply,
+            verify=None,
+        )
+    ]
+    fake_cache = cast(TypedCacheEngine, object())
+    await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="manufacturing_order",  # has recipe-row related_spec
+            entity_label="manufacturing order 42",
+            tool_name="modify_manufacturing_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(
+            cache=fake_cache,
+            refetch_for_merge=unused_refetch,  # unused: parent comes from outcome
+            refetch_related=(("manufacturing_order_recipe_row", slow_related),),
+            parent_from_outcome=True,
+        ),
+    )
+
+    # Parent (manufacturing_order) merged from the PATCH outcome; the recipe-row
+    # related merge was skipped because its refetch timed out.
+    assert merged_specs == ["manufacturing_order"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`modify_manufacturing_order` with a header-only payload intermittently took **30s+** even though the change had already applied — the field-reported #786 symptom. Reproduced live against the test tenant using the #853 `mo_modify_*` sub-step instrumentation: the stall is **Katana's 60-req/min rate limit**, not a slow cache-merge or a pagination explosion.

Each `modify_*` fires ~4 Katana calls (pre-fetch + PATCH + parent cache-merge GET + recipe-row refetch GET). A burst exhausts the budget; Katana returns `X-Ratelimit-Remaining: 0` with a reset ~40–47s out; `RateLimitTransport`'s proactive reset gate (correctly) blocks the next request until the window rolls. Whichever **post-apply GET** lands in that window eats the full wait — so the PATCH succeeds fast but the call hangs.

Two complementary, DB-safe changes (only the *network* refetches are bounded — never the aiosqlite writes, since cancelling those mid-statement risks the shared connection):

1. **`CacheMerge.parent_from_outcome`** (opt-in, default `False`) — the post-apply parent merge reuses the parent action's PATCH response (`apply_outcome`) instead of a separate GET. Removes one call per modify (~4→3) and is strictly fresher than a read-replica GET. Wired for `modify_manufacturing_order`; safe there because MO recipe rows aren't embedded in the parent merge (refreshed separately via `refetch_related`).
2. **Time-bound the post-apply network refetches** (`_CACHE_MERGE_FETCH_TIMEOUT_S = 8s`) — a refetch that stalls on the reset gate is abandoned best-effort (cache recovers on next sync) rather than hanging the already-succeeded tool call.

### Proven live

Post-fix probe (40× header-only modifies): the parent GET is gone entirely, and a post-apply refetch that hit the gate was capped at **~8s instead of ~48s**.

### Residual (documented, not fixable here)

If the gate engages *before* the PATCH, the essential write itself waits out the window (~45s) — fundamental rate-limiting, not a spurious hang, and the change has *not* yet applied in that case (unlike the reported symptom). See `LOGGING.md`.

### Follow-up

#905 tracks extending `parent_from_outcome` to `modify_sales_order` / `modify_purchase_order` / `modify_item` (needs per-endpoint verification of embedded-row handling — not a blind copy). The 8s time-bound already protects those tools from the hang today.

Refs #786

## Test plan

- [x] `uv run poe check` — 3900 unit + 47 browser tests pass
- [x] Live re-probe: parent GET eliminated; gate-caught refetch capped at ~8s
- [x] Dispatcher unit tests: `parent_from_outcome` reuse, row-only fallback, None-outcome fallback, parent-refetch timeout, related-refetch timeout (timeouts use `@pytest.mark.looptime` — virtual clock, no real wall time)
- [x] `#853` instrumentation test updated (cache_merge span no longer fires on the happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)