### PR TITLE
feat: per-row location_id on purchase orders — client spec + MCP tools

### DIFF
--- a/docs/katana-openapi.yaml
+++ b/docs/katana-openapi.yaml
@@ -5934,6 +5934,17 @@ components:
           type: string
           format: date-time
           description: Expected arrival date for this line item
+        location_id:
+          type: integer
+          minimum: 1
+          maximum: 2147483647
+          description: |-
+            Destination location for this row. Declared by the gateway on the nested
+            create-PO row, but **not honored at PO-create time** — Katana silently
+            overrides nested rows to the order-level location (verified live
+            2026-06-09). To set a per-row location, use `POST /purchase_order_rows` /
+            `PATCH /purchase_order_rows/{id}` after creation, or pass it at receive time
+            via `POST /purchase_order_receive`.
       example:
         quantity: 250
         price_per_unit: 2.85
@@ -6591,6 +6602,14 @@ components:
           type: string
           format: date-time
           description: Optional received date in ISO 8601 format.
+        location_id:
+          type: integer
+          minimum: 1
+          maximum: 2147483647
+          description: |-
+            Destination location to receive this row into, enabling multi-location
+            receiving on a single purchase order. Defaults to the row's location (or the
+            order-level location) when omitted.
         batch_transactions:
           type: array
           description: Array of batch-specific transactions for this received quantity

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -142,6 +142,12 @@ class PurchaseOrderItem(BaseModel):
             "Naive datetimes (no timezone) are interpreted as UTC."
         ),
     )
+    # NOTE: no per-row `location_id` here. Katana silently overrides nested
+    # rows at PO-create time to the order-level location (live-verified
+    # 2026-06-09: requested row location is dropped, row comes back at the
+    # header location). Per-row destinations only stick via add_rows /
+    # update_rows (modify_purchase_order) and at receive time — exposing it
+    # here would be a silent no-op.
 
 
 class CreatePurchaseOrderRequest(BaseModel):
@@ -517,6 +523,14 @@ class ReceiveItemRequest(BaseModel):
             "variant correction)."
         ),
     )
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "Destination location to receive this row into. Enables receiving "
+            "a single purchase order across multiple locations. When omitted, "
+            "the row lands at its own location (or the order-level location)."
+        ),
+    )
     batch_transactions: list[ReceiveBatchTransaction] | None = Field(
         default=None,
         description=(
@@ -601,6 +615,21 @@ class ReceivedItemInfo(BaseModel):
         description="quantity * price_per_unit in the PO currency.",
     )
     currency: str | None = None
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "Effective per-row destination location: the receive-time override "
+            "when supplied, else the row's own location_id (set via add_rows / "
+            "PATCH). None when the row inherits the order-level receiving location."
+        ),
+    )
+    location_name: str | None = Field(
+        default=None,
+        description=(
+            "Resolved display name for the effective destination location "
+            "(via the typed cache). None when location_id is unset or unresolved."
+        ),
+    )
 
 
 class ReceivePurchaseOrderResponse(BaseModel):
@@ -718,13 +747,42 @@ async def _enrich_received_items(
             if vid is not None:
                 variant_ids.add(int(vid))
 
-    from katana_public_api_client.models_pydantic._generated import CachedVariant
+    from katana_public_api_client.models_pydantic._generated import (
+        CachedLocation,
+        CachedVariant,
+    )
 
     variants_by_id: dict[int, Any] = (
         await services.typed_cache.catalog.get_many_by_ids(
             CachedVariant, variant_ids, include_deleted=True
         )
         if variant_ids
+        else {}
+    )
+
+    # Effective destination for a row = the receive-time override when the
+    # caller supplied one, else the row's own per-row location_id (set via
+    # add_rows / PATCH). Falls back to None — the row inherits the order-level
+    # location, which the card shows in its header rather than per-row.
+    def _effective_location_id(item: ReceiveItemRequest) -> int | None:
+        if item.location_id is not None:
+            return item.location_id
+        po_row = po_rows_by_id.get(item.purchase_order_row_id)
+        return unwrap_unset(po_row.location_id, None) if po_row is not None else None
+
+    # Per-row destination locations (multi-location receiving): resolve all
+    # distinct effective location_ids in one batched lookup so the receipt card
+    # can name each destination without an N+1 cache hit.
+    row_location_ids: set[int] = {
+        loc
+        for item in request_items
+        if (loc := _effective_location_id(item)) is not None
+    }
+    locations_by_id: dict[int, Any] = (
+        await services.typed_cache.catalog.get_many_by_ids(
+            CachedLocation, row_location_ids, include_deleted=True
+        )
+        if row_location_ids
         else {}
     )
 
@@ -757,6 +815,11 @@ async def _enrich_received_items(
             item.received_date or default_received_date
         )
 
+        effective_loc = _effective_location_id(item)
+        row_location = (
+            locations_by_id.get(effective_loc) if effective_loc is not None else None
+        )
+
         received.append(
             ReceivedItemInfo(
                 purchase_order_row_id=item.purchase_order_row_id,
@@ -774,6 +837,12 @@ async def _enrich_received_items(
                 price_per_unit=ppu,
                 row_total=(ppu * item.quantity) if ppu is not None else None,
                 currency=currency,
+                location_id=effective_loc,
+                location_name=(
+                    getattr(row_location, "name", None)
+                    if row_location is not None
+                    else None
+                ),
             )
         )
     return received
@@ -951,6 +1020,7 @@ async def _receive_purchase_order_impl(
                 purchase_order_row_id=item.purchase_order_row_id,
                 quantity=item.quantity,
                 received_date=item.received_date or default_received_date,
+                location_id=to_unset(item.location_id),
                 batch_transactions=_convert_receive_batch_transactions(
                     item.batch_transactions
                 ),
@@ -2761,6 +2831,13 @@ class PORowAdd(BaseModel):
             "Naive datetimes (no timezone) are interpreted as UTC."
         ),
     )
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "Destination location for this row (multi-location receiving). "
+            "When omitted, the row inherits the order-level location."
+        ),
+    )
 
 
 class PORowUpdate(BaseModel):
@@ -2796,6 +2873,13 @@ class PORowUpdate(BaseModel):
             "New row-level arrival date — ISO 8601 date or datetime "
             "(e.g. '2026-05-08T14:30:00Z' or '2026-05-08T14:30:00-08:00'). "
             "Naive datetimes (no timezone) are interpreted as UTC."
+        ),
+    )
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "New destination location for this row (multi-location receiving). "
+            "Updatable only while the row's received_date is null."
         ),
     )
 

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -8919,12 +8919,22 @@ def _build_receipt_row_display(item: dict[str, Any]) -> dict[str, Any]:
             return f"{recv_str} of {float(ordered):g}"
         return recv_str
 
+    def _location_display() -> str:
+        # Blank when the row inherits the order-level location (the common
+        # case) — the column only carries signal for multi-location receives.
+        name = item.get("location_name")
+        if name:
+            return str(name)
+        loc_id = item.get("location_id")
+        return f"Location ID: {loc_id}" if loc_id is not None else ""
+
     received_date = item.get("received_date")
     row_total = item.get("row_total")
     return {
         "display_name": item.get("display_name") or "",
         "sku": item.get("sku") or "",
         "quantity": _qty_display(),
+        "location": _location_display(),
         "received_date": _iso_date_only(received_date) if received_date else "—",
         "batch_summary": item.get("batch_summary") or "",
         "row_total": (
@@ -9031,6 +9041,7 @@ def build_receipt_ui(
                         ),
                         DataTableColumn(key="sku", header="SKU", sortable=True),
                         DataTableColumn(key="quantity", header="Qty", align="right"),
+                        DataTableColumn(key="location", header="Destination"),
                         DataTableColumn(key="received_date", header="Received"),
                         DataTableColumn(key="batch_summary", header="Batch"),
                         DataTableColumn(

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -8074,9 +8074,19 @@ class TestBuildReceiptUI:
         envelope = build_receipt_ui(response).to_json()
         tables = _find_components_by_type(envelope, "DataTable")
         assert len(tables) == 1
-        # Column set pinned: Item / SKU / Qty / Received / Batch / Line Total
+        # Column set pinned: Item / SKU / Qty / Destination / Received / Batch / Line Total.
+        # "Destination" carries the per-row receiving location for multi-location
+        # receives (#945); blank when the row inherits the order-level location.
         headers = [c.get("header") for c in tables[0].get("columns", [])]
-        assert headers == ["Item", "SKU", "Qty", "Received", "Batch", "Line Total"]
+        assert headers == [
+            "Item",
+            "SKU",
+            "Qty",
+            "Destination",
+            "Received",
+            "Batch",
+            "Line Total",
+        ]
 
     def test_per_row_table_flattens_strings_into_state(self):
         """``DataTable.rows`` is a state-bound mustache reference. The
@@ -8112,6 +8122,39 @@ class TestBuildReceiptUI:
         assert row["received_date"] == "2026-05-18"  # date-only
         assert row["row_total"] == "$5,200.00"
         assert row["batch_summary"] == ""
+        # No per-row location supplied → Destination cell is blank (the row
+        # inherits the order-level receiving location). See #945.
+        assert row["location"] == ""
+
+    def test_per_row_location_renders_destination(self):
+        """Multi-location receiving (#945): a row carrying location_name
+        renders it in the Destination column; a row with only location_id
+        falls back to 'Location ID: N'; a row with neither stays blank."""
+        response = {
+            "order_number": "PO-001",
+            "order_id": 123,
+            "is_preview": True,
+            "items_received": 3,
+            "received_items": [
+                {
+                    "purchase_order_row_id": 1,
+                    "quantity": 1.0,
+                    "location_id": 42,
+                    "location_name": "West DC",
+                },
+                {
+                    "purchase_order_row_id": 2,
+                    "quantity": 1.0,
+                    "location_id": 99,
+                    "location_name": None,
+                },
+                {"purchase_order_row_id": 3, "quantity": 1.0},
+            ],
+        }
+        envelope = build_receipt_ui(response).to_json()
+        state = envelope.get("state") or envelope.get("$prefab", {}).get("state", {})
+        rows = state.get("received_items")
+        assert [r["location"] for r in rows] == ["West DC", "Location ID: 99", ""]
 
     def test_partial_receive_qty_shows_received_of_ordered(self):
         """Partial receives (qty < quantity_ordered) render as '52 of 60'

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -2207,6 +2207,9 @@ async def test_receive_purchase_order_preview_enriches_per_row_details():
         row.variant_id = variant_id
         row.quantity = qty
         row.price_per_unit = ppu
+        # Match the real attrs model default so the effective-location
+        # resolution sees UNSET (→ None), not a stray MagicMock attribute.
+        row.location_id = UNSET
         return row
 
     mock_po = MagicMock(spec=RegularPurchaseOrder)
@@ -2283,6 +2286,84 @@ async def test_receive_purchase_order_preview_enriches_per_row_details():
     assert row_b.variant_id == 101
     assert row_b.sku == "C1265080ST"
     assert row_b.batch_summary == "batch 42x30, batch 51x22"
+
+
+@pytest.mark.asyncio
+async def test_receive_enriches_effective_destination_location():
+    """Receipt rows resolve their *effective* destination location (#945).
+
+    Effective = the receive-time override when supplied, else the PO row's
+    own ``location_id`` (set earlier via add_rows / PATCH). A row that carries
+    neither inherits the order-level location and renders blank.
+    """
+    context, lifespan_ctx = create_mock_context()
+
+    def _row(row_id: int, variant_id: int, location_id: object) -> MagicMock:
+        row = MagicMock()
+        row.id = row_id
+        row.variant_id = variant_id
+        row.quantity = 10.0
+        row.price_per_unit = 1.0
+        row.location_id = location_id
+        return row
+
+    mock_po = MagicMock(spec=RegularPurchaseOrder)
+    mock_po.id = 1234
+    mock_po.order_no = "PO-LOC-001"
+    mock_po.status = MagicMock()
+    mock_po.status.value = "NOT_RECEIVED"
+    mock_po.supplier_id = UNSET
+    mock_po.currency = "USD"
+    mock_po.total = 30.0
+    mock_po.purchase_order_rows = [
+        _row(1, variant_id=100, location_id=UNSET),  # override at receive time
+        _row(2, variant_id=101, location_id=55),  # row's own per-row location
+        _row(3, variant_id=102, location_id=UNSET),  # inherits order-level
+    ]
+
+    variant = MagicMock(sku="SKU", display_name="Item")
+    loc_42 = MagicMock(name="loc42")
+    loc_42.name = "West DC"
+    loc_55 = MagicMock(name="loc55")
+    loc_55.name = "East DC"
+    # get_many_by_ids is called twice: variants first, then locations.
+    lifespan_ctx.typed_cache.catalog.get_many_by_ids = AsyncMock(
+        side_effect=[
+            {100: variant, 101: variant, 102: variant},
+            {42: loc_42, 55: loc_55},
+        ]
+    )
+
+    mock_get_response = MagicMock()
+    mock_get_response.status_code = 200
+    mock_get_response.parsed = mock_po
+    lifespan_ctx.client = MagicMock()
+    cast(Any, api_get_purchase_order).asyncio_detailed = AsyncMock(
+        return_value=mock_get_response
+    )
+
+    request = ReceivePurchaseOrderRequest(
+        order_id=1234,
+        items=[
+            ReceiveItemRequest(purchase_order_row_id=1, quantity=10.0, location_id=42),
+            ReceiveItemRequest(purchase_order_row_id=2, quantity=10.0),
+            ReceiveItemRequest(purchase_order_row_id=3, quantity=10.0),
+        ],
+        preview=True,
+    )
+
+    result = await _receive_purchase_order_impl(request, context)
+    by_row = {ri.purchase_order_row_id: ri for ri in result.received_items}
+
+    # Row 1: receive-time override wins.
+    assert by_row[1].location_id == 42
+    assert by_row[1].location_name == "West DC"
+    # Row 2: no override → falls back to the row's own per-row location.
+    assert by_row[2].location_id == 55
+    assert by_row[2].location_name == "East DC"
+    # Row 3: neither → inherits order-level location, rendered blank.
+    assert by_row[3].location_id is None
+    assert by_row[3].location_name is None
 
 
 @pytest.mark.asyncio

--- a/katana_public_api_client/models/purchase_order_receive_row.py
+++ b/katana_public_api_client/models/purchase_order_receive_row.py
@@ -24,6 +24,7 @@ class PurchaseOrderReceiveRow:
     purchase_order_row_id: int
     quantity: float
     received_date: datetime.datetime | Unset = UNSET
+    location_id: int | Unset = UNSET
     batch_transactions: list[PurchaseOrderReceiveRowBatchTransactionsItem] | Unset = (
         UNSET
     )
@@ -36,6 +37,8 @@ class PurchaseOrderReceiveRow:
         received_date: str | Unset = UNSET
         if not isinstance(self.received_date, Unset):
             received_date = self.received_date.isoformat()
+
+        location_id = self.location_id
 
         batch_transactions: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.batch_transactions, Unset):
@@ -54,6 +57,8 @@ class PurchaseOrderReceiveRow:
         )
         if received_date is not UNSET:
             field_dict["received_date"] = received_date
+        if location_id is not UNSET:
+            field_dict["location_id"] = location_id
         if batch_transactions is not UNSET:
             field_dict["batch_transactions"] = batch_transactions
 
@@ -77,6 +82,8 @@ class PurchaseOrderReceiveRow:
         else:
             received_date = datetime.datetime.fromisoformat(_received_date)
 
+        location_id = d.pop("location_id", UNSET)
+
         _batch_transactions = d.pop("batch_transactions", UNSET)
         batch_transactions: (
             list[PurchaseOrderReceiveRowBatchTransactionsItem] | Unset
@@ -96,6 +103,7 @@ class PurchaseOrderReceiveRow:
             purchase_order_row_id=purchase_order_row_id,
             quantity=quantity,
             received_date=received_date,
+            location_id=location_id,
             batch_transactions=batch_transactions,
         )
 

--- a/katana_public_api_client/models/purchase_order_row_request.py
+++ b/katana_public_api_client/models/purchase_order_row_request.py
@@ -27,6 +27,7 @@ class PurchaseOrderRowRequest:
     purchase_uom_conversion_rate: float | Unset = UNSET
     purchase_uom: str | Unset = UNSET
     arrival_date: datetime.datetime | Unset = UNSET
+    location_id: int | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         quantity = self.quantity
@@ -45,6 +46,8 @@ class PurchaseOrderRowRequest:
         if not isinstance(self.arrival_date, Unset):
             arrival_date = self.arrival_date.isoformat()
 
+        location_id = self.location_id
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -62,6 +65,8 @@ class PurchaseOrderRowRequest:
             field_dict["purchase_uom"] = purchase_uom
         if arrival_date is not UNSET:
             field_dict["arrival_date"] = arrival_date
+        if location_id is not UNSET:
+            field_dict["location_id"] = location_id
 
         return field_dict
 
@@ -87,6 +92,8 @@ class PurchaseOrderRowRequest:
         else:
             arrival_date = datetime.datetime.fromisoformat(_arrival_date)
 
+        location_id = d.pop("location_id", UNSET)
+
         purchase_order_row_request = cls(
             quantity=quantity,
             price_per_unit=price_per_unit,
@@ -95,6 +102,7 @@ class PurchaseOrderRowRequest:
             purchase_uom_conversion_rate=purchase_uom_conversion_rate,
             purchase_uom=purchase_uom,
             arrival_date=arrival_date,
+            location_id=location_id,
         )
 
         return purchase_order_row_request

--- a/katana_public_api_client/models_pydantic/_generated/purchase_orders.py
+++ b/katana_public_api_client/models_pydantic/_generated/purchase_orders.py
@@ -100,6 +100,14 @@ class PurchaseOrderRowRequest(KatanaPydanticBase):
         AwareDatetime | None,
         Field(description="Expected arrival date for this line item"),
     ] = None
+    location_id: Annotated[
+        int | None,
+        Field(
+            description="Destination location for this row. Declared by the gateway on the nested\ncreate-PO row, but **not honored at PO-create time** — Katana silently\noverrides nested rows to the order-level location (verified live\n2026-06-09). To set a per-row location, use `POST /purchase_order_rows` /\n`PATCH /purchase_order_rows/{id}` after creation, or pass it at receive time\nvia `POST /purchase_order_receive`.",
+            ge=1,
+            le=2147483647,
+        ),
+    ] = None
 
 
 class PurchaseOrderRow(DeletableEntity):
@@ -406,6 +414,14 @@ class PurchaseOrderReceiveRow(KatanaPydanticBase):
     received_date: Annotated[
         AwareDatetime | None,
         Field(description="Optional received date in ISO 8601 format."),
+    ] = None
+    location_id: Annotated[
+        int | None,
+        Field(
+            description="Destination location to receive this row into, enabling multi-location\nreceiving on a single purchase order. Defaults to the row's location (or the\norder-level location) when omitted.",
+            ge=1,
+            le=2147483647,
+        ),
     ] = None
     batch_transactions: Annotated[
         list[BatchTransaction5] | None,

--- a/packages/katana-client/src/generated/types.gen.ts
+++ b/packages/katana-client/src/generated/types.gen.ts
@@ -3428,6 +3428,15 @@ export type PurchaseOrderRowRequest = {
    * Expected arrival date for this line item
    */
   arrival_date?: string;
+  /**
+   * Destination location for this row. Declared by the gateway on the nested
+   * create-PO row, but **not honored at PO-create time** — Katana silently
+   * overrides nested rows to the order-level location (verified live
+   * 2026-06-09). To set a per-row location, use `POST /purchase_order_rows` /
+   * `PATCH /purchase_order_rows/{id}` after creation, or pass it at receive time
+   * via `POST /purchase_order_receive`.
+   */
+  location_id?: number;
 };
 
 /**
@@ -3848,6 +3857,12 @@ export type PurchaseOrderReceiveRow = {
    * Optional received date in ISO 8601 format.
    */
   received_date?: string;
+  /**
+   * Destination location to receive this row into, enabling multi-location
+   * receiving on a single purchase order. Defaults to the row's location (or the
+   * order-level location) when omitted.
+   */
+  location_id?: number;
   /**
    * Array of batch-specific transactions for this received quantity
    */


### PR DESCRIPTION
## Summary

Follow-up to #942, which added per-row `location_id` to purchase order rows but left
gaps. This finishes the feature across the client spec and the MCP tools.

Two commits:

### `fix(client)` — Closes #944

#942 added `location_id` to the standalone create/update row schemas and the
`PurchaseOrderRow` response, but missed two row schemas the live gateway also carries
it on (both invisible to `audit-spec` because their endpoints use inline upstream
schemas):

- `PurchaseOrderReceiveRow` (`POST /purchase_order_receive`)
- `PurchaseOrderRowRequest` (nested rows in `POST /purchase_orders`)

### `feat(mcp)` — Closes #945

Exposes per-row `location_id` only on the paths Katana actually honors (live-verified):

- `modify_purchase_order` → `add_rows` / `update_rows` (→ `POST`/`PATCH /purchase_order_rows`)
- `receive_purchase_order` → per-row receive location
- Receipt card → new **Destination** column (batched location-name resolution from the
  typed cache; blank when the row inherits the order-level location)

## Key finding: not all paths honor it

I live-probed the test tenant rather than trusting the published spec — and the gateway
**declares** `location_id` on whole-PO-create nested rows but the runtime **silently
overrides** them to the order-level location:

| Path | Per-row `location_id` honored? |
|---|---|
| `POST /purchase_orders` (nested rows) | ❌ silently overridden to order-level |
| `POST /purchase_order_rows` (standalone) | ✅ |
| `PATCH /purchase_order_rows/{id}` | ✅ |
| `POST /purchase_order_receive` | ✅ |

So the MCP layer **deliberately does not** expose `location_id` on `create_purchase_order`'s
row input — it would be a silent no-op (the silent-drop failure mode the backlog tracks).
The client spec keeps the field (it's in the published gateway contract) but its docstring
now carries the "not honored at create time" caveat.

## Test plan

- [x] `uv run poe check` green (lint, type-check, 4131 unit + 48 browser tests, strict audit)
- [x] Rebased on latest `main` (picked up the stricter audit-spec dimensions + enum fixes); re-validated, no generated-file drift
- [x] New + updated prefab tests pin the Destination column + per-row location rendering
- [x] **Live-verified** on the test tenant: standalone create-row, PATCH, and receive all
      honor per-row `location_id`; whole-PO-create does not. All probe fixtures self-cleaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review refinement (Copilot, #946)
- Receipt card now resolves each row's **effective** destination — the receive-time override when given, else the row's own `location_id` (set via `add_rows`/`PATCH`). Both the batched cache lookup and the rendered value use it. New test covers override / row-own / inherited.
- Confirmed `PurchaseOrderReceiveRow.location_id` stays non-nullable (live gateway declares `nullable: false`).
