### PR TITLE
fix: tolerate Katana literal-"null" serial dates + isolate malformed records in cache sync

### DIFF
--- a/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
+++ b/katana_mcp_server/src/katana_mcp/typed_cache/sync.py
@@ -410,6 +410,55 @@ def _convert(spec: EntitySpec, attrs_obj: Any) -> tuple[Any, list[Any]]:
     return parent, children
 
 
+def _convert_batch(
+    spec: EntitySpec, attrs_objs: Iterable[Any]
+) -> tuple[list[Any], list[Any]]:
+    """Convert a batch of attrs objects into cache rows, isolating failures.
+
+    A single malformed record must never abort the whole batch. ``_convert``
+    can raise a ``ValidationError`` (e.g. a Katana wire quirk that slips past
+    the sentinel-null coercion, an unforeseen type mismatch, or a nested row the
+    generated model can't accept) — and because ``_sync_one_locked`` advances
+    ``SyncState.last_synced`` only *after* the loop, that raise would strand the
+    entire entity type *and* leave the watermark un-advanced, so every retry
+    re-poisons on the same record (the "reconnect loop" failure mode). Convert
+    each record independently; log-and-skip the ones that raise so the rest of
+    the batch still lands and the watermark advances.
+
+    Skipped records are recoverable: a later ``updated_at`` bump re-syncs them,
+    and ``rebuild_cache`` re-pulls the full set from scratch.
+    """
+    cached_parents: list[Any] = []
+    cached_children: list[Any] = []
+    skipped = 0
+    for attrs_obj in attrs_objs:
+        try:
+            parent, children = _convert(spec, attrs_obj)
+        except Exception as exc:
+            # Catch-all on purpose: this is the batch-resilience backstop, so a
+            # never-before-seen conversion failure degrades to one dropped row
+            # instead of a whole-entity outage.
+            skipped += 1
+            logger.warning(
+                "cache_sync_skipped_record",
+                entity=spec.entity_key,
+                record_id=getattr(attrs_obj, "id", None),
+                error=str(exc),
+            )
+            continue
+        cached_parents.append(parent)
+        cached_children.extend(children)
+
+    if skipped:
+        logger.warning(
+            "cache_sync_skipped_records_total",
+            entity=spec.entity_key,
+            skipped=skipped,
+        )
+
+    return cached_parents, cached_children
+
+
 # SQLite caps each prepared statement at 999 bound parameters by default.
 # Headroom (900) keeps us safe on older / embedded builds without sacrificing
 # meaningful throughput. Wide schemas (``CachedSalesOrder`` at 33 cols) end up
@@ -563,12 +612,7 @@ async def _sync_one_locked(
     else:
         attrs_objs = unwrap_data(response, default=[])
 
-    cached_parents: list[Any] = []
-    cached_children: list[Any] = []
-    for attrs_obj in attrs_objs:
-        parent, children = _convert(spec, attrs_obj)
-        cached_parents.append(parent)
-        cached_children.extend(children)
+    cached_parents, cached_children = _convert_batch(spec, attrs_objs)
 
     async with cache.session() as session:
         # Parents first so child FK constraints resolve on insert.
@@ -676,12 +720,7 @@ async def merge_filtered_fetch(
 
     Empty input is a no-op (no session opened, no merge issued).
     """
-    cached_parents: list[Any] = []
-    cached_children: list[Any] = []
-    for attrs_obj in attrs_objs:
-        parent, children = _convert(spec, attrs_obj)
-        cached_parents.append(parent)
-        cached_children.extend(children)
+    cached_parents, cached_children = _convert_batch(spec, attrs_objs)
 
     if not cached_parents:
         return

--- a/katana_mcp_server/tests/test_typed_cache_invalidation.py
+++ b/katana_mcp_server/tests/test_typed_cache_invalidation.py
@@ -1063,3 +1063,142 @@ class TestReconcileChildren:
         assert summary.row_count == 1
         assert summary.rows is not None
         assert [r.id for r in summary.rows] == [1]
+
+
+class TestMalformedRecordResilience:
+    """One bad record must never black out a whole entity's sync.
+
+    Two complementary layers guard this:
+
+    1. ``KatanaPydanticBase.from_attrs`` coerces Katana's literal
+       ``"null"``/``"undefined"`` sentinel (seen on serial-number transfer
+       responses) to ``None`` on typed fields, so the quirky-but-otherwise-valid
+       record is *retained*, not dropped.
+    2. ``_convert_batch`` isolates any *other* per-record conversion failure —
+       log-and-skip the one bad row so the rest of the batch still lands and the
+       watermark advances (an unhandled raise would strand the entire entity and
+       leave ``SyncState`` un-advanced, re-poisoning every retry).
+
+    Regression for the live "``list_manufacturing_orders`` returns a
+    ``ValidationError`` for SerialNumber.transaction_date=='null'" outage.
+    """
+
+    @staticmethod
+    def _mo_attrs(order_id: int, serial_numbers: list[dict] | None = None):
+        from katana_public_api_client.models import ManufacturingOrder as AttrsMO
+
+        payload: dict = {
+            "id": order_id,
+            "order_no": f"MO-{order_id}",
+            "status": "NOT_STARTED",
+            "variant_id": 9001,
+            "planned_quantity": 5.0,
+            "location_id": 1,
+            "created_at": "2026-01-01T00:00:00.000Z",
+            "updated_at": "2026-01-02T00:00:00.000Z",
+        }
+        if serial_numbers is not None:
+            payload["serial_numbers"] = serial_numbers
+        return AttrsMO.from_dict(payload)
+
+    @pytest.mark.asyncio
+    async def test_sync_tolerates_null_string_serial_in_manufacturing_orders(
+        self, typed_cache_engine
+    ):
+        """A batch with a ``transaction_date="null"`` nested serial must fully land.
+
+        This is the exact wire shape that took the MO list down: a healthy MO
+        alongside one whose nested ``serial_numbers[]`` carries Katana's literal
+        ``"null"`` sentinel in a typed field. Both MOs must reach the cache, and
+        the quirky serial must be *retained* with the sentinel coerced to None —
+        the string field (``serial_number``) preserved verbatim.
+        """
+        from katana_mcp.typed_cache.sync import ensure_manufacturing_orders_synced
+
+        from katana_public_api_client.models_pydantic._generated import (
+            CachedManufacturingOrder,
+        )
+
+        good = self._mo_attrs(5001)
+        poisoned = self._mo_attrs(
+            5002,
+            serial_numbers=[
+                {
+                    "id": 42,
+                    "transaction_id": "undefined",
+                    "serial_number": "SN-KEEP",
+                    "resource_id": "null",
+                    "resource_type": "ManufacturingOrder",
+                    "transaction_date": "null",
+                    "quantity_change": 1,
+                }
+            ],
+        )
+
+        parsed = MagicMock()
+        parsed.data = [good, poisoned]
+        response = MagicMock()
+        response.status_code = 200
+        response.parsed = parsed
+
+        with (
+            patch(
+                "katana_mcp.typed_cache.sync.get_all_manufacturing_orders.asyncio_detailed",
+                new=AsyncMock(return_value=response),
+            ),
+            patch(
+                "katana_mcp.typed_cache.sync.get_all_manufacturing_order_recipe_rows.asyncio_detailed",
+                new=AsyncMock(return_value=_empty_response()),
+            ),
+        ):
+            await ensure_manufacturing_orders_synced(MagicMock(), typed_cache_engine)
+
+        async with typed_cache_engine.session() as session:
+            cached_good = await session.get(CachedManufacturingOrder, 5001)
+            cached_poisoned = await session.get(CachedManufacturingOrder, 5002)
+
+        assert cached_good is not None
+        assert cached_poisoned is not None, (
+            "poisoned MO must land — the null-string serial is coerced, not dropped"
+        )
+        assert cached_poisoned.serial_numbers is not None
+        assert len(cached_poisoned.serial_numbers) == 1
+        serial = cached_poisoned.serial_numbers[0]
+        assert serial["serial_number"] == "SN-KEEP"
+        assert serial["transaction_date"] is None
+        assert serial["resource_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_convert_batch_skips_unconvertible_record(self, monkeypatch):
+        """``_convert_batch`` isolates a raising record and keeps the rest.
+
+        The Layer-2 coercion can't anticipate every future Katana quirk, so the
+        sync loop needs a backstop: a record whose ``_convert`` raises for *any*
+        reason is logged and skipped, and the surviving records are still
+        returned for upsert.
+        """
+        from katana_mcp.typed_cache import (
+            MANUFACTURING_ORDER_SPEC,
+            sync as sync_mod,
+        )
+
+        good1 = self._mo_attrs(6001)
+        bad = self._mo_attrs(6002)
+        good2 = self._mo_attrs(6003)
+
+        real_convert = sync_mod._convert
+
+        def flaky_convert(spec, attrs_obj):
+            if getattr(attrs_obj, "id", None) == 6002:
+                raise ValueError("boom: simulated unforeseen conversion failure")
+            return real_convert(spec, attrs_obj)
+
+        monkeypatch.setattr(sync_mod, "_convert", flaky_convert)
+
+        parents, _children = sync_mod._convert_batch(
+            MANUFACTURING_ORDER_SPEC, [good1, bad, good2]
+        )
+
+        landed_ids = {p.id for p in parents}
+        assert landed_ids == {6001, 6003}
+        assert 6002 not in landed_ids

--- a/katana_public_api_client/models_pydantic/_base.py
+++ b/katana_public_api_client/models_pydantic/_base.py
@@ -9,8 +9,19 @@ from __future__ import annotations
 
 import datetime
 import enum
+import types
 from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast, get_args, get_origin
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    ClassVar,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+)
 
 from sqlmodel import SQLModel
 from sqlmodel._compat import SQLModelConfig
@@ -35,6 +46,69 @@ def _get_unset() -> Any:
     from ..client_types import UNSET
 
     return UNSET
+
+
+# Katana serializes some absent values as the literal *string* ``"null"`` or
+# ``"undefined"`` rather than a JSON null — documented on serial-number transfer
+# responses (see ``models/serial_number.py``: ``transaction_id`` may be
+# ``"undefined"``, ``resource_id`` may be ``"null"``). The generated attrs
+# parsers pass the raw string straight through (their ``_parse_<field>``
+# fallbacks ``return`` the value on parse failure), so it only blows up when the
+# value reaches a *typed* pydantic field — e.g. ``transaction_date:
+# AwareDatetime`` or ``resource_id: int`` rejects ``"null"`` with a
+# ``ValidationError``. In the typed-cache sync that single bad record would abort
+# the whole batch. Coerce the sentinel to ``None`` for any field that cannot hold
+# a string; leave string-typed fields (``transaction_id``, ``serial_number``)
+# untouched so a legitimate value that happens to be ``"null"`` still survives.
+_SENTINEL_NULL_STRINGS = frozenset({"null", "undefined"})
+
+
+def _flatten_member_types(annotation: Any) -> list[Any]:
+    """Flatten an annotation into its concrete member types.
+
+    Unwraps ``Annotated[T, ...]`` to ``T`` and expands unions (both
+    ``typing.Union`` and the ``X | Y`` ``types.UnionType`` form) so callers can
+    reason about each alternative of an ``Optional``/union field.
+    """
+    origin = get_origin(annotation)
+    if origin is Annotated:
+        return _flatten_member_types(get_args(annotation)[0])
+    if origin is Union or origin is types.UnionType:
+        flattened: list[Any] = []
+        for arg in get_args(annotation):
+            flattened.extend(_flatten_member_types(arg))
+        return flattened
+    return [annotation]
+
+
+def _annotation_accepts_str(annotation: Any) -> bool:
+    """Whether a plain ``str`` is a valid value for a field of this annotation.
+
+    ``True`` if any non-``None`` member is ``str`` / a ``str`` subclass (e.g. a
+    ``StrEnum``) or a permissive non-class construct (``Any``, ``object``);
+    ``False`` only when every member is a concrete non-string type. Used to gate
+    the ``"null"``/``"undefined"`` sentinel coercion so string-bearing fields are
+    never touched.
+    """
+    members = [m for m in _flatten_member_types(annotation) if m is not type(None)]
+    if not members:
+        return True
+    for member in members:
+        # Non-class constructs (``Any``, bare ``object`` reached via typing)
+        # accept anything, so a string is valid — stay permissive.
+        if not isinstance(member, type):
+            return True
+        if member is object or issubclass(member, str):
+            return True
+    return False
+
+
+def _coerce_sentinel_null(value: Any, annotation: Any) -> Any:
+    """Map Katana's literal ``"null"``/``"undefined"`` string to ``None`` when the
+    target field cannot hold a string; otherwise return ``value`` unchanged."""
+    if not isinstance(value, str) or value not in _SENTINEL_NULL_STRINGS:
+        return value
+    return None if not _annotation_accepts_str(annotation) else value
 
 
 class KatanaPydanticBase(SQLModel):
@@ -152,6 +226,14 @@ class KatanaPydanticBase(SQLModel):
             if field_name.endswith("_") and not field_name.startswith("_"):
                 # Remove trailing underscore for pydantic field
                 pydantic_field_name = field_name[:-1]
+
+            # Normalize Katana's literal ``"null"``/``"undefined"`` sentinel to
+            # None for typed (non-string) fields so a single quirky record
+            # doesn't fail ``model_validate`` below (and, in the typed-cache
+            # sync, abort the whole batch).
+            model_field = cls.model_fields.get(pydantic_field_name)
+            if model_field is not None:
+                value = _coerce_sentinel_null(value, model_field.annotation)
 
             data[pydantic_field_name] = value
 

--- a/tests/test_models_pydantic.py
+++ b/tests/test_models_pydantic.py
@@ -458,6 +458,85 @@ class TestServiceVariantNullSku:
         assert pydantic_service.variants[1].sku is None
 
 
+class TestSerialNumberSentinelNull:
+    """``from_attrs`` must tolerate Katana's literal ``"null"``/``"undefined"`` string.
+
+    On serial-number *transfer* responses Katana serializes absent values as the
+    literal string ``"null"`` (or ``"undefined"``) instead of a JSON null. The
+    generated attrs parser passes the raw string straight through (its
+    ``_parse_<field>`` fallbacks return the value on parse failure), so the break
+    only surfaces at the *typed* pydantic field: ``transaction_date:
+    AwareDatetime`` and ``resource_id: int`` reject ``"null"`` with a
+    ``ValidationError``. In the typed-cache MO sync that single quirky record
+    aborted the whole batch, blacking out ``list_manufacturing_orders`` entirely.
+
+    The fix coerces the sentinel to ``None`` in ``KatanaPydanticBase.from_attrs``
+    for any field that can't hold a string, while leaving genuine string fields
+    (``transaction_id``, ``serial_number``) untouched so a legitimate value that
+    happens to be ``"null"`` still survives. Pinned here at the conversion seam so
+    a future refactor can't silently reintroduce the crash.
+    """
+
+    def test_from_attrs_coerces_null_string_on_typed_fields(self) -> None:
+        """The crash path: ``SerialNumber.from_attrs`` with sentinel strings."""
+        from katana_public_api_client.models import SerialNumber as AttrsSerialNumber
+        from katana_public_api_client.models_pydantic._generated import SerialNumber
+
+        attrs_sn = AttrsSerialNumber.from_dict(
+            {
+                "id": 42,
+                "transaction_id": "undefined",
+                "serial_number": "SN-KEEP-001",
+                "resource_id": "null",
+                "resource_type": "ManufacturingOrder",
+                "transaction_date": "null",
+                "quantity_change": 1,
+            }
+        )
+        # attrs stores the raw sentinel strings — the tolerance lives downstream.
+        assert attrs_sn.transaction_date == "null"
+        assert attrs_sn.resource_id == "null"
+
+        pydantic_sn = SerialNumber.from_attrs(attrs_sn)
+
+        # Typed (non-string) fields: sentinel coerced to None → record survives.
+        assert pydantic_sn.transaction_date is None
+        assert pydantic_sn.resource_id is None
+        # String fields: sentinel preserved verbatim (a real value could be "null").
+        assert pydantic_sn.transaction_id == "undefined"
+        assert pydantic_sn.serial_number == "SN-KEEP-001"
+        # The rest of the record is retained, not dropped.
+        assert pydantic_sn.id == 42
+        assert pydantic_sn.quantity_change == 1
+
+    def test_from_attrs_preserves_real_datetime(self) -> None:
+        """A genuine ISO datetime must still parse — coercion only hits sentinels."""
+        from katana_public_api_client.models import SerialNumber as AttrsSerialNumber
+        from katana_public_api_client.models_pydantic._generated import SerialNumber
+
+        attrs_sn = AttrsSerialNumber.from_dict(
+            {
+                "id": 43,
+                "serial_number": "SN-002",
+                "transaction_date": "2026-01-15T10:00:00.000Z",
+                "quantity_change": -1,
+            }
+        )
+        pydantic_sn = SerialNumber.from_attrs(attrs_sn)
+        assert pydantic_sn.transaction_date is not None
+        assert pydantic_sn.transaction_date.year == 2026
+
+    def test_from_attrs_preserves_serial_number_literally_null(self) -> None:
+        """``serial_number`` is a string field: a literal ``"null"`` value is data,
+        not a sentinel, and must be preserved."""
+        from katana_public_api_client.models import SerialNumber as AttrsSerialNumber
+        from katana_public_api_client.models_pydantic._generated import SerialNumber
+
+        attrs_sn = AttrsSerialNumber.from_dict({"id": 44, "serial_number": "null"})
+        pydantic_sn = SerialNumber.from_attrs(attrs_sn)
+        assert pydantic_sn.serial_number == "null"
+
+
 class TestManufacturingOrderNullDeadline:
     """ManufacturingOrder.production_deadline_date must accept None.
 


### PR DESCRIPTION
Closes #986

## Problem

`list_manufacturing_orders` (and any MO typed-cache sync) fails **globally** with:

```
1 validation error for SerialNumber
transaction_date  Input should be a valid datetime … input_value='null'
```

On serial-number **transfer** responses, Katana serializes absent values as the literal **string** `"null"`/`"undefined"` regardless of declared type (already documented on `SerialNumber.transaction_id`). The generated **attrs** parser tolerates it (falls back to the raw string); the generated **pydantic** model then rejects it during the cache sync's attrs→pydantic conversion. Because the sync loop advances `SyncState.last_synced` only *after* the batch and has **no per-record isolation**, one bad record aborts the whole entity sync *and* wedges the watermark — so every retry re-poisons on the same record (tight reconnect loop, no `tools/call` lands). Live-reproduced on the dev tenant.

Same class as the null-SKU crash (#671) — one bad nested record blacks out a whole batch — but relaxing one field at a time never made the loop itself resilient.

## Fix — two complementary layers

**`fix(client)`: root cause, data-preserving.** `KatanaPydanticBase.from_attrs` coerces the `"null"`/`"undefined"` sentinel → `None` for any field that can't hold a string, leaving genuine `str` fields untouched. One central seam fixes every sentinel field on every model (`transaction_date`, `resource_id`, `quantity_change`, `id`, …) and *retains* the record.

**`fix(mcp)`: structural backstop.** A new `_convert_batch` helper wraps each record's conversion in try/except → log + skip the bad row so the rest of the batch lands and the watermark advances. Both batch loops (`_sync_one_locked`, `merge_filtered_fetch`) route through it, containing any *future* unforeseen quirk.

## Validation

- Reproduced the live failure, then confirmed the fix through the **real** `ensure_manufacturing_orders_synced` sync path: both MOs land; the quirky serial is retained with the sentinel nulled and `serial_number` preserved.
- 5 new regression tests (3 pydantic-seam + 2 sync-path/backstop); full cache/model suites green; `agent-check` clean.
- Touches only hand-maintained files — **no generated files, no spec, no regeneration**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
