### PR TITLE
feat(mcp): add get_sales_order detail card

### DIFF
--- a/katana_mcp_server/src/katana_mcp/resources/help.py
+++ b/katana_mcp_server/src/katana_mcp/resources/help.py
@@ -1608,8 +1608,13 @@ same filters in a single call.
 - `order_no` (optional): SO number (e.g., "#WEB20394")
 - `order_id` (optional): SO ID
 
+On UI-capable hosts this renders a read-only detail card (status, total,
+line items, resolved customer/location names, addresses, storefront link)
+with a single "View in Katana" action.
+
 **Returns:** Every field Katana exposes on the sales order record —
-identifiers (id, order_no, customer_id, location_id, source), status flags
+identifiers (id, order_no, customer_id, customer_name, location_id,
+location_name, source), status flags
 (status, production_status, invoicing_status, product_availability,
 ingredient_availability), dates (order_created_date, delivery_date,
 picked_date, product_expected_date, ingredient_expected_date), money (total,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/sales_orders.py
@@ -1594,7 +1594,27 @@ class GetSalesOrderResponse(SoftDeletableResponse):
     katana_url: str | None = None
     order_no: str | None = None
     customer_id: int | None = None
+    customer_name: str | None = Field(
+        default=None,
+        description=(
+            "Resolved customer display name (via ``resolve_entity_name`` on "
+            "``CachedCustomer``). Lets the detail card render ``'Customer: "
+            "<name>'`` instead of the bare ``'Customer ID: <id>'`` fallback "
+            "(card anti-pattern #2 / #7). ``None`` when the customer can't be "
+            "resolved from the typed cache (a cache-miss advisory is appended "
+            "to ``warnings``)."
+        ),
+    )
     location_id: int | None = None
+    location_name: str | None = Field(
+        default=None,
+        description=(
+            "Resolved location display name (via ``resolve_entity_name`` on "
+            "``CachedLocation``). Same role as ``customer_name`` for the "
+            "Location party line on the detail card. ``None`` on a cache miss "
+            "(advisory appended to ``warnings``)."
+        ),
+    )
     source: str | None = None
     order_created_date: str | None = None
 
@@ -1662,6 +1682,14 @@ class GetSalesOrderResponse(SoftDeletableResponse):
     rows: list[SalesOrderRowDetail] = Field(
         default_factory=list,
         description="Line items on the sales order.",
+    )
+
+    # Operator-facing advisories surfaced on the detail card (e.g. a
+    # typed-cache miss that left ``customer_name`` / ``location_name``
+    # unresolved). Empty in the happy path.
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Operator-facing advisories (e.g. name-resolution cache misses).",
     )
 
 
@@ -1796,12 +1824,47 @@ async def _get_sales_order_impl(
         for v_id in (unwrap_unset(r.variant_id, None) for r in raw_rows)
         if v_id is not None
     }
-    variants, addresses = await asyncio.gather(
+    customer_id = unwrap_unset(so.customer_id, None)
+    location_id = unwrap_unset(so.location_id, None)
+
+    async def _resolve_name(
+        cached_cls: Any, entity_id: int | None, *, entity_label: str
+    ) -> tuple[str | None, str | None]:
+        """``resolve_entity_name`` wrapper that no-ops on a ``None`` id.
+
+        SOs can carry a null ``location_id`` (and, defensively, a null
+        ``customer_id``); ``resolve_entity_name`` requires a concrete int,
+        so short-circuit to ``(None, None)`` rather than issuing a lookup
+        for a missing party.
+        """
+        if entity_id is None:
+            return None, None
+        return await resolve_entity_name(
+            services.typed_cache.catalog,
+            cached_cls,
+            entity_id,
+            entity_label=entity_label,
+        )
+
+    # Resolve the customer + location display names against the typed cache
+    # so the detail card renders ``'Customer: <name>'`` / ``'Location:
+    # <name>'`` instead of a bare ID (card anti-patterns #2 / #7) — same
+    # pattern ``create_sales_order`` uses. Gathered alongside the variant +
+    # address reads, which all depend only on the SO we just loaded.
+    (
+        variants,
+        addresses,
+        (customer_name, cust_warn),
+        (location_name, loc_warn),
+    ) = await asyncio.gather(
         services.typed_cache.catalog.get_many_by_ids(
             CachedVariant, variant_ids, include_deleted=True
         ),
         _fetch_sales_order_addresses(services, so.id),
+        _resolve_name(CachedCustomer, customer_id, entity_label="Customer"),
+        _resolve_name(CachedLocation, location_id, entity_label="Location"),
     )
+    resolution_warnings = [w for w in (cust_warn, loc_warn) if w]
 
     def _sku_for(v: Any) -> Any:
         if v is None:
@@ -1863,8 +1926,10 @@ async def _get_sales_order_impl(
         id=so.id,
         katana_url=katana_web_url("sales_order", so.id),
         order_no=unwrap_unset(so.order_no, None),
-        customer_id=unwrap_unset(so.customer_id, None),
-        location_id=unwrap_unset(so.location_id, None),
+        customer_id=customer_id,
+        customer_name=customer_name,
+        location_id=location_id,
+        location_name=location_name,
         source=unwrap_unset(so.source, None),
         order_created_date=iso_or_none(unwrap_unset(so.order_created_date, None)),
         status=enum_to_str(unwrap_unset(so.status, None)),
@@ -1908,6 +1973,7 @@ async def _get_sales_order_impl(
         updated_at=iso_or_none(unwrap_unset(so.updated_at, None)),
         deleted_at=iso_or_none(unwrap_unset(so.deleted_at, None)),
         rows=row_details,
+        warnings=resolution_warnings,
     )
 
 
@@ -1929,8 +1995,11 @@ async def get_sales_order(
     linked manufacturing order, batch tracking, serial numbers). Use with
     `list_sales_orders` for discovery; this is the single-call path to the rest.
     """
+    from katana_mcp.tools.prefab_ui import build_so_detail_ui
+
     response = await _get_sales_order_impl(request, context)
-    return make_json_result(response)
+    ui = build_so_detail_ui(response.model_dump())
+    return make_tool_result(response, ui=ui)
 
 
 # ============================================================================
@@ -2856,7 +2925,9 @@ def register_tools(mcp: FastMCP) -> None:
         meta=UI_META,
     )
     mcp.tool(tags={"orders", "sales", "read"}, annotations=_read)(list_sales_orders)
-    mcp.tool(tags={"orders", "sales", "read"}, annotations=_read)(get_sales_order)
+    mcp.tool(tags={"orders", "sales", "read"}, annotations=_read, meta=UI_META)(
+        get_sales_order
+    )
     register_preview_tool(
         mcp,
         modify_sales_order,

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -7220,6 +7220,269 @@ def build_so_modify_ui(
     return app
 
 
+# ============================================================================
+# Sales Order detail (read) card — build_so_detail_ui (#913)
+# ============================================================================
+
+
+# Tier-3 scalar reference fields rendered on the SO detail card, in order.
+# Each entry is ``(label, response_key)``; the line renders only when the
+# response carries a truthy value, so a sparse SO stays compact. Mirrors the
+# user-facing subset of ``_SO_HEADER_FIELD_SPEC`` that's worth surfacing on a
+# read card (the modify card's diff-overlay machinery doesn't apply here).
+_SO_DETAIL_SCALAR_FIELDS: tuple[tuple[str, str], ...] = (
+    ("Customer ref", "customer_ref"),
+    ("Order date", "order_created_date"),
+    ("Picked date", "picked_date"),
+    ("Notes", "additional_info"),
+)
+
+
+def _so_detail_header_section(so: dict[str, Any]) -> None:
+    """Tier 1 — title (linked to the Katana SO page when available) + status
+    badge.
+
+    The title links straight to the source-of-truth Katana sales-order page
+    (``katana_url``), so the footer needs no separate "View in Katana" button
+    — but the product spec for this card calls for an explicit footer link, so
+    we keep the title link AND the footer button (the link is the one-click
+    affordance; the footer button is the conventional read-card action slot).
+    Falls back to plain text when ``katana_url`` is missing.
+    """
+    order_no = so.get("order_no")
+    title_content = f"Sales Order {order_no}" if order_no else "Sales Order"
+    katana_url = so.get("katana_url")
+    status = so.get("status")
+
+    with Row(gap=2):
+        with CardTitle():
+            if katana_url:
+                Link(content=title_content, href=katana_url, target="_blank")
+            else:
+                Text(content=title_content)
+        if status:
+            Badge(
+                label=status,
+                variant=status_badge_variant("sales_order", status),
+            )
+
+
+def _so_detail_metrics_section(so: dict[str, Any]) -> None:
+    """Tier 2 — decision metrics: order Total, line-item count, delivery date.
+
+    Each Metric renders only when its underlying value is present, so a draft
+    SO with no delivery date doesn't paint an empty "Delivery" tile. The row
+    is skipped entirely when none of the three are available.
+    """
+    total = so.get("total")
+    currency = so.get("currency")
+    rows = so.get("rows") or []
+    delivery_date = so.get("delivery_date")
+
+    has_any = total is not None or rows or delivery_date
+    if not has_any:
+        return
+    with Row(gap=4):
+        if total is not None:
+            Metric(label="Total", value=_format_money(total, currency))
+        if rows:
+            Metric(label="Line Items", value=str(len(rows)))
+        if delivery_date:
+            Metric(label="Delivery", value=str(delivery_date))
+
+
+def _so_detail_rows_table(so: dict[str, Any]) -> None:
+    """Tier 3 — line-item DataTable (SKU, name, qty, unit price, line total).
+
+    Static inline table — no per-row drill-down (the SO is the destination;
+    row detail is inline, per the #913 product decision). Rows are read from
+    ``state.so.rows`` via the mandatory mustache binding. Each row carries
+    pre-formatted ``unit_price_display`` / ``line_total_display`` strings so
+    the money columns render currency-aware without a renderer-side formatter.
+    Renders a friendly empty-state when the SO has no line items.
+    """
+    rows = so.get("rows") or []
+    if not rows:
+        Separator()
+        Muted(content="No line items on this sales order.")
+        return
+    Separator()
+    Muted(content="Line items:")
+    DataTable(
+        columns=[
+            DataTableColumn(key="sku", header="SKU", sortable=True),
+            DataTableColumn(key="display_name", header="Name", sortable=True),
+            DataTableColumn(key="quantity", header="Qty", sortable=True, align="right"),
+            DataTableColumn(
+                key="unit_price_display", header="Unit Price", align="right"
+            ),
+            DataTableColumn(
+                key="line_total_display", header="Line Total", align="right"
+            ),
+        ],
+        rows="{{ so.rows }}",
+        **_paginate(len(rows)),
+    )
+
+
+def _so_detail_row_cells(so: dict[str, Any]) -> list[dict[str, Any]]:
+    """Pre-compute per-row display cells for the line-item DataTable.
+
+    The DataTable binds to ``state.so.rows`` (mustache), so the state copy of
+    each row needs the rendered ``sku`` / ``display_name`` / ``quantity`` plus
+    two pre-formatted money strings:
+
+    - ``unit_price_display`` — ``price_per_unit`` formatted via
+      ``_format_money`` in the SO currency (``"—"`` when null).
+    - ``line_total_display`` — the row ``total`` when Katana supplied it,
+      else ``price_per_unit * quantity`` as a fallback (``"—"`` when neither
+      is computable).
+
+    SKU coalesces to ``""`` (variants can have null SKUs — CLAUDE.md), and
+    ``display_name`` falls back to a ``"Variant <id>"`` label so a cache-miss
+    row still reads meaningfully instead of blank — or to a neutral
+    ``"Unknown item"`` when even ``variant_id`` is null (avoids a confusing
+    ``"Variant None"`` cell, since ``variant_id`` is optional in the response).
+    """
+    currency = so.get("currency")
+    cells: list[dict[str, Any]] = []
+    for r in so.get("rows") or []:
+        qty = r.get("quantity")
+        unit = float_or_none(r.get("price_per_unit"))
+        total = float_or_none(r.get("total"))
+        if total is None and unit is not None and qty is not None:
+            total = unit * qty
+        variant_id = r.get("variant_id")
+        display_name = r.get("display_name") or (
+            f"Variant {variant_id}" if variant_id is not None else "Unknown item"
+        )
+        cells.append(
+            {
+                "sku": r.get("sku") or "",
+                "display_name": display_name,
+                "quantity": qty,
+                "unit_price_display": (
+                    _format_money(unit, currency) if unit is not None else "—"
+                ),
+                "line_total_display": (
+                    _format_money(total, currency) if total is not None else "—"
+                ),
+            }
+        )
+    return cells
+
+
+def build_so_detail_ui(so: dict[str, Any]) -> PrefabApp:
+    """Build a read-only detail card for a sales order (``get_sales_order``).
+
+    Implements the four-tier framework from #537 for a pure read surface
+    (#913) — no Confirm/Cancel rail, no mutation buttons:
+
+    - **Tier 1 — Identity**: title as an external ``Link`` to the Katana
+      sales-order page; status Badge with the bucket-driven variant from
+      ``status_badge_variant("sales_order", ...)``.
+    - **Tier 2 — Decision metrics**: order Total (currency-aware via
+      ``_format_money``), line-item count, and delivery date — the facts an
+      operator scans first on an order. Rendered as ``Metric`` tiles.
+    - **Tier 3 — Reference**: Customer + Location party lines (resolved names
+      via ``_render_party_line``, never bare IDs — the impl side fills
+      ``customer_name`` / ``location_name`` from the typed cache), the
+      storefront deep-link (``_render_ecommerce_link``), scalar header fields
+      (customer ref / order date / picked date / notes), the billing +
+      shipping address blocks (``_render_address_block``), and the static
+      line-item ``DataTable`` (SKU / name / qty / unit price / line total —
+      no row drill-down). Any name-resolution cache-miss advisories surface
+      as warning badges.
+    - **Tier 4 — Actions**: a single "View in Katana" link button. Pure read
+      card — no Fulfill / Edit / mutation buttons (#913 product decision).
+
+    Reference template: ``build_item_detail_ui`` (parent entity with an
+    embedded child table) and ``build_variant_details_ui`` (Metric-row Tier 2
+    on a read card).
+    """
+    # The line-item DataTable binds to ``state.so.rows``; swap in the
+    # pre-formatted display cells so the money columns render currency-aware
+    # without a renderer-side formatter. Shallow-copy ``so`` so the caller's
+    # response dict isn't mutated.
+    so_state = {**so, "rows": _so_detail_row_cells(so)}
+
+    with PrefabApp(state={"so": so_state}, css_class="p-4") as app, Card():
+        with CardHeader(), Column(gap=1):
+            _so_detail_header_section(so)
+
+        with CardContent(), Column(gap=3):
+            # Tier 2 — metrics.
+            _so_detail_metrics_section(so)
+            Separator()
+
+            # Tier 3 — reference. Party lines first (the "who"), then
+            # storefront link, scalar header fields, addresses, and the
+            # line-item table.
+            _render_party_line(
+                "Customer",
+                name=so.get("customer_name"),
+                entity_id=so.get("customer_id"),
+                entity_kind="customer",
+            )
+            # Location has no per-entity Katana web page (same as the SO
+            # create / modify cards) — pass no ``entity_kind`` so the party
+            # line renders ``"Location: <name>"`` without a dead link.
+            _render_party_line(
+                "Location",
+                name=so.get("location_name"),
+                entity_id=so.get("location_id"),
+            )
+            _render_ecommerce_link(so)
+
+            for label, key in _SO_DETAIL_SCALAR_FIELDS:
+                value = so.get(key)
+                if value:
+                    Text(content=f"{label}: {value}")
+
+            # Tracking — render as a Link when a URL is present, else plain
+            # text, else nothing.
+            tracking_number = so.get("tracking_number")
+            tracking_url = so.get("tracking_number_url")
+            if tracking_number and tracking_url:
+                with Row(gap=1):
+                    Text(content="Tracking:")
+                    Link(content=tracking_number, href=tracking_url, target="_blank")
+            elif tracking_number:
+                Text(content=f"Tracking: {tracking_number}")
+
+            # Address blocks — billing + shipping, in that order. Each block
+            # self-skips when empty (returns False), so a partial / absent
+            # address set renders no dangling labels.
+            addresses = so.get("addresses") or []
+            for entity_type, label in (
+                ("billing", "Billing Address"),
+                ("shipping", "Shipping Address"),
+            ):
+                addr = next(
+                    (a for a in addresses if a.get("entity_type") == entity_type),
+                    None,
+                )
+                if addr is not None:
+                    _render_address_block(label, addr)
+
+            # Line-item table (Tier 3 decision driver) — last so the scalar
+            # reference context sits above it.
+            _so_detail_rows_table(so)
+
+            # Name-resolution cache-miss advisories, if any.
+            _render_warnings_block(so.get("warnings"))
+
+        with CardFooter(), Row(gap=2):
+            katana_url = so.get("katana_url")
+            if katana_url:
+                Button(
+                    label="View in Katana",
+                    variant="outline",
+                    on_click=OpenLink(url=katana_url),
+                )
+    return app
+
+
 def _render_mo_identity_lines(
     mo: dict[str, Any], changes: dict[str, FieldChangeView]
 ) -> None:

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -38,6 +38,7 @@ from katana_mcp.tools.prefab_ui import (
     build_product_bom_ui,
     build_search_results_ui,
     build_so_create_ui,
+    build_so_detail_ui,
     build_so_modify_ui,
     build_stock_adjustment_create_ui,
     build_stock_adjustment_delete_ui,
@@ -506,6 +507,76 @@ def _variant_batch_app() -> PrefabApp:
         ],
     }
     return build_variant_batch_ui(payload)
+
+
+def _so_detail_app() -> PrefabApp:
+    """build_so_detail_ui — read-only sales-order detail card (#913).
+
+    Exercises the static line-item DataTable (rows='{{ so.rows }}'), the
+    resolved customer/location party lines, billing+shipping address blocks,
+    storefront link, and the single View-in-Katana footer button.
+    """
+    so = {
+        "id": 4242,
+        "katana_url": "https://factory.katanamrp.com/salesorder/4242",
+        "order_no": "SO-4242",
+        "status": "PACKED",
+        "customer_id": 10,
+        "customer_name": "Bicycle Parts Co",
+        "location_id": 3,
+        "location_name": "Main Warehouse",
+        "total": 1500.0,
+        "currency": "USD",
+        "delivery_date": "2026-07-01",
+        "customer_ref": "PO-99",
+        "order_created_date": "2026-06-01",
+        "additional_info": "Rush order — ship by Friday",
+        "tracking_number": "TRK-12345",
+        "tracking_number_url": "https://track.example/TRK-12345",
+        "ecommerce_order_type": "shopify",
+        "ecommerce_store_name": "bikeparts.myshopify.com",
+        "ecommerce_order_id": "555",
+        "ecommerce_url": ("https://bikeparts.myshopify.com/admin/orders/555"),
+        "addresses": [
+            {
+                "entity_type": "billing",
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "line_1": "1 Main St",
+                "city": "Townsville",
+                "country": "US",
+            },
+            {
+                "entity_type": "shipping",
+                "company": "Bicycle Parts Co",
+                "line_1": "2 Dock Rd",
+                "city": "Portcity",
+                "state": "CA",
+                "zip": "90210",
+                "country": "US",
+            },
+        ],
+        "rows": [
+            {
+                "variant_id": 700001,
+                "sku": "FRAME-STD",
+                "display_name": "Frame / Standard",
+                "quantity": 2,
+                "price_per_unit": 500.0,
+                "total": 1000.0,
+            },
+            {
+                "variant_id": 700002,
+                "sku": "WHEEL-26",
+                "display_name": "Wheel / 26in",
+                "quantity": 5,
+                "price_per_unit": 100.0,
+                "total": 500.0,
+            },
+        ],
+        "warnings": [],
+    }
+    return build_so_detail_ui(so)
 
 
 def _batch_recipe_update_app() -> PrefabApp:
@@ -1756,6 +1827,7 @@ SCENARIOS: dict[str, Callable[[], PrefabApp]] = {
     "product_bom": _product_bom_app,
     "product_bom_empty": _product_bom_empty_app,
     "variant_batch": _variant_batch_app,
+    "so_detail": _so_detail_app,
     "inventory_check": _inventory_check_app,
     "inventory_at_single": _inventory_at_single_app,
     "inventory_at_batch": _inventory_at_batch_app,

--- a/katana_mcp_server/tests/browser/test_other_cards_render.py
+++ b/katana_mcp_server/tests/browser/test_other_cards_render.py
@@ -280,6 +280,36 @@ class TestOtherCardsRender:
         assert frame.locator("text=DOES-NOT-EXIST-1").count() >= 1
         assert frame.locator("text=999999999").count() >= 1
 
+    def test_so_detail_renders(self, render_scenario):
+        """``build_so_detail_ui`` — read-only SO detail card (#913).
+
+        Proves the static line-item DataTable (rows='{{ so.rows }}') mounts
+        and the card surfaces resolved names, addresses, and the single
+        View-in-Katana footer link — no Confirm/mutation buttons.
+        """
+        frame = render_scenario("so_detail")
+        # Tier 1 — title (linked) + status badge.
+        assert frame.locator("text=Sales Order SO-4242").count() >= 1
+        assert frame.locator("text=PACKED").count() >= 1
+        # Tier 2 — metrics.
+        assert frame.locator("text=Total").count() >= 1
+        assert frame.locator("text=$1,500.00").count() >= 1
+        # Tier 3 — resolved party names (NOT bare IDs).
+        assert frame.locator("text=Bicycle Parts Co").count() >= 1
+        assert frame.locator("text=Main Warehouse").count() >= 1
+        assert frame.locator("text=Customer ID:").count() == 0
+        # Address blocks.
+        assert frame.locator("text=Billing Address:").count() >= 1
+        assert frame.locator("text=Shipping Address:").count() >= 1
+        # Line-item DataTable with header + 2 rows.
+        assert frame.locator("table").count() == 1
+        assert frame.locator("table tr").count() >= 3
+        assert frame.locator("text=FRAME-STD").count() >= 1
+        assert frame.locator("text=Wheel / 26in").count() >= 1
+        # Tier 4 — single read action, no Confirm.
+        assert frame.locator("text=View in Katana").count() >= 1
+        assert frame.locator("text=Confirm").count() == 0
+
     def test_so_create_with_fees_preview_renders(self, render_scenario):
         """``build_so_create_ui`` with inline shipping fees on preview (#818).
 

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -34,6 +34,7 @@ from katana_mcp.tools.prefab_ui import (
     build_receipt_ui,
     build_search_results_ui,
     build_so_create_ui,
+    build_so_detail_ui,
     build_so_modify_ui,
     build_stock_transfer_modify_ui,
     build_variant_details_ui,
@@ -10344,3 +10345,292 @@ class TestDataTablePagination:
             "— route pagination through `**_paginate(len(rows))` instead so "
             "short tables don't render blank filler rows."
         )
+
+
+def _so_detail_response(
+    *,
+    with_customer_name: bool = True,
+    with_location_name: bool = True,
+    with_addresses: bool = True,
+    with_ecommerce: bool = True,
+    with_rows: bool = True,
+    warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a ``get_sales_order`` response dict for ``build_so_detail_ui`` tests.
+
+    Toggles let each test exercise one edge case (missing customer name,
+    empty addresses, no storefront link, empty rows) against an otherwise
+    full response.
+    """
+    rows = (
+        [
+            {
+                "variant_id": 700,
+                "sku": "SKU-A",
+                "display_name": "Widget / Red",
+                "quantity": 2,
+                "price_per_unit": 100.0,
+                "total": 200.0,
+            },
+            {
+                "variant_id": 701,
+                "sku": None,
+                "display_name": None,
+                "quantity": 5,
+                "price_per_unit": 10.0,
+                "total": None,
+            },
+        ]
+        if with_rows
+        else []
+    )
+    addresses = (
+        [
+            {
+                "entity_type": "billing",
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "line_1": "1 Main St",
+                "city": "Townsville",
+                "country": "US",
+            },
+            {
+                "entity_type": "shipping",
+                "company": "Acme Manufacturing",
+                "line_1": "2 Dock Rd",
+                "city": "Portcity",
+                "state": "CA",
+                "zip": "90210",
+                "country": "US",
+            },
+        ]
+        if with_addresses
+        else []
+    )
+    return {
+        "id": 42,
+        "katana_url": "https://factory.katanamrp.com/salesorder/42",
+        "order_no": "SO-1001",
+        "status": "PACKED",
+        "customer_id": 10,
+        "customer_name": "Acme Co" if with_customer_name else None,
+        "location_id": 3,
+        "location_name": "Main Warehouse" if with_location_name else None,
+        "total": 1500.0,
+        "currency": "USD",
+        "delivery_date": "2026-07-01",
+        "customer_ref": "PO-99",
+        "order_created_date": "2026-06-01",
+        "additional_info": "Rush order",
+        "tracking_number": "TRK123",
+        "tracking_number_url": "https://track.example/123",
+        "ecommerce_order_type": "shopify" if with_ecommerce else None,
+        "ecommerce_store_name": "mystore" if with_ecommerce else None,
+        "ecommerce_order_id": "555" if with_ecommerce else None,
+        "ecommerce_url": (
+            "https://mystore.myshopify.com/admin/orders/555" if with_ecommerce else None
+        ),
+        "addresses": addresses,
+        "rows": rows,
+        "warnings": warnings or [],
+    }
+
+
+class TestBuildSoDetailUI:
+    """``build_so_detail_ui`` — read-only sales-order detail card (#913)."""
+
+    def test_full_response_renders_valid_prefab(self) -> None:
+        app = build_so_detail_ui(_so_detail_response())
+        _assert_valid_prefab(app)
+
+    def test_title_links_to_katana(self) -> None:
+        """Tier 1 title is an external Link to the Katana SO page."""
+        envelope = build_so_detail_ui(_so_detail_response()).to_json()
+        links = _find_components_by_type(envelope, "Link")
+        title_links = [
+            link
+            for link in links
+            if link.get("content") == "Sales Order SO-1001"
+            and link.get("href") == "https://factory.katanamrp.com/salesorder/42"
+        ]
+        assert len(title_links) == 1, (
+            "Title must be an external Link to the Katana SO page."
+        )
+
+    def test_status_badge_uses_bucket_variant(self) -> None:
+        """PACKED is in the sales_order 'active' bucket → secondary variant."""
+        envelope = build_so_detail_ui(_so_detail_response()).to_json()
+        badges = _find_components_by_type(envelope, "Badge")
+        status_badges = [b for b in badges if b.get("label") == "PACKED"]
+        assert len(status_badges) == 1
+        assert status_badges[0].get("variant") == status_badge_variant(
+            "sales_order", "PACKED"
+        )
+
+    def test_customer_name_rendered_not_id(self) -> None:
+        """Resolved customer name renders as a Link; the bare-ID fallback
+        text must NOT appear (anti-pattern #2)."""
+        envelope = build_so_detail_ui(_so_detail_response()).to_json()
+        links = _find_components_by_type(envelope, "Link")
+        assert any(link.get("content") == "Acme Co" for link in links), (
+            "Customer name should render as a Link."
+        )
+        all_text = json.dumps(envelope)
+        assert "Customer ID: 10" not in all_text, (
+            "Card must not echo the bare customer ID when a name is resolved."
+        )
+
+    def test_location_name_rendered_without_link(self) -> None:
+        """Location has no Katana web page → renders as plain 'Location:
+        <name>' text, not a Link, and not the bare-ID fallback."""
+        envelope = build_so_detail_ui(_so_detail_response()).to_json()
+        texts = _collect_node_content(envelope, "Text")
+        assert "Location: Main Warehouse" in texts
+        assert "Location ID: 3" not in texts
+
+    def test_metrics_rendered(self) -> None:
+        """Tier 2 surfaces total / line-item count / delivery as Metrics."""
+        envelope = build_so_detail_ui(_so_detail_response()).to_json()
+        metrics = _find_components_by_type(envelope, "Metric")
+        labels = {m.get("label"): m.get("value") for m in metrics}
+        assert labels.get("Total") == "$1,500.00"
+        assert labels.get("Line Items") == "2"
+        assert labels.get("Delivery") == "2026-07-01"
+
+    def test_line_item_table_uses_mustache_rows(self) -> None:
+        """The line-item DataTable binds rows via mustache to state.so.rows."""
+        envelope = build_so_detail_ui(_so_detail_response()).to_json()
+        tables = _find_components_by_type(envelope, "DataTable")
+        assert len(tables) == 1
+        assert tables[0].get("rows") == "{{ so.rows }}"
+
+    def test_line_item_cells_formatted(self) -> None:
+        """Row state cells coalesce null SKU, fall back display_name, and
+        pre-format the money columns (incl. computed line total)."""
+        app = build_so_detail_ui(_so_detail_response())
+        rows = app.to_json()["state"]["so"]["rows"]
+        assert rows[0]["sku"] == "SKU-A"
+        assert rows[0]["unit_price_display"] == "$100.00"
+        assert rows[0]["line_total_display"] == "$200.00"
+        # Second row: null SKU → "", null name → "Variant 701", total
+        # computed from unit * qty.
+        assert rows[1]["sku"] == ""
+        assert rows[1]["display_name"] == "Variant 701"
+        assert rows[1]["line_total_display"] == "$50.00"
+
+    def test_null_variant_id_row_uses_neutral_label(self) -> None:
+        """A row with no display_name AND a null variant_id renders a neutral
+        "Unknown item" label, not a confusing "Variant None" (variant_id is
+        optional in the response)."""
+        response = {
+            **_so_detail_response(),
+            "rows": [
+                {
+                    "sku": None,
+                    "display_name": None,
+                    "variant_id": None,
+                    "quantity": 1,
+                    "price_per_unit": 10.0,
+                    "total": 10.0,
+                }
+            ],
+        }
+        rows = build_so_detail_ui(response).to_json()["state"]["so"]["rows"]
+        assert rows[0]["display_name"] == "Unknown item"
+
+    def test_address_blocks_rendered(self) -> None:
+        """Billing + shipping address blocks surface recipient / company /
+        street."""
+        envelope = build_so_detail_ui(_so_detail_response()).to_json()
+        texts = _collect_node_content(envelope, "Text")
+        assert "Billing Address:" in texts
+        assert "Shipping Address:" in texts
+        assert any("Jane Doe" in t for t in texts)
+        assert any("Acme Manufacturing" in t for t in texts)
+
+    def test_ecommerce_link_rendered(self) -> None:
+        """Storefront deep-link surfaces when the SO carries ecommerce
+        metadata."""
+        envelope = build_so_detail_ui(_so_detail_response()).to_json()
+        links = _find_components_by_type(envelope, "Link")
+        assert any(
+            link.get("href") == "https://mystore.myshopify.com/admin/orders/555"
+            for link in links
+        )
+
+    def test_footer_view_in_katana_only(self) -> None:
+        """Pure read card — the only footer action is View in Katana (no
+        Fulfill / Edit / mutation buttons)."""
+        envelope = build_so_detail_ui(_so_detail_response()).to_json()
+        view_buttons = _find_buttons_by_label(envelope, "View in Katana")
+        assert len(view_buttons) == 1
+        on_click = view_buttons[0].get("onClick") or view_buttons[0].get("on_click")
+        assert isinstance(on_click, dict)
+        assert on_click.get("url") == "https://factory.katanamrp.com/salesorder/42"
+        # No mutation buttons.
+        all_buttons = _find_components_by_type(envelope, "Button")
+        assert len(all_buttons) == 1, (
+            "Read card must render exactly one footer button (View in Katana)."
+        )
+
+    # ---- Edge cases ----
+
+    def test_missing_customer_name_falls_back_to_id(self) -> None:
+        """When name resolution missed, the party line surfaces the bare ID
+        (the only way to identify the customer)."""
+        envelope = build_so_detail_ui(
+            _so_detail_response(with_customer_name=False)
+        ).to_json()
+        texts = _collect_node_content(envelope, "Text")
+        assert "Customer ID: 10" in texts
+        _assert_valid_prefab(
+            build_so_detail_ui(_so_detail_response(with_customer_name=False))
+        )
+
+    def test_empty_addresses_renders_no_address_labels(self) -> None:
+        """No addresses → no dangling 'Billing Address:' / 'Shipping
+        Address:' labels."""
+        app = build_so_detail_ui(_so_detail_response(with_addresses=False))
+        _assert_valid_prefab(app)
+        texts = _collect_node_content(app.to_json(), "Text")
+        assert "Billing Address:" not in texts
+        assert "Shipping Address:" not in texts
+
+    def test_no_ecommerce_link_when_metadata_absent(self) -> None:
+        """No ecommerce metadata → no storefront link, card still valid."""
+        app = build_so_detail_ui(_so_detail_response(with_ecommerce=False))
+        _assert_valid_prefab(app)
+        texts = _collect_node_content(app.to_json(), "Text")
+        assert "Storefront:" not in texts
+
+    def test_empty_rows_renders_friendly_empty_state(self) -> None:
+        """No line items → friendly Muted message, no DataTable."""
+        app = build_so_detail_ui(_so_detail_response(with_rows=False))
+        _assert_valid_prefab(app)
+        envelope = app.to_json()
+        assert not _has_node_of_type(envelope, "DataTable")
+        muted = _collect_node_content(envelope, "Muted")
+        assert any("No line items" in m for m in muted)
+
+    def test_warnings_surface_as_badges(self) -> None:
+        """Name-resolution cache-miss advisories surface as warning badges."""
+        app = build_so_detail_ui(
+            _so_detail_response(
+                with_customer_name=False,
+                warnings=["Customer with id=10 was not found in the cache."],
+            )
+        )
+        _assert_valid_prefab(app)
+        badges = _find_components_by_type(app.to_json(), "Badge")
+        assert any("not found in the cache" in (b.get("label") or "") for b in badges)
+
+    def test_missing_katana_url_omits_footer_button(self) -> None:
+        """No katana_url → no View-in-Katana button, title renders as text."""
+        response = _so_detail_response()
+        response["katana_url"] = None
+        app = build_so_detail_ui(response)
+        _assert_valid_prefab(app)
+        envelope = app.to_json()
+        assert not _find_buttons_by_label(envelope, "View in Katana")
+        texts = _collect_node_content(envelope, "Text")
+        assert "Sales Order SO-1001" in texts

--- a/katana_mcp_server/tests/tools/test_sales_orders.py
+++ b/katana_mcp_server/tests/tools/test_sales_orders.py
@@ -2264,6 +2264,95 @@ async def test_get_sales_order_enriches_row_sku_from_cache():
     assert result.rows[1].display_name is None  # cache miss → no name
 
 
+@pytest.mark.asyncio
+async def test_get_sales_order_resolves_customer_and_location_names():
+    """Customer + location names resolve from the typed cache so the detail
+    card renders real names, not bare IDs (#913)."""
+    context, lifespan_ctx = create_mock_context()
+
+    # ``resolve_entity_name`` reads the cached row's ``name`` (dict-shaped
+    # fixtures are tolerated). Key by id so customer 42 / location 1 hit.
+    cache_by_id = {
+        42: {"id": 42, "name": "Acme Manufacturing"},
+        1: {"id": 1, "name": "Main Warehouse"},
+    }
+
+    async def fake_get_by_id(_cls, entity_id, **_kw):
+        return cache_by_id.get(entity_id)
+
+    lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(side_effect=fake_get_by_id)
+
+    mock_so = _make_mock_so(id=11, customer_id=42, location_id=1)
+
+    with (
+        patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
+    ):
+        result = await _get_sales_order_impl(GetSalesOrderRequest(order_id=11), context)
+
+    assert result.customer_name == "Acme Manufacturing"
+    assert result.location_name == "Main Warehouse"
+    # No cache-miss advisories on a clean resolution.
+    assert result.warnings == []
+
+
+@pytest.mark.asyncio
+async def test_get_sales_order_name_cache_miss_appends_warning():
+    """A customer/location cache miss leaves the name None and appends an
+    advisory warning (the card then falls back to the bare ID)."""
+    context, lifespan_ctx = create_mock_context()
+
+    # Default mock_catalog.get_by_id returns None → both lookups miss.
+    lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(return_value=None)
+
+    mock_so = _make_mock_so(id=12, customer_id=42, location_id=1)
+
+    with (
+        patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
+    ):
+        result = await _get_sales_order_impl(GetSalesOrderRequest(order_id=12), context)
+
+    assert result.customer_name is None
+    assert result.location_name is None
+    # One advisory per missed party.
+    assert len(result.warnings) == 2
+    assert any("Customer with id=42" in w for w in result.warnings)
+    assert any("Location with id=1" in w for w in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_get_sales_order_null_location_skips_resolution():
+    """A null ``location_id`` short-circuits resolution — no lookup, no
+    warning, ``location_name`` stays None."""
+    context, lifespan_ctx = create_mock_context()
+
+    async def fake_get_by_id(_cls, entity_id, **_kw):
+        return {"id": entity_id, "name": "Acme Manufacturing"}
+
+    get_by_id = AsyncMock(side_effect=fake_get_by_id)
+    lifespan_ctx.typed_cache.catalog.get_by_id = get_by_id
+
+    mock_so = _make_mock_so(id=13, customer_id=42)
+    mock_so.location_id = UNSET  # null location
+
+    with (
+        patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
+    ):
+        result = await _get_sales_order_impl(GetSalesOrderRequest(order_id=13), context)
+
+    assert result.customer_name == "Acme Manufacturing"
+    assert result.location_id is None
+    assert result.location_name is None
+    assert result.warnings == []
+    # Only the customer was looked up — the null-location party was skipped.
+    assert get_by_id.await_count == 1
+
+
 # ============================================================================
 # get_sales_order — exhaustive field coverage (#346)
 # ============================================================================
@@ -2581,6 +2670,33 @@ async def test_get_sales_order_format_json_returns_json():
     data = json.loads(_content_text(result))
     assert data["id"] == 9
     assert data["order_no"] == "SO-9"
+
+
+@pytest.mark.asyncio
+async def test_get_sales_order_emits_prefab_ui():
+    """``get_sales_order`` auto-renders the detail card: structured_content
+    carries a Prefab envelope (``$prefab``) while content stays JSON (#913)."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.get_by_id = AsyncMock(return_value=None)
+    mock_so = _make_mock_so(
+        id=14,
+        order_no="SO-14",
+        rows=[_make_mock_row(id=1, variant_id=500, quantity=2, price_per_unit=50.0)],
+    )
+
+    with (
+        patch(f"{_SO_GET}.asyncio_detailed", new_callable=AsyncMock),
+        patch(_SO_UNWRAP_AS, return_value=mock_so),
+        patch(_FETCH_ADDR_PATH, AsyncMock(return_value=[])),
+    ):
+        result = await get_sales_order(order_id=14, context=context)
+
+    # content remains the raw JSON the LLM reads.
+    data = json.loads(_content_text(result))
+    assert data["order_no"] == "SO-14"
+    # structured_content is the Prefab envelope for UI-capable hosts.
+    assert isinstance(result.structured_content, dict)
+    assert "$prefab" in result.structured_content
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Renders a read-only Prefab detail card for `get_sales_order`, matching how `get_item` / `get_variant_details` auto-render their cards. Previously `get_sales_order` returned plain JSON (`make_json_result`) with no card.

Follow-up to the storefront-link feature (#916); the shared `_render_ecommerce_link` helper built there is reused here.

Refs #913

## Card content (`build_so_detail_ui`)

Four-tier layout:

1. **Identity** — title as an external Link to the Katana SO page + status Badge (`status_badge_variant("sales_order", ...)`).
2. **Metrics** — order Total (`_format_money`), line-item count, delivery date as `Metric` tiles.
3. **Reference** — Customer + Location party lines (`_render_party_line`, resolved names), storefront deep-link (`_render_ecommerce_link`), scalar fields (customer ref / order date / picked date / notes / tracking), billing + shipping address blocks (`_render_address_block`), and a **static** line-item `DataTable` (SKU / Name / Qty / Unit Price / Line Total) with mustache `{{ so.rows }}` binding. Name-resolution cache-miss advisories surface as warning badges.
4. **Actions** — a single "View in Katana" link button.

## Response-model enrichment

`GetSalesOrderResponse` gains `customer_name` + `location_name`, resolved impl-side via `resolve_entity_name` against the typed cache (same pattern `create_sales_order` uses), plus a `warnings` list for cache-miss advisories. The card shows real names, never "Customer ID: 10". A null `location_id` short-circuits resolution (no lookup, no warning).

The tool fn now returns `make_tool_result(response, ui=build_so_detail_ui(...))` and registers with `meta=UI_META` so the card auto-renders on every call.

## Product decisions (per #913)

1. **Footer: "View in Katana" link only** — pure read card, no Fulfill/Edit/mutation buttons.
2. **Customer + location names resolved in this PR** via the typed cache.
3. **Line items: static inline DataTable**, no row-click drill-down — the SO is the destination.
4. **Auto-render** on every call (no preview/opt-in param), matching the other get_* tools.

## Test coverage

- `TestBuildSoDetailUI` (17 tests): happy path + edge cases — missing customer name (ID fallback), empty addresses, no storefront link, empty rows (friendly empty-state), warning badges, missing `katana_url` (no footer button), line-item cell formatting (null-SKU coalesce, display_name fallback, computed line total), footer = exactly one button.
- `get_sales_order` impl tests: customer/location name resolution, cache-miss advisories (2 warnings), null-location short-circuit (1 lookup), and the tool fn emitting a `$prefab` envelope in `structured_content`.
- Browser render scenario `so_detail` + render test (`test_so_detail_renders`) in `tests/browser/`.
- Synced the `help.py` resource for the detail card + resolved-name fields.

`uv run poe agent-check` clean (ruff/format/mdformat/ty); `uv run poe test` 3987 passed. The browser render test was validated in-process through the real render-server scenario dispatch (DataTable mounts with `{{ so.rows }}`, 2 state rows, single View-in-Katana button) — the headless Chromium run was blocked locally only because another worktree's `apps_dev` server held the shared ports; CI's `typescript-client`/browser job runs it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
