### PR TITLE
ci: migrate release automation off PAT to GitHub App token

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -293,7 +293,9 @@ When adding new workflows:
 - Verify a new `client-v*` tag was created
 - Check if MCP dependency is already up to date
 - Review update-mcp-dependency workflow logs
-- Ensure `SEMANTIC_RELEASE_TOKEN` has `pull-requests: write` permission
+- Ensure the `dougborg-release-please` GitHub App token (minted via
+  `RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_APP_PRIVATE_KEY`) has `contents: write`
+  permission
 
 **MCP release not triggering after dependency update:**
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,18 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
@@ -95,7 +103,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@39dd2052f2ce8282a5d932c31d58a2ca06d2550e # v10.6.1
         with:
-          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           verbosity: 2
 
       - name: Build client package
@@ -129,10 +137,18 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
@@ -164,7 +180,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@39dd2052f2ce8282a5d932c31d58a2ca06d2550e # v10.6.1
         with:
-          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           verbosity: 2
           directory: katana_mcp_server
 
@@ -249,11 +265,19 @@ jobs:
       # pyproject versions — re-locking there would be a no-op and the lock
       # would never catch up (#901). `ref: main` + an explicit reset to
       # origin/main guarantees we see the bumped versions before re-locking.
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: main
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Fast-forward to the post-release tip of main
         run: |

--- a/.github/workflows/update-mcp-dependency.yml
+++ b/.github/workflows/update-mcp-dependency.yml
@@ -16,11 +16,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Check for new client release
         id: check-release


### PR DESCRIPTION
## What

Replaces `secrets.SEMANTIC_RELEASE_TOKEN` (a long-lived, admin-owned PAT) with short-lived tokens minted per-job from the `dougborg-release-please` GitHub App (App ID 4392719), via `actions/create-github-app-token`.

Changed:
- `.github/workflows/release.yml` — `release-client`, `release-mcp`, and `sync-lockfile` jobs: checkout `token:`, `python-semantic-release`'s `github_token:`, and the lockfile-sync `git push` now authenticate with the App token instead of the PAT.
- `.github/workflows/update-mcp-dependency.yml` — checkout `token:` and the dependency-bump `git push` now use the App token.
- `.github/workflows/README.md` — troubleshooting note updated to reference the App token instead of the retired PAT's permission requirements.

Each mint step is scoped to `permission-contents: write` only — the minimum these jobs need (git push + release creation). No pull-request or issue scopes are granted since none of these jobs open PRs or touch issues.

Package/container registry auth is untouched: PyPI publishing still uses OIDC trusted publishing, and GHCR login still uses `secrets.GITHUB_TOKEN`.

## Why

`SEMANTIC_RELEASE_TOKEN` is a long-lived PAT belonging to an admin account, kept around solely so release automation could push version-bump commits/tags directly to `main` despite the "Protect Main" ruleset requiring PRs (the PAT works today only because that admin bypasses the ruleset). Swapping to GitHub App installation tokens gets the same capability with tokens that are short-lived (~1h), narrowly scoped, and not tied to a personal account.

**The ruleset is already handled — no action needed here.** The App (Integration actor 4392719) has already been added as an `always` bypass actor on the "Protect Main" ruleset (id 6756621), so App-token pushes to `main` will be permitted exactly like the PAT's were. This PR does not touch branch protection.

## Git identity

Left the existing `git config user.name/email "github-actions[bot]"` identity as-is in both the `sync-lockfile` and `update-mcp-dependency` commit steps. That identity is already generic and was never tied to the PAT-owning account, so there's no mismatch to fix — only the *auth* token backing the push changes, not the commit author.

## Follow-up (do not do yet)

`SEMANTIC_RELEASE_TOKEN` is intentionally **left in place** as a rollback path. Once a release has run successfully end-to-end on the new App token (version bump pushed to `main`, tag created, PyPI publish succeeded), the secret can be deleted from repo settings.

## Verification

- `actionlint` run on both changed workflow files before and after the change: no new findings. Pre-existing shellcheck warnings (`SC2046`/`SC2086`, unrelated quoting in existing `run:` blocks) are unchanged aside from shifting line numbers.
- Exhaustively grepped `.github/workflows/` for `SEMANTIC_RELEASE_TOKEN`; confirmed zero remaining references after the change.

**Not merging this PR** — leaving it open for review; the first release run after merge should be watched closely (see risk note in the accompanying report).