### PR TITLE
fix(mcp): preserve Field metadata when unpacking models into tool params

### DIFF
--- a/katana_mcp_server/src/katana_mcp/unpack.py
+++ b/katana_mcp_server/src/katana_mcp/unpack.py
@@ -4,6 +4,11 @@ This module provides a decorator that allows tools to use Pydantic models for
 validation while exposing flattened parameters to the MCP protocol, working around
 Claude Code's parameter serialization issues with nested objects.
 
+The flattened signature also carries each field's full metadata — description and
+constraints — into the MCP tool schema, by re-wrapping every param annotation as
+``Annotated[type, FieldInfo]`` (see ``unpack_pydantic_params``). So the decorator is
+both a protocol workaround and the source of tool-schema documentation (#930).
+
 Usage:
     from typing import Annotated
     from pydantic import BaseModel, Field
@@ -59,9 +64,9 @@ def _reconstruct_model_kwargs(
     """Collapse flat field kwargs back into the unpacked Pydantic model instances.
 
     For each unpacked parameter, pulls its declared fields out of ``kwargs``,
-    constructs + validates the model (re-raising ``ValidationError`` as-is), and
-    returns a new kwargs dict with the flat fields replaced by the reconstructed
-    model instance.
+    constructs + validates the model, and returns a new kwargs dict with the flat
+    fields replaced by the reconstructed model instance. Any ``ValidationError``
+    raised by model construction propagates to the caller unchanged.
 
     Only declared fields are collected into the model payload, so an unknown
     top-level kwarg never reaches model construction — which is why
@@ -112,7 +117,7 @@ def unpack_pydantic_params(func: Callable) -> Callable:
 
     Raises:
         TypeError: If the unpacked parameter is not a Pydantic BaseModel subclass.
-        ValidationError: If the collected parameters don't pass Pydantic validation.
+        pydantic.ValidationError: If the collected parameters don't pass validation.
 
     Example:
         @unpack_pydantic_params
@@ -184,7 +189,12 @@ def unpack_pydantic_params(func: Callable) -> Callable:
                     # source of the default. Leaving both in place makes pydantic raise
                     # "cannot specify both default and default_factory" for any field
                     # using ``default_factory`` (e.g. ``Field(default_factory=list)``).
+                    #
+                    # ``copy`` is shallow, so the copy's ``.metadata`` list aliases the
+                    # original ``model_fields`` entry; re-bind it to a fresh list so a
+                    # downstream mutation of one can never corrupt the class's field.
                     metadata = copy(field_info)
+                    metadata.metadata = list(field_info.metadata)
                     metadata.default = PydanticUndefined
                     metadata.default_factory = None
                     field_annotation = Annotated[field_info.annotation, metadata]

--- a/katana_mcp_server/src/katana_mcp/unpack.py
+++ b/katana_mcp_server/src/katana_mcp/unpack.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import functools
 import inspect
 from collections.abc import Callable
+from copy import copy
 from typing import Annotated, Any, cast, get_args, get_origin, get_type_hints
 
 from pydantic import BaseModel, ValidationError
@@ -132,8 +133,21 @@ def unpack_pydantic_params(func: Callable) -> Callable:
                 # Store fields to add them in correct order later
                 unpacked_fields = []
                 for field_name, field_info in model_class.model_fields.items():
-                    # Create parameter for each model field
-                    field_annotation = field_info.annotation
+                    # Re-wrap the bare type in ``Annotated[type, <metadata>]`` so the
+                    # field's description, constraints (ge/le/min_length/...), and
+                    # examples ride along into FastMCP's schema generator. Using the
+                    # bare ``field_info.annotation`` dropped all of it, leaving every
+                    # flattened param undocumented in the tool schema (#930).
+                    #
+                    # We embed a *copy* of the FieldInfo with its default cleared:
+                    # the ``default=`` on the ``inspect.Parameter`` below is the single
+                    # source of the default. Leaving both in place makes pydantic raise
+                    # "cannot specify both default and default_factory" for any field
+                    # using ``default_factory`` (e.g. ``Field(default_factory=list)``).
+                    metadata = copy(field_info)
+                    metadata.default = PydanticUndefined
+                    metadata.default_factory = None
+                    field_annotation = Annotated[field_info.annotation, metadata]
 
                     # Handle default values - convert PydanticUndefined to inspect.Parameter.empty
                     if field_info.default is not PydanticUndefined:

--- a/katana_mcp_server/src/katana_mcp/unpack.py
+++ b/katana_mcp_server/src/katana_mcp/unpack.py
@@ -34,7 +34,7 @@ from collections.abc import Callable
 from copy import copy
 from typing import Annotated, Any, cast, get_args, get_origin, get_type_hints
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
 
 from katana_mcp.logging import get_logger
@@ -50,6 +50,46 @@ class Unpack:
     """
 
     pass
+
+
+def _reconstruct_model_kwargs(
+    unpack_mapping: dict[str, tuple[type[BaseModel], list[str]]],
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Collapse flat field kwargs back into the unpacked Pydantic model instances.
+
+    For each unpacked parameter, pulls its declared fields out of ``kwargs``,
+    constructs + validates the model (re-raising ``ValidationError`` as-is), and
+    returns a new kwargs dict with the flat fields replaced by the reconstructed
+    model instance.
+
+    Only declared fields are collected into the model payload, so an unknown
+    top-level kwarg never reaches model construction — which is why
+    ``extra="forbid"`` on the dispatcher request model does NOT fire on
+    MCP-protocol traffic: the model simply doesn't see the extra key. (FastMCP's
+    TypeAdapter against the flattened function signature rejects unknown top-level
+    args even earlier, before this helper runs.) The dispatcher-level
+    ``extra="forbid"`` is defense in depth for direct Python callers (tests,
+    internal ``_impl`` calls); the load-bearing forbid for wire-level silent drops
+    lives on the nested sub-payload models — see #487.
+
+    Note an unknown kwarg is NOT silently dropped from the call: it isn't a
+    declared field of any model, so it stays in the returned dict and is forwarded
+    to the wrapped function, where it surfaces as a ``TypeError`` (unexpected
+    keyword argument). That loud failure is intentional — a silent drop is the
+    failure mode #487 exists to prevent.
+    """
+    reconstructed = kwargs.copy()
+    for original_param_name, (model_class, field_names) in unpack_mapping.items():
+        model_data = {
+            field_name: kwargs[field_name]
+            for field_name in field_names
+            if field_name in kwargs
+        }
+        model_instance = model_class(**model_data)
+        reconstructed = {k: v for k, v in reconstructed.items() if k not in field_names}
+        reconstructed[original_param_name] = model_instance
+    return reconstructed
 
 
 def unpack_pydantic_params(func: Callable) -> Callable:
@@ -207,75 +247,17 @@ def unpack_pydantic_params(func: Callable) -> Callable:
     # Create new signature with flattened parameters
     new_sig = sig.replace(parameters=new_params)
 
-    # Create wrapper function that reconstructs models at runtime
+    # Create wrapper functions that reconstruct models at runtime. Both share the
+    # same reconstruction logic (_reconstruct_model_kwargs); they differ only in
+    # await — async tools get the coroutine wrapper, sync tools the plain one.
     @functools.wraps(func)
     async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-        # Reconstruct Pydantic models from flat parameters
-        reconstructed_kwargs = kwargs.copy()
-
-        for original_param_name, (model_class, field_names) in unpack_mapping.items():
-            # Only declared fields make it to ``model_data`` — unknown
-            # top-level kwargs are stripped here, before construction. As a
-            # consequence, ``extra="forbid"`` on the dispatcher request model
-            # does NOT fire on MCP-protocol traffic (FastMCP's TypeAdapter
-            # against the function signature catches top-level typos earlier).
-            # The dispatcher-level ``extra="forbid"`` is defense in depth for
-            # direct Python callers (tests, internal ``_impl`` calls). The
-            # load-bearing ``extra="forbid"`` for catching wire-level silent
-            # drops lives on the nested sub-payload models — see #487.
-            model_data = {}
-            for field_name in field_names:
-                if field_name in kwargs:
-                    model_data[field_name] = kwargs.pop(field_name)
-
-            # Build and validate the model
-            try:
-                model_instance = model_class(**model_data)
-            except ValidationError:
-                # Re-raise Pydantic validation errors as-is
-                raise
-
-            # Add reconstructed model to kwargs
-            reconstructed_kwargs = {
-                k: v for k, v in reconstructed_kwargs.items() if k not in field_names
-            }
-            reconstructed_kwargs[original_param_name] = model_instance
-
+        reconstructed_kwargs = _reconstruct_model_kwargs(unpack_mapping, kwargs)
         return await func(*args, **reconstructed_kwargs)
 
     @functools.wraps(func)
     def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
-        # Reconstruct Pydantic models from flat parameters
-        reconstructed_kwargs = kwargs.copy()
-
-        for original_param_name, (model_class, field_names) in unpack_mapping.items():
-            # Only declared fields make it to ``model_data`` — unknown
-            # top-level kwargs are stripped here, before construction. As a
-            # consequence, ``extra="forbid"`` on the dispatcher request model
-            # does NOT fire on MCP-protocol traffic (FastMCP's TypeAdapter
-            # against the function signature catches top-level typos earlier).
-            # The dispatcher-level ``extra="forbid"`` is defense in depth for
-            # direct Python callers (tests, internal ``_impl`` calls). The
-            # load-bearing ``extra="forbid"`` for catching wire-level silent
-            # drops lives on the nested sub-payload models — see #487.
-            model_data = {}
-            for field_name in field_names:
-                if field_name in kwargs:
-                    model_data[field_name] = kwargs.pop(field_name)
-
-            # Build and validate the model
-            try:
-                model_instance = model_class(**model_data)
-            except ValidationError:
-                # Re-raise Pydantic validation errors as-is
-                raise
-
-            # Add reconstructed model to kwargs
-            reconstructed_kwargs = {
-                k: v for k, v in reconstructed_kwargs.items() if k not in field_names
-            }
-            reconstructed_kwargs[original_param_name] = model_instance
-
+        reconstructed_kwargs = _reconstruct_model_kwargs(unpack_mapping, kwargs)
         return func(*args, **reconstructed_kwargs)
 
     # Choose wrapper based on whether original function is async

--- a/katana_mcp_server/tests/test_mcp_parameter_passing.py
+++ b/katana_mcp_server/tests/test_mcp_parameter_passing.py
@@ -5,6 +5,7 @@ parameters are passed as individual kwargs, not as a nested request object.
 """
 
 import inspect
+from typing import Annotated, get_args, get_origin
 
 import pytest
 from katana_mcp.tools.foundation.inventory import (
@@ -13,6 +14,18 @@ from katana_mcp.tools.foundation.inventory import (
     check_inventory,
     list_low_stock_items,
 )
+
+
+def _base_type(annotation: object) -> object:
+    """Unwrap ``Annotated[T, FieldInfo]`` -> ``T``.
+
+    The unpack decorator re-wraps flattened params as ``Annotated[type, FieldInfo]``
+    so field descriptions / constraints reach the tool schema (#930).
+    """
+    if get_origin(annotation) is Annotated:
+        return get_args(annotation)[0]
+    return annotation
+
 
 # The mock_context fixture is now in tests/conftest.py
 # It's automatically available to all tests in this package
@@ -94,8 +107,8 @@ class TestMCPParameterPassing:
             "list_low_stock_items has flattened params: "
             "threshold, limit, include_archived, context"
         )
-        assert sig.parameters["threshold"].annotation is int
-        assert sig.parameters["limit"].annotation is int
+        assert _base_type(sig.parameters["threshold"].annotation) is int
+        assert _base_type(sig.parameters["limit"].annotation) is int
         assert sig.parameters["threshold"].default == 10
         assert sig.parameters["limit"].default == 50
         assert sig.parameters["include_archived"].default is False
@@ -153,8 +166,8 @@ class TestMCPProtocolSimulation:
         assert "request" not in sig.parameters
 
         # Verify parameter types
-        assert sig.parameters["threshold"].annotation is int
-        assert sig.parameters["limit"].annotation is int
+        assert _base_type(sig.parameters["threshold"].annotation) is int
+        assert _base_type(sig.parameters["limit"].annotation) is int
         assert sig.parameters["threshold"].default == 10
         assert sig.parameters["limit"].default == 50
 

--- a/katana_mcp_server/tests/test_unpack.py
+++ b/katana_mcp_server/tests/test_unpack.py
@@ -287,6 +287,14 @@ class TestUnpackDecorator:
             "ge=1 constraint not carried"
         )
 
+        # The embedded FieldInfo is a copy whose mutable ``metadata`` list is
+        # decoupled from the model's own field, so a downstream mutation of one can
+        # never corrupt the other (the copy is shallow; the list is re-bound).
+        assert (
+            cid_meta.metadata
+            is not DocumentedRequest.model_fields["customer_id"].metadata
+        )
+
         # The embedded FieldInfo must not also carry the default (would re-introduce
         # the default/default_factory collision); the param default is the source.
         from pydantic_core import PydanticUndefined

--- a/katana_mcp_server/tests/test_unpack.py
+++ b/katana_mcp_server/tests/test_unpack.py
@@ -1,11 +1,33 @@
 """Tests for the Unpack decorator that flattens Pydantic models into tool parameters."""
 
 import inspect
-from typing import Annotated
+from typing import Annotated, get_args, get_origin
 
 import pytest
 from katana_mcp.unpack import Unpack, unpack_pydantic_params
 from pydantic import BaseModel, Field, ValidationError
+from pydantic.fields import FieldInfo
+
+
+def _base_type(annotation: object) -> object:
+    """Unwrap ``Annotated[T, FieldInfo]`` -> ``T``.
+
+    The unpack decorator re-wraps each flattened param's annotation in
+    ``Annotated[type, FieldInfo]`` so the field's description / constraints reach
+    the tool schema (#930). Tests that care about the underlying type unwrap here.
+    """
+    if get_origin(annotation) is Annotated:
+        return get_args(annotation)[0]
+    return annotation
+
+
+def _field_meta(annotation: object) -> FieldInfo | None:
+    """Return the FieldInfo carried in ``Annotated[type, FieldInfo]``, if any."""
+    if get_origin(annotation) is Annotated:
+        for extra in get_args(annotation)[1:]:
+            if isinstance(extra, FieldInfo):
+                return extra
+    return None
 
 
 # Test models
@@ -51,8 +73,8 @@ class TestUnpackDecorator:
         assert "request" not in sig.parameters
 
         # Check parameter details
-        assert sig.parameters["name"].annotation is str
-        assert sig.parameters["limit"].annotation is int
+        assert _base_type(sig.parameters["name"].annotation) is str
+        assert _base_type(sig.parameters["limit"].annotation) is int
         assert sig.parameters["limit"].default == 10
 
         # Test calling with flattened params
@@ -89,8 +111,8 @@ class TestUnpackDecorator:
 
         # Check signature
         sig = inspect.signature(process)
-        assert sig.parameters["required_field"].annotation is str
-        assert sig.parameters["optional_field"].annotation == (str | None)
+        assert _base_type(sig.parameters["required_field"].annotation) is str
+        assert _base_type(sig.parameters["optional_field"].annotation) == (str | None)
         assert sig.parameters["default_field"].default == 100
 
         # Test with only required field
@@ -226,6 +248,60 @@ class TestUnpackDecorator:
         result = process(name="test", tags=["a", "b"])
         assert result == {"name": "test", "tags": ["a", "b"]}
 
+    def test_field_metadata_rides_into_flattened_annotation(self):
+        """#930: field description + constraints survive the flattening.
+
+        The decorator re-wraps each param annotation as ``Annotated[type, FieldInfo]``
+        so FastMCP's schema generator advertises the field's description and
+        constraints. A bare-type annotation (the old behavior) dropped both, leaving
+        every flattened tool param undocumented.
+        """
+
+        class DocumentedRequest(BaseModel):
+            customer_id: int = Field(..., description="Katana customer ID", ge=1)
+            qty: int = Field(5, description="Quantity", ge=1, le=100)
+            # default_factory must not collide with the param default (the bug that
+            # raised "cannot specify both default and default_factory").
+            tags: list[str] = Field(default_factory=list, description="Tag list")
+
+        @unpack_pydantic_params
+        def process(request: Annotated[DocumentedRequest, Unpack()]) -> dict:
+            return {"customer_id": request.customer_id}
+
+        sig = inspect.signature(process)
+
+        # Description is carried for every field.
+        for name, expected in [
+            ("customer_id", "Katana customer ID"),
+            ("qty", "Quantity"),
+            ("tags", "Tag list"),
+        ]:
+            meta = _field_meta(sig.parameters[name].annotation)
+            assert meta is not None, f"{name} lost its FieldInfo"
+            assert meta.description == expected
+
+        # Numeric constraints are carried in the FieldInfo metadata.
+        cid_meta = _field_meta(sig.parameters["customer_id"].annotation)
+        assert cid_meta is not None
+        assert any(getattr(m, "ge", None) == 1 for m in cid_meta.metadata), (
+            "ge=1 constraint not carried"
+        )
+
+        # The embedded FieldInfo must not also carry the default (would re-introduce
+        # the default/default_factory collision); the param default is the source.
+        from pydantic_core import PydanticUndefined
+
+        tags_meta = _field_meta(sig.parameters["tags"].annotation)
+        assert tags_meta is not None
+        assert tags_meta.default is PydanticUndefined
+        assert tags_meta.default_factory is None
+        assert sig.parameters["tags"].default == []
+
+        # Defaults + validation still work end-to-end through the wrapper.
+        assert process(customer_id=7) == {"customer_id": 7}
+        with pytest.raises(ValidationError):
+            process(customer_id=0)  # violates ge=1
+
 
 class TestUnpackWithFastMCPSimulation:
     """Test that unpacked functions work as expected when called by FastMCP."""
@@ -262,9 +338,9 @@ class TestUnpackWithFastMCPSimulation:
 
         # Verify parameter metadata is preserved for schema generation
         name_param = sig.parameters["name"]
-        assert name_param.annotation is str
+        assert _base_type(name_param.annotation) is str
         assert name_param.default == inspect.Parameter.empty  # Required field
 
         limit_param = sig.parameters["limit"]
-        assert limit_param.annotation is int
+        assert _base_type(limit_param.annotation) is int
         assert limit_param.default == 10  # Has default value


### PR DESCRIPTION
## Summary

The `Unpack()` decorator flattens each write tool's top-level Pydantic request model
into individual keyword params. It rebuilt every flattened `inspect.Parameter` from the
bare `field_info.annotation`, **discarding the `FieldInfo`** — so all **58 unpacked
params across 14 tool modules** (the entire create/modify write surface) shipped to the
model with **no description and no constraints** in the MCP tool schema, even though the
source model fields carried them.

This was discovered while verifying an eBay-parity report against `create_sales_order`:
`notes` / `status` / `customer_id` / `picked_date` / `ecommerce_order_type` all showed
`description=MISSING` in the emitted schema despite having descriptions on the model.

### What changed

- **Restore field metadata (Tier 1 of #930):** re-wrap each param annotation as
  `Annotated[type, FieldInfo]` so FastMCP's schema generator advertises descriptions +
  constraints. The embedded `FieldInfo` is a copy with its default cleared (the
  `inspect.Parameter` default stays the single source of the default) — otherwise
  pydantic raises *"cannot specify both default and default_factory"* for any
  `default_factory` field. The copy's mutable `.metadata` list is re-bound to a fresh
  list so it can't alias (and corrupt) the class's own `model_fields` entry.
- **Dedupe the wrappers (Tier 2 of #930):** `async_wrapper` / `sync_wrapper` had
  byte-identical model-reconstruction bodies; extracted into a module-level
  `_reconstruct_model_kwargs()`. Behavior unchanged.
- **Docstrings refreshed** to reflect that the decorator is now also the source of
  tool-schema field documentation.

### Verification

Confirmed against the live in-memory `create_sales_order` schema: every flattened param
now carries its description (and numeric constraints). Added a regression test
(`test_field_metadata_rides_into_flattened_annotation`) pinning description + `ge`
constraint + the no-default-collision invariant + the metadata-list decoupling; updated 5
tests that pinned the old bare-type annotation.

`Closes #930` (Tier 1 + Tier 2). Tier 3 — the keep-vs-drop-the-decorator host-reliability
spike, informed by upstream PrefectHQ/fastmcp#1784 rejecting native unpacking — is tracked
separately in #931.

## Test plan

- [x] `uv run poe check` green (3996 passed, 11 skipped; browser suite skips w/o chromium)
- [x] Live schema introspection shows descriptions/constraints on all flattened params
- [x] Regression test covers metadata survival, default_factory collision, list decoupling

🤖 Generated with [Claude Code](https://claude.com/claude-code)