### PR TITLE
feat(mcp): create_sales_order accepts status + picked_date (closes #907)

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1497,6 +1497,22 @@ Create a sales order with preview/apply pattern.
 - `notes`: Internal notes (additional_info on the wire)
 - `customer_ref`: Customer's reference number
 
+**Initial status & picking** (#907):
+- `status` (optional): Initial SO status. Katana's `POST /sales_orders`
+  accepts only `NOT_SHIPPED` or `PENDING`; omit to default to `PENDING`.
+  Pass `NOT_SHIPPED` to skip the transient `PENDING` state when
+  back-filling an already-confirmed order — this avoids the forced
+  PENDING→NOT_SHIPPED transition that otherwise strands the SO in PENDING
+  and silently blocks `fulfill_order`. `PACKED`/`DELIVERED` are rejected
+  here (BLOCK) — reach them by shipping the order via
+  `fulfill_order(order_type='sales')`.
+- `picked_date` (ISO 8601, optional): When items were picked. Wire-level,
+  Katana's `POST /sales_orders` rejects `picked_date`, so the apply path
+  sets it via a follow-up `PATCH /sales_orders/{id}` after the SO exists.
+  Best-effort: the SO is durable; a failed patch surfaces a warning and a
+  retry hint pointing at `modify_sales_order(id=<so_id>,
+  update_header={'picked_date': ...})`.
+
 **Shipping / tracking:**
 - `tracking_number`, `tracking_number_url`: Set if a carrier label is
   already known at creation time; otherwise patch in via

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -262,6 +262,19 @@ class SOShippingFeeUpdate(BaseModel):
     )
 
 
+# Valid SO statuses. NOTE: the wire ``POST /sales_orders`` only accepts
+# ``NOT_SHIPPED`` / ``PENDING`` (``CreateSalesOrderStatus``); ``PACKED`` /
+# ``DELIVERED`` are reached by shipping the order via ``fulfill_order``. The
+# wider literal here is shared with ``SOHeaderPatch`` (the PATCH endpoint does
+# accept all four); ``create_sales_order`` validates the create-time subset in
+# its impl so it can return an actionable refusal pointing at ``fulfill_order``.
+SalesOrderStatusLiteral = Literal["NOT_SHIPPED", "PENDING", "PACKED", "DELIVERED"]
+
+# Statuses that are only reachable post-create (via fulfillment), never at
+# ``POST /sales_orders`` time.
+_CREATE_TERMINAL_STATUSES: tuple[str, ...] = ("PACKED", "DELIVERED")
+
+
 class CreateSalesOrderRequest(BaseModel):
     """Request to create a sales order."""
 
@@ -345,6 +358,33 @@ class CreateSalesOrderRequest(BaseModel):
             "Names must already exist on the SO custom-field collection "
             "(configured via Katana's UI) and value types must match each "
             "field's configured type."
+        ),
+    )
+    status: SalesOrderStatusLiteral | None = Field(
+        default=None,
+        description=(
+            "Initial status for the new SO. Katana's `POST /sales_orders` accepts "
+            "only `NOT_SHIPPED` or `PENDING` — leave None to default to `PENDING` "
+            "(unchanged legacy behavior). Pass `NOT_SHIPPED` to skip the transient "
+            "`PENDING` state entirely (e.g. back-filling an already-confirmed "
+            "marketplace order): this avoids the forced PENDING→NOT_SHIPPED "
+            "transition that otherwise strands the SO in PENDING and silently "
+            "blocks `fulfill_order`. `PACKED`/`DELIVERED` are NOT valid here — "
+            "reach them by shipping the order via `fulfill_order(order_type="
+            "'sales')` after it exists."
+        ),
+    )
+    picked_date: WireDatetime | None = Field(
+        default=None,
+        description=(
+            "When items were picked from inventory — ISO 8601 date or datetime "
+            "(e.g. '2026-05-29T00:00:00Z'). Naive datetimes are interpreted as "
+            "UTC. Wire-level: Katana's `POST /sales_orders` rejects `picked_date`, "
+            "so the apply path sets it via a follow-up `PATCH /sales_orders/{id}` "
+            "after the SO is created. Best-effort — if the SO succeeds but the "
+            "picked_date patch fails, the SO is preserved and the response carries "
+            "a warning; retry via `modify_sales_order(id=<so_id>, "
+            "update_header={'picked_date': ...})`."
         ),
     )
     shipping_fees: list[SOShippingFeeAdd] | None = Field(
@@ -597,6 +637,39 @@ async def _create_sales_order_impl(
         if loc_warn:
             resolution_warnings.append(loc_warn)
 
+    # BLOCK invalid initial statuses early (both preview and apply). The wire
+    # POST /sales_orders only accepts NOT_SHIPPED / PENDING — PACKED / DELIVERED
+    # are reached by shipping the order. Refuse with an actionable card instead
+    # of letting CreateSalesOrderStatus(<terminal>) raise a bare ValueError.
+    if request.status in _CREATE_TERMINAL_STATUSES:
+        return SalesOrderResponse(
+            order_number=request.order_number,
+            customer_id=request.customer_id,
+            customer_name=customer_name,
+            location_id=request.location_id,
+            location_name=location_name,
+            is_preview=True,
+            shipping_fee_outcomes=_outcomes_from_planned_fees(
+                request.shipping_fees or []
+            ),
+            warnings=[
+                f"{BLOCK_WARNING_PREFIX} status={request.status!r} cannot be set "
+                f"at creation — Katana's POST /sales_orders accepts only "
+                f"NOT_SHIPPED or PENDING. Create the order first, then reach "
+                f"{request.status} by shipping it via "
+                f"fulfill_order(order_type='sales').",
+                *resolution_warnings,
+            ],
+            next_actions=[
+                "Use status=NOT_SHIPPED or PENDING (or omit to default to PENDING)",
+                f"Reach {request.status} via fulfill_order after the order exists",
+            ],
+            message=(
+                f"Sales order {request.order_number} was NOT created — "
+                f"status {request.status} is not a valid initial status."
+            ),
+        )
+
     if request.preview:
         logger.info(
             f"Preview mode: SO {request.order_number} would have {len(request.items)} items"
@@ -623,7 +696,7 @@ async def _create_sales_order_impl(
             customer_name=customer_name,
             location_id=request.location_id,
             location_name=location_name,
-            status="PENDING",
+            status=request.status or "PENDING",
             total=total_estimate if total_estimate > 0 else None,
             currency=request.currency,
             delivery_date=request.delivery_date.isoformat()
@@ -750,7 +823,14 @@ async def _create_sales_order_impl(
             ecommerce_store_name=to_unset(request.ecommerce_store_name),
             ecommerce_order_id=to_unset(request.ecommerce_order_id),
             custom_fields=custom_fields_map,
-            status=CreateSalesOrderStatus.PENDING,
+            # request.status is guaranteed NOT_SHIPPED / PENDING / None here —
+            # terminal statuses were refused above. None preserves the legacy
+            # default of PENDING.
+            status=(
+                CreateSalesOrderStatus(request.status)
+                if request.status
+                else CreateSalesOrderStatus.PENDING
+            ),
         )
 
         # Call API
@@ -812,6 +892,34 @@ async def _create_sales_order_impl(
                     f"`modify_sales_order(id={so.id}, add_shipping_fees=[...])`."
                 )
 
+        # picked_date is NOT accepted by POST /sales_orders — the live API 422s
+        # on it as an unknown property (probed for #907). So when supplied, set
+        # it via PATCH /sales_orders/{id} after the SO exists. Best-effort,
+        # mirroring shipping fees: the SO is durable; a failed patch surfaces a
+        # warning + retry hint and leaves the SO intact.
+        picked_date_warnings: list[str] = []
+        if request.picked_date is not None:
+            try:
+                picked_resp = await api_update_sales_order.asyncio_detailed(
+                    client=services.client,
+                    id=so.id,
+                    body=APIUpdateSalesOrderRequest(picked_date=request.picked_date),
+                )
+                unwrap_as(picked_resp, SalesOrder)
+            except Exception as picked_exc:
+                logger.warning(
+                    "create_sales_order picked_date PATCH failed",
+                    sales_order_id=so.id,
+                    picked_date=str(request.picked_date),
+                    error=str(picked_exc),
+                )
+                picked_date_warnings.append(
+                    f"Sales order {so.id} was created, but setting picked_date "
+                    f"failed: {picked_exc}. The sales order is preserved — retry "
+                    f"via `modify_sales_order(id={so.id}, "
+                    f"update_header={{'picked_date': ...}})`."
+                )
+
         next_actions = [
             f"Sales order created with ID {so.id}",
             "Use fulfill_order to ship items when ready",
@@ -820,6 +928,11 @@ async def _create_sales_order_impl(
             next_actions.append(
                 f"Retry failed shipping fees via "
                 f"modify_sales_order(id={so.id}, add_shipping_fees=[...])"
+            )
+        if picked_date_warnings:
+            next_actions.append(
+                f"Retry picked_date via modify_sales_order(id={so.id}, "
+                f"update_header={{'picked_date': ...}})"
             )
 
         message = f"Successfully created sales order {so.order_no} (ID: {so.id})"
@@ -873,7 +986,12 @@ async def _create_sales_order_impl(
             currency=currency,
             is_preview=False,
             shipping_fee_outcomes=fee_outcomes,
-            warnings=(fee_warnings + resolution_warnings + apply_resolution_warnings),
+            warnings=(
+                fee_warnings
+                + picked_date_warnings
+                + resolution_warnings
+                + apply_resolution_warnings
+            ),
             katana_url=katana_web_url("sales_order", so.id),
             next_actions=next_actions,
             message=message,
@@ -1787,7 +1905,6 @@ class SOOperation(StrEnum):
 
 # Tool-facing literals — values match the API StrEnum's ``.value`` directly,
 # so ``EnumClass(literal)`` resolves the enum without a lookup table.
-SalesOrderStatusLiteral = Literal["NOT_SHIPPED", "PENDING", "PACKED", "DELIVERED"]
 FulfillmentStatusLiteral = Literal["DELIVERED", "PACKED"]
 AddressEntityTypeLiteral = Literal["billing", "shipping"]
 

--- a/katana_mcp_server/tests/test_field_set_drift.py
+++ b/katana_mcp_server/tests/test_field_set_drift.py
@@ -97,10 +97,12 @@ PAIRINGS: list[Pairing] = [
         },
     ),
     # ---- create_sales_order ----
-    # Skipped fields per the #627 deliberate-omissions table:
-    #   status: PENDING is the only sensible initial state; transitions
-    #     belong on modify_sales_order. Exposing forces agents to learn
-    #     the SO status enum at creation for no real benefit.
+    # `status` is now exposed (#907): #627's "PENDING is the only sensible
+    # initial state" call was reversed once the eBay/marketplace backfill
+    # workflow showed that forcing every caller through a follow-up
+    # PENDING→NOT_SHIPPED transition silently strands SOs in PENDING. The wire
+    # accepts NOT_SHIPPED / PENDING; the impl refuses PACKED / DELIVERED with a
+    # pointer to fulfill_order. No allowed_drops remain.
     Pairing(
         mcp_cls=CreateSalesOrderRequest,
         api_cls=ApiCreateSORequest,
@@ -108,12 +110,6 @@ PAIRINGS: list[Pairing] = [
             "order_no": "order_number",
             "sales_order_rows": "items",
             "additional_info": "notes",
-        },
-        allowed_drops={
-            "status": (
-                "PENDING-only at creation; status transitions belong on "
-                "modify_sales_order. Per #627 deliberate-omissions table."
-            ),
         },
     ),
     # ---- create_manufacturing_order ----

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -2,7 +2,7 @@
 
 import json
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any, Literal, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -30,6 +30,7 @@ from katana_mcp_server.tests.conftest import create_mock_context, patch_typed_ca
 
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.models import (
+    CreateSalesOrderStatus,
     SalesOrder,
     SalesOrderStatus,
 )
@@ -875,6 +876,281 @@ async def test_create_sales_order_apply_all_shipping_fees_fail():
     # the operator can copy-paste the retry call.
     assert "0/2 shipping fee(s) applied" in result.message
     assert str(result.id) in result.message
+
+
+# ----------------------------------------------------------------------------
+# status param (#907) — initial-status passthrough + terminal-status refusal
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_sales_order_apply_forwards_status():
+    """A caller-supplied initial ``status`` reaches the wire create body —
+    NOT_SHIPPED lets backfill flows skip the transient PENDING state (#907).
+    """
+    context, _lifespan_ctx = create_mock_context()
+
+    mock_so = SalesOrder(
+        id=4001,
+        customer_id=1501,
+        order_no="SO-STATUS-001",
+        location_id=1,
+        status=SalesOrderStatus.NOT_SHIPPED,
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = mock_so
+    mock_api_call = AsyncMock(return_value=mock_response)
+
+    import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
+
+    original = create_so_module.asyncio_detailed
+    cast(Any, create_so_module).asyncio_detailed = mock_api_call
+    try:
+        request = CreateSalesOrderRequest(
+            customer_id=1501,
+            order_number="SO-STATUS-001",
+            items=[SalesOrderItem(variant_id=2101, quantity=1)],
+            status="NOT_SHIPPED",
+            preview=False,
+        )
+        await _create_sales_order_impl(request, context)
+    finally:
+        cast(Any, create_so_module).asyncio_detailed = original
+
+    api_body = mock_api_call.call_args.kwargs["body"]
+    assert api_body.status == CreateSalesOrderStatus.NOT_SHIPPED
+
+
+@pytest.mark.asyncio
+async def test_create_sales_order_apply_defaults_status_pending():
+    """Omitting ``status`` preserves the legacy default — the wire body must
+    still carry PENDING, not UNSET (#907 must not change default behavior).
+    """
+    context, _lifespan_ctx = create_mock_context()
+
+    mock_so = SalesOrder(
+        id=4002,
+        customer_id=1501,
+        order_no="SO-STATUS-DEF",
+        location_id=1,
+        status=SalesOrderStatus.PENDING,
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.parsed = mock_so
+    mock_api_call = AsyncMock(return_value=mock_response)
+
+    import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
+
+    original = create_so_module.asyncio_detailed
+    cast(Any, create_so_module).asyncio_detailed = mock_api_call
+    try:
+        request = CreateSalesOrderRequest(
+            customer_id=1501,
+            order_number="SO-STATUS-DEF",
+            items=[SalesOrderItem(variant_id=2101, quantity=1)],
+            preview=False,
+        )
+        await _create_sales_order_impl(request, context)
+    finally:
+        cast(Any, create_so_module).asyncio_detailed = original
+
+    api_body = mock_api_call.call_args.kwargs["body"]
+    assert api_body.status == CreateSalesOrderStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_create_sales_order_preview_reflects_status():
+    """Preview card status mirrors the requested initial status (defaults to
+    PENDING when omitted), so the operator sees what they'll get."""
+    context, _lifespan_ctx = create_mock_context()
+
+    not_shipped = await _create_sales_order_impl(
+        CreateSalesOrderRequest(
+            customer_id=1501,
+            order_number="SO-PREV-NS",
+            items=[SalesOrderItem(variant_id=2101, quantity=1)],
+            status="NOT_SHIPPED",
+            preview=True,
+        ),
+        context,
+    )
+    assert not_shipped.is_preview is True
+    assert not_shipped.status == "NOT_SHIPPED"
+
+    defaulted = await _create_sales_order_impl(
+        CreateSalesOrderRequest(
+            customer_id=1501,
+            order_number="SO-PREV-DEF",
+            items=[SalesOrderItem(variant_id=2101, quantity=1)],
+            preview=True,
+        ),
+        context,
+    )
+    assert defaulted.status == "PENDING"
+
+
+@pytest.mark.parametrize("terminal", ["PACKED", "DELIVERED"])
+@pytest.mark.asyncio
+async def test_create_sales_order_rejects_terminal_status(
+    terminal: Literal["PACKED", "DELIVERED"],
+):
+    """PACKED / DELIVERED are unreachable at create (the wire caps status at
+    NOT_SHIPPED / PENDING). The tool BLOCKs with a pointer to fulfill_order and
+    does NOT create the SO."""
+    context, _lifespan_ctx = create_mock_context()
+
+    mock_api_call = AsyncMock()
+    import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
+
+    original = create_so_module.asyncio_detailed
+    cast(Any, create_so_module).asyncio_detailed = mock_api_call
+    try:
+        result = await _create_sales_order_impl(
+            CreateSalesOrderRequest(
+                customer_id=1501,
+                order_number="SO-TERM-001",
+                items=[SalesOrderItem(variant_id=2101, quantity=1)],
+                status=terminal,
+                preview=False,
+            ),
+            context,
+        )
+    finally:
+        cast(Any, create_so_module).asyncio_detailed = original
+
+    # No SO created.
+    mock_api_call.assert_not_called()
+    assert result.id is None
+    # Refusal renders as a preview card with a BLOCK warning.
+    assert result.is_preview is True
+    assert any(
+        w.startswith("BLOCK:") and "fulfill_order" in w and terminal in w
+        for w in result.warnings
+    )
+    assert "NOT created" in result.message
+    assert any("fulfill_order" in a for a in result.next_actions)
+
+
+# ----------------------------------------------------------------------------
+# picked_date (#907) — post-create PATCH chain (wire create rejects it)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_sales_order_apply_sets_picked_date_via_patch():
+    """picked_date can't ride on POST /sales_orders (live API 422s on it), so
+    the apply path PATCHes it in after the SO is created."""
+    context, _lifespan_ctx = create_mock_context()
+
+    mock_so = SalesOrder(
+        id=4101,
+        customer_id=1501,
+        order_no="SO-PICK-OK",
+        location_id=1,
+        status=SalesOrderStatus.NOT_SHIPPED,
+    )
+    create_resp = MagicMock()
+    create_resp.status_code = 200
+    create_resp.parsed = mock_so
+    patch_resp = MagicMock()
+    patch_resp.status_code = 200
+    patch_resp.parsed = mock_so
+
+    mock_create = AsyncMock(return_value=create_resp)
+    mock_patch = AsyncMock(return_value=patch_resp)
+
+    import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
+    import katana_public_api_client.api.sales_order.update_sales_order as update_so_module
+
+    create_orig = create_so_module.asyncio_detailed
+    update_orig = update_so_module.asyncio_detailed
+    cast(Any, create_so_module).asyncio_detailed = mock_create
+    cast(Any, update_so_module).asyncio_detailed = mock_patch
+
+    picked = datetime(2026, 5, 29, tzinfo=UTC)
+    try:
+        result = await _create_sales_order_impl(
+            CreateSalesOrderRequest(
+                customer_id=1501,
+                order_number="SO-PICK-OK",
+                items=[SalesOrderItem(variant_id=2101, quantity=1)],
+                status="NOT_SHIPPED",
+                picked_date=picked,
+                preview=False,
+            ),
+            context,
+        )
+    finally:
+        cast(Any, create_so_module).asyncio_detailed = create_orig
+        cast(Any, update_so_module).asyncio_detailed = update_orig
+
+    assert result.is_preview is False
+    assert result.id == 4101
+    # The PATCH fired once against the created SO, carrying picked_date.
+    mock_patch.assert_called_once()
+    assert mock_patch.call_args.kwargs["id"] == 4101
+    assert mock_patch.call_args.kwargs["body"].picked_date == picked
+    # Clean run — no picked_date warning.
+    assert not any("picked_date" in w for w in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_create_sales_order_picked_date_patch_failure_preserves_so():
+    """If the picked_date PATCH fails, the SO is preserved (best-effort, like
+    shipping fees): is_preview stays False, a non-BLOCK warning surfaces the
+    retry hint, and a retry next_action points at modify_sales_order."""
+    context, _lifespan_ctx = create_mock_context()
+
+    mock_so = SalesOrder(
+        id=4102,
+        customer_id=1501,
+        order_no="SO-PICK-FAIL",
+        location_id=1,
+        status=SalesOrderStatus.NOT_SHIPPED,
+    )
+    create_resp = MagicMock()
+    create_resp.status_code = 200
+    create_resp.parsed = mock_so
+
+    mock_create = AsyncMock(return_value=create_resp)
+    mock_patch = AsyncMock(side_effect=RuntimeError("picked_date PATCH boom"))
+
+    import katana_public_api_client.api.sales_order.create_sales_order as create_so_module
+    import katana_public_api_client.api.sales_order.update_sales_order as update_so_module
+
+    create_orig = create_so_module.asyncio_detailed
+    update_orig = update_so_module.asyncio_detailed
+    cast(Any, create_so_module).asyncio_detailed = mock_create
+    cast(Any, update_so_module).asyncio_detailed = mock_patch
+
+    try:
+        result = await _create_sales_order_impl(
+            CreateSalesOrderRequest(
+                customer_id=1501,
+                order_number="SO-PICK-FAIL",
+                items=[SalesOrderItem(variant_id=2101, quantity=1)],
+                status="NOT_SHIPPED",
+                picked_date=datetime(2026, 5, 29, tzinfo=UTC),
+                preview=False,
+            ),
+            context,
+        )
+    finally:
+        cast(Any, create_so_module).asyncio_detailed = create_orig
+        cast(Any, update_so_module).asyncio_detailed = update_orig
+
+    # SO durability: created despite the picked_date failure.
+    assert result.is_preview is False
+    assert result.id == 4102
+    assert any(
+        "picked_date" in w and not w.startswith("BLOCK:") and "4102" in w
+        for w in result.warnings
+    )
+    assert any(
+        "picked_date" in a and "modify_sales_order" in a for a in result.next_actions
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes the last create-time field gap on `create_sales_order`, reversing the
#627 deliberate omission once the eBay/marketplace backfill workflow showed that
forcing every caller through a follow-up PENDING→NOT_SHIPPED transition silently
strands SOs in `PENDING` (eight accumulated before diagnosis, blocking
`fulfill_order` with "row … is already pending").

After this PR, `create_sales_order` exposes **every** field the wire
`POST /sales_orders` accepts — full parity, verified end-to-end against the live
API (see #907 field-fidelity probe).

- **`status`** (new, optional): the wire accepts only `NOT_SHIPPED` / `PENDING`.
  `None` still defaults to `PENDING` (unchanged legacy behavior). `NOT_SHIPPED`
  lets backfills skip the transient PENDING state. `PACKED` / `DELIVERED` are
  refused at the MCP layer with a BLOCK card pointing at `fulfill_order`
  (terminal states are reached via fulfillment, never at create — confirmed by
  probe).
- **`picked_date`** (new, optional): the live wire **422s** on `picked_date` at
  create (`additionalProperties`), so it's applied via a follow-up
  `PATCH /sales_orders/{id}` after the SO exists — best-effort, mirroring the
  shipping-fee chain (#818): the SO is durable, a failed patch surfaces a warning
  + retry hint and leaves the SO intact.
- **Drift detector**: drop the `status` `allowed_drops` entry for
  `create_sales_order` (the field is now exposed); `create_sales_order` is back
  at full wire parity.
- **Help resource** + Field descriptions document both.

### Why `picked_date` is a PATCH chain, not a passthrough

Probed against the live API (test tenant): `POST /sales_orders` rejects
`picked_date` outright (`422 additionalProperties`), while `status=NOT_SHIPPED`
is accepted and persists. So `picked_date` is genuinely a post-create concern
and gets the same best-effort follow-up treatment as inline shipping fees.

## Test plan

- [x] `uv run poe check` — full gate green (incl. 47 browser render tests), exit 0
- [x] `status` forwarded to the wire create body; `None` still sends `PENDING`
- [x] preview card reflects the chosen initial status
- [x] `PACKED` / `DELIVERED` → BLOCK refusal, SO not created, points at `fulfill_order`
- [x] `picked_date` applied via PATCH after create; best-effort failure preserves the SO + emits a retry hint
- [x] field-set drift detector green with `status` exposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
