### PR TITLE
perf(scripts): parse large specs with libyaml CSafeLoader

### DIFF
--- a/scripts/_yaml.py
+++ b/scripts/_yaml.py
@@ -1,0 +1,29 @@
+"""Fast YAML loading for the large spec files in this repo.
+
+``yaml.safe_load`` uses PyYAML's *pure-Python* loader even when the libyaml C
+extension is installed — you have to ask for ``CSafeLoader`` explicitly. The
+upstream portal spec is ~1.5 MB and the local OpenAPI spec ~0.9 MB, where the C
+loader is ~7x faster (~920 ms → ~130 ms for the portal spec). That margin is
+enough to keep the spec-audit tests comfortably under their 30s pytest-timeout
+even on a contended CI runner, and it speeds the ``audit-spec`` / validation
+CLIs (and therefore ``poe check``) for free.
+
+Prefer the C loader when it's built; fall back to the pure-Python loader so the
+code still works on a libyaml-less install.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+try:
+    from yaml import CSafeLoader as _FastSafeLoader
+except ImportError:  # pragma: no cover - libyaml not built into this PyYAML
+    from yaml import SafeLoader as _FastSafeLoader
+
+
+def safe_load_yaml(text: str) -> Any:
+    """``yaml.safe_load`` equivalent, using libyaml's C loader when available."""
+    return yaml.load(text, Loader=_FastSafeLoader)

--- a/scripts/audit_spec_drift.py
+++ b/scripts/audit_spec_drift.py
@@ -72,6 +72,8 @@ from typing import Any
 
 import yaml
 
+from scripts._yaml import safe_load_yaml
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_LOCAL = REPO_ROOT / "docs" / "katana-openapi.yaml"
 DEFAULT_LIVE = REPO_ROOT / "docs" / "upstream-specs" / "live-gateway.yaml"
@@ -317,7 +319,7 @@ def load_spec(path: Path) -> dict[str, Any]:
     """Load a spec from JSON or YAML based on extension."""
     text = path.read_text(encoding="utf-8")
     if path.suffix.lower() in (".yaml", ".yml"):
-        return yaml.safe_load(text)
+        return safe_load_yaml(text)
     return json.loads(text)
 
 
@@ -804,7 +806,7 @@ def audit_responses(
 
 def load_overrides(path: Path) -> list[Override]:
     """Load + validate the override registry. Raises ValueError on bad schema."""
-    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    raw = safe_load_yaml(path.read_text(encoding="utf-8")) or {}
     entries = raw.get("overrides") or []
     if not isinstance(entries, list):
         raise ValueError(f"{path}: `overrides` must be a list")

--- a/scripts/regenerate_client.py
+++ b/scripts/regenerate_client.py
@@ -147,6 +147,8 @@ def _validate_with_openapi_spec_validator(spec_path: Path) -> bool:
         from openapi_spec_validator import validate_spec as openapi_validate_spec
         from openapi_spec_validator.exceptions import OpenAPISpecValidatorError
 
+        from scripts._yaml import safe_load_yaml
+
     except ImportError as e:
         print("   ❌ Required validation dependencies missing:")
         print(f"      Missing: {e.name}")
@@ -155,15 +157,16 @@ def _validate_with_openapi_spec_validator(spec_path: Path) -> bool:
 
     # Load and validate the spec
     try:
-        with open(spec_path, encoding="utf-8") as f:
-            spec = yaml.safe_load(f)
+        spec = safe_load_yaml(spec_path.read_text(encoding="utf-8"))
 
         openapi_validate_spec(spec)
         print("   ✅ openapi-spec-validator passed")
         return True
 
     except yaml.YAMLError as e:
-        print(f"   ❌ YAML parsing error: {e}")
+        # Include the path explicitly — parsing from a string (not a file
+        # handle) means PyYAML reports the source as "<unicode string>".
+        print(f"   ❌ YAML parsing error in {spec_path}: {e}")
         return False
     except OpenAPISpecValidatorError as e:
         print(f"   ❌ OpenAPI spec validation error: {e}")

--- a/scripts/validate_response_examples.py
+++ b/scripts/validate_response_examples.py
@@ -34,10 +34,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml
 from jsonschema import Draft202012Validator
 from referencing import Registry, Resource
 from referencing.jsonschema import DRAFT202012
+
+from scripts._yaml import safe_load_yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_LOCAL = REPO_ROOT / "docs" / "katana-openapi.yaml"
@@ -77,7 +78,7 @@ class ValidationReport:
 
 
 def load_yaml_spec(path: Path) -> dict[str, Any]:
-    return yaml.safe_load(path.read_text(encoding="utf-8"))
+    return safe_load_yaml(path.read_text(encoding="utf-8"))
 
 
 def _build_local_registry(local_spec: dict[str, Any]) -> Registry:

--- a/scripts/validate_spec_examples.py
+++ b/scripts/validate_spec_examples.py
@@ -40,10 +40,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml
 from jsonschema import Draft202012Validator
 from referencing import Registry, Resource
 from referencing.jsonschema import DRAFT202012
+
+from scripts._yaml import safe_load_yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_SPEC = REPO_ROOT / "docs" / "katana-openapi.yaml"
@@ -328,7 +329,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: spec not found: {args.spec}", file=sys.stderr)
         return 2
 
-    spec = yaml.safe_load(args.spec.read_text(encoding="utf-8"))
+    spec = safe_load_yaml(args.spec.read_text(encoding="utf-8"))
     report = validate_spec(spec)
     text = format_report(report)
     if args.output:


### PR DESCRIPTION
## Summary

The spec-audit test `test_strict_audit_is_green_with_committed_registry` intermittently tripped the 30s `pytest-timeout` on a loaded CI runner (seen on #960's 3.12 job). It has **no clock/sleep/network dependency** — the cost is parsing the upstream specs, and `yaml.safe_load` uses PyYAML's **pure-Python** loader even when libyaml is installed.

Fix: a shared `scripts/_yaml.safe_load_yaml` that uses `CSafeLoader` when available (falling back to `SafeLoader`), routed through every large-spec parse:
- `audit_spec_drift.load_spec` + `load_overrides`
- `validate_response_examples`, `validate_spec_examples`
- `regenerate_client`'s validation step

The 1.5 MB portal spec parses **~7× faster** (~920 ms → ~130 ms), giving the audit tests comfortable headroom under the 30s cap and speeding the `audit-spec` / validation CLIs (and `poe check`) for free. `CSafeLoader` and `SafeLoader` produce identical structures for these specs — behavior is unchanged.

## Testing

- `uv run poe lint` clean; `uv run poe test` → **4190 passed**.
- `tests/test_audit_spec_drift.py` → 40 passed (1.4s).
- `poe validate-examples` ✓, `poe audit-spec-strict` exit 0; `audit-spec --strict` and `from scripts.audit_spec_drift import …` both resolve the new import (dual-mode: direct-run + pytest).
- `load_spec(portal)` ~157 ms after the change (was ~920 ms).

## Note (out of scope)

`poe validate-response-examples` reports 79 response-example/schema mismatches — confirmed **pre-existing on main** (identical before this change) and a **soft reporting job** in `spec-drift-audit.yml` (not a gate), tracked under the spec-validation epic #573. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)