### PR TITLE
docs: record Katana's response on the serial-fulfillment gap (#784)

### DIFF
--- a/docs/escalations/katana-serial-fulfillment-gap.md
+++ b/docs/escalations/katana-serial-fulfillment-gap.md
@@ -7,6 +7,13 @@ via make-to-order\
 
 > **Status:** Submitted to Katana 2026-06-02; this is the consolidated statement after a
 > live investigation (test tenant + a browser network-trace of the UI close-out).\
+> **Katana response (2026-06-04):** gap acknowledged ("Public api and serial flows are
+> not great"). Fix planned as part of **bin-locations-on-sales**, which introduces a
+> unified `traceability` relation absorbing bin + batch + serial; fulfillments will no
+> longer specify traceability — pre-assignments (the make-to-order reservation)
+> **auto-carry into the delivered state** (matches options 2–3 in "What we need" below).
+> Expected **~end of June 2026**; no Katana ticket number provided. Re-probe the
+> make-to-order close-out when that release ships, then close or re-escalate.\
 > Internal tracking:
 > [#784](https://github.com/dougborg/katana-openapi-client/issues/784),
 > [#849](https://github.com/dougborg/katana-openapi-client/issues/849).


### PR DESCRIPTION
## Summary

- Records Katana support's **2026-06-04 response** to the make-to-order serial-fulfillment escalation in the Status block of `docs/escalations/katana-serial-fulfillment-gap.md`.
- First explicit acknowledgment from Katana that the gap is real ("Public api and serial flows are not great").
- Planned fix: **bin-locations-on-sales** introduces a unified `traceability` relation (bin + batch + serial); fulfillments will no longer specify traceability — pre-assignments auto-carry into the delivered state. This maps to options 2–3 in the doc's "What we need" list.
- Timeline: **~end of June 2026**; no Katana ticket number provided.
- Full response also captured as a comment on #784.

## Test plan

- [x] Docs-only change; `mdformat` + `pytest` pre-commit hooks pass.
- [ ] Re-probe the make-to-order close-out against the public API once the bin-locations-on-sales release ships (~end of June 2026), then close or re-escalate #784.

Refs #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)