### PR TITLE
fix(mcp): reflect post-apply total on modify_purchase_order card

### DIFF
--- a/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
+++ b/katana_mcp_server/src/katana_mcp/tools/_modification_dispatch.py
@@ -851,6 +851,7 @@ async def run_modify_plan(
     message, next_actions = summarize_modify_outcome(
         actions, len(plan), entity_label=entity_label, tool_name=tool_name
     )
+    merged_parent: Any | None = None
 
     # Bug #2 (2026-05-12 supplier session): the typed cache went stale after
     # every modify because nothing wrote the post-state through. The next
@@ -882,7 +883,7 @@ async def run_modify_plan(
             else None
         )
         try:
-            await _post_apply_cache_merge(
+            merged_parent = await _post_apply_cache_merge(
                 cache_merge=cache_merge,
                 entity_type=entity_type,
                 entity_id=request.id,
@@ -900,6 +901,26 @@ async def run_modify_plan(
                 f"next sync — does not affect the API write."
             )
 
+    # Surface the post-apply header state so the card's derived metrics
+    # (notably the recomputed ``total``) reflect the *applied* entity, not
+    # the pre-modify ``prior_state`` snapshot. ``_post_apply_cache_merge``
+    # already fetched (and cached) the fresh parent — reuse it here instead
+    # of a second GET. We drop *list-valued* nested collections (the PO/SO
+    # rows, additional costs): the card rebuilds line-item rows from
+    # ``actions``, and carrying the full row set would roughly double the
+    # payload. Scalar fields and small nested objects (e.g. the ``supplier``
+    # dict) are kept — the card's ``_normalize_po_prior_state`` reads
+    # ``supplier.name`` for the reference line. ``None`` merged_parent (not
+    # cached / timed out / deleted) leaves the card on the prior snapshot,
+    # same as before this change.
+    response_extras = dict(extras or {})
+    if merged_parent is not None:
+        post_apply_snapshot = serialize_for_prior_state(merged_parent)
+        if post_apply_snapshot:
+            response_extras["post_apply_state"] = {
+                k: v for k, v in post_apply_snapshot.items() if not isinstance(v, list)
+            }
+
     return ModificationResponse(
         entity_type=entity_type,
         entity_id=request.id,
@@ -910,7 +931,7 @@ async def run_modify_plan(
         next_actions=next_actions,
         katana_url=katana_url,
         message=message,
-        extras=extras or {},
+        extras=response_extras,
     )
 
 
@@ -988,8 +1009,15 @@ async def _post_apply_cache_merge(
     entity_id: int,
     parent_field_overlay: dict[str, Any] | None = None,
     parent_override: Any | None = None,
-) -> None:
+) -> Any | None:
     """Re-fetch the modified entity from Katana and merge into the typed cache.
+
+    Returns the post-apply parent attrs that were merged into the cache
+    (with any ``parent_field_overlay`` applied) so the caller can surface
+    server-recomputed derived fields — the recomputed ``total`` especially
+    — on the response/card. Returns ``None`` whenever no merge happened:
+    the entity type isn't cached, the refetch timed out, or the entity was
+    deleted out from under us.
 
     Looks up the ``EntitySpec`` by ``entity_type`` in ``ENTITY_SPECS`` —
     entity types that aren't cached (no spec) skip silently. Returns
@@ -1022,7 +1050,7 @@ async def _post_apply_cache_merge(
 
     spec = ENTITY_SPECS.get(entity_type)
     if spec is None:
-        return  # entity not cached — nothing to merge
+        return None  # entity not cached — nothing to merge
 
     if parent_override is not None:
         # PATCH response stands in for the GET (CacheMerge.parent_from_outcome):
@@ -1044,9 +1072,9 @@ async def _post_apply_cache_merge(
                 f"exceeded {_CACHE_MERGE_FETCH_TIMEOUT_S}s (likely rate-limit "
                 f"backoff) — skipping merge. Cache recovers on next sync."
             )
-            return
+            return None
     if parent is None:
-        return  # fetch returned nothing (e.g., the entity was deleted)
+        return None  # fetch returned nothing (e.g., the entity was deleted)
 
     # Overlay fresh PATCH-response values onto the (possibly stale) GET
     # refetch. Generated attrs models are mutable (no ``frozen=True``);
@@ -1108,6 +1136,8 @@ async def _post_apply_cache_merge(
             continue
         if related_rows:
             await merge_filtered_fetch(cache_merge.cache, related_spec, related_rows)
+
+    return parent
 
 
 async def run_delete_plan(

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -3910,9 +3910,11 @@ def _render_po_entity_view(
     - Each rendered field line looks up ``changes.get("<wire_field>")``
       and, if present, swaps its rendering for the before→after form.
     - Unchanged fields render the same as the create card.
-    - The Total Metric uses the post-change ``total_cost`` from the
-      response payload — line-item adds/removes already propagated into
-      the response's recomputed total by the dispatcher.
+    - The Total Metric shows ``entity["total_cost"]``. On the apply path
+      the caller overlays the dispatcher's post-apply header snapshot
+      (``extras["post_apply_state"]``, carrying Katana's server-recomputed
+      ``total``) so line-item adds/removes/qty edits are reflected; on the
+      preview path it's the pre-modify ``prior_state`` total.
 
     Must be called inside ``with PrefabApp(...) as app, Card(): with
     CardContent(), Column(gap=3):``.
@@ -4598,6 +4600,15 @@ def build_po_modify_ui(
     # unchanged-field rows surface real values in the rendered card.
     raw_prior_state = response.get("prior_state")
     prior_state = _normalize_po_prior_state(raw_prior_state)
+    # Apply path: the dispatcher stashes the post-modify header snapshot
+    # (server-recomputed ``total`` and friends) under
+    # ``extras["post_apply_state"]``. Normalize it the same way as
+    # prior_state and overlay it below so the Total metric reflects the
+    # *applied* PO, not the pre-modify snapshot. Empty on the preview path
+    # (nothing applied yet) — the card then falls back to prior_state.
+    post_apply_state = _normalize_po_prior_state(
+        (response.get("extras") or {}).get("post_apply_state")
+    )
     # Note: katana_url is read from RESULT via the Prefab template
     # ``{{ result.katana_url }}`` in _render_preview_footer's
     # applied-state View-in-Katana button — no need to pass it through
@@ -4612,7 +4623,11 @@ def build_po_modify_ui(
     # katana_url) win. Applied: the response carries the post-change
     # scalars too — the same overlay yields the post-change entity,
     # modulo nested collections which the dispatcher already updated.
-    entity = {**prior_state, **{k: v for k, v in response.items() if v is not None}}
+    entity = {
+        **prior_state,
+        **post_apply_state,
+        **{k: v for k, v in response.items() if v is not None},
+    }
     # ``entity_id`` from the response is the PO's identity; surface it
     # under the same key the create-card pattern uses so the header
     # Badge picks it up regardless of which payload populated it.

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -2561,6 +2561,52 @@ class TestBuildPOModifyUI:
         assert "NOT_RECEIVED" in rendered and "PARTIALLY_RECEIVED" in rendered
         assert "→" in rendered
 
+    def test_applied_total_reflects_post_apply_state_not_prior(self):
+        """Regression: the applied modify card's Total metric shows the
+        server-recomputed total from ``extras['post_apply_state']``, not the
+        stale pre-modify ``prior_state['total']``.
+
+        Before the fix the card rendered the prior total (``$1,250.00``)
+        even after row/qty edits changed it on the server (to ``$3,822.00``)
+        — the dispatcher wrote the fresh PO through to the cache but never
+        threaded its recomputed total back onto the card.
+        """
+        actions = [
+            {
+                "operation": "update_row",
+                "target_id": 5001,
+                "succeeded": True,
+                "changes": [{"field": "quantity", "old": 10, "new": 12}],
+            }
+        ]
+        app = build_po_modify_ui(
+            self._applied(
+                actions,
+                extras={"post_apply_state": {"total": 3822.0, "currency": "USD"}},
+            ),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        _assert_valid_prefab(app)
+        rendered = str(app.to_json())
+        # The Total metric reflects the applied (post-modify) total …
+        assert "$3,822.00" in rendered
+        # … and NOT the pre-modify prior_state total.
+        assert "$1,250.00" not in rendered
+
+    def test_preview_total_falls_back_to_prior_state(self):
+        """Without ``post_apply_state`` (the preview path — nothing applied
+        yet), the Total metric renders the pre-modify ``prior_state`` total.
+        Pins the fallback so the applied-path override doesn't regress
+        preview rendering."""
+        app = build_po_modify_ui(
+            self._preview([]),
+            confirm_request=_StubRequest(),
+            confirm_tool="modify_purchase_order",
+        )
+        rendered = str(app.to_json())
+        assert "$1,250.00" in rendered
+
     def test_supplier_change_renders_composite_diff(self):
         """A supplier change surfaces ``Supplier: <old> (<old_id>) → <new>``
         — the composite name+ID rendering keeps the diff readable without

--- a/katana_mcp_server/tests/tools/test_modification.py
+++ b/katana_mcp_server/tests/tools/test_modification.py
@@ -1013,6 +1013,123 @@ async def test_run_modify_plan_overlays_patch_response_on_stale_refetch(monkeypa
     assert merged.name == "FRESH"
 
 
+@pytest.mark.asyncio
+async def test_run_modify_plan_stashes_post_apply_header_state(monkeypatch):
+    """After a successful apply, the dispatcher surfaces the merged parent's
+    header scalars under ``extras['post_apply_state']`` — dropping nested
+    collections — so the card renders the server-recomputed total instead of
+    the stale pre-modify ``prior_state`` total (PO stale-total bug).
+    """
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    class _POStub:
+        def to_dict(self) -> dict:
+            return {
+                "id": 42,
+                "total": 3822.0,
+                "currency": "USD",
+                "status": "NOT_RECEIVED",
+                # nested collection — must be dropped from post_apply_state
+                # (the card rebuilds line-item rows from ``actions``).
+                "purchase_order_rows": [{"id": 1}, {"id": 2}],
+            }
+
+    refetched_parent = _POStub()
+
+    async def fake_merge(cache, spec, attrs_objs):
+        pass
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return object()
+
+    async def fake_refetch(_eid: int):
+        return refetched_parent
+
+    request = _SampleRequest(id=42, name="x", preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_header",
+            target_id=42,
+            diff=[FieldChange(field="status", old="DRAFT", new="NOT_RECEIVED")],
+            apply=fake_apply,
+            verify=None,
+        )
+    ]
+
+    fake_cache = cast(TypedCacheEngine, object())
+    response = await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 42",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(cache=fake_cache, refetch_for_merge=fake_refetch),
+    )
+
+    post = response.extras["post_apply_state"]
+    assert post["total"] == 3822.0
+    assert post["currency"] == "USD"
+    assert post["status"] == "NOT_RECEIVED"
+    # Nested collections are dropped to keep the payload lean.
+    assert "purchase_order_rows" not in post
+
+
+@pytest.mark.asyncio
+async def test_run_modify_plan_no_post_apply_state_when_parent_unserializable(
+    monkeypatch,
+):
+    """When the merged parent can't be serialized (no ``to_dict`` /
+    ``model_dump``), ``extras`` gains no ``post_apply_state`` key — the card
+    then falls back to ``prior_state``. Guards the ``None`` snapshot path."""
+    from katana_mcp.tools._modification_dispatch import run_modify_plan
+
+    async def fake_merge(cache, spec, attrs_objs):
+        pass
+
+    monkeypatch.setattr("katana_mcp.typed_cache.sync.merge_filtered_fetch", fake_merge)
+
+    async def fake_apply():
+        return object()
+
+    async def fake_refetch(_eid: int):
+        return object()  # no to_dict/model_dump → serialize returns None
+
+    request = _SampleRequest(id=42, name="x", preview=False)
+    plan = [
+        ActionSpec(
+            operation="update_header",
+            target_id=42,
+            diff=[FieldChange(field="status", old="DRAFT", new="DONE")],
+            apply=fake_apply,
+            verify=None,
+        )
+    ]
+
+    fake_cache = cast(TypedCacheEngine, object())
+    response = await run_modify_plan(
+        request=request,
+        naming=EntityNaming(
+            entity_type="purchase_order",
+            entity_label="purchase order 42",
+            tool_name="modify_purchase_order",
+        ),
+        web_url_kind=None,
+        existing=None,
+        plan=plan,
+        has_get_endpoint=False,
+        cache_merge=CacheMerge(cache=fake_cache, refetch_for_merge=fake_refetch),
+    )
+
+    assert "post_apply_state" not in response.extras
+
+
 # ============================================================================
 # #786: post-apply merge must not stall on the rate-limit reset gate.
 #   - ``parent_from_outcome`` reuses the PATCH response (no parent GET).


### PR DESCRIPTION
## Summary

The "Modify Purchase Order Applied" card rendered a **stale Total** — it read `total_cost` from the pre-modify `prior_state` snapshot, so any qty/price/row change left the header total showing the *old* value even though the write landed and the typed cache was refreshed correctly.

**Root cause:** after applying, `run_modify_plan` re-fetches the updated PO and writes it back to the cache (`_post_apply_cache_merge`), but that fresh PO was **discarded** — never threaded onto the response. `ModificationResponse` carries no total field, so the card's `{**prior_state, **response}` overlay could never overwrite the stale total.

## Changes

- **`_post_apply_cache_merge`** now returns the merged parent it already fetched instead of discarding it (no extra network call).
- **`run_modify_plan`** stashes that parent's header scalars — nested row/cost collections dropped to keep the payload lean — under `extras["post_apply_state"]`. Generic across all `modify_*` tools.
- **`build_po_modify_ui`** overlays `post_apply_state` between `prior_state` and the response so the Total metric reflects the *applied* PO. Preview path unchanged (no `post_apply_state` → falls back to `prior_state`).
- Best-effort safe: a timed-out / unserializable / absent merge adds no `post_apply_state`, so the card falls back to prior behavior.
- Corrected the false docstring in `_render_po_entity_view` that claimed the dispatcher recomputed the total.

## Not in scope

The separate `(unresolved)` variant rows (added variants missing from the local catalog) are tracked in #981 — that's a cache-coverage limitation of add-row resolution, orthogonal to this fix.

## Test plan

- [x] `test_run_modify_plan_stashes_post_apply_header_state` — scalars surfaced, nested collections dropped
- [x] `test_run_modify_plan_no_post_apply_state_when_parent_unserializable` — fallback path
- [x] `test_applied_total_reflects_post_apply_state_not_prior` — core regression: card shows fresh total, not stale
- [x] `test_preview_total_falls_back_to_prior_state` — preview still shows prior total
- [x] `uv run poe check` green (full suite + 50 browser render tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)