### PR TITLE
ci: pin actions to SHAs and add zizmor workflow audit

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -90,7 +90,28 @@ mkdocs.yml, etc.) to avoid unnecessary builds.
 - Code security analysis
 - License compliance checks
 
-**Permissions:** `contents: read`, `security-events: write`
+**Permissions:** `contents: read`, `security-events: write` (scoped to the
+`security-scan` job)
+
+### [zizmor.yml](zizmor.yml)
+
+**Trigger:** PRs and pushes touching `.github/workflows/**` or `.github/zizmor.yml`,
+plus a weekly schedule and manual dispatch
+
+**Purpose:** Static analysis of our own GitHub Actions workflows — catches template
+injection, excessive token permissions, credential persistence, dangerous triggers, and
+unpinned actions
+
+**Steps:**
+
+- Run [`zizmor`](https://docs.zizmor.sh) over `.github/workflows/`
+- Upload SARIF to the Security tab
+- Fail the job on any finding (regression gate)
+
+**Permissions:** `contents: read`, `security-events: write` (job-scoped)
+
+**Note:** Deliberate, reviewed exceptions live in [`.github/zizmor.yml`](../zizmor.yml)
+with a rationale per entry — not blanket suppressions.
 
 ### [update-mcp-dependency.yml](update-mcp-dependency.yml)
 
@@ -218,9 +239,17 @@ act push -W .github/workflows/release.yml
 
 ### Updating Actions
 
+**All actions are pinned to a full commit SHA** with a trailing version comment
+(`uses: actions/checkout@<sha> # v6.0.3`) — a mutable tag can be moved by anyone who
+compromises the upstream action, so SHAs are the supply-chain baseline. Dependabot
+updates SHA pins automatically and keeps the version comment current, so the normal flow
+is unchanged. When adding a new action, pin it with
+[`pinact`](https://github.com/suzuki-shunsuke/pinact) (`pinact run`) rather than by
+hand.
+
 Keep actions up to date by:
 
-1. Monitoring Dependabot alerts
+1. Monitoring Dependabot alerts and the weekly `zizmor` scan
 1. Reviewing action changelogs
 1. Testing in a branch before merging
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       spec: ${{ steps.filter.outputs.spec }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -56,11 +58,13 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.code == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         if: needs.changes.outputs.code == 'true'
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -84,7 +88,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: needs.changes.outputs.code == 'true'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.xml
           fail_ci_if_error: false
@@ -109,11 +113,13 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.code == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         if: needs.changes.outputs.code == 'true'
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -125,7 +131,7 @@ jobs:
 
       - name: Cache Playwright browsers
         if: needs.changes.outputs.code == 'true'
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           # Bust the cache when the playwright pin changes — the
@@ -150,11 +156,13 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.code == 'true' || needs.changes.outputs.spec == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         if: needs.changes.outputs.code == 'true' || needs.changes.outputs.spec == 'true'
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -215,11 +223,13 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.code == 'true' || needs.changes.outputs.spec == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         if: needs.changes.outputs.code == 'true' || needs.changes.outputs.spec == 'true'
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -282,11 +292,13 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.code == 'true' || needs.changes.outputs.spec == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         if: needs.changes.outputs.code == 'true' || needs.changes.outputs.spec == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/codespaces-prebuild.yml
+++ b/.github/workflows/codespaces-prebuild.yml
@@ -13,14 +13,21 @@ on:
     - cron: '0 2 * * 0'
   workflow_dispatch:
 
+# Least privilege at the workflow level; jobs opt into the scopes they need.
+permissions: {}
+
 jobs:
   # This workflow triggers GitHub to create a new prebuild
   # The actual prebuild happens via Codespaces settings
   trigger-prebuild:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Log prebuild trigger
         run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,10 +30,12 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,8 @@ on:
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# Least privilege at the workflow level; jobs opt into the scopes they need.
+permissions: {}
 
 # Allow only one concurrent deployment
 concurrency:
@@ -24,14 +22,17 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -50,7 +51,7 @@ jobs:
           DISABLE_MKDOCS_2_WARNING: "true"
 
       - name: Upload documentation artifacts
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./site
 
@@ -60,7 +61,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/live-integration.yml
+++ b/.github/workflows/live-integration.yml
@@ -57,10 +57,12 @@ jobs:
       KATANA_TEST_BASE_URL: ${{ vars.KATANA_TEST_BASE_URL }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -88,7 +90,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: live-integration-report
           path: live-integration-report.txt
@@ -125,10 +127,12 @@ jobs:
       KATANA_TEST_BASE_URL: ${{ vars.KATANA_TEST_BASE_URL }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -154,7 +158,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mcp-smoke-report
           path: mcp-smoke-report.txt

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -10,20 +10,25 @@ on:
         description: 'Version to release (e.g., 0.1.0a1)'
         required: true
 
-permissions:
-  contents: write
-  id-token: write
+# Least privilege at the workflow level; jobs opt into the scopes they need.
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          enable-cache: true
+          # No dependency cache in the release build — a poisoned cache could
+          # contaminate the published artifact (zizmor: cache-poisoning).
+          enable-cache: false
           python-version: "3.14"
 
       - name: Install dependencies
@@ -42,7 +47,7 @@ jobs:
           uv build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: katana_mcp_server/dist/
@@ -55,13 +60,13 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (v1.14.0)
         with:
           packages-dir: dist/
           attestations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -59,13 +60,13 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -92,7 +93,7 @@ jobs:
       - name: Python Semantic Release (Client)
         if: steps.check.outputs.has_changes == 'true'
         id: release
-        uses: python-semantic-release/python-semantic-release@v10.5.3
+        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         with:
           github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
           verbosity: 2
@@ -109,7 +110,7 @@ jobs:
           (steps.release.outcome == 'success' &&
           steps.release.outputs.released == 'true') ||
           inputs.force_publish_client == true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: client-dist
           path: dist/
@@ -128,13 +129,13 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -161,7 +162,7 @@ jobs:
       - name: Python Semantic Release (MCP)
         if: steps.check.outputs.has_changes == 'true'
         id: release
-        uses: python-semantic-release/python-semantic-release@v10.5.3
+        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         with:
           github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
           verbosity: 2
@@ -179,7 +180,7 @@ jobs:
           (steps.release.outcome == 'success' &&
           steps.release.outputs.released == 'true') ||
           inputs.force_publish_mcp == true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mcp-dist
           path: dist/
@@ -193,13 +194,13 @@ jobs:
       id-token: write
     steps:
       - name: Download client build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: client-dist
           path: dist/
 
       - name: Publish client to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (v1.14.0)
         with:
           attestations: true
 
@@ -212,13 +213,13 @@ jobs:
       id-token: write
     steps:
       - name: Download MCP build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: mcp-dist
           path: dist/
 
       - name: Publish MCP to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (v1.14.0)
         with:
           attestations: true
 
@@ -248,7 +249,7 @@ jobs:
       # pyproject versions — re-locking there would be a no-op and the lock
       # would never catch up (#901). `ref: main` + an explicit reset to
       # origin/main guarantees we see the bumped versions before re-locking.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: main
@@ -260,7 +261,7 @@ jobs:
           git reset --hard origin/main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -297,15 +298,20 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Determine MCP version for tagging
         id: version
+        env:
+          # Pass via env rather than inline ${{ }} to avoid template injection
+          # into the run block (zizmor: template-injection).
+          MCP_VERSION: ${{ needs.release-mcp.outputs.version }}
         run: |
-          if [ -n "${{ needs.release-mcp.outputs.version }}" ]; then
-            echo "mcp_version=${{ needs.release-mcp.outputs.version }}" >> $GITHUB_OUTPUT
+          if [ -n "$MCP_VERSION" ]; then
+            echo "mcp_version=$MCP_VERSION" >> $GITHUB_OUTPUT
           else
             # No MCP release this run — use the latest mcp-v* tag
             LATEST_TAG=$(git tag --list 'mcp-v*' --sort=-version:refname | head -n 1)
@@ -313,10 +319,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -324,7 +330,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/katana-mcp-server
           tags: |
@@ -334,7 +340,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./katana_mcp_server
           file: ./katana_mcp_server/Dockerfile

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,19 +9,23 @@ on:
     # Run weekly on Sundays at 00:00 UTC
     - cron: 0 0 * * 0
 
-permissions:
-  contents: read
-  security-events: write
+# Least privilege at the workflow level; jobs opt into the scopes they need.
+permissions: {}
 
 jobs:
   security-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -31,7 +35,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -39,7 +43,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
@@ -50,7 +54,7 @@ jobs:
           semgrep --config=auto --sarif --output=semgrep.sarif .
 
       - name: Upload Semgrep SARIF file
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: semgrep.sarif
         if: always()
@@ -58,6 +62,8 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
     steps:
       - name: Dependency Review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/spec-drift-audit.yml
+++ b/.github/workflows/spec-drift-audit.yml
@@ -39,10 +39,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -64,7 +66,7 @@ jobs:
         run: uv run poe validate-examples | tee validate-examples-report.md
 
       - name: Upload reports as artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spec-drift-reports
           path: |

--- a/.github/workflows/update-mcp-dependency.yml
+++ b/.github/workflows/update-mcp-dependency.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
@@ -53,8 +53,10 @@ jobs:
       - name: Check current MCP dependency
         id: check-current
         if: steps.check-release.outputs.has_release == 'true'
+        env:
+          # Pass via env rather than inline ${{ }} (zizmor: template-injection).
+          CLIENT_VERSION: ${{ steps.check-release.outputs.client_version }}
         run: |
-          CLIENT_VERSION="${{ steps.check-release.outputs.client_version }}"
           CURRENT_DEP=$(grep "katana-openapi-client>=" katana_mcp_server/pyproject.toml | sed 's/.*>=\([0-9.]*\).*/\1/')
 
           echo "current_version=$CURRENT_DEP" >> $GITHUB_OUTPUT
@@ -69,7 +71,7 @@ jobs:
 
       - name: Install uv
         if: steps.check-current.outputs.needs_update == 'true'
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -77,9 +79,10 @@ jobs:
 
       - name: Update MCP dependency
         if: steps.check-current.outputs.needs_update == 'true'
+        env:
+          # Pass via env rather than inline ${{ }} (zizmor: template-injection).
+          CLIENT_VERSION: ${{ steps.check-release.outputs.client_version }}
         run: |
-          CLIENT_VERSION="${{ steps.check-release.outputs.client_version }}"
-
           # Update the dependency in pyproject.toml
           sed -i \
             "s/katana-openapi-client>=.*\",/katana-openapi-client>=$CLIENT_VERSION\",/" \
@@ -96,9 +99,12 @@ jobs:
 
       - name: Commit and push
         if: steps.check-current.outputs.needs_update == 'true'
+        env:
+          # Pass via env rather than inline ${{ }} (zizmor: template-injection).
+          CLIENT_VERSION: ${{ steps.check-release.outputs.client_version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add katana_mcp_server/pyproject.toml uv.lock
-          git commit -m "chore(mcp): update client dependency to v${{ steps.check-release.outputs.client_version }}"
+          git commit -m "chore(mcp): update client dependency to v${CLIENT_VERSION}"
           git push origin main

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,67 @@
+name: zizmor
+
+# Static analysis of our own GitHub Actions workflows (zizmor). Catches
+# template injection, excessive token permissions, credential persistence,
+# dangerous triggers, and unpinned actions before they reach main.
+#
+# Findings are uploaded to the Security tab as SARIF; the job also fails on any
+# finding so a regression blocks the PR. Deliberate exceptions are documented in
+# .github/zizmor.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/zizmor.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/zizmor.yml"
+  schedule:
+    # Weekly, alongside the other security scans.
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: true
+          python-version: "3.14"
+
+      - name: Run zizmor
+        # zizmor emits SARIF to stdout (there is no --output flag); redirect it
+        # to a file. The exit code is the gate — zizmor exits non-zero on any
+        # finding, which fails this step and blocks the PR. The SARIF upload
+        # below still runs (if: always()) so findings reach the Security tab
+        # even on failure. Documented intentional cases are exempted in
+        # .github/zizmor.yml. Pinned to a known version so CI matches local
+        # runs; bump deliberately to pick up new audits.
+        # GH_TOKEN enables zizmor's online audits (e.g. known-vulnerable actions).
+        run: >-
+          uvx zizmor@1.25.2 --persona regular --format sarif .github/workflows/
+          > zizmor.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF to the Security tab
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        if: always()
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,36 @@
+# zizmor configuration — https://docs.zizmor.sh/configuration/
+#
+# Every entry below is a deliberate, reviewed exception with a rationale — not a
+# blanket suppression. The repo's house rule is "fix the finding, don't silence
+# it"; these are the cases where the flagged pattern is load-bearing and the fix
+# would break the workflow.
+
+rules:
+  artipacked:
+    # These checkouts intentionally persist the Git credential because the job
+    # pushes back to the repo. `persist-credentials: false` is set on every
+    # other (read-only) checkout in the tree.
+    ignore:
+      # release-client / release-mcp jobs: python-semantic-release pushes the
+      # version-bump commit and tag using SEMANTIC_RELEASE_TOKEN.
+      - release.yml:63
+      - release.yml:132
+      # sync-lockfile job: commits the regenerated uv.lock and pushes to main.
+      - release.yml:252
+      # update-mcp-dependency: commits the client bump and pushes to main.
+      - update-mcp-dependency.yml:19
+
+  dangerous-triggers:
+    # update-mcp-dependency runs on `workflow_run` after the Release workflow
+    # completes on main. It does not check out or execute untrusted PR code —
+    # it only bumps the MCP client dependency on the already-trusted main ref.
+    # This is the documented way to chain a job after another workflow.
+    #
+    # dependabot-auto-merge uses `pull_request_target` — the only trigger that
+    # gives a Dependabot PR a write-scoped token to enable auto-merge. It never
+    # checks out or runs PR code (API-only via gh), which is the documented safe
+    # pattern. (That workflow lands in sibling PR #958; this entry is here so the
+    # gate stays green once both merge — a no-op until the file exists.)
+    ignore:
+      - update-mcp-dependency.yml:3
+      - dependabot-auto-merge.yml:13


### PR DESCRIPTION
## Summary

Supply-chain hardening for the CI pipeline. Part of #952.

- **Pin every GitHub Action to a full commit SHA** (via `pinact`) with a trailing version comment. Mutable tags can be moved by a compromised upstream action — the `tj-actions/changed-files` (March 2025) vector. Dependabot keeps SHA pins **and** their version comments current, so the update flow is unchanged. The PyPA publish actions (referenced by the rolling `release/v1` branch) are pinned to that branch's head.
- **Add a `zizmor` gate** (`.github/workflows/zizmor.yml`) that statically analyzes our own workflows, uploads SARIF to the Security tab, and fails on findings.

### Findings fixed (not suppressed)

- **excessive-permissions** — drop workflow-level write scopes to `{}` and grant least privilege per job (docs, release-mcp, security, codespaces).
- **cache-poisoning** — disable the dependency cache in the `release-mcp` build so a poisoned cache can't contaminate the published artifact.
- **template-injection** — route step outputs through `env:` instead of inline `${{ }}` in run blocks (release, update-mcp-dependency).
- **artipacked** — `persist-credentials: false` on every read-only checkout; push jobs keep credentials.

### Documented exceptions

The 5 genuinely-intentional findings (4 push-job checkouts that must persist credentials + the `update-mcp-dependency` `workflow_run` trigger) are documented in `.github/zizmor.yml` with a per-entry rationale — not blanket suppressions. `uvx zizmor` exits clean.

## Testing

- `uvx zizmor --persona regular .github/workflows/` → no findings (5 ignored, intentional).
- All workflows parse as YAML; pre-commit suite (mdformat, yamllint, pytest) green.

Closes #953
Closes #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)