### PR TITLE
feat(mcp): surface 3 query filters in list/search tools

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/items.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from enum import StrEnum
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
@@ -249,6 +249,17 @@ class SearchItemsRequest(BaseModel):
             'with {"update_header": {"is_archived": false}}.'
         ),
     )
+    type: Literal["product", "material"] | None = Field(
+        default=None,
+        description=(
+            "Restrict results to a single item type: 'product' (sellable "
+            "finished goods) or 'material' (raw components). Omit to return "
+            "products, materials, and services. The filter runs *after* the "
+            "fuzzy search picks its top ``limit`` matches, so you may get fewer "
+            "than ``limit`` results even when more items of that type exist "
+            "further down the ranking — raise ``limit`` to widen the candidate set."
+        ),
+    )
 
 
 class ItemInfo(BaseModel):
@@ -340,6 +351,12 @@ async def _search_items_impl(
     # Resolve each row's type once and reuse it below (the parent-id resolution
     # and the ItemInfo build both need it).
     typed_variants = [(v, _item_type(v)) for v in variants]
+
+    # Optional item-type narrowing. Post-filters the top fuzzy matches (the
+    # cache's smart_search has no type predicate); product/material are the
+    # only filterable types — the API rejects `service` here (see #937).
+    if request.type is not None:
+        typed_variants = [(v, t) for v, t in typed_variants if t == request.type]
 
     # The parent *item* id that modify_item/get_item need differs from the
     # variant ``id`` search returns. Products/materials carry it on the row

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/purchase_orders.py
@@ -2191,6 +2191,13 @@ async def verify_order_document(
 # ============================================================================
 
 
+# Values the cache stores for ``CachedPurchaseOrder.last_document_status``
+# (DocumentSendStatus). The API's `last_document_status` *filter* uses the
+# camelCase wire form (notSent/sending/sent/failed); the cache and this
+# request use the UPPER_SNAKE response form, coerced to the cache enum below.
+FindPurchaseOrdersLastDocumentStatus = Literal["NOT_SENT", "SENDING", "SENT", "FAILED"]
+
+
 class ListPurchaseOrdersRequest(BaseModel):
     """Request to list/filter purchase orders (list-tool pattern v2)."""
 
@@ -2241,6 +2248,15 @@ class ListPurchaseOrdersRequest(BaseModel):
     billing_status: FindPurchaseOrdersBillingStatus | None = Field(
         default=None,
         description="Filter by billing status: BILLED, NOT_BILLED, PARTIALLY_BILLED.",
+    )
+    last_document_status: FindPurchaseOrdersLastDocumentStatus | None = Field(
+        default=None,
+        description=(
+            "Filter by the send status of the PO's last document: "
+            "NOT_SENT, SENDING, SENT, FAILED. These are the cache/response-form "
+            "values (UPPER_SNAKE) — not the Katana API filter's camelCase form "
+            "(notSent/sending/sent/failed), so pass the UPPER_SNAKE spelling here."
+        ),
     )
     currency: str | None = Field(
         default=None, description="Filter by currency code (e.g. 'USD')"
@@ -2336,6 +2352,7 @@ class PurchaseOrderSummary(BaseModel):
     order_no: str | None
     status: str | None
     billing_status: str | None
+    last_document_status: str | None = None
     entity_type: str | None
     supplier_id: int | None
     location_id: int | None
@@ -2379,6 +2396,7 @@ def _apply_purchase_order_filters(
 
     from katana_public_api_client.models_pydantic._generated import (
         CachedPurchaseOrder,
+        DocumentSendStatus,
         PurchaseOrderBillingStatus,
         PurchaseOrderEntityType,
         PurchaseOrderStatus,
@@ -2403,6 +2421,15 @@ def _apply_purchase_order_filters(
             CachedPurchaseOrder.billing_status
             == coerce_enum(
                 request.billing_status, PurchaseOrderBillingStatus, "billing_status"
+            )
+        )
+    if request.last_document_status is not None:
+        stmt = stmt.where(
+            CachedPurchaseOrder.last_document_status
+            == coerce_enum(
+                request.last_document_status,
+                DocumentSendStatus,
+                "last_document_status",
             )
         )
     if request.currency is not None:
@@ -2580,6 +2607,7 @@ async def _list_purchase_orders_impl(
                 order_no=po.order_no,
                 status=enum_to_str(po.status),
                 billing_status=enum_to_str(po.billing_status),
+                last_document_status=enum_to_str(po.last_document_status),
                 entity_type=enum_to_str(po.entity_type),
                 supplier_id=po.supplier_id,
                 location_id=po.location_id,

--- a/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
+++ b/katana_mcp_server/src/katana_mcp/tools/foundation/reference.py
@@ -7,6 +7,7 @@ FTS5 with difflib fallback) and ``limit`` (default 50, max 250).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
@@ -49,11 +50,19 @@ def _normalize_query(query: str | None) -> str | None:
     return stripped or None
 
 
+# Ranked-window size pulled from smart_search when a Python predicate narrows
+# results, so the filter sees matches beyond the caller's `limit`. Far larger
+# than any tenant's reference-table row count (locations, tax rates, suppliers),
+# so predicate filtering on the fuzzy-search path is exhaustive in practice.
+_PREDICATE_SCAN_LIMIT = 1000
+
+
 async def _fetch_rows(
     context: Context,
     cached_cls: type[SQLModel],
     query: str | None,
     limit: int,
+    predicate: Callable[[Any], bool] | None = None,
 ) -> tuple[list[Any], int]:
     """Return ``(rows, total_before_limit)`` for a reference list query.
 
@@ -68,15 +77,29 @@ async def _fetch_rows(
     treat the filtered count as the visible total. Without a query,
     ``get_all`` returns every (filtered) row and we slice to ``limit``.
 
+    ``predicate`` is an optional row test applied *before* the limit slice
+    and the visible-total count, for column filters the ``CatalogQueries``
+    adapter doesn't push down (e.g. ``is_primary`` on locations). On the
+    fuzzy-search path the predicate would otherwise run *after*
+    ``smart_search`` already capped at ``limit`` — dropping matches ranked
+    beyond it — so when a predicate is set we pull a wider ranked window
+    (``_PREDICATE_SCAN_LIMIT``) and slice to ``limit`` only after filtering.
+    These reference tables are tiny, so this is exhaustive in practice.
+
     ``query`` must already be normalized (see ``_normalize_query``).
     """
     services = get_services(context)
     catalog = services.typed_cache.catalog
     if query is not None:
-        rows = await catalog.smart_search(cached_cls, query, limit=limit)
-        return rows, len(rows)
+        scan_limit = _PREDICATE_SCAN_LIMIT if predicate is not None else limit
+        rows = await catalog.smart_search(cached_cls, query, limit=scan_limit)
+        if predicate is not None:
+            rows = [r for r in rows if predicate(r)]
+        return rows[:limit], len(rows)
 
     raw = await catalog.get_all(cached_cls)
+    if predicate is not None:
+        raw = [r for r in raw if predicate(r)]
     total = len(raw)
     return raw[:limit], total
 
@@ -273,6 +296,13 @@ class ListLocationsRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     query: str | None = Field(default=None, description="Fuzzy search by location name")
+    is_primary: bool | None = Field(
+        default=None,
+        description=(
+            "Filter to the primary location (true) or non-primary locations "
+            "(false). Omit to return all."
+        ),
+    )
     limit: int = Field(default=50, ge=1, le=250)
 
 
@@ -350,7 +380,17 @@ async def _list_locations_impl(
     request: ListLocationsRequest, context: Context
 ) -> ListLocationsResponse:
     query = _normalize_query(request.query)
-    rows, total = await _fetch_rows(context, CachedLocation, query, request.limit)
+    predicate = (
+        # Strict equality (not bool(...)) so is_primary=False matches only rows
+        # explicitly flagged non-primary; a NULL/unknown is_primary matches
+        # neither true nor false rather than being lumped in with false.
+        (lambda loc: getattr(loc, "is_primary", None) == request.is_primary)
+        if request.is_primary is not None
+        else None
+    )
+    rows, total = await _fetch_rows(
+        context, CachedLocation, query, request.limit, predicate=predicate
+    )
     return ListLocationsResponse(
         locations=[_location_from_row(r) for r in rows],
         total_count=total,

--- a/katana_mcp_server/tests/factories.py
+++ b/katana_mcp_server/tests/factories.py
@@ -37,6 +37,7 @@ from katana_public_api_client.models_pydantic._generated import (
     CachedStockAdjustmentRow,
     CachedStockTransfer,
     CachedStockTransferRow,
+    DocumentSendStatus,
     ManufacturingOrderStatus,
     PurchaseOrderBillingStatus,
     PurchaseOrderEntityType,
@@ -348,6 +349,7 @@ def make_purchase_order(
     entity_type: PurchaseOrderEntityType | str = "regular",
     status: PurchaseOrderStatus | str | None = None,
     billing_status: PurchaseOrderBillingStatus | str | None = None,
+    last_document_status: DocumentSendStatus | str | None = None,
     supplier_id: int | None = 4001,
     location_id: int | None = 1,
     tracking_location_id: int | None = None,
@@ -384,6 +386,11 @@ def make_purchase_order(
         if isinstance(billing_status, str)
         else billing_status
     )
+    resolved_last_document_status = (
+        DocumentSendStatus(last_document_status)
+        if isinstance(last_document_status, str)
+        else last_document_status
+    )
 
     cached = CachedPurchaseOrder(
         id=id,
@@ -391,6 +398,7 @@ def make_purchase_order(
         entity_type=resolved_entity_type,
         status=resolved_status,
         billing_status=resolved_billing_status,
+        last_document_status=resolved_last_document_status,
         supplier_id=supplier_id,
         location_id=location_id,
         tracking_location_id=tracking_location_id,

--- a/katana_mcp_server/tests/tools/test_inventory.py
+++ b/katana_mcp_server/tests/tools/test_inventory.py
@@ -618,6 +618,27 @@ async def test_search_items():
 
 
 @pytest.mark.asyncio
+async def test_search_items_filters_by_type():
+    """`type` narrows results to a single item type (product/material)."""
+    context, lifespan_ctx = create_mock_context()
+    lifespan_ctx.typed_cache.catalog.smart_search = AsyncMock(
+        return_value=[
+            {"id": 1, "sku": "P-1", "type": "product", "display_name": "Prod"},
+            {"id": 2, "sku": "M-1", "type": "material", "display_name": "Mat"},
+            {"id": 3, "sku": "S-1", "type": "service", "display_name": "Svc"},
+        ]
+    )
+
+    result = await _search_items_impl(
+        SearchItemsRequest(query="x", limit=20, type="material"), context
+    )
+
+    assert [i.id for i in result.items] == [2]
+    assert result.total_count == 1
+    assert result.items[0].item_type == "material"
+
+
+@pytest.mark.asyncio
 async def test_search_items_handles_optional_fields():
     """Test search_items handles missing optional fields."""
     context, lifespan_ctx = create_mock_context()

--- a/katana_mcp_server/tests/tools/test_purchase_orders.py
+++ b/katana_mcp_server/tests/tools/test_purchase_orders.py
@@ -3531,6 +3531,36 @@ async def test_list_purchase_orders_filters_by_status_and_billing(
 
 
 @pytest.mark.asyncio
+async def test_list_purchase_orders_filters_by_last_document_status(
+    context_with_typed_cache, no_sync
+):
+    """`last_document_status` filters on the cached DocumentSendStatus column."""
+    from katana_mcp.tools.foundation.purchase_orders import (
+        ListPurchaseOrdersRequest,
+        _list_purchase_orders_impl,
+    )
+
+    context, _, typed_cache = context_with_typed_cache
+    await seed_cache(
+        typed_cache,
+        [
+            make_purchase_order(id=1, last_document_status="FAILED"),
+            make_purchase_order(id=2, last_document_status="SENT"),
+            make_purchase_order(id=3, last_document_status="FAILED"),
+        ],
+    )
+
+    result = await _list_purchase_orders_impl(
+        ListPurchaseOrdersRequest(last_document_status="FAILED"),
+        context,
+    )
+
+    assert {o.id for o in result.orders} == {1, 3}
+    # the value is also surfaced on the summary so the filter is visible
+    assert all(o.last_document_status == "FAILED" for o in result.orders)
+
+
+@pytest.mark.asyncio
 async def test_list_purchase_orders_filters_by_entity_type_and_tracking_location(
     context_with_typed_cache, no_sync
 ):

--- a/katana_mcp_server/tests/tools/test_reference.py
+++ b/katana_mcp_server/tests/tools/test_reference.py
@@ -343,6 +343,58 @@ class TestListLocations:
         }
 
     @pytest.mark.asyncio
+    async def test_is_primary_filter(self):
+        """`is_primary=True` returns only the primary location; total reflects it."""
+        cached = [
+            _location(id=1, name="Primary WH", is_primary=True),
+            _location(id=2, name="Overflow WH", is_primary=False),
+            _location(id=3, name="Returns WH", is_primary=None),
+        ]
+        context, _ = _make_context(get_all=cached)
+        result = await list_locations(is_primary=True, limit=50, context=context)
+        payload = json.loads(_extract_text(result))
+        assert [loc["id"] for loc in payload["locations"]] == [1]
+        assert payload["total_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_is_primary_false_excludes_primary_and_unknown(self):
+        """`is_primary=False` returns only rows explicitly flagged non-primary.
+
+        A NULL/unknown ``is_primary`` (id=3) matches neither true nor false — it
+        is not lumped in with the explicit ``False`` rows. The predicate uses
+        strict equality rather than ``bool(...)`` to avoid that surprise.
+        """
+        cached = [
+            _location(id=1, name="Primary WH", is_primary=True),
+            _location(id=2, name="Overflow WH", is_primary=False),
+            _location(id=3, name="Returns WH", is_primary=None),
+        ]
+        context, _ = _make_context(get_all=cached)
+        result = await list_locations(is_primary=False, limit=50, context=context)
+        payload = json.loads(_extract_text(result))
+        assert {loc["id"] for loc in payload["locations"]} == {2}
+
+    @pytest.mark.asyncio
+    async def test_is_primary_with_query_scans_wide_window(self):
+        """query + predicate pulls a wider ranked window so a match ranked
+        beyond the caller's `limit` isn't dropped before the filter runs."""
+        from katana_mcp.tools.foundation.reference import _PREDICATE_SCAN_LIMIT
+
+        matches = [
+            _location(id=1, name="WH north", is_primary=False),
+            _location(id=2, name="WH south", is_primary=True),
+        ]
+        context, lifespan_ctx = _make_context(smart_search=matches, get_all=[])
+        result = await list_locations(
+            query="WH", is_primary=True, limit=1, context=context
+        )
+        # smart_search is asked for the wide scan window, not the caller's limit=1
+        _, kwargs = lifespan_ctx.typed_cache.catalog.smart_search.call_args
+        assert kwargs["limit"] == _PREDICATE_SCAN_LIMIT
+        payload = json.loads(_extract_text(result))
+        assert [loc["id"] for loc in payload["locations"]] == [2]
+
+    @pytest.mark.asyncio
     async def test_partial_address_from_dict_shape(self):
         """``_address_from_obj`` accepts either a ``LocationAddress`` or a
         raw dict (legacy cache shape). Pin the partial-field dict path —


### PR DESCRIPTION
## Summary

Closes #947 (the MCP-side follow-up to #937). Wires three of the newly-exposed query filters into the **cache-backed** MCP list/search tools. These tools query the typed SQLite cache (not the Katana API), so each filter is a WHERE/predicate on an existing cached column — no API plumbing.

| Filter | Tool | How |
|---|---|---|
| `last_document_status` | `list_purchase_orders` | WHERE on `CachedPurchaseOrder.last_document_status` via `coerce_enum` (mirrors the existing `status` filter); also added to `PurchaseOrderSummary` output so the value is visible |
| `type` (product/material) | `search_items` | `Literal["product","material"]` field; post-filters the fuzzy matches by item type |
| `is_primary` | `list_locations` | extended the shared `_fetch_rows` with an optional row predicate (applied before the limit slice + visible total, so counts stay exact) |

### Enum-value note
The PO filter uses the **cache** enum's `UPPER_SNAKE` values (`NOT_SENT`/`SENDING`/`SENT`/`FAILED`), not #937's camelCase API-filter enum — the cache stores the response form and the two don't share string values. `search_items.type` excludes `service` because the API rejects it as a filter value (verified in #937).

### Out of scope (documented on #947)
- `category_name` — lives on the parent `CachedProduct`/`CachedMaterial`, not `CachedVariant`; needs sync-time denormalization first.
- `invoice_status` — no `CachedSalesOrderFulfillment` table exists (fulfillments are a JSON column on `CachedSalesOrder`); needs a new cached entity + list tool.

## Test plan
- [x] 4 new tests (PO `last_document_status`, `search_items` `type`, `list_locations` `is_primary` true/false) + factory kwarg
- [x] `uv run poe check` — 4136 + 48 browser tests pass
- [x] typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)