### PR TITLE
test(client): harden ecommerce PATCH-rejection parsing against missing info

### DIFF
--- a/tests/integration/test_so_ecommerce_link_live.py
+++ b/tests/integration/test_so_ecommerce_link_live.py
@@ -221,9 +221,10 @@ async def test_ecommerce_fields_are_create_only_patch_rejected(
         payload = resp.json()
         details = payload.get("error", payload).get("details") or []
         rejected = {
-            d["info"]["additionalProperty"]
+            prop
             for d in details
             if d.get("code") == "additionalProperties"
+            and (prop := (d.get("info") or {}).get("additionalProperty")) is not None
         }
         assert {
             "ecommerce_order_type",


### PR DESCRIPTION
## Summary

Post-merge review follow-up from #920. The live test `test_ecommerce_fields_are_create_only_patch_rejected` extracted rejected field names with `d[\"info\"][\"additionalProperty\"]`, which raises `KeyError` if a `details` entry has `code == \"additionalProperties\"` but no (or a null) `info` object — crashing during extraction instead of failing on the actual assertion.

## Change

Parse defensively and drop `None`:

```python
rejected = {
    prop
    for d in details
    if d.get(\"code\") == \"additionalProperties\"
    and (prop := (d.get(\"info\") or {}).get(\"additionalProperty\")) is not None
}
```

`(d.get(\"info\") or {})` tolerates both an absent `info` key and a present-but-null `info`.

## Verification

- `uv run poe agent-check` clean.
- Re-ran the live test against the test tenant — **passes** (PATCH→422, all three `ecommerce_*` fields still correctly extracted as rejected).

## Related

The deeper issue this review surfaced — the spec models error bodies flat while Katana wraps them in `{\"error\": {...}}`, so the generated client's 422 parser silently drops `details` — is **not** this PR; it's tracked in #746 (I added the 422/`DetailedErrorResponse` evidence there). This PR only hardens the test's extraction.

Refs #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)