### PR TITLE
chore(ci): pin openapi-ts nightly against Dependabot downgrade churn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,16 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # @hey-api/openapi-ts is intentionally pinned to the `next` nightly: the
+      # stable line (0.99.0) calls the TypeScript Compiler API (`ts.SyntaxKind`),
+      # which tsgo removed, so it crashes `npm run generate` under TypeScript 7.
+      # The v1 line (nightly-only today) dropped that dependency. Without this
+      # ignore, Dependabot would "update" the locked nightly down to the 0.99.0
+      # `latest` tag — a downgrade that re-breaks the TS 7 build. Remove this and
+      # move the pin to ^1.0.0 once hey-api ships a stable v1
+      # (check: `npm view @hey-api/openapi-ts dist-tags`).
+      - dependency-name: "@hey-api/openapi-ts"
     commit-message:
       prefix: "chore(deps)"
       include: "scope"


### PR DESCRIPTION
Small follow-up to #993 (TypeScript 7). The TS client pins `@hey-api/openapi-ts` to the **`next` nightly** because the stable line (0.99.0) calls `ts.SyntaxKind` — removed by tsgo — and crashes `npm run generate` under TS 7.

**Problem this fixes:** Dependabot reads the locked `0.0.0-next-*` version and would try to "update" it to the 0.99.0 `latest` tag — a **downgrade that re-breaks the TS 7 build** and generates recurring noise PRs.

**Change:** one Dependabot `ignore` rule for `@hey-api/openapi-ts`, with an inline comment documenting the follow-up — remove the ignore and move the pin to `^1.0.0` once hey-api ships a stable v1 (`npm view @hey-api/openapi-ts dist-tags`).

This also gives the "un-pin at stable v1" follow-up a durable home (in the config the next person will edit) instead of a tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)