### PR TITLE
fix(release): serialize release-client and release-mcp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,12 @@ jobs:
           path: dist/
 
   release-mcp:
-    needs: test
+    # Depends on release-client (not just test) so the two python-semantic-release
+    # jobs never push to main concurrently. When they ran in parallel, whichever
+    # finished second aborted with "Upstream branch 'origin/main' has changed!"
+    # (run 30171587653) — PSR correctly refuses to release from a stale ref.
+    needs: [test, release-client]
+    if: always() && needs.test.result == 'success'
     runs-on: ubuntu-latest
     concurrency:
       group: release-mcp
@@ -148,6 +153,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          ref: main
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
@@ -156,6 +162,14 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
           python-version: "3.14"
+
+      # Same reasoning as sync-lockfile below (#901): release-client may have
+      # pushed a `chore(release)` bump to main after this run started, so the
+      # default checkout (github.sha) is stale and PSR aborts on a stale ref.
+      - name: Fast-forward to the post-release tip of main
+        run: |
+          git fetch origin main
+          git reset --hard origin/main
 
       - name: Install dependencies
         run: uv sync --all-extras


### PR DESCRIPTION
## Problem

`release-client` and `release-mcp` both depended only on `test`, so they ran in parallel and both invoked `python-semantic-release`, which pushes version-bump commits to `main`.

In [run 30171587653](https://github.com/dougborg/katana-openapi-client/actions/runs/30171587653) `release-mcp` finished first and pushed `chore(release): mcp ...`. `release-client` then aborted:

```
[LOCAL SHA] d23b26f476129e2a605c2caddbc71371d996174a != 84ad40dce891b594be3e0f02d9bdd9d3714629cd [UPSTREAM SHA].
Upstream branch 'origin/main' has changed!
Upstream branch has changed. Please pull the latest changes and try again.
```

Net effect: the MCP package released and published to PyPI, while the client release was skipped entirely. PSR behaved correctly here — it refuses to release from a stale ref rather than force-pushing.

This race predates the App-token migration (#999) and was not caused by it. It was previously masked because `SEMANTIC_RELEASE_TOKEN` had stopped working, so the jobs failed at auth before they could race.

## Fix

1. `release-mcp` now `needs: [test, release-client]`, so the two PSR jobs are serialized.
2. `if: always() && needs.test.result == 'success'` preserves the existing behaviour: MCP still releases even when the client does not.
3. `release-mcp` checks out `ref: main` and hard-resets to `origin/main`, so it starts from the post-client-release tip. This reuses the pattern this workflow already applies to `sync-lockfile` for the same underlying cause (#901).

## Related

The sibling repo `stocktrim-openapi-client` hit the same class of bug from the opposite direction (its `release-mcp` was already serialized but checked out a stale ref) — fixed there in #236.

## Verification

- `actionlint`: 8 findings on `main`, 8 on this branch — identical pre-existing shellcheck warnings, no new findings.
- Trade-off: serializing makes the release workflow slower, since MCP no longer starts until the client release finishes. That is the cost of correctness here; the jobs cannot safely push to `main` concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhJ5dF3N3z7X63aRaDBcQ