### PR TITLE
chore(deps): upgrade TS client dev-deps (biome 2, TypeScript 6, @types/node 26)

### DIFF
--- a/packages/katana-client/biome.json
+++ b/packages/katana-client/biome.json
@@ -1,12 +1,10 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": {
         "noUnusedImports": "error",
         "noUnusedVariables": "error"
@@ -27,13 +25,13 @@
     }
   },
   "files": {
-    "ignore": ["dist", "node_modules"]
+    "includes": ["**", "!**/dist", "!**/node_modules"]
   },
   "overrides": [
     {
-      "include": ["src/generated/**"],
+      "includes": ["**/src/generated/**"],
       "linter": { "enabled": false },
-      "organizeImports": { "enabled": false }
+      "assist": { "actions": { "source": { "organizeImports": "off" } } }
     }
   ]
 }

--- a/packages/katana-client/package-lock.json
+++ b/packages/katana-client/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@biomejs/biome": "^1.9.4",
+        "@biomejs/biome": "^2.5.2",
         "@hey-api/openapi-ts": "^0.99.0",
-        "@types/node": "^24.10.1",
+        "@types/node": "^26.1.0",
         "@vitest/coverage-v8": "^4.1.10",
         "tsup": "^8.3.5",
-        "typescript": "^5.7.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.0.15"
       },
       "engines": {
@@ -82,11 +82,10 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.2.tgz",
+      "integrity": "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
         "biome": "bin/biome"
@@ -99,20 +98,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.9.4",
-        "@biomejs/cli-darwin-x64": "1.9.4",
-        "@biomejs/cli-linux-arm64": "1.9.4",
-        "@biomejs/cli-linux-arm64-musl": "1.9.4",
-        "@biomejs/cli-linux-x64": "1.9.4",
-        "@biomejs/cli-linux-x64-musl": "1.9.4",
-        "@biomejs/cli-win32-arm64": "1.9.4",
-        "@biomejs/cli-win32-x64": "1.9.4"
+        "@biomejs/cli-darwin-arm64": "2.5.2",
+        "@biomejs/cli-darwin-x64": "2.5.2",
+        "@biomejs/cli-linux-arm64": "2.5.2",
+        "@biomejs/cli-linux-arm64-musl": "2.5.2",
+        "@biomejs/cli-linux-x64": "2.5.2",
+        "@biomejs/cli-linux-x64-musl": "2.5.2",
+        "@biomejs/cli-win32-arm64": "2.5.2",
+        "@biomejs/cli-win32-x64": "2.5.2"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==",
       "cpu": [
         "arm64"
       ],
@@ -127,9 +126,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==",
       "cpu": [
         "x64"
       ],
@@ -144,9 +143,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==",
       "cpu": [
         "arm64"
       ],
@@ -161,9 +160,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.2.tgz",
+      "integrity": "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==",
       "cpu": [
         "arm64"
       ],
@@ -178,9 +177,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==",
       "cpu": [
         "x64"
       ],
@@ -195,9 +194,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.2.tgz",
+      "integrity": "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==",
       "cpu": [
         "x64"
       ],
@@ -212,9 +211,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.2.tgz",
+      "integrity": "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==",
       "cpu": [
         "arm64"
       ],
@@ -229,9 +228,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==",
       "cpu": [
         "x64"
       ],
@@ -1010,9 +1009,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1030,9 +1026,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1050,9 +1043,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1070,9 +1060,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1090,9 +1077,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1110,9 +1094,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1600,13 +1581,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -2560,9 +2541,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2584,9 +2562,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2608,9 +2583,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2632,9 +2604,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3441,9 +3410,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3462,9 +3431,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/katana-client/package.json
+++ b/packages/katana-client/package.json
@@ -58,12 +58,12 @@
     "node": ">=18.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
+    "@biomejs/biome": "^2.5.2",
     "@hey-api/openapi-ts": "^0.99.0",
-    "@types/node": "^24.10.1",
+    "@types/node": "^26.1.0",
     "@vitest/coverage-v8": "^4.1.10",
     "tsup": "^8.3.5",
-    "typescript": "^5.7.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.15"
   },
   "sideEffects": false

--- a/packages/katana-client/src/client.ts
+++ b/packages/katana-client/src/client.ts
@@ -8,15 +8,15 @@
 import { createClient, createConfig } from './generated/client/index.js';
 import type { Client } from './generated/client/types.gen.js';
 import {
+  createPaginatedFetch,
   DEFAULT_PAGINATION_CONFIG,
   type PaginationConfig,
-  createPaginatedFetch,
 } from './transport/pagination.js';
-import { DEFAULT_RATE_LIMIT_CONFIG, createRateLimitedFetch } from './transport/rateLimit.js';
+import { createRateLimitedFetch, DEFAULT_RATE_LIMIT_CONFIG } from './transport/rateLimit.js';
 import {
+  createResilientFetch,
   DEFAULT_RETRY_CONFIG,
   type RetryConfig,
-  createResilientFetch,
 } from './transport/resilient.js';
 
 /**

--- a/packages/katana-client/src/index.ts
+++ b/packages/katana-client/src/index.ts
@@ -29,41 +29,36 @@ export { KatanaClient, type KatanaClientOptions } from './client.js';
 // `ValidationErrorDetail` (the Ajv-style union) comes from the generated types
 // via `export * from './types.js'` below — not re-declared here.
 export {
-  KatanaError,
   AuthenticationError,
-  RateLimitError,
-  ValidationError,
-  ServerError,
+  KatanaError,
   NetworkError,
   parseError,
+  RateLimitError,
+  ServerError,
+  ValidationError,
 } from './errors.js';
-
+// Re-export the Client type for advanced usage
+export type { Client } from './generated/client/types.gen.js';
+// Re-export generated SDK functions for direct API access
+export * from './generated/sdk.gen.js';
+export {
+  createPaginatedFetch,
+  DEFAULT_PAGINATION_CONFIG,
+  type PaginatedResponse,
+  type PaginationConfig,
+} from './transport/pagination.js';
+export {
+  createRateLimitedFetch,
+  DEFAULT_RATE_LIMIT_CONFIG,
+  type RateLimitConfig,
+  type RateLimitedFetchOptions,
+} from './transport/rateLimit.js';
 // Re-export transport utilities for advanced usage
 export {
   createResilientFetch,
-  type RetryConfig,
   DEFAULT_RETRY_CONFIG,
+  type RetryConfig,
 } from './transport/resilient.js';
-
-export {
-  createPaginatedFetch,
-  type PaginationConfig,
-  DEFAULT_PAGINATION_CONFIG,
-  type PaginatedResponse,
-} from './transport/pagination.js';
-
-export {
-  createRateLimitedFetch,
-  type RateLimitConfig,
-  type RateLimitedFetchOptions,
-  DEFAULT_RATE_LIMIT_CONFIG,
-} from './transport/rateLimit.js';
-
-// Re-export generated SDK functions for direct API access
-export * from './generated/sdk.gen.js';
-
-// Re-export the Client type for advanced usage
-export type { Client } from './generated/client/types.gen.js';
 
 // Re-export all generated types for convenience
 export * from './types.js';

--- a/packages/katana-client/tests/client.test.ts
+++ b/packages/katana-client/tests/client.test.ts
@@ -35,7 +35,6 @@ describe('KatanaClient', () => {
     it('should throw descriptive error when no API key is available', async () => {
       // Temporarily remove env var if present
       const originalEnv = process.env.KATANA_API_KEY;
-      // biome-ignore lint/performance/noDelete: Need to actually remove env var, not set to "undefined" string
       delete process.env.KATANA_API_KEY;
 
       try {
@@ -61,7 +60,6 @@ describe('KatanaClient', () => {
         if (originalEnv) {
           process.env.KATANA_API_KEY = originalEnv;
         } else {
-          // biome-ignore lint/performance/noDelete: Need to actually remove env var, not set to "undefined" string
           delete process.env.KATANA_API_KEY;
         }
       }

--- a/packages/katana-client/tests/errors.test.ts
+++ b/packages/katana-client/tests/errors.test.ts
@@ -7,10 +7,10 @@ import {
   AuthenticationError,
   KatanaError,
   NetworkError,
+  parseError,
   RateLimitError,
   ServerError,
   ValidationError,
-  parseError,
 } from '../src/errors.js';
 
 describe('Error Classes', () => {

--- a/packages/katana-client/tests/transport/retry.test.ts
+++ b/packages/katana-client/tests/transport/retry.test.ts
@@ -6,9 +6,9 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  DEFAULT_RETRY_CONFIG,
   calculateRetryDelay,
   createResilientFetch,
+  DEFAULT_RETRY_CONFIG,
   shouldRetry,
 } from '../../src/transport/resilient.js';
 

--- a/packages/katana-client/tsconfig.json
+++ b/packages/katana-client/tsconfig.json
@@ -20,7 +20,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
Consolidates the three open dependabot bumps for the TypeScript client into one PR, because each needed accompanying config/source changes and could not merge as an isolated bump.

## What was blocking each upgrade

| Dependabot PR | Bump | Root cause | Fix |
|---|---|---|---|
| #970 | `@biomejs/biome` 1.9→2.5 | v2 breaking config schema + stricter import sort + dropped `noDelete` rule | `biome migrate` + `biome check --write` + remove 2 stale `biome-ignore` comments |
| #972 | `typescript` 5.7→6.0 | TS 6.0 no longer auto-includes `@types/node` globals → `typeof process` guard raised `TS2591` in `client.ts` | add `"types": ["node"]` to `tsconfig.json` (also valid on TS 5.9) |
| #971 | `@types/node` 24→26 | none — the stale branch just predated the `prettier`→`biome:format` codegen fix already on `main` | rebase only (no source change) |

None are upstream library bugs; all three are intentional major-version breaking changes that needed our config caught up.

## Changes
- `biome.json`: migrated to the biome v2 schema (`recommended`→`preset`, `files.ignore`→`includes`, `organizeImports`→`assist`)
- `tsconfig.json`: `"types": ["node"]`
- `src/client.ts`, `src/index.ts`, `tests/*`: biome v2 import/export re-sort (no behavior change)
- `tests/client.test.ts`: dropped two now-unused `biome-ignore lint/performance/noDelete` suppressions
- `package.json` / `package-lock.json`: the three version bumps

## Verification
Ran the full `typescript-client` CI sequence locally against the updated lockfile: `npm ci` → `lint` → `typecheck` → **123 tests pass** → `generate` + `typecheck` regen gate, with **no generated drift**.

Closes #970
Closes #971
Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)