### PR TITLE
fix(ci): realign zizmor artipacked ignores after App-token migration

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -12,13 +12,13 @@ rules:
     # other (read-only) checkout in the tree.
     ignore:
       # release-client / release-mcp jobs: python-semantic-release pushes the
-      # version-bump commit and tag using SEMANTIC_RELEASE_TOKEN.
-      - release.yml:63
-      - release.yml:132
+      # version-bump commit and tag using the GitHub App token minted in-job.
+      - release.yml:71
+      - release.yml:153
       # sync-lockfile job: commits the regenerated uv.lock and pushes to main.
-      - release.yml:252
+      - release.yml:290
       # update-mcp-dependency: commits the client bump and pushes to main.
-      - update-mcp-dependency.yml:19
+      - update-mcp-dependency.yml:27
 
   dangerous-triggers:
     # update-mcp-dependency runs on `workflow_run` after the Release workflow


### PR DESCRIPTION
## Problem

`.github/zizmor.yml` suppresses `artipacked` by **exact line number**. #999 (App-token migration) and #1001 (job serialization) inserted steps into `release.yml`, shifting every checkout below them. Three of the four ignore entries no longer point at a checkout.

Measured on current `main`:

```
23 findings (1 ignored, 18 suppressed, 4 unsafe fixes): 4 medium
```

With this change:

```
No findings to report. Good job! (5 ignored, 18 suppressed)
```

## Changes

| Entry | Was | Now |
|---|---|---|
| release-client checkout | `release.yml:63` | `release.yml:71` |
| release-mcp checkout | `release.yml:132` | `release.yml:153` |
| sync-lockfile checkout | `release.yml:252` | `release.yml:290` |
| update-mcp-dependency checkout | `update-mcp-dependency.yml:19` | `update-mcp-dependency.yml:27` |

Also updates the rationale comment, which still referenced `SEMANTIC_RELEASE_TOKEN` — those jobs now mint a GitHub App token in-job.

Note the last entry anchors to the step's `- name:` line (27), not its `uses:` line (28); zizmor reports the span from the step start.

The suppressions themselves are unchanged in intent — these checkouts still deliberately persist credentials because their jobs push back to the repo.

## Supersedes #987

#987 (opened 2026-07-15) made this same realignment as part of its own App-token migration. That migration landed via #999 instead, so #987's workflow changes are now redundant — but its `zizmor.yml` update was the one piece #999 missed, which is what this PR restores. #987's proposed line numbers (79/160/292/30) were derived from its own diff and do not match what actually landed.

## Note on fragility

Line-number-pinned suppressions break silently on any edit above them — the config stays valid, the findings just quietly return. If zizmor supports anchoring by job/step id in a future version, that would be worth adopting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhJ5dF3N3z7X63aRaDBcQ