### PR TITLE
perf(mcp): extend parent_from_outcome to modify_item + header-only modify_sales_order

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -1732,6 +1732,15 @@ async def _modify_item_impl(
             refetch_for_merge=lambda eid: _safe_fetch_item_attrs(
                 services, eid, request.type
             ),
+            # #905: reuse the PATCH response for the parent merge instead of a
+            # GET — one fewer call that could stall on the rate-limit reset gate
+            # (#786). Unconditionally safe for items: the product/material/service
+            # EntitySpecs embed NO children (no ``rows_field``), so the parent
+            # merge writes only the item row; variants are a separate top-level
+            # spec, lazy-synced (this modify wires no variant ``refetch_related``),
+            # so a variant add/update/delete is unaffected by the parent merge
+            # source either way.
+            parent_from_outcome=True,
         ),
     )
 

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -3230,6 +3230,18 @@ async def _modify_purchase_order_impl(
         cache_merge=CacheMerge(
             cache=services.typed_cache,
             refetch_for_merge=lambda eid: _fetch_purchase_order_attrs(services, eid),
+            # #905: deliberately NOT setting ``parent_from_outcome`` here.
+            # Unlike the SO and item modifies, PATCH /purchase_orders/{id}
+            # returns the PO with an EMPTY ``purchase_order_rows`` (verified
+            # against the live tenant 2026-06-03: GET embeds 4 rows, the PATCH
+            # response embeds 0). Because ``_PURCHASE_ORDER_SPEC`` sets
+            # ``reconcile_children=True``, merging that rows-less response would
+            # reconcile the cached PO rows to the empty set and delete them all
+            # — so the parent GET (which embeds rows) is required. PO already
+            # gets the #786 post-apply fetch time-bound, so this only forgoes a
+            # call reduction, not hang protection. A later optimization (graft
+            # the refetch_related rows onto the rows-less PATCH outcome) is
+            # tracked in #915.
             # Soft-deleted rows are hidden from the parent fetch even
             # when ``include_deleted=true`` is set on the PO endpoint
             # (the flag only controls top-level inclusion). Fan out to

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -2606,6 +2606,22 @@ async def _modify_sales_order_impl(
         )
     )
 
+    # #905: reuse the PATCH response for the parent merge (skip the GET — one
+    # fewer call that could stall on the rate-limit reset gate, #786) ONLY when
+    # this modify changes no rows. PATCH /sales_orders/{id} embeds
+    # ``sales_order_rows`` (verified live 2026-06-03: 1-row and 2-row SOs both
+    # round-trip their rows), so for a row-unchanged modify the response is the
+    # complete post-state and the embedded-row reconcile (``reconcile_children``
+    # on ``_SALES_ORDER_SPEC``) is correct. But the header action runs FIRST in
+    # the plan, so when there ARE row actions its outcome predates them — stale
+    # embedded rows could make reconcile clobber the just-changed rows, and
+    # content freshness would hang on the (time-bounded) related refetch. Fall
+    # back to the GET there: it runs post-apply and reflects the final row state.
+    # Only row CRUD matters: address / fulfillment / shipping-fee sub-payloads
+    # don't touch ``sales_order_rows``, so they keep the optimization.
+    so_no_row_crud = not (
+        request.add_rows or request.update_rows or request.delete_row_ids
+    )
     response = await run_modify_plan(
         request=request,
         naming=EntityNaming(
@@ -2630,6 +2646,7 @@ async def _modify_sales_order_impl(
                     lambda eid: _fetch_so_row_attrs_for_merge(services, eid),
                 ),
             ),
+            parent_from_outcome=so_no_row_crud,
         ),
     )
 

--- a/katana_mcp_server/tests/conftest.py
+++ b/katana_mcp_server/tests/conftest.py
@@ -8,6 +8,15 @@ import pytest
 import pytest_asyncio
 
 
+class StopForCapture(Exception):
+    """Sentinel to short-circuit an impl after capturing a call argument.
+
+    Lets a wiring test patch a downstream call (e.g. ``run_modify_plan``) to
+    record an argument it was handed and bail out before the (unmocked) rest of
+    the impl runs. Shared so per-tool wiring tests don't each redeclare it.
+    """
+
+
 @pytest.fixture(autouse=True)
 def _disable_cache_warmup_by_default(
     request: pytest.FixtureRequest,

--- a/katana_mcp_server/tests/tools/test_items.py
+++ b/katana_mcp_server/tests/tools/test_items.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import datetime
 import json
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,6 +25,7 @@ from katana_mcp.tools.foundation.items import (
     get_variant_details,
 )
 from katana_mcp_server.tests.conftest import (
+    StopForCapture,
     create_mock_context,
     mock_item as _mock_item,
 )
@@ -2261,6 +2262,45 @@ async def test_modify_item_archive_verifies_when_diff_fetch_misses():
     assert action.succeeded is True
     assert action.verified is True
     assert action.actual_after is None
+
+
+@pytest.mark.asyncio
+async def test_modify_item_wires_parent_from_outcome():
+    """#905: modify_item reuses the PATCH response for the parent merge.
+
+    The product/material/service EntitySpecs embed no children, so the parent
+    merge writes only the item row — unconditionally safe to source from the
+    PATCH ``apply_outcome`` (one fewer GET that could stall on the rate-limit
+    gate). Asserted at the wiring level: the ``CacheMerge`` handed to
+    ``run_modify_plan`` carries ``parent_from_outcome=True``.
+    """
+    from katana_mcp.tools.foundation import items as items_mod
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run(**kwargs: Any) -> Any:
+        captured["cache_merge"] = kwargs["cache_merge"]
+        raise StopForCapture
+
+    context, _ = create_mock_context()
+    request = items_mod.ModifyItemRequest(
+        id=7,
+        type=ItemType.PRODUCT,
+        update_header=items_mod.ItemHeaderPatch(name="Renamed"),
+        preview=False,
+    )
+    with (
+        patch(
+            "katana_mcp.tools.foundation.items._fetch_item_for_diff",
+            new_callable=AsyncMock,
+            return_value=_mock_item(id=7, name="Widget"),
+        ),
+        patch.object(items_mod, "run_modify_plan", side_effect=fake_run),
+        pytest.raises(StopForCapture),
+    ):
+        await items_mod._modify_item_impl(request, context)
+
+    assert captured["cache_merge"].parent_from_outcome is True
 
 
 @pytest.mark.asyncio

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -26,7 +26,11 @@ from katana_mcp.tools.foundation.sales_orders import (
     get_sales_order,
     list_sales_orders,
 )
-from katana_mcp_server.tests.conftest import create_mock_context, patch_typed_cache_sync
+from katana_mcp_server.tests.conftest import (
+    StopForCapture,
+    create_mock_context,
+    patch_typed_cache_sync,
+)
 
 from katana_public_api_client.client_types import UNSET
 from katana_public_api_client.models import (
@@ -2613,6 +2617,93 @@ _MODIFY_SO_UNWRAP_AS_LOCAL = "katana_mcp.tools._modification_dispatch.unwrap_as"
 def _mock_so(order_id: int = 1, order_no: str = "SO-1"):
     """Build a mock SalesOrder attrs object with all fields defaulted to UNSET."""
     return mock_entity_for_modify(SalesOrder, id=order_id, order_no=order_no)
+
+
+async def _capture_so_cache_merge(request: ModifySalesOrderRequest):
+    """Run ``_modify_sales_order_impl`` far enough to capture the ``CacheMerge``
+    it hands to ``run_modify_plan``, then bail before the apply path."""
+    from katana_mcp.tools.foundation import sales_orders as so_mod
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run(**kwargs: Any) -> Any:
+        captured["cache_merge"] = kwargs["cache_merge"]
+        raise StopForCapture
+
+    context, _ = create_mock_context()
+    with (
+        patch(
+            "katana_mcp.tools.foundation.sales_orders._fetch_sales_order_attrs",
+            new_callable=AsyncMock,
+            return_value=_mock_so(order_id=42, order_no="SO-1"),
+        ),
+        patch.object(so_mod, "run_modify_plan", side_effect=fake_run),
+        pytest.raises(StopForCapture),
+    ):
+        await so_mod._modify_sales_order_impl(request, context)
+    return captured["cache_merge"]
+
+
+@pytest.mark.asyncio
+async def test_modify_so_parent_from_outcome_header_only():
+    """#905: a header-only SO modify reuses the PATCH response for the parent
+    merge (`parent_from_outcome=True`). PATCH /sales_orders/{id} embeds rows
+    (verified live), so the response is the complete post-state — one fewer GET
+    that could stall on the rate-limit gate (#786)."""
+    cache_merge = await _capture_so_cache_merge(
+        ModifySalesOrderRequest(
+            id=42, update_header=SOHeaderPatch(status="PACKED"), preview=False
+        )
+    )
+    assert cache_merge.parent_from_outcome is True
+
+
+@pytest.mark.asyncio
+async def test_modify_so_parent_from_outcome_disabled_with_row_actions():
+    """#905: an SO modify with row actions falls back to the GET
+    (`parent_from_outcome=False`). The header action runs first, so its PATCH
+    outcome predates the row changes — stale embedded rows would mislead
+    `reconcile_children`; the post-apply GET reflects the final row state."""
+    cache_merge = await _capture_so_cache_merge(
+        ModifySalesOrderRequest(
+            id=42,
+            update_header=SOHeaderPatch(status="PACKED"),
+            add_rows=[SORowAdd(variant_id=100, quantity=2)],
+            preview=False,
+        )
+    )
+    assert cache_merge.parent_from_outcome is False
+
+
+@pytest.mark.asyncio
+async def test_modify_so_parent_from_outcome_disabled_for_row_only_plan():
+    """#905: row CRUD disables the optimization even with no ``update_header``
+    — the gate keys off row actions, not header presence. (A row-only plan also
+    has no parent-targeted action, so the dispatcher would fall back to the GET
+    regardless; this pins the gate's intent.)"""
+    cache_merge = await _capture_so_cache_merge(
+        ModifySalesOrderRequest(
+            id=42,
+            delete_row_ids=[555],
+            preview=False,
+        )
+    )
+    assert cache_merge.parent_from_outcome is False
+
+
+@pytest.mark.asyncio
+async def test_modify_so_parent_from_outcome_enabled_for_non_row_subpayload():
+    """#905: a non-row modify (here shipping-fee-only, no header, no rows) keeps
+    the optimization — fees/addresses/fulfillments don't touch
+    ``sales_order_rows``, so the PATCH response is a sound parent-merge source."""
+    cache_merge = await _capture_so_cache_merge(
+        ModifySalesOrderRequest(
+            id=42,
+            add_shipping_fees=[SOShippingFeeAdd(amount="12.50")],
+            preview=False,
+        )
+    )
+    assert cache_merge.parent_from_outcome is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #786/#909. #909 added `CacheMerge.parent_from_outcome` (the post-apply parent cache merge reuses the parent action's PATCH response instead of a GET — one fewer call that can stall on Katana's 60-req/min rate-limit reset gate). This extends it to the remaining modify tools, **scoped by live test-tenant probes of each endpoint's PATCH-response shape** — the decisive, non-obvious part:

| Tool | Probe finding | Decision |
|---|---|---|
| `modify_item` | product/material/service EntitySpecs embed **no** children (no `rows_field`); variants are a separate top-level spec, lazy-synced | ✅ `parent_from_outcome=True`, unconditional |
| `modify_sales_order` | PATCH `/sales_orders/{id}` **embeds rows** (verified: 1-row→1, 2-row→2) | ⚠️ enabled only when no row CRUD — the header action runs first, so a plan with row actions would feed stale embedded rows to `reconcile_children`; those keep the GET |
| `modify_purchase_order` | PATCH `/purchase_orders/{id}` **drops rows** (GET 4 → PATCH 0) | ❌ not enabled — merging the rows-less response would reconcile cached PO rows to empty and delete them all |

PO keeps the GET-based parent merge (correct + already hang-protected by the #786 time-bound); the call-reduction optimization for PO is tracked in #915.

## Test plan

- [x] `uv run poe check` — full suite + 47 browser tests green
- [x] Wiring tests (assert the `CacheMerge` handed to `run_modify_plan`):
  - item → `parent_from_outcome=True`
  - SO header-only / shipping-fee-only → `True`; SO with `add_rows` / `delete_row_ids` → `False`
- [x] Live probes documented in #905 (SO embeds rows on PATCH; PO drops them)

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)