### PR TITLE
ci: mint release tokens from a GitHub App instead of an expiring PAT

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -226,6 +226,18 @@ graph TD
 
 - `GITHUB_TOKEN` - Automatically provided by GitHub Actions
 - PyPI publishing uses Trusted Publishers (no manual tokens needed)
+- `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` - Credentials for the **GitHub App** used
+  by the Release and Update-MCP-Dependency workflows to push the `chore(release)`
+  version bumps + tags to `main`. These replace the old `SEMANTIC_RELEASE_TOKEN` PAT,
+  whose fine-grained-token expiry silently broke every release. Set up the App once:
+  1. Create a GitHub App (org or user) with **Repository permissions → Contents: Read
+     and write** and **Pull requests: Read and write**.
+  1. Install it on `katana-openapi-client`.
+  1. Add it to the `main` ruleset's **bypass list** so it can push the release
+     commit/tag directly (the ruleset otherwise blocks direct pushes).
+  1. Store the App's **App ID** as `RELEASE_APP_ID` and a generated **private key**
+     (`.pem` contents) as `RELEASE_APP_PRIVATE_KEY` in repo Actions secrets. The private
+     key does not expire the way a fine-grained PAT does.
 
 ### Environments
 
@@ -293,7 +305,8 @@ When adding new workflows:
 - Verify a new `client-v*` tag was created
 - Check if MCP dependency is already up to date
 - Review update-mcp-dependency workflow logs
-- Ensure `SEMANTIC_RELEASE_TOKEN` has `pull-requests: write` permission
+- Ensure the release GitHub App (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) has
+  `Contents: write` + `Pull requests: write` and is on the `main` ruleset bypass list
 
 **MCP release not triggering after dependency update:**
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,26 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
+      # Mint a short-lived installation token from a GitHub App instead of a
+      # long-lived PAT. The App's private key doesn't silently expire the way a
+      # fine-grained PAT does (which is what took the release pipeline down), and
+      # the token it issues is scoped to this repo and lasts only for the run.
+      - name: Generate a GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Scope the token to exactly what the release jobs need (push the
+          # version-bump commit + tag / lockfile sync, and let semantic-release
+          # comment on the released PRs). Avoids the blanket-permission token.
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
@@ -95,7 +111,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@39dd2052f2ce8282a5d932c31d58a2ca06d2550e # v10.6.1
         with:
-          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           verbosity: 2
 
       - name: Build client package
@@ -129,10 +145,22 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
+      - name: Generate a GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Scope the token to exactly what the release jobs need (push the
+          # version-bump commit + tag / lockfile sync, and let semantic-release
+          # comment on the released PRs). Avoids the blanket-permission token.
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
@@ -164,7 +192,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@39dd2052f2ce8282a5d932c31d58a2ca06d2550e # v10.6.1
         with:
-          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           verbosity: 2
           directory: katana_mcp_server
 
@@ -249,11 +277,23 @@ jobs:
       # pyproject versions — re-locking there would be a no-op and the lock
       # would never catch up (#901). `ref: main` + an explicit reset to
       # origin/main guarantees we see the bumped versions before re-locking.
+      - name: Generate a GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Scope the token to exactly what the release jobs need (push the
+          # version-bump commit + tag / lockfile sync, and let semantic-release
+          # comment on the released PRs). Avoids the blanket-permission token.
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: main
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Fast-forward to the post-release tip of main
         run: |

--- a/.github/workflows/update-mcp-dependency.yml
+++ b/.github/workflows/update-mcp-dependency.yml
@@ -16,11 +16,22 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Same durable App-token approach as the Release workflow — this job also
+      # pushes to main, so it needs a token that can, and one that won't expire.
+      - name: Generate a GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Only needs to push the dependency-bump commit to main.
+          permission-contents: write
+
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Check for new client release
         id: check-release

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -12,13 +12,13 @@ rules:
     # other (read-only) checkout in the tree.
     ignore:
       # release-client / release-mcp jobs: python-semantic-release pushes the
-      # version-bump commit and tag using SEMANTIC_RELEASE_TOKEN.
-      - release.yml:63
-      - release.yml:132
+      # version-bump commit and tag using the GitHub App token minted in-job.
+      - release.yml:79
+      - release.yml:160
       # sync-lockfile job: commits the regenerated uv.lock and pushes to main.
-      - release.yml:252
+      - release.yml:292
       # update-mcp-dependency: commits the client bump and pushes to main.
-      - update-mcp-dependency.yml:19
+      - update-mcp-dependency.yml:30
 
   dangerous-triggers:
     # update-mcp-dependency runs on `workflow_run` after the Release workflow


### PR DESCRIPTION
## Why

The `Release` workflow (and `Update-MCP-Dependency`) authenticated their push-to-`main` git operations with the `SEMANTIC_RELEASE_TOKEN` PAT. That token is a **fine-grained PAT that silently expired** ~30 days after it was last set (2026-05-08) — and **every release since ~2026-06-08 has failed** at checkout with `fatal: could not read Username for 'https://github.com'`. No client/mcp package has published for weeks, despite green CI and merged release commits. (Discovered while confirming today's traceability + cache-fix merges would ship.)

## What

Replace the expiring PAT with a **GitHub App token minted per-run** (`actions/create-github-app-token`) in each job that pushes to `main`:

- `release-client`, `release-mcp` — semantic-release version bump + tag
- `sync-lockfile` — post-release `uv.lock` commit
- `update-mcp-dependency` — client-dependency bump commit

An App private key doesn't lapse the way a fine-grained PAT does, so this **kills the recurring outage** for good. Each token is **scoped** (`permission-contents: write` everywhere; `permission-pull-requests: write` on the semantic-release jobs) rather than inheriting blanket installation permissions — keeps zizmor's `github-app` audit green. The `artipacked` ignores are re-pointed to the shifted checkout lines (the credential still legitimately persists for the push), and the workflows README documents the new secrets.

**Validation:** ran the CI-pinned `zizmor@1.25.2` locally over `.github/workflows/` → **No findings**. YAML + mdformat + yamllint clean.

## ⚠️ Required one-time setup (repo admin)

This PR **won't fix releases until the GitHub App exists** — but releases are already red, so there's no regression risk in merging. Setup:

1. Create a **GitHub App** with **Repository permissions → Contents: Read and write** + **Pull requests: Read and write**.
2. Install it on `katana-openapi-client`.
3. Add it to the **`main` ruleset bypass list** (so it can push the release commit/tag directly past the "PRs only" rule).
4. Store its **App ID** as `RELEASE_APP_ID` and a generated **private key** (`.pem`) as `RELEASE_APP_PRIVATE_KEY` in repo Actions secrets.

Then re-run `Release` (or push any release-worthy commit) and the backlog of unpublished versions will cut. The old `SEMANTIC_RELEASE_TOKEN` secret can be deleted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
