### PR TITLE
ci: add npm Dependabot ecosystem and Dependabot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 10
+    # Wait 7 days before proposing a bump to a newly published version, so a
+    # freshly compromised or yanked release has time to surface before it lands.
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "python"
@@ -50,6 +54,8 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "typescript"
@@ -72,6 +78,8 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "github-actions"
@@ -93,6 +101,8 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "docker"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@
 #
 # Supported ecosystems:
 # - uv: Python dependencies via pyproject.toml and uv.lock (GA since March 2025)
+# - npm: TypeScript client deps via packages/katana-client/package-lock.json
+#        (the lockfile CI gates with `npm ci` in the typescript-client job)
 # - github-actions: Workflow action versions
 # - docker: Base images in Dockerfiles
 #
@@ -36,6 +38,31 @@ updates:
       prefix: "chore(deps)"
       include: "scope"
 
+  # TypeScript client (npm — packages/katana-client/package-lock.json)
+  # This is the lockfile CI installs from (`npm ci` in the typescript-client job).
+  # The root pnpm workspace lockfile is not gated by CI, so it's intentionally
+  # not tracked here to avoid churning a lockfile nothing verifies.
+  - package-ecosystem: "npm"
+    directory: "/packages/katana-client"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "typescript"
+    groups:
+      # Group minor/patch updates to reduce PR noise
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -48,7 +75,7 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-      - "ci/cd"
+      - "ci-cd"
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -144,6 +144,25 @@ See
 [Automated Dependency Management](../../docs/MONOREPO_SEMANTIC_RELEASE.md#automated-dependency-management)
 for details.
 
+### [dependabot-auto-merge.yml](dependabot-auto-merge.yml)
+
+**Trigger:** `pull_request_target` on Dependabot PRs
+
+**Purpose:** Enable GitHub native auto-merge on low-risk Dependabot PRs so they merge
+once required CI checks pass
+
+**Steps:**
+
+- Read update metadata via `dependabot/fetch-metadata`
+- For patch/minor updates, run `gh pr merge --auto --squash`
+- Major version bumps are skipped and left for human review
+
+**Permissions:** `contents: write`, `pull-requests: write`
+
+**Requires:** "Allow auto-merge" enabled in repo settings, and branch protection on
+`main` with required status checks (auto-merge waits for green; it never bypasses a
+failing check).
+
 ### [copilot-setup-steps.yml](copilot-setup-steps.yml)
 
 **Type:** Reusable workflow

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -154,7 +154,8 @@ once required CI checks pass
 **Steps:**
 
 - Read update metadata via `dependabot/fetch-metadata`
-- For patch/minor updates, run `gh pr merge --auto --squash`
+- For **semver** patch/minor updates, run `gh pr merge --auto --squash` (PEP440 Python
+  bumps and anything not semver patch/minor are left for human review)
 - Major version bumps are skipped and left for human review
 
 **Permissions:** `contents: write`, `pull-requests: write`

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,7 +10,13 @@ name: Dependabot auto-merge
 #   - Branch protection on `main` with required status checks, so a PR cannot
 #     merge until CI is green.
 
-on: pull_request_target
+on:
+  pull_request_target:
+    # Only the events where enabling auto-merge is meaningful. Notably excludes
+    # `closed`: pull_request_target fires on close/merge too, and re-running
+    # `gh pr merge --auto` against an already-closed PR just fails with a noisy
+    # red check.
+    types: [opened, reopened, synchronize, ready_for_review]
 
 # Least privilege at the workflow level; the job opts into the write scopes it
 # needs. Keeps any future job added here from inheriting repo write access by

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -39,7 +39,7 @@ jobs:
         id: meta
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
 
-      - name: Enable auto-merge for patch and minor updates
+      - name: Enable auto-merge for semver patch/minor updates
         # Explicit allow-list: only semver patch/minor bumps auto-merge. A bare
         # `!= semver-major` would also let through pep440-major (Python packages
         # use PEP440 versioning, and this repo has a `uv` ecosystem), plus

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,50 @@
+name: Dependabot auto-merge
+
+# Enable GitHub's native auto-merge on low-risk Dependabot PRs so they merge
+# themselves once required CI checks pass. Branch protection still gates the
+# merge — this only flips the "auto-merge when green" switch; it never bypasses
+# a failing check. Major version bumps are intentionally left for human review.
+#
+# Requires:
+#   - "Allow auto-merge" enabled in repo settings (Settings → General).
+#   - Branch protection on `main` with required status checks, so a PR cannot
+#     merge until CI is green.
+
+on: pull_request_target
+
+# Least privilege at the workflow level; the job opts into the write scopes it
+# needs. Keeps any future job added here from inheriting repo write access by
+# default — important since this workflow runs on pull_request_target.
+permissions: {}
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    # Gate on the PR author from the event payload, not github.actor — actor is
+    # whoever triggered the event (a human editing/labeling a Dependabot PR would
+    # be the actor), whereas user.login is the stable PR author. This is the form
+    # GitHub's own Dependabot auto-merge docs use.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+
+      - name: Enable auto-merge for patch and minor updates
+        # Explicit allow-list: only semver patch/minor bumps auto-merge. A bare
+        # `!= semver-major` would also let through pep440-major (Python packages
+        # use PEP440 versioning, and this repo has a `uv` ecosystem), plus
+        # `indeterminate`, `in-range`/`outside-range`, and security update-types
+        # — anything not on this list is left for human review. Grouped PRs
+        # report the highest bump in the group, so a group containing a major
+        # falls through to manual review.
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Closes the two gaps in our automated dependency-update story.

- **npm Dependabot ecosystem** for `packages/katana-client` — the `package-lock.json` CI actually installs from (`npm ci` in the `typescript-client` job). The TypeScript client's deps previously got zero automated updates. Weekly, minor/patch grouped, `chore(deps)` prefix, `typescript` label. The root pnpm workspace lockfile is intentionally **not** tracked (nothing in CI gates it).
- **`dependabot-auto-merge.yml`** — enables GitHub native auto-merge on patch/minor Dependabot PRs via `dependabot/fetch-metadata` + `gh pr merge --auto --squash`. Major bumps are left for human review.

## ⚠️ Repo-settings prerequisites for auto-merge

These can't be set from code:

1. **Settings → General → "Allow auto-merge"** must be enabled.
2. **Branch protection on `main` with required status checks** — without required checks, `--auto` merges on approval rather than waiting for green CI.

The workflow uses `pull_request_target` but does **not** check out PR code (API-only), which is the recommended safe pattern.

## Testing

- YAML validated; pre-commit suite (mdformat, yamllint, pytest) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)