### PR TITLE
fix(mcp): keep SO row IDs + discounts in structured_content for host channel-drop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,29 @@ fits topically — to one of the linked docs below if it's subsystem-scoped, or 
 
 ### Cross-cutting
 
+- **A UI-emitting tool's model-critical data MUST live in `structured_content`, not only
+  `content` — some hosts drop the `content` channel.** `make_tool_result` puts the full
+  response JSON in `content` and the Prefab card in `structured_content`. The MCP Apps
+  prose says `content` is model-visible and `structured_content` is UI-only — but that
+  is **host-dependent and not guaranteed**: Claude Code forwards **only**
+  `structuredContent` to the model when both are present, dropping `content[].text`
+  entirely (anthropics/claude-code#55677, closed "not planned"; claude.ai web currently
+  sends both). Large payloads are a second drop path (Claude Code truncates MCP output
+  above ~25k tokens via `MAX_MCP_OUTPUT_TOKENS`; claude.ai spills payloads above ~150k
+  chars to a pointer). **Consequence:** any identifier the model needs for a follow-up
+  action (row / line / address / fulfillment `id`, `variant_id`, discounts, tax IDs)
+  must be in the PrefabApp's `state=`, never reduced to display-only cells there. The
+  classic bug: a detail card doing `state = {**entity, "rows": display_cells}` —
+  overwriting authoritative rows with formatted cells — which stripped SO row IDs +
+  discounts and sent an agent scraping the Katana web UI. **Fix pattern:** put display
+  cells under a *separate* key via `with_display_rows(entity, cells)` (refuses to
+  clobber) and bind the DataTable to `{{ <entity>.rows_display }}`, leaving
+  `state.<entity>.rows` authoritative. Read tools that return `make_json_result` (or a
+  raw `ToolResult` with `structured_content=response.model_dump()`) are inherently safe
+  — full data in *both* channels. Pinned by
+  `tests/test_prefab_ui.py::TestWithDisplayRows` and
+  `::TestBuildSoDetailUI::test_authoritative_row_data_survives_in_structured_content`.
+
 - **Multiple `katana-mcp-server` instances share one machine-wide SQLite cache — the
   "Unable to reach katana-erp-dev" reconnect loop.** The typed cache defaults to a
   single path (`platformdirs.user_cache_dir("katana-mcp")/typed_cache.db`), so every

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -7320,11 +7320,15 @@ def _so_detail_rows_table(so: dict[str, Any]) -> None:
     """Tier 3 — line-item DataTable (SKU, name, qty, unit price, line total).
 
     Static inline table — no per-row drill-down (the SO is the destination;
-    row detail is inline, per the #913 product decision). Rows are read from
-    ``state.so.rows`` via the mandatory mustache binding. Each row carries
-    pre-formatted ``unit_price_display`` / ``line_total_display`` strings so
-    the money columns render currency-aware without a renderer-side formatter.
-    Renders a friendly empty-state when the SO has no line items.
+    row detail is inline, per the #913 product decision). The table binds to
+    ``state.so.rows_display`` — pre-formatted display cells carrying
+    ``unit_price_display`` / ``line_total_display`` strings so the money columns
+    render currency-aware without a renderer-side formatter. The authoritative
+    ``state.so.rows`` (full row data incl. ``id`` / ``total_discount`` /
+    ``variant_id`` / ``tax_rate_id``) is kept separately so the model still sees
+    row identifiers when the host forwards only ``structured_content`` — see
+    :func:`build_so_detail_ui`. Renders a friendly empty-state when the SO has
+    no line items.
     """
     rows = so.get("rows") or []
     if not rows:
@@ -7345,7 +7349,7 @@ def _so_detail_rows_table(so: dict[str, Any]) -> None:
                 key="line_total_display", header="Line Total", align="right"
             ),
         ],
-        rows="{{ so.rows }}",
+        rows="{{ so.rows_display }}",
         **_paginate(len(rows)),
     )
 
@@ -7353,9 +7357,12 @@ def _so_detail_rows_table(so: dict[str, Any]) -> None:
 def _so_detail_row_cells(so: dict[str, Any]) -> list[dict[str, Any]]:
     """Pre-compute per-row display cells for the line-item DataTable.
 
-    The DataTable binds to ``state.so.rows`` (mustache), so the state copy of
-    each row needs the rendered ``sku`` / ``display_name`` / ``quantity`` plus
-    two pre-formatted money strings:
+    These cells are stored under ``state.so.rows_display`` (via
+    :func:`with_display_rows`) and the DataTable binds to
+    ``{{ so.rows_display }}`` — kept separate from the authoritative
+    ``state.so.rows`` so the reduction here never strips row identifiers. Each
+    cell needs the rendered ``sku`` / ``display_name`` / ``quantity`` plus two
+    pre-formatted money strings:
 
     - ``unit_price_display`` — ``price_per_unit`` formatted via
       ``_format_money`` in the SO currency (``"—"`` when null).
@@ -7425,11 +7432,18 @@ def build_so_detail_ui(so: dict[str, Any]) -> PrefabApp:
     embedded child table) and ``build_variant_details_ui`` (Metric-row Tier 2
     on a read card).
     """
-    # The line-item DataTable binds to ``state.so.rows``; swap in the
-    # pre-formatted display cells so the money columns render currency-aware
-    # without a renderer-side formatter. Shallow-copy ``so`` so the caller's
-    # response dict isn't mutated.
-    so_state = {**so, "rows": _so_detail_row_cells(so)}
+    # The line-item DataTable binds to ``state.so.rows_display`` — pre-formatted
+    # display cells so the money columns render currency-aware without a
+    # renderer-side formatter. Crucially, we ADD that key rather than overwriting
+    # ``state.so.rows``: the authoritative rows (row ``id``, ``total_discount``,
+    # ``variant_id``, ``tax_rate_id`` …) stay in ``state.so.rows`` so a host that
+    # forwards only ``structured_content`` to the model still exposes the row
+    # identifiers an agent needs to edit pricing safely. (Claude Code drops the
+    # ``content`` JSON channel when ``structuredContent`` is present —
+    # anthropics/claude-code#55677 — so display-only cells there would strip the
+    # IDs, which sent an agent scraping the Katana web UI for row data.)
+    # Shallow-copy ``so`` so the caller's response dict isn't mutated.
+    so_state = {**so, "rows_display": _so_detail_row_cells(so)}
 
     with PrefabApp(state={"so": so_state}, css_class="p-4") as app, Card():
         with CardHeader(), Column(gap=1):

--- a/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
+++ b/katana_mcp_server/src/katana_mcp/tools/prefab_ui.py
@@ -177,6 +177,44 @@ def _paginate(
     return {"paginated": False}
 
 
+def with_display_rows(
+    entity: dict[str, Any],
+    cells: list[dict[str, Any]],
+    *,
+    display_key: str = "rows_display",
+) -> dict[str, Any]:
+    """Attach pre-formatted DataTable display cells to an entity's card state
+    WITHOUT clobbering its authoritative row data.
+
+    A detail card binds its line-item DataTable to a mustache key in
+    ``PrefabApp(state=...)``. The natural-but-wrong shape is
+    ``{**entity, "rows": cells}`` — overwriting the authoritative rows (which
+    carry row ``id`` / ``variant_id`` / discounts / tax IDs) with display-only
+    cells. That drops the identifiers a follow-up mutation keys on
+    (``update_rows`` / ``delete_row_ids`` …). It only *looks* harmless because
+    the full row data still rides in the ToolResult ``content`` channel — but
+    some hosts forward **only** ``structured_content`` to the model and drop
+    ``content`` (anthropics/claude-code#55677), so a display-only reduction
+    there strips the IDs from model context. (This is what sent an agent
+    scraping the Katana web UI for sales-order row data.)
+
+    This helper enforces the fix: it writes ``cells`` to a **separate**
+    ``display_key`` (bind the DataTable to that) and leaves the entity's own
+    authoritative keys untouched. It refuses to overwrite an existing
+    ``display_key`` so a future caller can't reintroduce the clobber by accident.
+
+    Bind the table to ``{{ <entity>.<display_key> }}`` and let the model read
+    identifiers from the entity's authoritative row key. See
+    :func:`build_so_detail_ui` for the canonical call site.
+    """
+    if display_key in entity:
+        raise ValueError(
+            f"with_display_rows: {display_key!r} already present on entity — "
+            f"refusing to overwrite (would risk clobbering authoritative data)."
+        )
+    return {**entity, display_key: cells}
+
+
 def _split_warnings(
     warnings: list[str] | None,
 ) -> tuple[list[str], list[str]]:
@@ -7432,18 +7470,13 @@ def build_so_detail_ui(so: dict[str, Any]) -> PrefabApp:
     embedded child table) and ``build_variant_details_ui`` (Metric-row Tier 2
     on a read card).
     """
-    # The line-item DataTable binds to ``state.so.rows_display`` — pre-formatted
-    # display cells so the money columns render currency-aware without a
-    # renderer-side formatter. Crucially, we ADD that key rather than overwriting
-    # ``state.so.rows``: the authoritative rows (row ``id``, ``total_discount``,
-    # ``variant_id``, ``tax_rate_id`` …) stay in ``state.so.rows`` so a host that
-    # forwards only ``structured_content`` to the model still exposes the row
-    # identifiers an agent needs to edit pricing safely. (Claude Code drops the
-    # ``content`` JSON channel when ``structuredContent`` is present —
-    # anthropics/claude-code#55677 — so display-only cells there would strip the
-    # IDs, which sent an agent scraping the Katana web UI for row data.)
+    # The line-item DataTable binds to ``state.so.rows_display`` (pre-formatted
+    # display cells) while ``state.so.rows`` stays authoritative (row ``id`` /
+    # ``total_discount`` / ``variant_id`` / ``tax_rate_id``). ``with_display_rows``
+    # enforces the non-clobber invariant so the identifiers survive on a host
+    # that forwards only ``structured_content`` (see the helper's docstring).
     # Shallow-copy ``so`` so the caller's response dict isn't mutated.
-    so_state = {**so, "rows_display": _so_detail_row_cells(so)}
+    so_state = with_display_rows(so, _so_detail_row_cells(so))
 
     with PrefabApp(state={"so": so_state}, css_class="p-4") as app, Card():
         with CardHeader(), Column(gap=1):

--- a/katana_mcp_server/tests/browser/render_test_server.py
+++ b/katana_mcp_server/tests/browser/render_test_server.py
@@ -513,7 +513,7 @@ def _variant_batch_app() -> PrefabApp:
 def _so_detail_app() -> PrefabApp:
     """build_so_detail_ui — read-only sales-order detail card (#913).
 
-    Exercises the static line-item DataTable (rows='{{ so.rows }}'), the
+    Exercises the static line-item DataTable (rows='{{ so.rows_display }}'), the
     resolved customer/location party lines, billing+shipping address blocks,
     storefront link, and the single View-in-Katana footer button.
     """

--- a/katana_mcp_server/tests/browser/test_other_cards_render.py
+++ b/katana_mcp_server/tests/browser/test_other_cards_render.py
@@ -283,7 +283,7 @@ class TestOtherCardsRender:
     def test_so_detail_renders(self, render_scenario):
         """``build_so_detail_ui`` — read-only SO detail card (#913).
 
-        Proves the static line-item DataTable (rows='{{ so.rows }}') mounts
+        Proves the static line-item DataTable (rows='{{ so.rows_display }}') mounts
         and the card surfaces resolved names, addresses, and the single
         View-in-Katana footer link — no Confirm/mutation buttons.
         """

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -10454,20 +10454,26 @@ def _so_detail_response(
     rows = (
         [
             {
+                "id": 5001,
                 "variant_id": 700,
                 "sku": "SKU-A",
                 "display_name": "Widget / Red",
                 "quantity": 2,
                 "price_per_unit": 100.0,
                 "total": 200.0,
+                "tax_rate_id": 9,
+                "total_discount": "15.00",
             },
             {
+                "id": 5002,
                 "variant_id": 701,
                 "sku": None,
                 "display_name": None,
                 "quantity": 5,
                 "price_per_unit": 10.0,
                 "total": None,
+                "tax_rate_id": 9,
+                "total_discount": "0.00",
             },
         ]
         if with_rows
@@ -10587,17 +10593,20 @@ class TestBuildSoDetailUI:
         assert labels.get("Delivery") == "2026-07-01"
 
     def test_line_item_table_uses_mustache_rows(self) -> None:
-        """The line-item DataTable binds rows via mustache to state.so.rows."""
+        """The line-item DataTable binds rows via mustache to the display-cell
+        key ``state.so.rows_display`` (NOT ``state.so.rows``, which is kept as
+        the authoritative row data — see
+        ``test_authoritative_row_data_survives_in_structured_content``)."""
         envelope = build_so_detail_ui(_so_detail_response()).to_json()
         tables = _find_components_by_type(envelope, "DataTable")
         assert len(tables) == 1
-        assert tables[0].get("rows") == "{{ so.rows }}"
+        assert tables[0].get("rows") == "{{ so.rows_display }}"
 
     def test_line_item_cells_formatted(self) -> None:
-        """Row state cells coalesce null SKU, fall back display_name, and
+        """Row display cells coalesce null SKU, fall back display_name, and
         pre-format the money columns (incl. computed line total)."""
         app = build_so_detail_ui(_so_detail_response())
-        rows = app.to_json()["state"]["so"]["rows"]
+        rows = app.to_json()["state"]["so"]["rows_display"]
         assert rows[0]["sku"] == "SKU-A"
         assert rows[0]["unit_price_display"] == "$100.00"
         assert rows[0]["line_total_display"] == "$200.00"
@@ -10607,10 +10616,37 @@ class TestBuildSoDetailUI:
         assert rows[1]["display_name"] == "Variant 701"
         assert rows[1]["line_total_display"] == "$50.00"
 
+    def test_authoritative_row_data_survives_in_structured_content(self) -> None:
+        """P0 regression guard (anthropics/claude-code#55677): the row ``id``,
+        ``total_discount``, ``variant_id`` and ``tax_rate_id`` an agent needs to
+        edit pricing MUST live in ``state.so.rows`` — the structured_content
+        channel — so they survive on a host that drops the ``content`` JSON
+        channel when ``structuredContent`` is present. The display-cell
+        transform must never clobber this authoritative data.
+
+        This is the fix for the incident where an agent, seeing only the
+        rendered card, believed ``get_sales_order`` "stripped" row IDs and
+        discounts and went scraping the Katana web UI for them.
+        """
+        state_so = build_so_detail_ui(_so_detail_response()).to_json()["state"]["so"]
+        rows = state_so["rows"]
+        assert [r["id"] for r in rows] == [5001, 5002], (
+            "Row IDs must survive in state.so.rows for the model to target "
+            "update_rows / delete_row_ids."
+        )
+        assert [r["total_discount"] for r in rows] == ["15.00", "0.00"], (
+            "Per-line discounts must survive so the model can edit pricing "
+            "without a browser round-trip."
+        )
+        assert [r["variant_id"] for r in rows] == [700, 701]
+        assert all(r["tax_rate_id"] == 9 for r in rows)
+
     def test_null_variant_id_row_uses_neutral_label(self) -> None:
         """A row with no display_name AND a null variant_id renders a neutral
         "Unknown item" label, not a confusing "Variant None" (variant_id is
-        optional in the response)."""
+        optional in the response). The neutral label is a *display* fallback, so
+        it lives in the ``rows_display`` cells — ``state.so.rows`` keeps the raw
+        null ``display_name``."""
         response = {
             **_so_detail_response(),
             "rows": [
@@ -10624,8 +10660,8 @@ class TestBuildSoDetailUI:
                 }
             ],
         }
-        rows = build_so_detail_ui(response).to_json()["state"]["so"]["rows"]
-        assert rows[0]["display_name"] == "Unknown item"
+        cells = build_so_detail_ui(response).to_json()["state"]["so"]["rows_display"]
+        assert cells[0]["display_name"] == "Unknown item"
 
     def test_address_blocks_rendered(self) -> None:
         """Billing + shipping address blocks surface recipient / company /

--- a/katana_mcp_server/tests/test_prefab_ui.py
+++ b/katana_mcp_server/tests/test_prefab_ui.py
@@ -40,6 +40,7 @@ from katana_mcp.tools.prefab_ui import (
     build_variant_details_ui,
     build_verification_ui,
     status_badge_variant,
+    with_display_rows,
     with_preview_coaching,
 )
 from prefab_ui.app import PrefabApp
@@ -10529,6 +10530,30 @@ def _so_detail_response(
         "rows": rows,
         "warnings": warnings or [],
     }
+
+
+class TestWithDisplayRows:
+    """``with_display_rows`` — the non-clobber invariant that keeps authoritative
+    row identifiers in ``structured_content`` state (anthropics/claude-code#55677)."""
+
+    def test_adds_display_key_without_touching_authoritative_rows(self) -> None:
+        entity = {"id": 1, "rows": [{"id": 99, "total_discount": "5.00"}]}
+        cells = [{"sku": "SKU-A", "unit_price_display": "$1.00"}]
+        result = with_display_rows(entity, cells)
+        # Authoritative rows are preserved verbatim...
+        assert result["rows"] == [{"id": 99, "total_discount": "5.00"}]
+        # ...and the display cells land under the separate key.
+        assert result["rows_display"] == cells
+
+    def test_does_not_mutate_input(self) -> None:
+        entity = {"rows": [{"id": 99}]}
+        with_display_rows(entity, [{"sku": "X"}])
+        assert "rows_display" not in entity
+
+    def test_refuses_to_overwrite_existing_display_key(self) -> None:
+        entity = {"rows": [{"id": 99}], "rows_display": [{"sku": "old"}]}
+        with pytest.raises(ValueError, match="already present"):
+            with_display_rows(entity, [{"sku": "new"}])
 
 
 class TestBuildSoDetailUI:


### PR DESCRIPTION
## Summary

Fixes the root cause of an incident where an agent, asked to edit sales-order pricing, went scraping the Katana **web UI** for line-item row IDs and per-line discounts — believing `get_sales_order` "stripped" them.

It didn't strip them from `content`. But **some hosts forward only `structuredContent` to the model and drop the `content[].text` channel** (anthropics/claude-code#55677, closed "not planned"; claude.ai web currently sends both). Our `make_tool_result` puts the full response JSON in `content` and the Prefab card in `structured_content` — so on a content-dropping host, the model only ever saw the card's `state`.

And the SO detail card's `state` had **reduced** the rows to display-only cells:

```python
so_state = {**so, "rows": _so_detail_row_cells(so)}  # overwrote authoritative rows
```

`_so_detail_row_cells` emits only `{sku, display_name, quantity, unit_price_display, line_total_display}` — dropping row `id`, `variant_id`, `total_discount`, `tax_rate_id`. Those are exactly the identifiers `update_rows` / `delete_row_ids` key on. So on that host the agent genuinely could not see them, and the browser detour was rational.

### The fix
- Add display cells under a **separate** `state.so.rows_display` key (the DataTable binds there); keep `state.so.rows` as the **authoritative** rows. Identifiers now survive regardless of which channel the host forwards.
- Extract `with_display_rows(entity, cells)` — a guard that writes to a separate `rows_display` key and **refuses to overwrite** it, so no future detail card can silently reintroduce the clobber.
- Document the trap as a cross-cutting Known Pitfall in `CLAUDE.md` (content-channel drop + payload-size thresholds).

### Audit — is anything else affected?
Audited all 32 `build_*_ui` builders. **`build_so_detail_ui` was the only one.** Why the rest are safe:
- Every create/modify/delete card is a preview→apply card that embeds the full apply arguments (**including row/target IDs**) in its Confirm button's `toolCall` action inside the PrefabApp tree.
- Read tools other than `get_sales_order` return `make_json_result` (or a raw `ToolResult` with `structured_content=response.model_dump()`) — full data in **both** channels, nothing to drop.
- List/readout cards keep authoritative dicts or preserve `variant_id`/`sku`.

## Test plan
- [x] `TestBuildSoDetailUI::test_authoritative_row_data_survives_in_structured_content` — row `id` + `total_discount` + `variant_id` + `tax_rate_id` present in `state.so.rows`
- [x] `TestWithDisplayRows` — non-clobber invariant + raise-on-overwrite + no input mutation
- [x] Updated the two tests that read the old `state.so.rows` display cells → `rows_display`
- [x] `so_detail` **browser render** test confirms the renderer resolves the new `{{ so.rows_display }}` binding cross-runtime
- [x] Full `uv run poe check` green (incl. 50 browser render tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)