### PR TITLE
feat(ts-client)!: port Ajv-style 422 errors + proactive rate limiting

### DIFF
--- a/packages/katana-client/README.md
+++ b/packages/katana-client/README.md
@@ -102,6 +102,30 @@ The client implements the same retry strategy as the Python client:
 **Key behavior**: POST and PATCH requests are retried for rate limiting (429) because
 rate limits are transient and don't indicate idempotency issues.
 
+## Proactive Rate Limiting
+
+Beyond reactive 429 retries, the client **proactively paces** outgoing requests through
+a token bucket (60 req/min by default) and adapts to Katana's `X-Ratelimit-*` headers:
+
+- **Sync down** — if the server reports fewer remaining requests than expected (e.g.
+  another client sharing the API key), the local budget drains to match. It never syncs
+  up; the server is authoritative on the lower bound only.
+- **Reset gate** — when `X-Ratelimit-Remaining` hits `0`, all requests block until
+  `X-Ratelimit-Reset` elapses, so the client doesn't fire into an exhausted window.
+
+The limiter sits innermost in the fetch chain, so each retry attempt and each paginated
+page consumes one token — matching how Katana counts requests server-side.
+
+```typescript
+// Tune the budget
+const client = await KatanaClient.create({ requestsPerMinute: 120 });
+
+// Disable proactive limiting (reactive 429 retry still applies)
+const client = await KatanaClient.create({ requestsPerMinute: null });
+```
+
+This mirrors the Python client's `RateLimitTransport`.
+
 ## Auto-Pagination
 
 Auto-pagination is **ON by default** for all GET requests:
@@ -150,8 +174,11 @@ if (!response.ok) {
   } else if (error instanceof RateLimitError) {
     console.error(`Rate limited. Retry after ${error.retryAfter}s`);
   } else if (error instanceof ValidationError) {
-    console.error('Validation errors:', error.details);
-    // [{ field: 'name', message: 'Required', code: 'missing' }]
+    // `error.message` is a human-readable, multi-line summary; `error.details`
+    // is the structured Ajv error array exactly as Katana sends it.
+    console.error(error.message);
+    console.error(error.details);
+    // [{ path: '/name', code: 'required', message: '...', info: { missingProperty: 'name' } }]
   } else {
     console.error(`Error ${error.statusCode}: ${error.message}`);
   }
@@ -162,10 +189,15 @@ Available error classes:
 
 - `AuthenticationError` (401)
 - `RateLimitError` (429) - includes `retryAfter` seconds
-- `ValidationError` (422) - includes `details` array
+- `ValidationError` (422) - includes `details`, the Ajv-style validation error array
+  (`{ path, code, message, info }` per item, where `code` is the failed Ajv keyword).
+  `message` is a formatted, multi-line summary mirroring the Python client's wording.
 - `ServerError` (5xx)
 - `NetworkError` - connection failures
 - `KatanaError` - base class for all errors
+
+The catch-all path also surfaces messages from Katana's nested `{ "error": { ... } }`
+envelope, including for undocumented status codes.
 
 ## HTTP Methods
 

--- a/packages/katana-client/docs/cookbook.md
+++ b/packages/katana-client/docs/cookbook.md
@@ -320,7 +320,8 @@ async function handleApiCall<T>(
     if (error instanceof ValidationError) {
       console.error(`Validation failed for ${resourceName}:`);
       for (const detail of error.details) {
-        console.error(`  - ${detail.field}: ${detail.message}`);
+        // Ajv-style detail: `path` is the JSON pointer, `code` the failed keyword.
+        console.error(`  - ${detail.path} (${detail.code}): ${detail.message}`);
       }
       throw error;
     }

--- a/packages/katana-client/docs/guide.md
+++ b/packages/katana-client/docs/guide.md
@@ -136,6 +136,31 @@ Retry delays follow exponential backoff:
 
 The client also respects the `Retry-After` header when present.
 
+### Proactive Rate Limiting
+
+In addition to reactive 429 retries, the client proactively paces outgoing requests
+through a token bucket and adapts to Katana's `X-Ratelimit-*` response headers —
+mirroring the Python client's `RateLimitTransport`:
+
+- **Token bucket** — 60 requests/minute by default; configurable via
+  `requestsPerMinute`.
+- **Sync down** — drains the local budget to match `X-Ratelimit-Remaining` when the
+  server reports fewer requests left than expected (never syncs up).
+- **Reset gate** — when `X-Ratelimit-Remaining` reaches `0`, all requests block until
+  `X-Ratelimit-Reset` elapses.
+
+The limiter sits innermost in the fetch chain, so each retry attempt and each paginated
+page consumes one token.
+
+```typescript
+const client = await KatanaClient.create({
+  requestsPerMinute: 120, // raise the budget
+});
+
+// Disable proactive limiting entirely (reactive 429 retry still applies):
+const client = await KatanaClient.create({ requestsPerMinute: null });
+```
+
 ## Auto-Pagination
 
 Auto-pagination is **ON by default** for all GET requests. All pages are automatically
@@ -296,8 +321,11 @@ if (!response.ok) {
   } else if (error instanceof RateLimitError) {
     console.error(`Rate limited. Retry after ${error.retryAfter}s`);
   } else if (error instanceof ValidationError) {
-    console.error('Validation errors:', error.details);
-    // [{ field: 'name', message: 'Required', code: 'missing' }]
+    // `error.message` is a formatted, multi-line human summary; `error.details`
+    // is the structured Ajv error array exactly as Katana sends it.
+    console.error(error.message);
+    console.error(error.details);
+    // [{ path: '/name', code: 'required', message: '...', info: { missingProperty: 'name' } }]
   } else if (error instanceof ServerError) {
     console.error(`Server error: ${error.statusCode}`);
   } else {

--- a/packages/katana-client/docs/testing.md
+++ b/packages/katana-client/docs/testing.md
@@ -170,9 +170,17 @@ describe('parseError', () => {
     expect((error as RateLimitError).retryAfter).toBe(30);
   });
 
-  it('should return ValidationError for 422 with details', () => {
+  it('should return ValidationError for 422 with Ajv-style details', () => {
     const response = new Response(null, { status: 422 });
-    const body = { errors: [{ field: 'name', message: 'Required' }] };
+    // Katana wraps 422s in a nested `error` envelope with an Ajv `details[]` array.
+    const body = {
+      error: {
+        message: 'The request body is invalid.',
+        details: [
+          { path: '/name', code: 'required', message: 'missing', info: { missingProperty: 'name' } },
+        ],
+      },
+    };
     const error = parseError(response, body);
     expect(error).toBeInstanceOf(ValidationError);
     expect((error as ValidationError).details).toHaveLength(1);

--- a/packages/katana-client/src/client.ts
+++ b/packages/katana-client/src/client.ts
@@ -12,6 +12,7 @@ import {
   type PaginationConfig,
   createPaginatedFetch,
 } from './transport/pagination.js';
+import { DEFAULT_RATE_LIMIT_CONFIG, createRateLimitedFetch } from './transport/rateLimit.js';
 import {
   DEFAULT_RETRY_CONFIG,
   type RetryConfig,
@@ -45,6 +46,14 @@ export interface KatanaClientOptions {
    * Pagination configuration for auto-pagination
    */
   pagination?: Partial<PaginationConfig>;
+
+  /**
+   * Proactive request budget per minute. The client paces outgoing requests
+   * through a token bucket and adapts to Katana's `X-Ratelimit-*` headers.
+   * Default: 60. Pass `null` to disable proactive rate limiting entirely
+   * (reactive 429 retry still applies).
+   */
+  requestsPerMinute?: number | null;
 
   /**
    * Whether auto-pagination is enabled by default.
@@ -165,7 +174,11 @@ export class KatanaClient {
 
     const baseFetch = options.fetch ?? globalThis.fetch;
 
-    // Create the fetch chain: base -> resilient (retry) -> paginated -> authenticated
+    // Fetch chain (innermost -> outermost): base -> rate-limit -> retry ->
+    // paginated -> authenticated. Rate limiting sits innermost so every actual
+    // HTTP request — each retry attempt and each paginated page — consumes a
+    // token, matching how Katana counts requests server-side (mirrors the
+    // Python client's transport stack).
     const retryConfig: RetryConfig = {
       ...DEFAULT_RETRY_CONFIG,
       ...options.retry,
@@ -176,9 +189,23 @@ export class KatanaClient {
       ...options.pagination,
     };
 
-    // First wrap with retry logic
+    // Proactive rate limiting (innermost). `requestsPerMinute: null` disables
+    // the layer entirely; otherwise default to 60/min.
+    const rateLimitedFetch =
+      options.requestsPerMinute === null
+        ? baseFetch
+        : createRateLimitedFetch(baseFetch, {
+            rateLimit: {
+              ...DEFAULT_RATE_LIMIT_CONFIG,
+              requestsPerMinute:
+                options.requestsPerMinute ?? DEFAULT_RATE_LIMIT_CONFIG.requestsPerMinute,
+            },
+            logger: this.logger,
+          });
+
+    // Then wrap with retry logic
     const fetchWithRetry = createResilientFetch({
-      baseFetch,
+      baseFetch: rateLimitedFetch,
       retry: retryConfig,
       logger: this.logger,
     });

--- a/packages/katana-client/src/errors.ts
+++ b/packages/katana-client/src/errors.ts
@@ -4,6 +4,8 @@
  * Mirrors the Python client's error handling pattern from katana_client.py
  */
 
+import type { ValidationErrorDetail } from './generated/types.gen.js';
+
 /**
  * Base error class for all Katana API errors
  */
@@ -63,17 +65,15 @@ export class RateLimitError extends KatanaError {
 }
 
 /**
- * Validation error details from the API
- */
-export interface ValidationErrorDetail {
-  field?: string;
-  message: string;
-  code?: string;
-  value?: unknown;
-}
-
-/**
  * Validation error (422 Unprocessable Entity)
+ *
+ * `details` carries the Ajv-style validation error array exactly as Katana
+ * sends it — each item is `{ path, code, message, info }` where `code` is the
+ * failed Ajv keyword and `info` holds keyword-specific params (see
+ * `ValidationErrorDetail` in the generated types). The structured array is the
+ * stable, programmatic contract; the human-readable `message` is built by
+ * `formatValidationDetail`, which mirrors the Python client's
+ * `_format_ajv_detail` wording for cross-runtime parity.
  */
 export class ValidationError extends KatanaError {
   public readonly details: ValidationErrorDetail[];
@@ -136,7 +136,9 @@ export function parseError(response: Response, body?: unknown): KatanaError {
 
   if (status === 422) {
     const details = parseValidationDetails(body);
-    return new ValidationError('Validation failed', {
+    const base = extractMessage(body) ?? 'Validation failed';
+    const message = buildValidationMessage(base, details);
+    return new ValidationError(message, {
       response,
       body,
       details,
@@ -144,18 +146,16 @@ export function parseError(response: Response, body?: unknown): KatanaError {
   }
 
   if (status >= 500) {
-    return new ServerError(`Server error (${status})`, {
+    return new ServerError(extractMessage(body) ?? `Server error (${status})`, {
       statusCode: status,
       response,
       body,
     });
   }
 
-  // Generic client error
-  const message =
-    typeof body === 'object' && body !== null && 'message' in body
-      ? String((body as Record<string, unknown>).message)
-      : `Request failed with status ${status}`;
+  // Generic client error — surface the body's message even for statuses the
+  // spec doesn't document, unwrapping Katana's nested `{ "error": {...} }`.
+  const message = extractMessage(body) ?? `Request failed with status ${status}`;
 
   return new KatanaError(message, {
     statusCode: status,
@@ -165,45 +165,185 @@ export function parseError(response: Response, body?: unknown): KatanaError {
 }
 
 /**
- * Parse validation error details from response body
+ * Unwrap Katana's nested `{ "error": {...} }` envelope. Some endpoints wrap the
+ * error fields under a top-level `error` key; most return them flat. Returns the
+ * object carrying `message` / `name` / `details`, or `undefined` for non-objects.
+ *
+ * Mirrors the Python client's `_extract_error_fields` / `_try_parse_error_body`.
+ */
+function unwrapErrorEnvelope(body: unknown): Record<string, unknown> | undefined {
+  if (!body || typeof body !== 'object') {
+    return undefined;
+  }
+  const obj = body as Record<string, unknown>;
+  const inner = obj.error;
+  if (inner && typeof inner === 'object' && !Array.isArray(inner)) {
+    return inner as Record<string, unknown>;
+  }
+  return obj;
+}
+
+/**
+ * Pull a human-readable message out of an (optionally enveloped) error body.
+ */
+function extractMessage(body: unknown): string | undefined {
+  const core = unwrapErrorEnvelope(body);
+  return core && typeof core.message === 'string' ? core.message : undefined;
+}
+
+/**
+ * Runtime guard for an Ajv-style validation detail (`BaseValidationError` shape).
+ */
+function isValidationDetail(value: unknown): value is ValidationErrorDetail {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.path === 'string' && typeof obj.code === 'string' && typeof obj.message === 'string'
+  );
+}
+
+/**
+ * Parse the Ajv-style `details[]` array from a 422 body (envelope-aware).
  */
 function parseValidationDetails(body: unknown): ValidationErrorDetail[] {
-  if (!body || typeof body !== 'object') {
+  const core = unwrapErrorEnvelope(body);
+  if (!core || !Array.isArray(core.details)) {
     return [];
   }
+  return core.details.filter(isValidationDetail);
+}
 
-  const bodyObj = body as Record<string, unknown>;
+/**
+ * Combine the base error message with one formatted line per validation detail.
+ * Mirrors the Python client's `ValidationError.__str__` (base message, then a
+ * newline-joined block of `_format_ajv_detail` lines).
+ */
+function buildValidationMessage(base: string, details: ValidationErrorDetail[]): string {
+  if (details.length === 0) {
+    return base;
+  }
+  return `${base}\n${details.map(formatValidationDetail).join('\n')}`;
+}
 
-  // Handle Katana's error format
-  if (Array.isArray(bodyObj.errors)) {
-    return bodyObj.errors.map((err: unknown) => {
-      if (typeof err === 'object' && err !== null) {
-        const errObj = err as Record<string, unknown>;
-        return {
-          field: typeof errObj.field === 'string' ? errObj.field : undefined,
-          message: typeof errObj.message === 'string' ? errObj.message : String(err),
-          code: typeof errObj.code === 'string' ? errObj.code : undefined,
-          value: errObj.value,
-        };
+/**
+ * Render one Ajv-style validation detail as a human-readable line, dispatching
+ * on the Ajv keyword (`code`) and reading keyword-specific params from `info`.
+ *
+ * Mirrors the Python client's `_format_ajv_detail` (utils.py) wording for
+ * cross-runtime parity. Reads only `code` + `info` — Katana does not send the
+ * offending value (Ajv `data`) on the wire, and neither client needs it.
+ */
+function formatValidationDetail(detail: ValidationErrorDetail): string {
+  // `path` is Ajv's instancePath; drop the leading separator — JSON Pointer "/"
+  // (the live wire format) or the legacy dotted "." form the schema also documents —
+  // so the field name reads cleanly either way.
+  const field = detail.path.replace(/^[/.]+/, '');
+  // `info` is read as a loose record (the union isn't narrowed by `code` here), so
+  // each branch validates the params it needs and falls through to the generic
+  // formatter below when they're missing or the wrong type — e.g. a
+  // GenericValidationError carrying an unexpected `code` and no `info`. This keeps a
+  // malformed detail from rendering "must not exceed undefined characters".
+  const info = ((detail as { info?: unknown }).info ?? {}) as Record<string, unknown>;
+  const isNum = (v: unknown): v is number => typeof v === 'number';
+  const isStr = (v: unknown): v is string => typeof v === 'string';
+
+  switch (detail.code) {
+    // String / format keywords
+    case 'maxLength':
+      if (isNum(info.limit)) return `  Field '${field}' must not exceed ${info.limit} characters`;
+      break;
+    case 'minLength':
+      if (isNum(info.limit)) return `  Field '${field}' must be at least ${info.limit} characters`;
+      break;
+    case 'format':
+      if (isStr(info.format)) return `  Field '${field}' must match format: ${info.format}`;
+      break;
+    case 'pattern':
+      if (isStr(info.pattern)) return `  Field '${field}' must match pattern: ${info.pattern}`;
+      break;
+
+    // Numeric keywords
+    case 'minimum':
+      if (isNum(info.limit)) return `  Field '${field}' must be >= ${info.limit}`;
+      break;
+    case 'maximum':
+      if (isNum(info.limit)) return `  Field '${field}' must be <= ${info.limit}`;
+      break;
+    case 'exclusiveMinimum':
+      if (isNum(info.limit)) return `  Field '${field}' must be > ${info.limit}`;
+      break;
+    case 'exclusiveMaximum':
+      if (isNum(info.limit)) return `  Field '${field}' must be < ${info.limit}`;
+      break;
+    case 'multipleOf':
+      if (isNum(info.multipleOf))
+        return `  Field '${field}' must be a multiple of ${info.multipleOf}`;
+      break;
+
+    // Array keywords
+    case 'minItems':
+      if (isNum(info.limit)) return `  Field '${field}' must have at least ${info.limit} items`;
+      break;
+    case 'maxItems':
+      if (isNum(info.limit)) return `  Field '${field}' must have at most ${info.limit} items`;
+      break;
+    case 'uniqueItems':
+      if (isNum(info.i) && isNum(info.j))
+        return `  Field '${field}' contains duplicate items at indices ${info.i} and ${info.j}`;
+      break;
+
+    // Object keywords
+    case 'required':
+      if (isStr(info.missingProperty)) return `  Missing required field: '${info.missingProperty}'`;
+      break;
+    case 'additionalProperties':
+      if (isStr(info.additionalProperty))
+        return `  Field '${field}' has unexpected property: '${info.additionalProperty}'`;
+      break;
+    case 'dependencies':
+      if (isStr(info.property) && isStr(info.missingProperty))
+        return `  Field '${field}' has property '${info.property}' but is missing dependent property '${info.missingProperty}'`;
+      break;
+
+    // Type / composition keywords
+    case 'type':
+      if (isStr(info.type)) return `  Field '${field}' must be of type: ${info.type}`;
+      break;
+    case 'enum':
+      if (Array.isArray(info.allowedValues))
+        return `  Field '${field}' must be one of: ${formatAllowedValues(info.allowedValues)}`;
+      break;
+    case 'const':
+      if ('allowedValue' in info)
+        return `  Field '${field}' must equal: ${JSON.stringify(info.allowedValue)}`;
+      break;
+    case 'oneOf': {
+      const passing = info.passingSchemas;
+      if (passing === null || passing === undefined) {
+        return `  Field '${field}' did not match any allowed schema`;
       }
-      return { message: String(err) };
-    });
+      if (Array.isArray(passing))
+        return `  Field '${field}' matched multiple allowed schemas (indices ${formatAllowedValues(passing)}); must match exactly one`;
+      break;
+    }
   }
 
-  // Handle detail array format
-  if (Array.isArray(bodyObj.detail)) {
-    return bodyObj.detail.map((detail: unknown) => {
-      if (typeof detail === 'object' && detail !== null) {
-        const detailObj = detail as Record<string, unknown>;
-        return {
-          field: Array.isArray(detailObj.loc) ? detailObj.loc.join('.') : undefined,
-          message: typeof detailObj.msg === 'string' ? detailObj.msg : String(detail),
-          code: typeof detailObj.type === 'string' ? detailObj.type : undefined,
-        };
-      }
-      return { message: String(detail) };
-    });
-  }
+  // Generic fallback: GenericValidationError, an unknown/future keyword, or a typed
+  // keyword whose params were missing or malformed.
+  const prefix = detail.code ? `(${detail.code}) ` : '';
+  const suffix = Object.keys(info).length > 0 ? ` — info: ${JSON.stringify(info)}` : '';
+  const message = detail.message || '<no message>';
+  return `  Field '${field}': ${prefix}${message}${suffix}`;
+}
 
-  return [];
+/**
+ * Render an `allowedValues` / index list for display (e.g. `enum`, `oneOf`).
+ */
+function formatAllowedValues(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((v) => (typeof v === 'string' ? v : JSON.stringify(v))).join(', ');
+  }
+  return String(value);
 }

--- a/packages/katana-client/src/index.ts
+++ b/packages/katana-client/src/index.ts
@@ -25,7 +25,9 @@
 // Re-export the main client
 export { KatanaClient, type KatanaClientOptions } from './client.js';
 
-// Re-export error types and utilities
+// Re-export error types and utilities.
+// `ValidationErrorDetail` (the Ajv-style union) comes from the generated types
+// via `export * from './types.js'` below — not re-declared here.
 export {
   KatanaError,
   AuthenticationError,
@@ -34,7 +36,6 @@ export {
   ServerError,
   NetworkError,
   parseError,
-  type ValidationErrorDetail,
 } from './errors.js';
 
 // Re-export transport utilities for advanced usage
@@ -50,6 +51,13 @@ export {
   DEFAULT_PAGINATION_CONFIG,
   type PaginatedResponse,
 } from './transport/pagination.js';
+
+export {
+  createRateLimitedFetch,
+  type RateLimitConfig,
+  type RateLimitedFetchOptions,
+  DEFAULT_RATE_LIMIT_CONFIG,
+} from './transport/rateLimit.js';
 
 // Re-export generated SDK functions for direct API access
 export * from './generated/sdk.gen.js';

--- a/packages/katana-client/src/transport/rateLimit.ts
+++ b/packages/katana-client/src/transport/rateLimit.ts
@@ -1,0 +1,264 @@
+/**
+ * Proactive rate-limit transport layer for the Katana API.
+ *
+ * Mirrors the Python client's `RateLimitTransport` (katana_client.py): a token
+ * bucket sized for Katana's documented budget (60 req/min by default) gates
+ * every request *before* it goes out, and after each response the layer reads
+ * `X-Ratelimit-Remaining` / `X-Ratelimit-Reset` and adapts:
+ *
+ * - **Sync down**: when the server reports fewer remaining tokens than our local
+ *   estimate (e.g. another client sharing the API key), drain the local bucket to
+ *   match. We never sync *up* — the server is authoritative on the lower bound only.
+ * - **Reset gate**: when remaining hits 0, all requests block until
+ *   `X-Ratelimit-Reset` elapses, so we don't fire the burst budget into a window
+ *   the server has already declared exhausted.
+ *
+ * Placed **innermost** in the fetch chain (closest to the network, below retry and
+ * pagination) so every actual HTTP request — each retry attempt and each paginated
+ * page — consumes one token, matching how Katana counts requests server-side.
+ *
+ * `Retry-After` waiting on 429 stays in the retry layer; this layer only updates the
+ * reset gate from headers (sleeping here too would double-delay).
+ *
+ * Zero-dependency on purpose — the transport layer is otherwise dep-free, and the
+ * adaptive header logic is bespoke regardless of any token-bucket library.
+ */
+
+/** Header names Katana uses (case-insensitive lookup via `Headers.get`). */
+const HEADER_REMAINING = 'X-Ratelimit-Remaining';
+/**
+ * Reset deadline as a Unix epoch in **milliseconds** — Katana's convention
+ * (verified against the live wire; mirrors the Python client). Note most APIs
+ * use seconds: if Katana ever switches, the gate math here must change too.
+ */
+const HEADER_RESET = 'X-Ratelimit-Reset';
+
+/**
+ * Configuration for the proactive rate limiter.
+ */
+export interface RateLimitConfig {
+  /** Steady-state request budget per window. Default: 60 */
+  requestsPerMinute: number;
+  /** Window length in milliseconds the budget refills over. Default: 60000 */
+  windowMs: number;
+}
+
+/**
+ * Default rate-limit configuration (60 requests / minute, per Katana's spec).
+ */
+export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
+  requestsPerMinute: 60,
+  windowMs: 60_000,
+};
+
+/**
+ * Options for creating a rate-limited fetch function.
+ */
+export interface RateLimitedFetchOptions {
+  /** Rate-limit configuration. */
+  rateLimit?: Partial<RateLimitConfig>;
+  /** Optional logger for state changes. */
+  logger?: {
+    debug: (message: string, ...args: unknown[]) => void;
+    info: (message: string, ...args: unknown[]) => void;
+    warn: (message: string, ...args: unknown[]) => void;
+    error: (message: string, ...args: unknown[]) => void;
+  };
+}
+
+/** Sleep for a number of milliseconds (timer-based; fakeable in tests). */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Wrap a fetch function with proactive, header-adaptive rate limiting.
+ *
+ * @param baseFetch - The fetch function to wrap (innermost; closest to the network).
+ * @param options - Rate-limit configuration and optional logger.
+ * @returns A fetch function that throttles outgoing requests.
+ *
+ * @example
+ * ```typescript
+ * const limited = createRateLimitedFetch(globalThis.fetch, {
+ *   rateLimit: { requestsPerMinute: 60 },
+ * });
+ * ```
+ */
+export function createRateLimitedFetch(
+  baseFetch: typeof fetch,
+  options: RateLimitedFetchOptions = {}
+): typeof fetch {
+  const config: RateLimitConfig = {
+    ...DEFAULT_RATE_LIMIT_CONFIG,
+    ...options.rateLimit,
+  };
+  // Fail fast on invalid config: a non-positive rate or window makes the refill
+  // rate 0/NaN, which would make `acquireToken` spin forever or sleep for NaN ms.
+  if (config.requestsPerMinute <= 0 || config.windowMs <= 0) {
+    throw new Error(
+      `createRateLimitedFetch: requestsPerMinute and windowMs must be positive (got requestsPerMinute=${config.requestsPerMinute}, windowMs=${config.windowMs}). To disable rate limiting, omit this layer from the fetch chain (or, via KatanaClient, set \`requestsPerMinute: null\`).`
+    );
+  }
+  const logger = options.logger ?? {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+
+  const capacity = config.requestsPerMinute;
+  const refillPerMs = capacity / config.windowMs;
+
+  // ── Token bucket ─────────────────────────────────────────────────────────
+  // `tokens` is the single source of truth for the local budget: it refills over
+  // the window AND is clamped down to the server's `X-Ratelimit-Remaining` (never
+  // up). Sync-down reads it directly — there is no separate decrement-only estimate
+  // that could clamp permanently at 0 when the server never reports remaining=0.
+  let tokens = capacity;
+  let lastRefillMs = Date.now();
+
+  function refill(): void {
+    const now = Date.now();
+    const elapsed = now - lastRefillMs;
+    if (elapsed > 0) {
+      tokens = Math.min(capacity, tokens + elapsed * refillPerMs);
+      lastRefillMs = now;
+    }
+  }
+
+  // The token check-and-debit is synchronous (no `await`), so concurrent
+  // acquisitions can't double-spend — only the wait between attempts yields.
+  async function acquireToken(weight = 1): Promise<void> {
+    for (;;) {
+      refill();
+      if (tokens >= weight) {
+        tokens -= weight;
+        return;
+      }
+      const waitMs = Math.max(1, Math.ceil((weight - tokens) / refillPerMs));
+      await sleep(waitMs);
+    }
+  }
+
+  // ── Reset gate ───────────────────────────────────────────────────────────
+  // `gate` is non-null only while a reset window is active; pending requests
+  // await it. `gateDeadlineMs` tracks the latest observed reset so out-of-order
+  // responses with an earlier deadline can't shorten the gate.
+  let gate: Promise<void> | null = null;
+  let gateResolve: (() => void) | null = null;
+  let gateDeadlineMs: number | null = null;
+  let gateTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function engageResetGate(deadlineMs: number): void {
+    // Ignore a stale/earlier reset when a later gate is already active.
+    if (gateDeadlineMs !== null && deadlineMs <= gateDeadlineMs) {
+      return;
+    }
+    gateDeadlineMs = deadlineMs;
+    if (gate === null) {
+      gate = new Promise<void>((resolve) => {
+        gateResolve = resolve;
+      });
+    }
+    if (gateTimer !== null) {
+      clearTimeout(gateTimer);
+    }
+    const waitMs = Math.max(0, deadlineMs - Date.now());
+    gateTimer = setTimeout(releaseResetGate, waitMs);
+    logger.info(`Rate limit reset gate engaged for ${waitMs}ms (remaining hit 0)`);
+  }
+
+  function releaseResetGate(): void {
+    // Defensive: only act when a gate is actually engaged. The timer is
+    // cleared on re-engage so this can't double-fire today, but guarding keeps
+    // the function safe if gate management is refactored.
+    if (gate === null) {
+      return;
+    }
+    gateTimer = null;
+    gateDeadlineMs = null;
+    // The server's window has rolled: restore the full budget.
+    tokens = capacity;
+    lastRefillMs = Date.now();
+    const resolve = gateResolve;
+    gate = null;
+    gateResolve = null;
+    resolve?.();
+  }
+
+  // ── Response observation ─────────────────────────────────────────────────
+  function observeResponse(response: Response): void {
+    const remainingStr = response.headers.get(HEADER_REMAINING);
+    const resetStr = response.headers.get(HEADER_RESET);
+    // Defensive: many endpoints (auth, redirects, errors) omit these headers.
+    if (remainingStr === null || resetStr === null) {
+      return;
+    }
+    const remaining = Number.parseInt(remainingStr, 10);
+    const resetEpochMs = Number.parseInt(resetStr, 10);
+    if (Number.isNaN(remaining) || Number.isNaN(resetEpochMs)) {
+      logger.warn(`Invalid rate-limit headers: remaining=${remainingStr} reset=${resetStr}`);
+      return;
+    }
+
+    // Stale-window guard: a reset deadline already in the past describes a
+    // window that has rolled — acting on its `remaining` would clamp us on
+    // outdated state under the never-sync-up rule.
+    if (resetEpochMs <= Date.now()) {
+      return;
+    }
+
+    // Refill first so the bucket reflects time elapsed during the round-trip,
+    // then compare against the server's report.
+    refill();
+
+    // Fast path: the server has at least as much budget as our local bucket.
+    if (remaining > 0 && remaining >= tokens) {
+      return;
+    }
+
+    // Sync down only — clamp the bucket to the server's lower remaining (never up).
+    if (remaining > 0 && remaining < tokens) {
+      logger.info(
+        `Rate limit synced down: ${Math.floor(tokens)} -> ${remaining} tokens (remote remaining)`
+      );
+      tokens = remaining;
+    }
+
+    // When remaining hits 0 the gate alone blocks until the window rolls; we
+    // deliberately do not also drain the bucket to zero (the gate is the override).
+    if (remaining === 0) {
+      engageResetGate(resetEpochMs);
+    }
+  }
+
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    // Block on any active reset window before spending a token.
+    if (gate !== null) {
+      await gate;
+    }
+
+    await acquireToken(1);
+
+    // A reset gate can engage between the acquire above and this check (a
+    // concurrent observer seeing remaining=0). If we simply waited and proceeded,
+    // the token we just debited would be wiped by `releaseResetGate`'s
+    // `tokens = capacity` reset, letting this request slip into the next window
+    // uncounted — under-throttling by the number of requests that raced in here.
+    // Instead, refund the debit, wait for the window to roll, and re-acquire so
+    // the request is charged against the NEW window's budget.
+    while (gate !== null) {
+      tokens = Math.min(capacity, tokens + 1);
+      await gate;
+      await acquireToken(1);
+    }
+
+    // `acquireToken` debited the bucket for this request, so the server's
+    // `remaining` for it will line up with `tokens` rather than reading one lower.
+    const response = await baseFetch(input, init);
+
+    observeResponse(response);
+    return response;
+  };
+}

--- a/packages/katana-client/tests/client.test.ts
+++ b/packages/katana-client/tests/client.test.ts
@@ -5,7 +5,7 @@
  * retry and pagination transport layers.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { KatanaClient } from '../src/client.js';
 
 describe('KatanaClient', () => {
@@ -113,6 +113,46 @@ describe('KatanaClient', () => {
 
       const [, options] = mockFetch.mock.calls[0];
       expect(options.headers.get('Content-Type')).toBe('application/json');
+    });
+  });
+
+  describe('rate limiting (requestsPerMinute)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('paces requests when a low budget is configured', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+      const client = KatanaClient.withApiKey(TEST_API_KEY, {
+        fetch: mockFetch,
+        autoPagination: false,
+        requestsPerMinute: 1, // capacity 1: second request is paced a full window
+      });
+
+      const pending = [client.fetch('/products'), client.fetch('/products')];
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      await Promise.all(pending);
+    });
+
+    it('disables proactive limiting when requestsPerMinute is null', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+      const client = KatanaClient.withApiKey(TEST_API_KEY, {
+        fetch: mockFetch,
+        autoPagination: false,
+        requestsPerMinute: null,
+      });
+
+      const pending = [client.fetch('/products'), client.fetch('/products')];
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetch).toHaveBeenCalledTimes(2); // no token bucket -> no pacing
+      await Promise.all(pending);
     });
   });
 

--- a/packages/katana-client/tests/errors.test.ts
+++ b/packages/katana-client/tests/errors.test.ts
@@ -75,10 +75,10 @@ describe('Error Classes', () => {
       expect(error.name).toBe('ValidationError');
     });
 
-    it('should store validation details', () => {
+    it('should store Ajv-style validation details verbatim', () => {
       const details = [
-        { field: 'name', message: 'Name is required' },
-        { field: 'sku', message: 'SKU must be unique', code: 'unique' },
+        { path: '/name', code: 'required', message: 'must have required property', info: {} },
+        { path: '/sku', code: 'maxLength', message: 'too long', info: { limit: 40 } },
       ];
       const error = new ValidationError('Validation failed', { details });
       expect(error.details).toEqual(details);
@@ -134,27 +134,113 @@ describe('parseError', () => {
     expect((error as RateLimitError).retryAfter).toBe(30);
   });
 
-  it('should return ValidationError for 422', () => {
+  it("should parse a 422 from Katana's nested {error:{details}} envelope (live wire shape)", () => {
     const response = new Response(null, { status: 422 });
+    // Exact shape captured from a live POST /custom_field_definitions 422.
     const body = {
-      errors: [{ field: 'name', message: 'Required' }],
+      error: {
+        statusCode: 422,
+        name: 'UnprocessableEntityError',
+        message: 'The request body is invalid. See error object `details` property for more info.',
+        code: 'VALIDATION_FAILED',
+        details: [
+          {
+            path: '/label',
+            code: 'maxLength',
+            message: 'must NOT have more than 255 characters',
+            info: { limit: 255 },
+          },
+        ],
+      },
     };
-    const error = parseError(response, body);
+    const error = parseError(response, body) as ValidationError;
     expect(error).toBeInstanceOf(ValidationError);
-    expect((error as ValidationError).details).toHaveLength(1);
-    expect((error as ValidationError).details[0].field).toBe('name');
+    // Structured details preserved verbatim (the cross-runtime contract).
+    expect(error.details).toHaveLength(1);
+    expect(error.details[0]).toEqual({
+      path: '/label',
+      code: 'maxLength',
+      message: 'must NOT have more than 255 characters',
+      info: { limit: 255 },
+    });
+    // Display message: base (from the envelope) + a formatted, path-stripped line.
+    expect(error.message).toContain('The request body is invalid');
+    expect(error.message).toContain("Field 'label' must not exceed 255 characters");
   });
 
-  it('should parse validation details from detail array format', () => {
+  it('should format each Ajv keyword family, mirroring the Python wording', () => {
     const response = new Response(null, { status: 422 });
     const body = {
-      detail: [{ loc: ['body', 'name'], msg: 'field required', type: 'value_error.missing' }],
+      error: {
+        message: 'invalid',
+        details: [
+          { path: '/sku', code: 'minLength', message: 'short', info: { limit: 3 } },
+          {
+            path: '/fieldType',
+            code: 'enum',
+            message: 'bad',
+            info: { allowedValues: ['shortText', 'number'] },
+          },
+          { path: '/price', code: 'minimum', message: 'low', info: { limit: 1, comparison: '>=' } },
+          { path: '', code: 'required', message: 'missing', info: { missingProperty: 'status' } },
+          { path: '/qty', code: 'type', message: 'wrong', info: { type: 'number' } },
+        ],
+      },
     };
-    const error = parseError(response, body);
+    const { message } = parseError(response, body) as ValidationError;
+    expect(message).toContain("Field 'sku' must be at least 3 characters");
+    expect(message).toContain("Field 'fieldType' must be one of: shortText, number");
+    expect(message).toContain("Field 'price' must be >= 1");
+    expect(message).toContain("Missing required field: 'status'");
+    expect(message).toContain("Field 'qty' must be of type: number");
+  });
+
+  it('should fall back gracefully for unknown/future keywords', () => {
+    const response = new Response(null, { status: 422 });
+    const body = {
+      error: {
+        message: 'invalid',
+        details: [{ path: '/x', code: 'futureKeyword', message: 'nope', info: { detail: 1 } }],
+      },
+    };
+    const { message, details } = parseError(response, body) as ValidationError;
+    expect(details).toHaveLength(1);
+    expect(message).toContain("Field 'x': (futureKeyword) nope");
+    expect(message).toContain('info:');
+  });
+
+  it('should fall back to generic formatting when a typed keyword is missing its info params', () => {
+    const response = new Response(null, { status: 422 });
+    // maxLength with no info.limit — must NOT render "must not exceed undefined characters".
+    const body = {
+      error: {
+        message: 'invalid',
+        details: [{ path: '/name', code: 'maxLength', message: 'too long' }],
+      },
+    };
+    const { message } = parseError(response, body) as ValidationError;
+    expect(message).not.toContain('undefined');
+    expect(message).toContain("Field 'name': (maxLength) too long");
+  });
+
+  it('should strip a legacy dotted path the same as a JSON pointer', () => {
+    const response = new Response(null, { status: 422 });
+    const body = {
+      error: {
+        message: 'invalid',
+        details: [{ path: '.city', code: 'maxLength', message: 'too long', info: { limit: 10 } }],
+      },
+    };
+    const { message } = parseError(response, body) as ValidationError;
+    expect(message).toContain("Field 'city' must not exceed 10 characters");
+  });
+
+  it('should not throw and yield empty details when 422 body lacks details', () => {
+    const response = new Response(null, { status: 422 });
+    const error = parseError(response, { error: { message: 'bad input' } }) as ValidationError;
     expect(error).toBeInstanceOf(ValidationError);
-    expect((error as ValidationError).details[0].field).toBe('body.name');
-    expect((error as ValidationError).details[0].message).toBe('field required');
-    expect((error as ValidationError).details[0].code).toBe('value_error.missing');
+    expect(error.details).toEqual([]);
+    expect(error.message).toBe('bad input');
   });
 
   it('should return ServerError for 5xx', () => {
@@ -178,5 +264,22 @@ describe('parseError', () => {
     const response = new Response(null, { status: 400 });
     const error = parseError(response);
     expect(error.message).toBe('Request failed with status 400');
+  });
+
+  it("should surface a message from Katana's nested {error:{message}} envelope on a 4xx", () => {
+    const response = new Response(null, { status: 404 });
+    const body = { error: { name: 'NotFoundError', message: 'Product not found' } };
+    const error = parseError(response, body);
+    expect(error).toBeInstanceOf(KatanaError);
+    expect(error).not.toBeInstanceOf(AuthenticationError);
+    expect(error.message).toBe('Product not found');
+    expect(error.statusCode).toBe(404);
+  });
+
+  it('should surface a nested-envelope message for an undocumented 5xx status', () => {
+    const response = new Response(null, { status: 599 });
+    const error = parseError(response, { error: { message: 'upstream exploded' } });
+    expect(error).toBeInstanceOf(ServerError);
+    expect(error.message).toBe('upstream exploded');
   });
 });

--- a/packages/katana-client/tests/transport/rateLimit.test.ts
+++ b/packages/katana-client/tests/transport/rateLimit.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for the proactive rate-limit transport.
+ *
+ * Mirrors the Python client's test_rate_limit_transport.py. Uses vitest fake
+ * timers throughout — the token bucket reads Date.now() and schedules timers,
+ * so the real wall clock is never consulted (per the repo's fake-time rule).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRateLimitedFetch } from '../../src/transport/rateLimit.js';
+
+/** Build a 200 Response, optionally carrying rate-limit headers. */
+function ok(headers?: Record<string, string>): Response {
+  return new Response('{}', { status: 200, headers });
+}
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+describe('createRateLimitedFetch', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allows a burst up to the bucket capacity immediately', async () => {
+    mockFetch.mockResolvedValue(ok());
+    const limited = createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+      rateLimit: { requestsPerMinute: 60, windowMs: 60_000 },
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await limited('https://api/x');
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+  });
+
+  it('paces requests beyond the burst capacity as tokens refill', async () => {
+    mockFetch.mockResolvedValue(ok());
+    // capacity 2, refill 2 tokens / 1000ms => 1 token per 500ms.
+    const limited = createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+      rateLimit: { requestsPerMinute: 2, windowMs: 1_000 },
+    });
+
+    const pending = [limited('https://api/x'), limited('https://api/x'), limited('https://api/x')];
+
+    // First two consume the burst immediately; the third waits for a refill.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+
+    await Promise.all(pending);
+  });
+
+  it('engages the reset gate on remaining=0 and releases after the reset window', async () => {
+    const reset = Date.now() + 200;
+    mockFetch
+      .mockResolvedValueOnce(
+        ok({ 'X-Ratelimit-Remaining': '0', 'X-Ratelimit-Reset': String(reset) })
+      )
+      .mockResolvedValue(ok());
+    const limited = createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+      rateLimit: { requestsPerMinute: 60, windowMs: 60_000 },
+      logger: silentLogger,
+    });
+
+    await limited('https://api/x'); // observes remaining=0 -> gate engaged
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const blocked = limited('https://api/x');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // still gated
+
+    await vi.advanceTimersByTimeAsync(200); // window rolls -> gate releases
+    await blocked;
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('extends the reset gate when a later in-flight response reports a further reset', async () => {
+    const earlier = Date.now() + 200;
+    const later = Date.now() + 500;
+    mockFetch
+      .mockResolvedValueOnce(
+        ok({ 'X-Ratelimit-Remaining': '0', 'X-Ratelimit-Reset': String(earlier) })
+      )
+      .mockResolvedValueOnce(
+        ok({ 'X-Ratelimit-Remaining': '0', 'X-Ratelimit-Reset': String(later) })
+      )
+      .mockResolvedValue(ok());
+    const limited = createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+      rateLimit: { requestsPerMinute: 60, windowMs: 60_000 },
+      logger: silentLogger,
+    });
+
+    // Two concurrent requests both pass the gate and observe remaining=0; the
+    // second carries a later reset, which must extend (not shorten) the gate.
+    await Promise.all([limited('https://api/x'), limited('https://api/x')]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    const blocked = limited('https://api/x');
+    await vi.advanceTimersByTimeAsync(200); // earlier deadline passes...
+    expect(mockFetch).toHaveBeenCalledTimes(2); // ...but the gate held to the later one
+
+    await vi.advanceTimersByTimeAsync(300); // total 500 -> later deadline
+    await blocked;
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('syncs the budget down when the server reports fewer remaining', async () => {
+    const reset = Date.now() + 60_000;
+    mockFetch
+      .mockResolvedValueOnce(
+        ok({ 'X-Ratelimit-Remaining': '1', 'X-Ratelimit-Reset': String(reset) })
+      )
+      .mockResolvedValue(ok());
+    // capacity 10, refill 10 tokens / 1000ms => 1 token per 100ms.
+    const limited = createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+      rateLimit: { requestsPerMinute: 10, windowMs: 1_000 },
+      logger: silentLogger,
+    });
+
+    // First request acquires (10->9); observing remaining=1 drains down to ~1 token.
+    await limited('https://api/x');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const pending = [limited('https://api/x'), limited('https://api/x')];
+    await vi.advanceTimersByTimeAsync(0);
+    // Only ~1 token remained, so the second request fires and the third must wait.
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(100); // refill one token
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+
+    await Promise.all(pending);
+  });
+
+  it('re-charges a token for a request gated after it acquired (no cross-window under-throttle)', async () => {
+    // capacity 1, 1 token/sec. R1 takes the token and engages the gate (late
+    // reset). R2 finds no token, sleeps in acquire, then acquires a refilled token
+    // *while the gate is still engaged* -> it gets gated post-acquire and must
+    // refund + re-acquire so it's charged against the new window (not let through free).
+    mockFetch
+      .mockResolvedValueOnce(
+        ok({ 'X-Ratelimit-Remaining': '0', 'X-Ratelimit-Reset': String(Date.now() + 2_000) })
+      )
+      .mockResolvedValue(ok());
+    const limited = createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+      rateLimit: { requestsPerMinute: 1, windowMs: 1_000 },
+      logger: silentLogger,
+    });
+
+    const r1 = limited('https://api/x'); // takes the only token, returns remaining=0
+    const r2 = limited('https://api/x'); // no token -> sleeps in acquireToken
+    await vi.advanceTimersByTimeAsync(1_000); // r2 acquires a refilled token, gate still engaged -> gated
+    await r1;
+    expect(mockFetch).toHaveBeenCalledTimes(1); // only r1 has been sent; r2 is gated
+
+    await vi.advanceTimersByTimeAsync(1_000); // total 2000 -> gate releases; r2 re-acquires and sends
+    await r2;
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // r2 was charged against the new window, so the bucket is empty: a third
+    // request must wait for a refill (without the re-charge it would fire now).
+    const r3 = limited('https://api/x');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await r3;
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws on non-positive rate-limit config', () => {
+    expect(() =>
+      createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+        rateLimit: { requestsPerMinute: 0, windowMs: 60_000 },
+      })
+    ).toThrow(/must be positive/);
+    expect(() =>
+      createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+        rateLimit: { requestsPerMinute: 60, windowMs: 0 },
+      })
+    ).toThrow(/must be positive/);
+  });
+
+  it('keeps syncing down after the bucket cycles (estimate never clamps at 0)', async () => {
+    // Regression for the prior decrement-only estimate: header-less traffic +
+    // a refill must NOT prevent a later low `remaining` from syncing down.
+    const okH = (remaining: number) =>
+      ok({
+        'X-Ratelimit-Remaining': String(remaining),
+        'X-Ratelimit-Reset': String(Date.now() + 120_000),
+      });
+    mockFetch
+      .mockResolvedValueOnce(okH(2)) // syncs bucket down to 2
+      .mockResolvedValueOnce(ok()) // header-less drains toward 0
+      .mockResolvedValueOnce(ok())
+      .mockResolvedValueOnce(okH(5)) // after a full refill: must sync down again
+      .mockResolvedValue(ok());
+    // 60/min => 1 token/sec, so the in-test awaits don't refill meaningfully.
+    const limited = createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+      rateLimit: { requestsPerMinute: 60, windowMs: 60_000 },
+      logger: silentLogger,
+    });
+
+    await limited('https://api/x'); // -> tokens 2
+    await limited('https://api/x'); // -> ~1
+    await limited('https://api/x'); // -> ~0
+    await vi.advanceTimersByTimeAsync(60_000); // window rolls: bucket refills to 60
+    await limited('https://api/x'); // observes remaining=5 -> bucket clamped to 5
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+
+    // Bucket now holds ~5 tokens: five more fire immediately, a sixth is paced.
+    const burst = Array.from({ length: 6 }, () => limited('https://api/x'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockFetch).toHaveBeenCalledTimes(9); // 4 + 5 immediate; 6th gated on a token
+    await vi.advanceTimersByTimeAsync(1_000);
+    await Promise.all(burst);
+    expect(mockFetch).toHaveBeenCalledTimes(10);
+  });
+
+  it('is a no-op when rate-limit headers are absent', async () => {
+    mockFetch.mockResolvedValue(ok()); // no rate-limit headers
+    const limited = createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+      rateLimit: { requestsPerMinute: 60, windowMs: 60_000 },
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await limited('https://api/x');
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+  });
+
+  it('treats malformed rate-limit headers as a no-op and warns', async () => {
+    const warn = vi.fn();
+    mockFetch.mockResolvedValue(ok({ 'X-Ratelimit-Remaining': 'abc', 'X-Ratelimit-Reset': 'xyz' }));
+    const limited = createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+      rateLimit: { requestsPerMinute: 60, windowMs: 60_000 },
+      logger: { ...silentLogger, warn },
+    });
+
+    await limited('https://api/x');
+    await limited('https://api/x');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('ignores a reset window whose deadline is already in the past', async () => {
+    const stale = Date.now() - 1_000;
+    mockFetch
+      .mockResolvedValueOnce(
+        ok({ 'X-Ratelimit-Remaining': '0', 'X-Ratelimit-Reset': String(stale) })
+      )
+      .mockResolvedValue(ok());
+    const limited = createRateLimitedFetch(mockFetch as unknown as typeof fetch, {
+      rateLimit: { requestsPerMinute: 60, windowMs: 60_000 },
+      logger: silentLogger,
+    });
+
+    await limited('https://api/x'); // remaining=0 but reset is stale -> no gate
+    const next = limited('https://api/x');
+    await vi.advanceTimersByTimeAsync(0);
+    await next;
+    expect(mockFetch).toHaveBeenCalledTimes(2); // not blocked
+  });
+});


### PR DESCRIPTION
## Summary

Brings the TypeScript client (`packages/katana-client`) to parity with two recent Python-client improvements that never reached it (the TS client had drifted; the regen + CI drift-gate landed separately in #903's follow-up, this PR ports the *behavior*).

### Ajv-style 422 validation errors
- `ValidationError.details` now uses the generated `ValidationErrorDetail` union (`{ path, code, message, info }`), parsed from Katana's **nested `{ "error": { details: [...] } }` envelope** — verified against a live 422 probe.
- New keyword-dispatch formatter (`formatValidationDetail`) mirroring the Python client's `_format_ajv_detail` wording, surfaced as `ValidationError.message`.
  - **Hand-rolled** rather than via `@segment/ajv-human-errors`: that lib crashes on `maxLength`/`minLength`/items keywords without the validated `data` instance, which Katana doesn't send on the wire (confirmed by probe). Hand-rolling needs only `code` + `info`, gives Python-parity wording, and adds zero deps.
- `parseError` now unwraps the nested `error` envelope and surfaces messages for undocumented status codes.

### Proactive rate limiting
- New `createRateLimitedFetch` transport: zero-dep token bucket (60/min default) + adaptive sync-down from `X-Ratelimit-Remaining` + reset gate on `Remaining: 0`, mirroring the Python `RateLimitTransport`.
- Wired **innermost** in the client fetch chain (base → rate-limit → retry → paginated → auth) so each retry attempt and each paginated page consumes a token.
- New `requestsPerMinute` option (default 60, `null` disables).

### ⚠️ Breaking
`ValidationError.details` items changed from `{ field, message, code, value }` to the Ajv shape `{ path, code, message, info }`; the hand-written `ValidationErrorDetail` interface is removed in favor of the generated union.

## Follow-ups filed
- #910 — enrich 422s with request-context (value-vs-constraint) via a transport-layer error-context seam (benefits client + MCP).
- #911 — typecheck the currently-excluded TS test files (surfaces latent mock-typing drift).

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run build` — clean
- [x] `npm test` — 118 tests pass (new Ajv-keyword + rate-limit suites, fake-timer based)
- [x] `uv run poe check` — green (no Python-side regression; change is TS-only)
- [x] Live 422 probe confirmed the wire shape (`/label` maxLength, nested `error` envelope, epoch-ms reset)
- [x] `code-reviewer` pass: 1 blocking + 4 suggestions addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)