### PR TITLE
fix(tests): align MCP package asyncio_mode with the root

### DIFF
--- a/katana_mcp_server/pyproject.toml
+++ b/katana_mcp_server/pyproject.toml
@@ -79,7 +79,7 @@ packages = ["src/katana_mcp"]
 # Pytest Configuration (Native TOML - pytest 9.0+)
 [tool.pytest]
 testpaths = ["tests"]
-asyncio_mode = "strict"
+asyncio_mode = "auto"
 markers = [
     "unit: Unit tests with mocks",
     "integration: Integration tests requiring API key",


### PR DESCRIPTION
## Preventive, not a bug fix — nothing is broken today

`katana_mcp_server/pyproject.toml:82` declares `asyncio_mode = "strict"`; the root declares `"auto"`. pytest resolves `rootdir`/`configfile` from the target path, so `pytest katana_mcp_server/tests` and a root-level run read **different** configs.

To be clear about scope: this package's tests pass under **both** settings, verified in this worktree:

| Mode | Result |
|---|---|
| `strict` (baseline) | 1782 passed, 100 skipped |
| `auto` (this PR) | 1782 passed, 100 skipped |

That is because this package is strict-clean: 905 of its 952 async tests carry `@pytest.mark.asyncio` (plus 4 module-level `pytestmark`), and its async fixtures use `@pytest_asyncio.fixture`.

## Why change it at all

The sibling repo `frontapp-openapi-client` has the identical divergence, and there it **does** break — 136 tests fail when run from the package directory, because its tests are not strict-clean (dougborg/frontapp-openapi-client#166). The divergence is a latent hazard here: it holds only as long as every future async test remembers its marker, and CI would not catch a regression because it only ever runs pytest from the root.

Aligning the two configs removes the failure mode rather than relying on discipline.

I deliberately did **not** delete the `[tool.pytest]` block, even though a single root config would be tidier — it also carries `testpaths` and this repo's marker registrations, including `browser` and `cache_warmup_enabled`, which would be lost.

## Follow-up worth considering (not in this PR)

CI only exercises the root invocation, which is why this class of drift is invisible. A job that runs the MCP package's tests from inside its own directory would catch it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhJ5dF3N3z7X63aRaDBcQ