### PR TITLE
feat(mcp): derive ecommerce storefront deep-links for sales orders

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1530,11 +1530,15 @@ Create a sales order with preview/apply pattern.
     intact. Retry failed fees via
     `modify_sales_order(id=<so_id>, add_shipping_fees=[...])`.
 
-**Ecommerce cross-references** (set when the SO mirrors an order from a
-storefront — Shopify, WooCommerce, etc.):
-- `ecommerce_order_type`: e.g. 'shopify_order'
-- `ecommerce_store_name`: e.g. 'Acme Online Store'
-- `ecommerce_order_id`: Original platform order ID
+**Ecommerce cross-references** (set when the SO came from a native ecommerce
+integration). All three are **create-only** — they cannot be changed via
+`modify_sales_order`:
+- `ecommerce_order_type`: case-sensitive platform id. Deep-linkable values:
+  `shopify`, `wooCommerce`, `bigCommerce` (camelCase). Other strings are
+  accepted but don't render a storefront link.
+- `ecommerce_store_name`: storefront hostname for Shopify/WooCommerce
+  (e.g. 'acme.myshopify.com'); the bare store slug for BigCommerce.
+- `ecommerce_order_id`: original platform order id (e.g. '19433769').
 
 **Custom fields:**
 - `custom_fields`: `list[{field_name, field_value}]`. Names must already
@@ -1614,7 +1618,9 @@ total_in_base_currency, currency, conversion_rate, conversion_date), notes
 tracking_number_url), address pointers (billing_address_id,
 shipping_address_id) plus the full resolved `addresses` list fetched from
 /sales_order_addresses, `shipping_fee` block, `linked_manufacturing_order_id`,
-ecommerce metadata (ecommerce_order_type/store_name/order_id), timestamps
+ecommerce metadata (ecommerce_order_type/store_name/order_id, plus a derived
+`ecommerce_url` "Open in {platform}" storefront deep-link for Shopify/
+WooCommerce/BigCommerce orders), timestamps
 (created_at, updated_at, deleted_at), and per-line `rows` with every
 `SalesOrderRow` field (variant_id, SKU via variant cache, quantity, pricing,
 discounts, tax, cogs, linked MO, batch/serial tracking, timestamps).

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -65,7 +65,11 @@ from katana_mcp.tools.tool_result_utils import (
     resolve_entity_name,
 )
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
-from katana_mcp.web_urls import katana_web_url
+from katana_mcp.web_urls import (
+    RECOGNIZED_ECOMMERCE_TYPES,
+    ecommerce_storefront_url,
+    katana_web_url,
+)
 
 # Modify/delete API endpoints used by ``modify_sales_order`` /
 # ``delete_sales_order``. Hoisted to module scope for declarative dependency
@@ -332,22 +336,30 @@ class CreateSalesOrderRequest(BaseModel):
     ecommerce_order_type: str | None = Field(
         default=None,
         description=(
-            "Type of ecommerce order, e.g. 'shopify_order' / 'woocommerce_order'. "
-            "Use when the SO mirrors an order from an ecommerce store."
+            "Ecommerce integration type. Values that produce an 'Open in "
+            "storefront' deep-link are case-sensitive: 'shopify', 'wooCommerce', "
+            "'bigCommerce' (note the camelCase). Other strings are accepted by "
+            "Katana but won't render a storefront link. These ecommerce fields "
+            "are CREATE-ONLY — they cannot be changed via modify_sales_order "
+            "(the API rejects them on update), so set them correctly here."
         ),
     )
     ecommerce_store_name: str | None = Field(
         default=None,
         description=(
-            "Name of the ecommerce store the order originated from "
-            "(e.g. 'Acme Online Store')."
+            "Storefront identifier the deep-link is built from. For Shopify and "
+            "WooCommerce this is the full storefront hostname "
+            "(e.g. 'acme.myshopify.com'); for BigCommerce it is the bare store "
+            "subdomain slug (used as 'store-{slug}.mybigcommerce.com'). "
+            "Create-only."
         ),
     )
     ecommerce_order_id: str | None = Field(
         default=None,
         description=(
             "Original order ID from the ecommerce platform — used to "
-            "cross-reference the Katana SO back to the storefront record."
+            "cross-reference the Katana SO back to the storefront record and to "
+            "build the storefront deep-link. Create-only."
         ),
     )
     custom_fields: dict[str, Any] | None = Field(
@@ -561,6 +573,26 @@ def _validate_shipping_fee_amounts(
     return warnings
 
 
+def _ecommerce_type_warning(order_type: str | None) -> str | None:
+    """Advisory warning when ``ecommerce_order_type`` won't deep-link.
+
+    The wire accepts any string for this field (no server enum), but only the
+    recognized camelCase platforms render an "Open in storefront" link, and the
+    field is create-only — a mis-typed value bakes in permanently. Returns a
+    plain (non-``BLOCK:``) warning so it advises without gating the Confirm
+    button, or ``None`` when the value is recognized or unset.
+    """
+    if order_type and order_type not in RECOGNIZED_ECOMMERCE_TYPES:
+        recognized = ", ".join(sorted(RECOGNIZED_ECOMMERCE_TYPES))
+        return (
+            f"ecommerce_order_type {order_type!r} is not a recognized "
+            f"deep-linkable platform ({recognized}); the order will be created "
+            f"but won't get an 'Open in storefront' link. This field is "
+            f"create-only and cannot be changed afterward."
+        )
+    return None
+
+
 def _outcomes_from_planned_fees(
     fees: list[SOShippingFeeAdd],
 ) -> list[ShippingFeeOutcome]:
@@ -636,6 +668,14 @@ async def _create_sales_order_impl(
         )
         if loc_warn:
             resolution_warnings.append(loc_warn)
+
+    # Advise (don't block) when ecommerce_order_type won't deep-link. Threading
+    # this through ``resolution_warnings`` carries it into the preview, apply,
+    # and terminal-status-refusal branches alike — and the field is create-only,
+    # so this is the only chance to flag a mis-typed value.
+    ecommerce_warn = _ecommerce_type_warning(request.ecommerce_order_type)
+    if ecommerce_warn:
+        resolution_warnings.append(ecommerce_warn)
 
     # BLOCK invalid initial statuses early (both preview and apply). The wire
     # POST /sales_orders only accepts NOT_SHIPPED / PENDING — PACKED / DELIVERED
@@ -1602,6 +1642,17 @@ class GetSalesOrderResponse(SoftDeletableResponse):
     ecommerce_order_type: str | None = None
     ecommerce_store_name: str | None = None
     ecommerce_order_id: str | None = None
+    ecommerce_url: str | None = Field(
+        default=None,
+        description=(
+            'Storefront deep-link ("Open in {platform}") derived from the '
+            "ecommerce metadata when the order came from a recognized native "
+            "integration (Shopify / WooCommerce / BigCommerce). None for other "
+            "or absent integrations (e.g. an eBay order imported via "
+            "middleware) — mirrors what Katana's own UI links. Built by "
+            "ecommerce_storefront_url()."
+        ),
+    )
 
     # Timestamps
     created_at: str | None = None
@@ -1848,6 +1899,11 @@ async def _get_sales_order_impl(
         ecommerce_order_type=unwrap_unset(so.ecommerce_order_type, None),
         ecommerce_store_name=unwrap_unset(so.ecommerce_store_name, None),
         ecommerce_order_id=unwrap_unset(so.ecommerce_order_id, None),
+        ecommerce_url=ecommerce_storefront_url(
+            unwrap_unset(so.ecommerce_order_type, None),
+            unwrap_unset(so.ecommerce_store_name, None),
+            unwrap_unset(so.ecommerce_order_id, None),
+        ),
         created_at=iso_or_none(unwrap_unset(so.created_at, None)),
         updated_at=iso_or_none(unwrap_unset(so.updated_at, None)),
         deleted_at=iso_or_none(unwrap_unset(so.deleted_at, None)),

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -135,7 +135,12 @@ from katana_mcp.tools.foundation.po_row_table import (
     prepare_po_row_table_rows,
 )
 from katana_mcp.tools.tool_result_utils import BLOCK_WARNING_PREFIX
-from katana_mcp.web_urls import EntityKind, katana_web_url
+from katana_mcp.web_urls import (
+    EntityKind,
+    ecommerce_platform_label,
+    ecommerce_storefront_url,
+    katana_web_url,
+)
 
 logger = get_logger(__name__)
 
@@ -3650,6 +3655,35 @@ def _init_create_card_state(response: dict[str, Any]) -> dict[str, Any]:
     return state
 
 
+def _render_ecommerce_link(entity: dict[str, Any]) -> None:
+    """Render the 'Open in {platform}' storefront link for a sales order, or
+    nothing.
+
+    Reads the precomputed ``ecommerce_url`` (set impl-side on the
+    ``get_sales_order`` detail response) and falls back to deriving it from the
+    raw ``ecommerce_order_type`` / ``ecommerce_store_name`` /
+    ``ecommerce_order_id`` fields — the shape the modify card's ``prior_state``
+    snapshot (``SalesOrder.to_dict()``) carries, where ``ecommerce_url`` is
+    absent. Renders nothing when the order has no recognized storefront link
+    (unrecognized integration such as an eBay order imported via middleware, or
+    a missing store/order id), so callers invoke it unconditionally.
+
+    Must be called inside a ``Column`` / ``CardContent`` context.
+    """
+    order_type = entity.get("ecommerce_order_type")
+    url = entity.get("ecommerce_url") or ecommerce_storefront_url(
+        order_type,
+        entity.get("ecommerce_store_name"),
+        entity.get("ecommerce_order_id"),
+    )
+    if not url:
+        return
+    label = ecommerce_platform_label(order_type) or "storefront"
+    with Row(gap=1):
+        Text(content="Storefront:")
+        Link(content=f"Open in {label}", href=url, target="_blank")
+
+
 def _render_party_line(
     label: str,
     *,
@@ -6688,6 +6722,10 @@ def _render_so_entity_view(
             name=prior_location_name,
             entity_id=entity.get("location_id"),
         )
+
+    # Storefront deep-link — when the SO came from a native ecommerce
+    # integration (Shopify / WooCommerce / BigCommerce). No-op otherwise.
+    _render_ecommerce_link(entity)
 
     # Header scalar diffs — driven by ``_SO_HEADER_FIELD_SPEC``. Each
     # entry maps a user-facing label to (change-key candidates,

--- a/katana_mcp_server/src/katana_mcp/web_urls.py
+++ b/katana_mcp_server/src/katana_mcp/web_urls.py
@@ -93,13 +93,26 @@ _ECOMMERCE_TEMPLATES: dict[str, str] = {
 }
 
 # Human labels for the same keys, so a card button reads "Open in Shopify"
-# rather than the camelCase literal. Kept adjacent to the templates so the
-# drift audit can assert both maps share the same key set.
+# rather than the camelCase literal. Kept adjacent to the templates, and the
+# key-set invariant below pins them together so adding a template without its
+# label (or vice-versa) fails fast at import.
 _ECOMMERCE_LABELS: dict[str, str] = {
     "shopify": "Shopify",
     "wooCommerce": "WooCommerce",
     "bigCommerce": "BigCommerce",
 }
+
+# Invariant: every deep-linkable platform must have BOTH a URL template and a
+# human label, so any recognized order can render an "Open in {platform}" link.
+# Enforced here at import (deterministic) rather than in the drift audit, which
+# only diffs template keys against the live frontend and soft-fails when the CDN
+# is unreachable — it would never catch a missing label.
+if _ECOMMERCE_TEMPLATES.keys() != _ECOMMERCE_LABELS.keys():
+    _divergent = sorted(_ECOMMERCE_TEMPLATES.keys() ^ _ECOMMERCE_LABELS.keys())
+    raise RuntimeError(
+        f"ecommerce template/label key sets diverged: {_divergent}. "
+        "Every _ECOMMERCE_TEMPLATES key needs a matching _ECOMMERCE_LABELS entry."
+    )
 
 # The recognized deep-linkable ``ecommerce_order_type`` values, derived from the
 # template map so there's one source of truth. Consumed by the create-time

--- a/katana_mcp_server/src/katana_mcp/web_urls.py
+++ b/katana_mcp_server/src/katana_mcp/web_urls.py
@@ -14,7 +14,9 @@ See issue #442 for the motivation and full URL pattern list.
 from __future__ import annotations
 
 import os
+import re
 from typing import Literal
+from urllib.parse import urlsplit
 
 EntityKind = Literal[
     "sales_order",
@@ -58,3 +60,118 @@ def katana_web_url(kind: EntityKind, id: int | None) -> str | None:
     if id is None:
         return None
     return f"{_base_url()}{_PATHS[kind].format(id=id)}"
+
+
+# --- Ecommerce storefront deep-links -----------------------------------------
+#
+# Sales orders imported from a *native* Katana ecommerce integration carry
+# ``ecommerce_order_type`` / ``ecommerce_store_name`` / ``ecommerce_order_id``.
+# Katana's web UI renders an "Open in {platform}" link from them via its
+# frontend ``EcomLink`` component. There is no API field for the link — Katana
+# derives it — so we derive it the same way, to surface it on tool responses.
+#
+# Provenance: transcribed by hand from Katana's public (unauthenticated)
+# module-federation frontend bundles — the ``sales-mf`` ``EcommerceIntegrationType``
+# enum + the ``EcomLink`` component — captured 2026-06-03. Confirmed against a
+# real captured API payload (``katana.myshopify.com`` / order ``19433769``) and a
+# live test-tenant round-trip. See issue #913. ``poe audit-frontend-enums``
+# re-checks these keys against the live bundle (soft-fail).
+#
+# Keys are the EXACT camelCase ``EcommerceIntegrationType`` values — matching is
+# case-sensitive (the wire stores the literal verbatim and PATCH cannot change
+# it). ``{store}`` = ``ecommerce_store_name``, ``{order_id}`` = ``ecommerce_order_id``.
+# For Shopify/WooCommerce ``{store}`` is a full hostname (``acme.myshopify.com``);
+# for BigCommerce it is a bare subdomain slug — we mirror the frontend's
+# ``store-{store}`` interpolation verbatim. eBay (and every other marketplace) is
+# intentionally absent: it lives in ``ThirdPartyIntegrationType``, never gets the
+# ``ecommerce_*`` fields populated (it arrives via middleware that writes
+# ``order_no``), and the frontend does not deep-link it.
+_ECOMMERCE_TEMPLATES: dict[str, str] = {
+    "shopify": "https://{store}/admin/orders/{order_id}",
+    "wooCommerce": "https://{store}/wp-admin/post.php?post={order_id}&action=edit",
+    "bigCommerce": "https://store-{store}.mybigcommerce.com/manage/orders/{order_id}",
+}
+
+# Human labels for the same keys, so a card button reads "Open in Shopify"
+# rather than the camelCase literal. Kept adjacent to the templates so the
+# drift audit can assert both maps share the same key set.
+_ECOMMERCE_LABELS: dict[str, str] = {
+    "shopify": "Shopify",
+    "wooCommerce": "WooCommerce",
+    "bigCommerce": "BigCommerce",
+}
+
+# The recognized deep-linkable ``ecommerce_order_type`` values, derived from the
+# template map so there's one source of truth. Consumed by the create-time
+# advisory guard (warn on unrecognized values) and the ``audit-frontend-enums``
+# drift check (diff against the live frontend enum).
+RECOGNIZED_ECOMMERCE_TYPES: frozenset[str] = frozenset(_ECOMMERCE_TEMPLATES)
+
+# ``ecommerce_store_name`` / ``ecommerce_order_id`` are free-text, create-only
+# wire fields that we interpolate straight into an ``https://`` link. Validate
+# their shape before building a URL so a crafted value can't repoint the link
+# (userinfo ``@``, path/query/fragment ``/ ? #``, or whitespace → somewhere
+# unintended) or inject extra query params. ``store`` must look like a hostname
+# or a bare subdomain slug (BigCommerce); ``order_id`` must be a bare token. On
+# any mismatch we return ``None`` (no link) — better no link than a wrong one.
+# ASCII-only labels also reject IDN homograph lookalikes (e.g. a Cyrillic
+# U+0430 that mimics an ASCII "a").
+# Matched with ``fullmatch`` (not ``match``) so a trailing newline can't slip
+# through Python's newline-lenient ``$``; lengths are capped to bound pathological
+# input (253 = max DNS hostname; order ids are short numeric strings in practice).
+_HOST_LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?"
+_STORE_RE = re.compile(rf"{_HOST_LABEL}(?:\.{_HOST_LABEL})*")
+_ORDER_ID_RE = re.compile(r"[A-Za-z0-9_-]+")
+_MAX_STORE_LEN = 253
+_MAX_ORDER_ID_LEN = 64
+
+
+def ecommerce_storefront_url(
+    order_type: str | None,
+    store_name: str | None,
+    order_id: str | None,
+) -> str | None:
+    """Build the storefront "Open in {platform}" URL, or ``None``.
+
+    Exact-match ``order_type`` against the camelCase ``EcommerceIntegrationType``
+    keys — **no** case normalization (a mis-cased ``"woocommerce"`` returns
+    ``None`` by design; the wire stores the literal and coercing it would diverge
+    from what Katana's own link matches). Returns ``None`` when the type is
+    unrecognized, when ``store_name`` or ``order_id`` is missing/empty, or when
+    either fails its host/id-shape guard (see ``_STORE_RE`` / ``_ORDER_ID_RE``) —
+    so callers can invoke it unconditionally on any sales order and never surface
+    a malformed or attacker-controlled link.
+    """
+    if not order_type or not store_name or not order_id:
+        return None
+    template = _ECOMMERCE_TEMPLATES.get(order_type)
+    if template is None:
+        return None
+    if (
+        len(store_name) > _MAX_STORE_LEN
+        or len(order_id) > _MAX_ORDER_ID_LEN
+        or not _STORE_RE.fullmatch(store_name)
+        or not _ORDER_ID_RE.fullmatch(order_id)
+    ):
+        return None
+    url = template.format(store=store_name, order_id=order_id)
+    # Defense-in-depth: re-parse the assembled URL and refuse anything that isn't
+    # a plain ``https`` link with no userinfo. The input guards above already
+    # cover today's templates; this also catches a *future* template edit that
+    # accidentally drops ``{store}`` into a userinfo/path position, which the
+    # per-field checks alone wouldn't notice.
+    parsed = urlsplit(url)
+    if parsed.scheme != "https" or parsed.username or parsed.password:
+        return None
+    return url
+
+
+def ecommerce_platform_label(order_type: str | None) -> str | None:
+    """Return the human platform label (e.g. ``"Shopify"``) or ``None``.
+
+    ``None`` for any type that isn't a recognized deep-linkable platform, so
+    callers can gate a button/label on it the same way they gate the URL.
+    """
+    if not order_type:
+        return None
+    return _ECOMMERCE_LABELS.get(order_type)

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -4052,6 +4052,53 @@ class TestBuildSOModifyUI:
         assert "NOT_SHIPPED" in rendered and "PACKED" in rendered
         assert "→" in rendered
 
+    def test_storefront_link_renders_for_native_ecommerce_order(self):
+        """A Shopify-sourced SO surfaces an 'Open in Shopify' storefront link,
+        derived from the raw ``ecommerce_*`` fields the modify card's
+        ``prior_state`` snapshot carries (#913)."""
+        prior = {
+            **self._SO_PRIOR,
+            "ecommerce_order_type": "shopify",
+            "ecommerce_store_name": "katana.myshopify.com",
+            "ecommerce_order_id": "19433769",
+        }
+        app = build_so_modify_ui(
+            self._preview(prior_state=prior),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_sales_order",
+        )
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        assert "Open in Shopify" in rendered
+        assert "https://katana.myshopify.com/admin/orders/19433769" in rendered
+
+    def test_no_storefront_link_for_unrecognized_or_absent_ecommerce(self):
+        """eBay (unrecognized) and plain orders get no storefront link —
+        mirrors Katana, which only deep-links the three native platforms."""
+        ebay = build_so_modify_ui(
+            self._preview(
+                prior_state={
+                    **self._SO_PRIOR,
+                    "ecommerce_order_type": "ebay",
+                    "ecommerce_store_name": "ebay.example",
+                    "ecommerce_order_id": "EB-1",
+                }
+            ),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_sales_order",
+        )
+        # Assert on the storefront section's own marker ("Storefront:" Text) so
+        # the test stays scoped to this feature and won't break if an unrelated
+        # "Open in …" link is ever added elsewhere on the SO modify card.
+        assert "Storefront:" not in str(ebay.to_json())
+        # A plain SO with no ecommerce metadata at all also renders none.
+        plain = build_so_modify_ui(
+            self._preview(),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_sales_order",
+        )
+        assert "Storefront:" not in str(plain.to_json())
+
     def test_customer_change_renders_composite_diff(self):
         """A customer change surfaces ``Customer: <old> (<old_id>) → <new>``
         — the composite name+ID rendering keeps the diff readable. Same

--- a/katana_mcp_server/tests/test_web_urls.py
+++ b/katana_mcp_server/tests/test_web_urls.py
@@ -176,3 +176,17 @@ def test_platform_label() -> None:
 def test_recognized_set_is_exactly_the_three_native_platforms() -> None:
     """Pins the deep-linkable set; ``audit-frontend-enums`` guards live drift."""
     assert {"shopify", "wooCommerce", "bigCommerce"} == RECOGNIZED_ECOMMERCE_TYPES
+
+
+def test_every_recognized_platform_has_a_label() -> None:
+    """Template and label maps must share an identical key set.
+
+    The import-time invariant in ``web_urls`` enforces this so a new template
+    can't ship without its "Open in {platform}" label; this test pins the
+    contract independently (the drift audit only checks template keys against
+    the live frontend and never inspects the labels).
+    """
+    assert all(
+        ecommerce_platform_label(platform) is not None
+        for platform in RECOGNIZED_ECOMMERCE_TYPES
+    )

--- a/katana_mcp_server/tests/test_web_urls.py
+++ b/katana_mcp_server/tests/test_web_urls.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 import pytest
-from katana_mcp.web_urls import DEFAULT_WEB_BASE_URL, EntityKind, katana_web_url
+from katana_mcp.web_urls import (
+    DEFAULT_WEB_BASE_URL,
+    RECOGNIZED_ECOMMERCE_TYPES,
+    EntityKind,
+    ecommerce_platform_label,
+    ecommerce_storefront_url,
+    katana_web_url,
+)
 
 
 @pytest.mark.parametrize(
@@ -49,3 +56,123 @@ def test_trailing_slash_on_base_is_stripped(monkeypatch: pytest.MonkeyPatch) -> 
 def test_default_constant_matches_documented_value() -> None:
     """The default must match the value documented in CLAUDE.md and #442."""
     assert DEFAULT_WEB_BASE_URL == "https://factory.katanamrp.com"
+
+
+# --- Ecommerce storefront deep-links -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("order_type", "store", "order_id", "expected"),
+    [
+        # Verified against a real captured Katana payload (#913): a Shopify
+        # order stores the myshopify host + numeric order id.
+        (
+            "shopify",
+            "katana.myshopify.com",
+            "19433769",
+            "https://katana.myshopify.com/admin/orders/19433769",
+        ),
+        (
+            "wooCommerce",
+            "shop.acme.com",
+            "501",
+            "https://shop.acme.com/wp-admin/post.php?post=501&action=edit",
+        ),
+        # BigCommerce stores the bare slug; the frontend prefixes ``store-``.
+        (
+            "bigCommerce",
+            "acme",
+            "777",
+            "https://store-acme.mybigcommerce.com/manage/orders/777",
+        ),
+    ],
+)
+def test_storefront_url_happy_paths(
+    order_type: str, store: str, order_id: str, expected: str
+) -> None:
+    assert ecommerce_storefront_url(order_type, store, order_id) == expected
+
+
+@pytest.mark.parametrize(
+    ("order_type", "store", "order_id"),
+    [
+        # eBay/Etsy/etc. are not deep-linkable (ThirdPartyIntegrationType).
+        ("ebay", "store", "1"),
+        # Mis-cased platform must NOT coerce — the wire stores the literal and
+        # the frontend matches camelCase exactly.
+        ("woocommerce", "shop.acme.com", "1"),
+        ("Shopify", "acme.myshopify.com", "1"),
+        # Missing pieces — can't build a link.
+        ("shopify", None, "1"),
+        ("shopify", "acme.myshopify.com", None),
+        ("shopify", "", "1"),
+        ("shopify", "acme.myshopify.com", ""),
+        (None, "acme.myshopify.com", "1"),
+    ],
+)
+def test_storefront_url_returns_none(
+    order_type: str | None, store: str | None, order_id: str | None
+) -> None:
+    assert ecommerce_storefront_url(order_type, store, order_id) is None
+
+
+@pytest.mark.parametrize(
+    ("store", "order_id"),
+    [
+        # store_name with userinfo / path / query / fragment / port / whitespace
+        # could repoint the rendered link — reject, don't interpolate.
+        ("evil.com/@phish", "1"),
+        ("acme.myshopify.com@evil.com", "1"),
+        ("acme.myshopify.com/admin", "1"),
+        ("acme.myshopify.com?x=1", "1"),
+        ("acme.myshopify.com#frag", "1"),
+        ("acme.myshopify.com:8080", "1"),
+        ("acme .myshopify.com", "1"),
+        ("-acme.myshopify.com", "1"),
+        ("acme..myshopify.com", "1"),
+        # order_id that could inject extra path/query segments (e.g. an extra
+        # &param into the WooCommerce query) must be refused too.
+        ("acme.myshopify.com", "1/2"),
+        ("acme.myshopify.com", "1&action=delete"),
+        ("acme.myshopify.com", "1 2"),
+        ("acme.myshopify.com", "1?x=2"),
+        # Trailing newline must NOT slip through (Python's ``$`` is newline-
+        # lenient; we use fullmatch precisely to close this).
+        ("acme.myshopify.com\n", "1"),
+        ("acme.myshopify.com", "1\n"),
+        # IDN homograph: a Cyrillic U+0430 that *looks* like ASCII "a" must be
+        # rejected — labels are ASCII-only.
+        ("\u0430cme.myshopify.com", "1"),
+        # Over-length input is bounded (253 host / 64 order-id caps).
+        ("a" * 254, "1"),
+        ("acme.myshopify.com", "1" * 65),
+    ],
+)
+def test_storefront_url_rejects_unsafe_values(store: str, order_id: str) -> None:
+    """Free-text ecommerce fields that don't look host/id-like build no link,
+    so a crafted value can't produce a malformed or attacker-controlled URL."""
+    assert ecommerce_storefront_url("shopify", store, order_id) is None
+
+
+def test_storefront_url_allows_max_length_boundary() -> None:
+    """A host/id exactly at the cap still builds a link — the bound is
+    inclusive, so we don't reject legitimate long-but-valid values."""
+    store = ("a" * 60 + ".") * 4 + "co"  # 245 chars, well-formed labels
+    assert len(store) <= 253
+    assert (
+        ecommerce_storefront_url("shopify", store, "1" * 64)
+        == f"https://{store}/admin/orders/{'1' * 64}"
+    )
+
+
+def test_platform_label() -> None:
+    assert ecommerce_platform_label("shopify") == "Shopify"
+    assert ecommerce_platform_label("wooCommerce") == "WooCommerce"
+    assert ecommerce_platform_label("bigCommerce") == "BigCommerce"
+    assert ecommerce_platform_label("ebay") is None
+    assert ecommerce_platform_label(None) is None
+
+
+def test_recognized_set_is_exactly_the_three_native_platforms() -> None:
+    """Pins the deep-linkable set; ``audit-frontend-enums`` guards live drift."""
+    assert {"shopify", "wooCommerce", "bigCommerce"} == RECOGNIZED_ECOMMERCE_TYPES

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -92,6 +92,55 @@ async def test_create_sales_order_preview():
 
 
 @pytest.mark.asyncio
+async def test_create_sales_order_warns_on_unrecognized_ecommerce_type():
+    """An ``ecommerce_order_type`` outside the deep-linkable set gets an
+    advisory (non-BLOCK) warning. The field is create-only, so this is the
+    only chance to flag a typo before it bakes in (#913)."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(
+        return_value={"id": 1501, "name": "Acme"}
+    )
+    request = CreateSalesOrderRequest(
+        customer_id=1501,
+        order_number="SO-ECOM-1",
+        items=[SalesOrderItem(variant_id=2101, quantity=1)],
+        location_id=1,
+        delivery_date=datetime(2024, 1, 22, 14, 0, 0, tzinfo=UTC),
+        ecommerce_order_type="ebay",
+        ecommerce_store_name="ebay.example",
+        ecommerce_order_id="EB-1",
+        preview=True,
+    )
+    result = await _create_sales_order_impl(request, context)
+    advisory = [w for w in result.warnings if "ecommerce_order_type" in w]
+    assert advisory, "expected an advisory warning for an unrecognized ecommerce type"
+    assert not advisory[0].startswith("BLOCK:")
+    assert "ebay" in advisory[0]
+
+
+@pytest.mark.asyncio
+async def test_create_sales_order_no_warning_for_recognized_ecommerce_type():
+    """A recognized camelCase platform produces no ecommerce advisory."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(
+        return_value={"id": 1501, "name": "Acme"}
+    )
+    request = CreateSalesOrderRequest(
+        customer_id=1501,
+        order_number="SO-ECOM-2",
+        items=[SalesOrderItem(variant_id=2101, quantity=1)],
+        location_id=1,
+        delivery_date=datetime(2024, 1, 22, 14, 0, 0, tzinfo=UTC),
+        ecommerce_order_type="shopify",
+        ecommerce_store_name="katana.myshopify.com",
+        ecommerce_order_id="19433769",
+        preview=True,
+    )
+    result = await _create_sales_order_impl(request, context)
+    assert not [w for w in result.warnings if "ecommerce_order_type" in w]
+
+
+@pytest.mark.asyncio
 async def test_create_sales_order_preview_minimal_fields():
     """Test create_sales_order preview with only required fields."""
     context, lifespan_ctx = create_mock_context()
@@ -2098,6 +2147,49 @@ async def test_get_sales_order_by_id():
     assert result.rows[0].id == 10
     assert result.rows[0].variant_id == 500
     assert result.rows[0].quantity == 3
+
+
+@pytest.mark.asyncio
+async def test_get_sales_order_derives_ecommerce_url_for_native_order():
+    """A Shopify-sourced SO surfaces a derived ``ecommerce_url`` storefront
+    deep-link built from the persisted ecommerce_* fields (#913)."""
+    context, _ = create_mock_context()
+    mock_so = _make_mock_so(id=808, order_no="SO-ECOM")
+    mock_so.ecommerce_order_type = "shopify"
+    mock_so.ecommerce_store_name = "katana.myshopify.com"
+    mock_so.ecommerce_order_id = "19433769"
+
+    with (
+        patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
+    ):
+        result = await _get_sales_order_impl(
+            GetSalesOrderRequest(order_id=808), context
+        )
+
+    assert result.ecommerce_url == "https://katana.myshopify.com/admin/orders/19433769"
+
+
+@pytest.mark.asyncio
+async def test_get_sales_order_ecommerce_url_none_for_unrecognized_platform():
+    """An eBay order (unrecognized) gets no storefront link — mirrors Katana."""
+    context, _ = create_mock_context()
+    mock_so = _make_mock_so(id=809, order_no="SO-EBAY")
+    mock_so.ecommerce_order_type = "ebay"
+    mock_so.ecommerce_store_name = "ebay.example"
+    mock_so.ecommerce_order_id = "EB-1"
+
+    with (
+        patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
+    ):
+        result = await _get_sales_order_impl(
+            GetSalesOrderRequest(order_id=809), context
+        )
+
+    assert result.ecommerce_url is None
 
 
 @pytest.mark.asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -562,15 +562,18 @@ format-check = ["format-python-check", "format-markdown-check"]
 # Type check it separately from its own directory.
 # scripts/ is excluded as it contains utility/development scripts with varied typing.
 # tests/conftest.py is excluded because it is pytest-specific support code.
-# tests/test_generate_tools_json.py is excluded because it imports a script via
-# sys.path manipulation that ty cannot resolve statically.
+# tests/test_generate_tools_json.py, tests/test_audit_frontend_enums.py, and
+# tests/integration/test_so_ecommerce_link_live.py are all excluded for the same
+# reason: each imports a ``scripts/``-resident module via ``sys.path``
+# manipulation (the audit script and ``spec_drift_verify`` respectively) that ty
+# cannot resolve statically, since ``scripts/`` is itself excluded below.
 # katana_public_api_client/models_pydantic/_generated/ is excluded because ty
 # rejects the ``Annotated[Mapped[T | None], Field(...)] = None`` field shape
 # emitted by ``wrap_cache_fields_in_mapped`` (the trailing ``= None`` doesn't
 # match the declared ``Mapped[T | None]`` type), while pyright accepts it.
 # Generated files are auto-emitted; consistent exclusion across both checkers
 # matches ``pyrightconfig.json``'s existing ``_generated/`` skip.
-typecheck = "ty check --exclude 'tests/conftest.py' --exclude 'tests/test_generate_tools_json.py' --exclude 'scripts/' --exclude 'katana_public_api_client/models_pydantic/_generated/' --exclude '.claude/worktrees/'"
+typecheck = "ty check --exclude 'tests/conftest.py' --exclude 'tests/test_generate_tools_json.py' --exclude 'tests/test_audit_frontend_enums.py' --exclude 'tests/integration/test_so_ecommerce_link_live.py' --exclude 'scripts/' --exclude 'katana_public_api_client/models_pydantic/_generated/' --exclude '.claude/worktrees/'"
 # Pyright runs alongside ty: ty is the primary CI gate (faster, drives
 # CI), pyright catches things ty doesn't yet (e.g., generic-invariance
 # on ``Response[T]`` unions, pydantic positional-default detection).
@@ -647,6 +650,10 @@ validate-openapi-redocly = "npx @redocly/cli lint docs/katana-openapi.yaml"
 refresh-upstream-spec = "python scripts/pull_upstream_specs.py"
 # Compare the local spec with the live upstream spec; reports drift.
 audit-spec = "python scripts/audit_spec_drift.py"
+# Re-check the hand-maintained ecommerce deep-link platform set against
+# Katana's live frontend EcommerceIntegrationType enum. Soft-fail (always
+# exit 0 unless --strict + genuine drift); NOT part of regenerate-all.
+audit-frontend-enums = "python scripts/audit_frontend_enums.py"
 # Validate inline `example:` blocks against their schemas.
 validate-examples = "python scripts/validate_spec_examples.py"
 # Validate README.io developer-portal response examples (from

--- a/scripts/audit_frontend_enums.py
+++ b/scripts/audit_frontend_enums.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Audit the hand-maintained ecommerce deep-link platform set against Katana's
+live frontend ``EcommerceIntegrationType`` enum.
+
+``katana_mcp.web_urls._ECOMMERCE_TEMPLATES`` is transcribed by hand from
+Katana's frontend (it's the only authoritative source — no API exposes the
+deep-linkable platform set). This script re-checks the *keys* of that map
+against the live frontend enum so the transcription can't silently rot when
+Katana adds or renames an ecommerce platform.
+
+How it finds the enum (slug-agnostic, only the CDN host + micro-frontend name
+are pinned):
+
+1. Fetch the ``sales-mf`` module-federation container ``remoteEntry.js`` at a
+   stable, unhashed path — it carries the webpack chunk-id→content-hash map.
+2. Resolve the current ``katana-npm`` chunk filename from that map and fetch it.
+3. Regex the ``EcommerceIntegrationType`` enum members out of the chunk.
+4. Diff the enum's string values against
+   ``katana_mcp.web_urls.RECOGNIZED_ECOMMERCE_TYPES``.
+
+Falls back to the ``header-mf`` container if ``sales-mf`` is unreachable (it
+carries the same enum). **This is a soft-fail audit:** any network error,
+chunk-resolution miss, or regex-parse failure is reported and exits **0** — a
+Katana frontend deploy rotates chunk hashes constantly and the CDN host can
+change, and none of that should break CI. Pass ``--strict`` to exit 1 when a
+genuine *drift* (not unreachability) is detected, for on-demand gating.
+
+This script is intentionally **not** part of ``regenerate-all`` — it targets a
+live, ever-moving frontend, not a pinned spec input.
+
+Usage:
+
+    uv run python scripts/audit_frontend_enums.py
+    uv run python scripts/audit_frontend_enums.py --json
+    uv run poe audit-frontend-enums
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+
+import httpx
+from katana_mcp.web_urls import RECOGNIZED_ECOMMERCE_TYPES
+
+# The CloudFront distribution + micro-frontends that carry the enum. These are
+# the only pinned assumptions; if Katana rotates the distribution host the audit
+# soft-fails (and logs the host so a silent-forever audit is noticeable). The
+# ``remoteEntry.js`` path under each is stable and unhashed.
+CDN_HOST = "https://d2ymm186steve7.cloudfront.net"
+# (micro-frontend name, sub-path prefix on the CDN). sales-mf is primary
+# (it hosts the EcomLink component + enum); header-mf is the fallback (enum only).
+MICRO_FRONTENDS: tuple[tuple[str, str], ...] = (
+    ("sales-mf", "sales-mf"),
+    ("header-mf", "header-mf"),
+)
+HTTP_TIMEOUT = 20.0
+
+# Matches the minified ``function(e){e.Shopify="shopify",...}(a||(t.EcommerceIntegrationType=a={}))``
+# IIFE, anchored on the EcommerceIntegrationType binding so the look-alike
+# PascalCase import-status enum in header-mf (bound to ``({})``, not to
+# EcommerceIntegrationType) is never matched. Group 1 = the IIFE param, group 2
+# = the member-assignment body.
+_ENUM_IIFE_RE = re.compile(
+    r"function\((\w+)\)\{([^{}]*?)\}\([^)]*?EcommerceIntegrationType"
+)
+# Within a matched body, pull each ``<param>.Member="value"`` pair.
+_MEMBER_RE_TMPL = r'{param}\.(\w+)="([^"]*)"'
+# remoteEntry chunk maps.
+_NAME_MAP_RE = re.compile(r'(\d+):"(npm\.[a-zA-Z0-9._-]*katana-npm[a-zA-Z0-9._-]*)"')
+_HASH_MAP_RE = re.compile(r'(\d+):"([0-9a-f]{16,})"')
+
+
+@dataclass
+class AuditResult:
+    """Outcome of one audit run."""
+
+    reachable: bool = False
+    source: str | None = None  # which MF + chunk url the enum came from
+    frontend_values: set[str] = field(default_factory=set)
+    expected_values: set[str] = field(
+        default_factory=lambda: set(RECOGNIZED_ECOMMERCE_TYPES)
+    )
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def added(self) -> set[str]:
+        """Platforms the frontend has that we don't (the actionable case)."""
+        return self.frontend_values - self.expected_values
+
+    @property
+    def removed(self) -> set[str]:
+        """Platforms we have that the frontend no longer lists."""
+        return self.expected_values - self.frontend_values
+
+    @property
+    def has_drift(self) -> bool:
+        return self.reachable and bool(self.added or self.removed)
+
+
+def _fetch_text(url: str, client: httpx.Client) -> str | None:
+    """GET ``url`` and return its body, or ``None`` on any error."""
+    try:
+        resp = client.get(url, timeout=HTTP_TIMEOUT)
+    except httpx.HTTPError:
+        return None
+    if resp.status_code != 200:
+        return None
+    return resp.text
+
+
+def resolve_katana_npm_chunk_url(remote_entry_js: str, base: str) -> str | None:
+    """Resolve the current ``katana-npm`` chunk URL from a remoteEntry body.
+
+    Returns ``None`` if the chunk can't be located (the soft-fail trigger).
+    """
+    names = dict(_NAME_MAP_RE.findall(remote_entry_js))
+    hashes = dict(_HASH_MAP_RE.findall(remote_entry_js))
+    for chunk_id, name in names.items():
+        digest = hashes.get(chunk_id)
+        if digest:
+            return f"{base}/{name}.{digest}.chunk.js"
+    return None
+
+
+def extract_ecommerce_enum(chunk_js: str) -> dict[str, str] | None:
+    """Extract the ``EcommerceIntegrationType`` members from a chunk body.
+
+    Returns ``{Member: "value"}`` or ``None`` when the enum can't be found.
+    """
+    match = _ENUM_IIFE_RE.search(chunk_js)
+    if match is None:
+        return None
+    param, body = match.group(1), match.group(2)
+    member_re = re.compile(_MEMBER_RE_TMPL.format(param=re.escape(param)))
+    members = dict(member_re.findall(body))
+    return members or None
+
+
+def _audit_one_mf(
+    mf_name: str, sub_path: str, client: httpx.Client, result: AuditResult
+) -> bool:
+    """Try one micro-frontend; on success populate ``result`` and return True."""
+    base = f"{CDN_HOST}/{sub_path}"
+    remote_entry = _fetch_text(f"{base}/remoteEntry.js", client)
+    if remote_entry is None:
+        result.notes.append(f"{mf_name}: remoteEntry.js unreachable")
+        return False
+    chunk_url = resolve_katana_npm_chunk_url(remote_entry, base)
+    if chunk_url is None:
+        result.notes.append(f"{mf_name}: could not resolve katana-npm chunk")
+        return False
+    chunk = _fetch_text(chunk_url, client)
+    if chunk is None:
+        result.notes.append(f"{mf_name}: chunk unreachable ({chunk_url})")
+        return False
+    enum = extract_ecommerce_enum(chunk)
+    if enum is None:
+        result.notes.append(f"{mf_name}: EcommerceIntegrationType not found in chunk")
+        return False
+    result.reachable = True
+    result.source = chunk_url
+    result.frontend_values = set(enum.values())
+    return True
+
+
+def audit(client: httpx.Client | None = None) -> AuditResult:
+    """Run the audit, trying each micro-frontend until one yields the enum."""
+    result = AuditResult()
+    owns_client = client is None
+    client = client or httpx.Client(follow_redirects=True)
+    try:
+        for mf_name, sub_path in MICRO_FRONTENDS:
+            if _audit_one_mf(mf_name, sub_path, client, result):
+                break
+    finally:
+        if owns_client:
+            client.close()
+    return result
+
+
+def format_markdown(result: AuditResult) -> str:
+    lines = ["# Frontend ecommerce-enum drift audit", ""]
+    if not result.reachable:
+        lines.append("**Could not reach the live frontend enum (soft-fail).**")
+        lines.append(f"- CDN host: {CDN_HOST}")
+        for note in result.notes:
+            lines.append(f"- {note}")
+        lines.append("")
+        lines.append("No conclusion drawn — re-run later or verify manually.")
+        return "\n".join(lines)
+
+    lines.append(f"- Source: {result.source}")
+    lines.append(f"- Frontend enum values: {sorted(result.frontend_values)}")
+    lines.append(f"- Our recognized set: {sorted(result.expected_values)}")
+    lines.append("")
+    if not result.has_drift:
+        lines.append("✅ No drift — the hand-maintained set matches the frontend.")
+        return "\n".join(lines)
+
+    lines.append("⚠️ **Drift detected.**")
+    if result.added:
+        lines.append(
+            f"- Frontend ADDED (we should add a template): {sorted(result.added)}"
+        )
+    if result.removed:
+        lines.append(
+            f"- We have but frontend dropped (verify before removing): "
+            f"{sorted(result.removed)}"
+        )
+    lines.append("")
+    lines.append(
+        "Update `_ECOMMERCE_TEMPLATES` in `katana_mcp_server/.../web_urls.py` "
+        "(grab any new template from the EcomLink component) and re-run."
+    )
+    return "\n".join(lines)
+
+
+def format_json(result: AuditResult) -> str:
+    return json.dumps(
+        {
+            "reachable": result.reachable,
+            "source": result.source,
+            "frontend_values": sorted(result.frontend_values),
+            "expected_values": sorted(result.expected_values),
+            "added": sorted(result.added),
+            "removed": sorted(result.removed),
+            "has_drift": result.has_drift,
+            "notes": result.notes,
+        },
+        indent=2,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n\n", 1)[0])
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 on genuine drift (not on unreachability). For CI gating.",
+    )
+    args = parser.parse_args(argv)
+
+    result = audit()
+    print(format_json(result) if args.json else format_markdown(result))
+
+    if args.strict and result.has_drift:
+        return 1
+    # Soft-fail: unreachable / parse failure / non-strict drift all exit 0.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_so_ecommerce_link_live.py
+++ b/tests/integration/test_so_ecommerce_link_live.py
@@ -1,0 +1,167 @@
+"""Live write test: ecommerce storefront deep-link round-trips (#913).
+
+Creates a synthetic sales order carrying ecommerce metadata on the test tenant,
+reads it back, and asserts the ``ecommerce_*`` fields round-trip as the literal
+camelCase key *and* that :func:`ecommerce_storefront_url` builds the expected
+"Open in {platform}" link from the persisted values. Covers a Shopify order
+(verified against a real captured Katana payload — ``katana.myshopify.com`` /
+``19433769``) and a BigCommerce slug order.
+
+This is the empirical proof behind the feature: the wire stores
+``ecommerce_order_type`` verbatim (no coercion), and ``ecommerce_store_name``
+holds a host/slug the templates can interpolate. It's also the permanent
+regression guard.
+
+Cleanup: the ecommerce fields are **create-only** (PATCH rejects them), so
+there's no in-place revert — cleanup is a delete. Per the SDT-tagging contract
+(``tests/integration/README.md``) every created SO is SDT-tagged, recorded to
+the ledger immediately after create (belt-and-suspenders if the process dies),
+and deleted in a ``finally`` block. Skips when ``KATANA_TEST_API_KEY`` is unset
+(the skip lives in the ``live_client`` fixture).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from katana_mcp.web_urls import ecommerce_storefront_url
+
+from katana_public_api_client import KatanaClient
+from katana_public_api_client.api.sales_order import (
+    create_sales_order,
+    delete_sales_order,
+    get_all_sales_orders,
+    get_sales_order,
+)
+from katana_public_api_client.client_types import UNSET
+from katana_public_api_client.models import CreateSalesOrderRequest, SalesOrder
+from katana_public_api_client.models.create_sales_order_request_sales_order_rows_item import (
+    CreateSalesOrderRequestSalesOrderRowsItem,
+)
+from katana_public_api_client.utils import unwrap_as, unwrap_data
+
+_scripts_dir = str(Path(__file__).resolve().parents[2] / "scripts")
+# Scope the sys.path mutation to just this import: insert, import, then remove
+# in a finally so the entry doesn't linger for the whole test session (where it
+# could shadow other imports or shift resolution order). spec_drift_verify is
+# cached in sys.modules after the first import, so dropping the path is safe.
+sys.path.insert(0, _scripts_dir)
+try:
+    from spec_drift_verify import (  # type: ignore[import-not-found]
+        SDT_PREFIX,
+        record_artifact,
+    )
+finally:
+    sys.path.remove(_scripts_dir)
+
+pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.asyncio]
+
+
+def _clean(value: Any) -> Any:
+    return None if (value is UNSET or value is None) else value
+
+
+async def _known_customer_and_variant(client: KatanaClient) -> tuple[int, int]:
+    """Source a valid customer + variant from an existing SO so the created
+    order references real entities (avoids tenant-specific fixtures)."""
+    # page=1 pins a single GET: an explicit page param disables the
+    # PaginationTransport auto-pagination that limit=1 alone would otherwise
+    # trigger (which, at page_size=1, walks up to max_pages GETs).
+    listing = await get_all_sales_orders.asyncio_detailed(
+        client=client, limit=1, page=1
+    )
+    data = unwrap_data(listing)
+    if not data:
+        pytest.skip("test tenant has no sales orders to source a customer/variant from")
+    full = await get_sales_order.asyncio_detailed(client=client, id=data[0].id)
+    so = unwrap_as(full, SalesOrder)
+    rows = _clean(so.sales_order_rows) or []
+    if not rows:
+        pytest.skip("source sales order has no rows to source a variant from")
+    customer_id = _clean(so.customer_id)
+    variant_id = _clean(rows[0].variant_id)
+    # Both must be present or the create call below fails for an unrelated
+    # reason (missing FK) instead of testing the ecommerce round-trip — skip
+    # with a clear message rather than emit a confusing live-API failure.
+    if customer_id is None or variant_id is None:
+        pytest.skip(
+            "source sales order is missing a customer_id or row variant_id to reference"
+        )
+    return customer_id, variant_id
+
+
+@pytest.mark.parametrize(
+    ("order_type", "store", "order_id", "expected_url"),
+    [
+        (
+            "shopify",
+            "katana.myshopify.com",
+            "19433769",
+            "https://katana.myshopify.com/admin/orders/19433769",
+        ),
+        (
+            "bigCommerce",
+            "acme",
+            "777",
+            "https://store-acme.mybigcommerce.com/manage/orders/777",
+        ),
+    ],
+)
+async def test_ecommerce_fields_round_trip_and_build_link(
+    live_client: KatanaClient,
+    order_type: str,
+    store: str,
+    order_id: str,
+    expected_url: str,
+) -> None:
+    customer_id, variant_id = await _known_customer_and_variant(live_client)
+
+    request = CreateSalesOrderRequest(
+        customer_id=customer_id,
+        order_no=f"{SDT_PREFIX}-ECOM-{order_type}",
+        sales_order_rows=[
+            CreateSalesOrderRequestSalesOrderRowsItem(quantity=1, variant_id=variant_id)
+        ],
+        ecommerce_order_type=order_type,
+        ecommerce_store_name=store,
+        ecommerce_order_id=order_id,
+    )
+    created = await create_sales_order.asyncio_detailed(
+        client=live_client, body=request
+    )
+    # unwrap_as raises (loudly failing the test) on a non-2xx / error body.
+    so_id = _clean(unwrap_as(created, SalesOrder).id)
+    # Pin the failure at the real cause site: a missing id would otherwise
+    # surface as a confusing error in record_artifact / get / delete below.
+    assert so_id is not None, "create_sales_order returned a SalesOrder without an id"
+
+    # Enter the try BEFORE recording the artifact: once so_id is known the SO
+    # exists on the tenant and must be deleted, so any failure from here on
+    # (including record_artifact itself) has to fall through to the finally.
+    try:
+        record_artifact(endpoint="/sales_orders", entity_id=so_id, issue="#913")
+        got = await get_sales_order.asyncio_detailed(client=live_client, id=so_id)
+        parsed = unwrap_as(got, SalesOrder)
+        # The literal camelCase key must round-trip with no coercion.
+        assert _clean(parsed.ecommerce_order_type) == order_type
+        assert _clean(parsed.ecommerce_store_name) == store
+        assert _clean(parsed.ecommerce_order_id) == order_id
+        # And the persisted values build exactly the expected storefront link.
+        assert (
+            ecommerce_storefront_url(
+                _clean(parsed.ecommerce_order_type),
+                _clean(parsed.ecommerce_store_name),
+                _clean(parsed.ecommerce_order_id),
+            )
+            == expected_url
+        )
+    finally:
+        deleted = await delete_sales_order.asyncio_detailed(
+            client=live_client, id=so_id
+        )
+        assert deleted.status_code in (200, 204), (
+            f"cleanup delete returned {deleted.status_code}"
+        )

--- a/tests/test_audit_frontend_enums.py
+++ b/tests/test_audit_frontend_enums.py
@@ -1,0 +1,185 @@
+"""Tests for ``scripts/audit_frontend_enums.py`` — the soft-fail drift audit
+that re-checks the hand-maintained ecommerce deep-link platform set against
+Katana's live frontend enum.
+
+All network I/O is faked with ``httpx.MockTransport`` so the tests are
+deterministic; the live chain is exercised separately by running
+``poe audit-frontend-enums``.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+
+scripts_dir = Path(__file__).resolve().parent.parent / "scripts"
+# Scope the sys.path mutation to just this import: insert, import, then remove
+# in a finally so the entry doesn't linger for the whole test session (where it
+# could shadow other imports or shift resolution order). audit_frontend_enums
+# is cached in sys.modules after the first import, so dropping the path is safe.
+sys.path.insert(0, str(scripts_dir))
+try:
+    from audit_frontend_enums import (  # type: ignore[import-not-found]
+        AuditResult,
+        audit,
+        extract_ecommerce_enum,
+        main,
+        resolve_katana_npm_chunk_url,
+    )
+finally:
+    sys.path.remove(str(scripts_dir))
+
+# A minimal remoteEntry.js: a webpack name map (id -> npm.katana-npm) plus a
+# hash map (id -> content hash), the two things the resolver needs.
+_REMOTE_ENTRY = (
+    'var n=({8494:"npm.katana-npm"}[e]||e)+"."+'
+    '{8494:"deadbeefdeadbeef1234"}[e]+".chunk.js";'
+)
+# A chunk containing the real-shaped EcommerceIntegrationType IIFE.
+_CHUNK_OK = (
+    'function(e){e.Shopify="shopify",e.WooCommerce="wooCommerce",'
+    'e.BigCommerce="bigCommerce"}(a||(t.EcommerceIntegrationType=a={}))'
+)
+# Same, but the frontend has gained a 4th platform — the drift case.
+_CHUNK_DRIFT = (
+    'function(e){e.Shopify="shopify",e.WooCommerce="wooCommerce",'
+    'e.BigCommerce="bigCommerce",e.Squarespace="squarespace"}'
+    "(a||(t.EcommerceIntegrationType=a={}))"
+)
+# A chunk that resolves/fetches fine but has no enum (parse-failure path).
+_CHUNK_NO_ENUM = 'function(e){e.Foo="bar"}(a||(t.SomethingElse=a={}))'
+
+
+_Handler = Callable[[httpx.Request], httpx.Response]
+
+
+@pytest.fixture
+def make_client() -> Iterator[Callable[[_Handler], httpx.Client]]:
+    """Yield a factory that builds ``MockTransport``-backed clients and closes
+    every one it handed out in teardown — so no test leaks an open
+    ``httpx.Client`` (which would emit a ResourceWarning)."""
+    clients: list[httpx.Client] = []
+
+    def factory(handler: _Handler) -> httpx.Client:
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        clients.append(client)
+        return client
+
+    yield factory
+    for client in clients:
+        client.close()
+
+
+def _route(*, sales_remote=_REMOTE_ENTRY, sales_chunk=_CHUNK_OK):
+    """Build a handler serving the sales-mf remoteEntry + chunk."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/sales-mf/remoteEntry.js":
+            return httpx.Response(200, text=sales_remote)
+        if path.startswith("/sales-mf/npm.katana-npm."):
+            return httpx.Response(200, text=sales_chunk)
+        return httpx.Response(404)
+
+    return handler
+
+
+def test_resolver_builds_chunk_url() -> None:
+    url = resolve_katana_npm_chunk_url(_REMOTE_ENTRY, "https://cdn/sales-mf")
+    assert url == "https://cdn/sales-mf/npm.katana-npm.deadbeefdeadbeef1234.chunk.js"
+
+
+def test_resolver_returns_none_when_no_katana_npm() -> None:
+    assert resolve_katana_npm_chunk_url('{1:"npm.vendor.react"}', "https://cdn") is None
+
+
+def test_extract_enum_finds_camelcase_values() -> None:
+    enum = extract_ecommerce_enum(_CHUNK_OK)
+    assert enum == {
+        "Shopify": "shopify",
+        "WooCommerce": "wooCommerce",
+        "BigCommerce": "bigCommerce",
+    }
+
+
+def test_extract_enum_ignores_unrelated_iife() -> None:
+    # A PascalCase look-alike enum NOT bound to EcommerceIntegrationType (the
+    # header-mf decoy) must not be matched.
+    decoy = 'function(e){e.Shopify="Shopify"}(({}))'
+    assert extract_ecommerce_enum(decoy) is None
+
+
+def test_audit_no_drift(make_client: Callable[[_Handler], httpx.Client]) -> None:
+    result = audit(client=make_client(_route()))
+    assert result.reachable is True
+    assert result.frontend_values == {"shopify", "wooCommerce", "bigCommerce"}
+    assert result.has_drift is False
+    assert result.added == set()
+
+
+def test_audit_detects_added_platform(
+    make_client: Callable[[_Handler], httpx.Client],
+) -> None:
+    result = audit(client=make_client(_route(sales_chunk=_CHUNK_DRIFT)))
+    assert result.reachable is True
+    assert result.added == {"squarespace"}
+    assert result.has_drift is True
+
+
+def test_audit_falls_back_to_header_mf(
+    make_client: Callable[[_Handler], httpx.Client],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.startswith("/sales-mf/"):
+            return httpx.Response(503)  # sales-mf down
+        if path == "/header-mf/remoteEntry.js":
+            return httpx.Response(200, text=_REMOTE_ENTRY)
+        if path.startswith("/header-mf/npm.katana-npm."):
+            return httpx.Response(200, text=_CHUNK_OK)
+        return httpx.Response(404)
+
+    result = audit(client=make_client(handler))
+    assert result.reachable is True
+    assert "header-mf" in (result.source or "")
+    assert result.has_drift is False
+
+
+def test_audit_both_unreachable_is_soft(
+    make_client: Callable[[_Handler], httpx.Client],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no network", request=request)
+
+    result = audit(client=make_client(handler))
+    assert result.reachable is False
+    assert result.has_drift is False  # never drift when we couldn't read
+    assert result.notes  # records why each MF failed
+
+
+def test_audit_parse_failure_is_soft(
+    make_client: Callable[[_Handler], httpx.Client],
+) -> None:
+    result = audit(client=make_client(_route(sales_chunk=_CHUNK_NO_ENUM)))
+    assert result.reachable is False
+    assert any("not found" in n for n in result.notes)
+
+
+def test_main_exit_codes(monkeypatch: pytest.MonkeyPatch) -> None:
+    drift = AuditResult(reachable=True, frontend_values={"shopify", "etsy"})
+    monkeypatch.setattr("audit_frontend_enums.audit", lambda: drift)
+    # Soft by default: drift still exits 0.
+    assert main([]) == 0
+    # --strict gates on genuine drift.
+    assert main(["--strict"]) == 1
+
+
+def test_main_unreachable_never_gates(monkeypatch: pytest.MonkeyPatch) -> None:
+    unreachable = AuditResult(reachable=False)
+    monkeypatch.setattr("audit_frontend_enums.audit", lambda: unreachable)
+    # Even --strict must exit 0 when we simply couldn't reach the frontend.
+    assert main(["--strict"]) == 0


### PR DESCRIPTION
## Summary

Sales orders imported from a *native* Katana ecommerce integration carry `ecommerce_order_type` / `ecommerce_store_name` / `ecommerce_order_id`. Katana's web UI renders an "Open in {platform}" deep-link from them (its frontend `EcomLink` component), but the MCP server did nothing with them — and the `create_sales_order` field hint was wrong (`'shopify_order'` / `'woocommerce_order'` — a bogus `_order` suffix **and** wrong casing).

This derives the storefront link server-side, exactly the way Katana does, and guards the (necessarily hand-transcribed) platform set against drift.

## What this does

- **`web_urls.ecommerce_storefront_url()`** builds the link for the three native deep-linkable platforms — `shopify`, `wooCommerce`, `bigCommerce` (camelCase, exact-match, no coercion) — and returns `None` for everything else. `_ECOMMERCE_TEMPLATES` is the single source of truth.
- **`get_sales_order`** surfaces a derived `ecommerce_url`.
- **The SO modify/delete/correct card** renders an "Open in {platform}" link when present (shared helper, reusable by the future detail card).
- **`create_sales_order`** fixes the three field hints (correct literals, per-platform `store_name` semantics, create-only note) and adds an **advisory, non-blocking** warning when `ecommerce_order_type` won't deep-link — the fields are create-only, so this is the only chance to catch a typo.
- **`poe audit-frontend-enums`** — a soft-fail drift audit that re-checks the platform set against Katana's *live* frontend enum, slug-agnostically (resolves the `sales-mf` module-federation `remoteEntry.js` → extracts `EcommerceIntegrationType`). Never gates CI; **not** part of `regenerate-all`.

## Why mirror Katana (only 3 platforms)

Investigation (frontend bundles + live probes + Katana's own support docs, captured in #913) showed eBay/Etsy/Magento/etc. arrive via **middleware** (Extensiv/Zapier/Make) that writes the source id into `order_no` (e.g. `EBAY-101`), **not** `ecommerce_*`. They aren't deep-linked by Katana and carry no data a link could use. Only Shopify/WooCommerce/BigCommerce populate `ecommerce_*` and deep-link. There is **no** settable URL field on the wire — Katana derives the link, so we derive it too.

## Ground truth

- Enum literals (camelCase) confirmed across multiple frontend chunks **and** a real captured API payload (`ecommerce_store_name: katana.myshopify.com`, `ecommerce_order_id: 19433769`).
- A **live test-tenant round-trip** (created → read back → deleted a synthetic Shopify + BigCommerce SO) confirmed `ecommerce_order_type` persists verbatim and `ecommerce_store_name` holds a host/slug the templates interpolate cleanly.

## Test plan

- Unit: URL builder happy/None paths (incl. mis-cased `woocommerce` → None, `ebay` → None), create-guard warning fires/doesn't, `get_sales_order` populates `ecommerce_url`, both card surfaces render/omit the link, audit script (no-drift / drift / MF fallback / unreachable / parse-failure) via `httpx.MockTransport`.
- Live: `tests/integration/test_so_ecommerce_link_live.py` round-trips Shopify + BigCommerce SOs on the test tenant (auto-skips without `KATANA_TEST_API_KEY`; SDT-tagged + deleted in teardown).
- `uv run poe check` green (full tier incl. 47 browser render tests). `uv run poe audit-frontend-enums` reports no drift against the live frontend.

## Deferred to follow-ups (not in this PR)

- The new `get_sales_order` detail card (the shared link helper is built ready for it) — isolated so it can go through `/card-review` independently.
- OpenAPI spec ecommerce description + example polish (fix the misleading `'Kitchen Pro Store'` example → `katana.myshopify.com`) — separate PR because it triggers `regenerate-all` + generated-file diffs.

Refs #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)