### PR TITLE
fix(mcp): strip whitespace from KATANA_API_KEY

### DIFF
--- a/katana_mcp_server/src/katana_mcp/server.py
+++ b/katana_mcp_server/src/katana_mcp/server.py
@@ -178,8 +178,11 @@ async def lifespan(server: FastMCP) -> AsyncIterator[Services]:
     # Load environment variables
     load_dotenv()
 
-    # Get configuration from environment
-    api_key = os.getenv("KATANA_API_KEY")
+    # Get configuration from environment. ``.strip()`` so a copy-paste with a
+    # trailing newline/space doesn't reach the auth layer as a malformed key
+    # (an all-whitespace value collapses to "" and fails the check below),
+    # mirroring the handling of ``KATANA_SYNC_API_KEY``.
+    api_key = (os.getenv("KATANA_API_KEY") or "").strip()
     base_url = os.getenv("KATANA_BASE_URL", "https://api.katanamrp.com/v1")
 
     # Validate required configuration

--- a/katana_mcp_server/tests/test_server.py
+++ b/katana_mcp_server/tests/test_server.py
@@ -169,6 +169,39 @@ class TestLifespan:
             )
 
     @pytest.mark.asyncio
+    async def test_lifespan_strips_whitespace_from_api_key(self):
+        """A KATANA_API_KEY with leading/trailing whitespace (a common
+        copy-paste artifact) is stripped before reaching the client, so it
+        can't fail auth as a malformed key.
+        """
+        mock_server = MagicMock(spec=FastMCP)
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "KATANA_API_KEY": "  key-with-spaces  \n",
+                    "MCP_DISABLE_CACHE_WARMUP": "1",
+                },
+                clear=True,
+            ),
+            patch("katana_mcp.server.load_dotenv"),
+            patch("katana_mcp.server.KatanaClient") as mock_client_class,
+        ):
+            mock_client_instance = AsyncMock(spec=KatanaClient)
+            mock_client_instance.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client_instance
+
+            async with lifespan(mock_server) as context:
+                assert isinstance(context, Services)
+
+            # The client was built with the stripped key, not the padded one.
+            assert mock_client_class.call_args.kwargs["api_key"] == "key-with-spaces"
+
+    @pytest.mark.asyncio
     async def test_lifespan_with_default_base_url(self):
         """Test lifespan uses default base URL when not provided."""
         mock_server = MagicMock(spec=FastMCP)


### PR DESCRIPTION
## Summary

Completes the "strip both keys" config-hygiene fix. #923 (just merged) strips `KATANA_SYNC_API_KEY`; this strips the primary `KATANA_API_KEY` too.

A trailing newline or space on a copy-pasted `KATANA_API_KEY` would otherwise reach the auth layer as a malformed key and fail the first API call with no signal at the config site. Stripping at the lifespan read fixes it; an all-whitespace value collapses to `""` and trips the existing required-key check (so a blank key still raises the clear `ValueError`).

## Test plan
- [x] `test_lifespan_strips_whitespace_from_api_key` — a padded `KATANA_API_KEY` reaches the client stripped
- [x] Existing `test_lifespan_missing_api_key` still raises (blank/whitespace → `ValueError`)
- [x] pyright clean; `test_server.py` green (42 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)